### PR TITLE
Add tracked pre-commit hook to run cargo fmt for src-tauri Rust files

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+if ! command -v cargo >/dev/null 2>&1; then
+  echo "error: cargo is not installed or not on PATH." >&2
+  exit 1
+fi
+
+rust_files=()
+while IFS= read -r -d '' file; do
+  case "$file" in
+    src-tauri/*.rs) rust_files+=("$file") ;;
+  esac
+done < <(git diff --cached --name-only -z --diff-filter=ACMR -- src-tauri)
+
+if [ ${#rust_files[@]} -eq 0 ]; then
+  exit 0
+fi
+
+echo "Formatting staged Rust files in src-tauri with cargo fmt..."
+cargo fmt --manifest-path src-tauri/Cargo.toml
+
+echo "Re-adding formatted Rust files to the index..."
+while IFS= read -r -d '' file; do
+  case "$file" in
+    *.rs) git add -- "$file" ;;
+  esac
+done < <(git diff --name-only -z --diff-filter=AM -- src-tauri)
+
+echo "cargo fmt completed and rust files in src-tauri have been re-staged."

--- a/README.md
+++ b/README.md
@@ -111,11 +111,12 @@ sudo apt install -y build-essential curl wget file libssl-dev libgtk-3-dev libwe
     ```
 
 #### 3. Run Development Server
+
 ```bash
 bun install
+bun run install:git-hooks # sets core.hooksPath to use the repository's tracked .githooks/pre-commit hook
 bun run tauri dev
 ```
-
 #### 4. Build Production Bundle
 ```bash
 bun run tauri build

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build": "svelte-kit sync && vite build",
     "preview": "vite preview",
     "prepare": "svelte-kit sync",
+    "install:git-hooks": "git config core.hooksPath .githooks",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
     "tauri": "tauri",


### PR DESCRIPTION
Adds a repository-tracked pre-commit hook under .githooks/pre-commit that formats staged Rust files in src-tauri using cargo fmt, re-stages formatted files, and documents how to enable the hook via bun run install:git-hooks.