### PR TITLE
Refine pre-commit hook Rust file detection logic

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -11,9 +11,9 @@ fi
 
 rust_files=()
 while IFS= read -r -d '' file; do
-  case "$file" in
-    src-tauri/*.rs) rust_files+=("$file") ;;
-  esac
+  if [[ "$file" == src-tauri/* && "$file" == *.rs ]]; then
+    rust_files+=("$file")
+  fi
 done < <(git diff --cached --name-only -z --diff-filter=ACMR -- src-tauri)
 
 if [ ${#rust_files[@]} -eq 0 ]; then


### PR DESCRIPTION
Updates the src-tauri pre-commit hook to more precisely detect staged Rust files and avoid false positives.