### PR TITLE
Floating glass PlayDock, theme-wide glassmorphism, and cleanup

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,6 @@
       "name": "luminous",
       "dependencies": {
         "@tailwindcss/vite": "^4.3.2",
-        "@tanstack/svelte-table": "^8.21.3",
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2.7.1",
         "@tauri-apps/plugin-opener": "^2",
@@ -222,10 +221,6 @@
     "@tailwindcss/oxide-win32-x64-msvc": ["@tailwindcss/oxide-win32-x64-msvc@4.3.2", "", { "os": "win32", "cpu": "x64" }, "sha512-QI9BO7KlNZsp2GuO0jwAAj5jCDABOKXRkCk2XuKTSaNEFSdfzqswYVTtCHBNKHLsqyjFyFkqlDiwkNbTYSssMQ=="],
 
     "@tailwindcss/vite": ["@tailwindcss/vite@4.3.2", "", { "dependencies": { "@tailwindcss/node": "4.3.2", "@tailwindcss/oxide": "4.3.2", "tailwindcss": "4.3.2" }, "peerDependencies": { "vite": "^5.2.0 || ^6 || ^7 || ^8" } }, "sha512-eHpMeX4JXfVNJDEcsouTeCBubJBTcTLigeaw/NTUW6PB5ATKKXdyonnXgTBX2VuRbjz1hjfz6C5XAhr52ImQXA=="],
-
-    "@tanstack/svelte-table": ["@tanstack/svelte-table@8.21.3", "", { "dependencies": { "@tanstack/table-core": "8.21.3" }, "peerDependencies": { "svelte": "^4.0.0 || ^3.49.0" } }, "sha512-VwLt2xfsYHdchdYdFfcl9bxlJts1I6JK50xqhH+KMB9co98rnIyL4pRhTMSDfuB448yQR9E7d6oBLjx8r69cVg=="],
-
-    "@tanstack/table-core": ["@tanstack/table-core@8.21.3", "", {}, "sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg=="],
 
     "@tauri-apps/api": ["@tauri-apps/api@2.11.1", "", {}, "sha512-M2FPuYND2m+wh5hfW9ZpSdxMPdEJovPBWwoHJmwUpysTYNHaOkVFN419m/K0LIgjb/7KU2vBgsUepJWugQCvAA=="],
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@tailwindcss/vite": "^4.3.2",
-        "@tanstack/svelte-table": "^8.21.3",
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2.7.1",
         "@tauri-apps/plugin-opener": "^2",
@@ -288,7 +287,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -305,7 +303,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -322,7 +319,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -339,7 +335,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -356,7 +351,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -373,7 +367,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -390,7 +383,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -407,7 +399,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -424,7 +415,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -441,7 +431,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -458,7 +447,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -475,7 +463,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -492,7 +479,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -509,7 +495,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -526,7 +511,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -543,7 +527,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -560,7 +543,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -577,7 +559,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -594,7 +575,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -611,7 +591,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -628,7 +607,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -645,7 +623,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -662,7 +639,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -679,7 +655,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -696,7 +671,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -713,7 +687,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -800,7 +773,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -814,7 +786,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -828,7 +799,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -842,7 +812,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -856,7 +825,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -870,7 +838,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -884,7 +851,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -901,7 +867,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "libc": [
         "musl"
       ],
@@ -918,7 +883,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -935,7 +899,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "libc": [
         "musl"
       ],
@@ -952,7 +915,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -969,7 +931,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "libc": [
         "musl"
       ],
@@ -986,7 +947,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -1003,7 +963,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "libc": [
         "musl"
       ],
@@ -1020,7 +979,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -1037,7 +995,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "libc": [
         "musl"
       ],
@@ -1054,7 +1011,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -1071,7 +1027,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -1088,7 +1043,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "libc": [
         "musl"
       ],
@@ -1105,7 +1059,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1119,7 +1072,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1133,7 +1085,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1147,7 +1098,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1161,7 +1111,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1175,7 +1124,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1193,7 +1141,6 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.11.tgz",
       "integrity": "sha512-LFuZUkjJ9iF7JZye/aG5XM0SFcQ5VyL0oVX4WJ9dc0Va3R3s0OauX1BESVCb+YN/ol8TAfqGDDAQsTG627Y5kw==",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^8.9.0"
@@ -1568,38 +1515,6 @@
       },
       "peerDependencies": {
         "vite": "^5.2.0 || ^6 || ^7 || ^8"
-      }
-    },
-    "node_modules/@tanstack/svelte-table": {
-      "version": "8.21.3",
-      "resolved": "https://registry.npmjs.org/@tanstack/svelte-table/-/svelte-table-8.21.3.tgz",
-      "integrity": "sha512-VwLt2xfsYHdchdYdFfcl9bxlJts1I6JK50xqhH+KMB9co98rnIyL4pRhTMSDfuB448yQR9E7d6oBLjx8r69cVg==",
-      "license": "MIT",
-      "dependencies": {
-        "@tanstack/table-core": "8.21.3"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      },
-      "peerDependencies": {
-        "svelte": "^4.0.0 || ^3.49.0"
-      }
-    },
-    "node_modules/@tanstack/table-core": {
-      "version": "8.21.3",
-      "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.21.3.tgz",
-      "integrity": "sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@tauri-apps/api": {
@@ -1995,14 +1910,13 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "26.1.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
       "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~8.3.0"
@@ -2012,7 +1926,6 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@vitest/expect": {
@@ -2132,7 +2045,6 @@
       "version": "8.17.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -2188,7 +2100,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
       "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.4"
@@ -2234,7 +2145,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
       "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -2350,7 +2260,6 @@
       "version": "5.8.1",
       "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.1.tgz",
       "integrity": "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/dom-accessibility-api": {
@@ -2397,7 +2306,6 @@
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
       "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -2439,14 +2347,12 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.2.2.tgz",
       "integrity": "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/esrap": {
       "version": "2.2.13",
       "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.13.tgz",
       "integrity": "sha512-m8jH5hZgJE2RRUK/jjkGPcJEDAV+dYnZYFkosQaPTcE+Yw4xynXHOo6FUdwaWBtdR3b1MMa7wEDTSHeR2VWsGA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.4.15"
@@ -2484,7 +2390,6 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -2502,7 +2407,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -2553,7 +2457,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
       "integrity": "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.6"
@@ -2891,7 +2794,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
       "integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lru-cache": {
@@ -2981,7 +2883,6 @@
       "version": "3.3.15",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
       "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3034,14 +2935,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -3086,7 +2985,6 @@
       "version": "8.5.16",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
       "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -3185,7 +3083,6 @@
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
       "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.9"
@@ -3321,7 +3218,6 @@
       "version": "5.56.4",
       "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.56.4.tgz",
       "integrity": "sha512-/d0QHehmRuJW8gVz395MTkPcPozxzdjBMBE8oEYGz8O3b9KTMzzQ9ZHJQLuFKOHOPQbU6kx/X4iid/EBBzH7iw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/remapping": "^2.3.4",
@@ -3382,7 +3278,6 @@
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.1.tgz",
       "integrity": "sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.4"
@@ -3435,7 +3330,6 @@
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
       "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -3542,14 +3436,13 @@
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
       "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/vite": {
       "version": "6.4.3",
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
       "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",
@@ -3624,7 +3517,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -3831,7 +3723,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/zimmerframe/-/zimmerframe-1.1.4.tgz",
       "integrity": "sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==",
-      "dev": true,
       "license": "MIT"
     }
   }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.3.2",
-    "@tanstack/svelte-table": "^8.21.3",
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-dialog": "^2.7.1",
     "@tauri-apps/plugin-opener": "^2",

--- a/src/lib/components/CollectionView.svelte
+++ b/src/lib/components/CollectionView.svelte
@@ -292,7 +292,7 @@
   </div>
 
   <!-- Main View Scrollable Container -->
-  <div class="flex-1 p-6 {collectionStore.activeSubTab === 'songs' ? 'overflow-hidden flex flex-col' : 'overflow-y-auto'}">
+  <div class="flex-1 p-6 pb-24 {collectionStore.activeSubTab === 'songs' ? 'overflow-hidden flex flex-col' : 'overflow-y-auto'}">
     {#if collectionStore.activeSubTab === "songs"}
       <!-- Songs Table View -->
       <div class="flex-1 overflow-hidden border border-brand-border rounded-lg bg-brand-sidebar/40 flex flex-col min-h-0">

--- a/src/lib/components/FoldersView.svelte
+++ b/src/lib/components/FoldersView.svelte
@@ -173,7 +173,7 @@
   </div>
 
   <!-- Content Area -->
-  <div class="flex-1 overflow-y-auto p-6 max-w-4xl space-y-6">
+  <div class="flex-1 overflow-y-auto p-6 pb-24 max-w-4xl space-y-6">
     {#if settingsTab === "folders"}
       <!-- Watched Folders Section -->
       <div class="flex justify-between items-center">

--- a/src/lib/components/HomeView.svelte
+++ b/src/lib/components/HomeView.svelte
@@ -56,7 +56,7 @@
   </div>
 
   <!-- Content Area -->
-  <div class="flex-1 overflow-y-auto px-6 py-8 space-y-12">
+  <div class="flex-1 overflow-y-auto px-6 py-8 pb-24 space-y-12">
     {#if isLoading}
       <div class="flex items-center justify-center h-64">
         <div class="text-brand-text-secondary">Loading your collection...</div>

--- a/src/lib/components/LyricsView.svelte
+++ b/src/lib/components/LyricsView.svelte
@@ -214,7 +214,7 @@
   </div>
 
   <!-- Lyrics Container Viewport -->
-  <div class="flex-1 overflow-y-auto px-6 py-12" bind:this={containerEl}>
+  <div class="flex-1 overflow-y-auto px-6 py-12 pb-24" bind:this={containerEl}>
     {#if isLoading}
       <div class="w-full h-full flex flex-col items-center justify-center gap-3">
         <LoaderCircle class="w-8 h-8 animate-spin text-brand-accent" />

--- a/src/lib/components/PlayerBar.svelte
+++ b/src/lib/components/PlayerBar.svelte
@@ -80,7 +80,7 @@
   }
 </script>
 
-<footer in:fade={{ duration: 600 }} class="h-20 bg-brand-playerbar border-t border-brand-border flex items-center justify-between px-6 text-brand-text-secondary select-none" class:glass-surface={themeStore.isGlassTheme}>
+<footer in:fade={{ duration: 600 }} class="h-20 bg-brand-playerbar border border-brand-border rounded-[2rem] flex items-center justify-between px-8 text-brand-text-secondary select-none" class:glass-surface={themeStore.isGlassTheme}>
   <!-- Track Metadata & Art -->
   <div class="flex items-center gap-3 w-1/3 min-w-[200px]">
     <CoverArt
@@ -235,6 +235,30 @@
 </footer>
 
 <style>
+  /* Accent glow: only the PlayDock gets it, not the other glass panels —
+     extends the shared --glass-shadow (elevation + highlight, app.css)
+     with --glass-glow (theme.svelte.ts) rather than baking the glow into
+     the shared variable itself. */
+  footer.glass-surface {
+    box-shadow: var(--glass-shadow, none), var(--glass-glow, none);
+  }
+
+  /* Liquid-glass "shine": a light-catching specular highlight on top of the
+     existing blur+tint (.glass-surface, app.css), modeled on the two-corner
+     inset highlight from https://codepen.io/lassiterda/pen/vEOpqMa. Plain
+     box-shadow — no backdrop-filter/SVG-filter interaction, so it renders
+     the same regardless of whether the blur itself composites. */
+  footer.glass-surface::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    pointer-events: none;
+    box-shadow:
+      inset 1.5px 1.5px 1px 0 rgba(255, 255, 255, 0.45),
+      inset -1px -1px 1px 0 rgba(255, 255, 255, 0.18);
+  }
+
   .volume-slider {
     -webkit-appearance: none;
     appearance: none;

--- a/src/lib/components/PlaylistView.svelte
+++ b/src/lib/components/PlaylistView.svelte
@@ -196,7 +196,7 @@
     </div>
 
     <!-- Tracks List Scrollable Container -->
-    <div class="flex-1 overflow-hidden p-6 relative z-10 flex flex-col">
+    <div class="flex-1 overflow-hidden p-6 pb-24 relative z-10 flex flex-col">
       <div class="flex-1 overflow-auto border border-brand-border rounded-lg bg-brand-sidebar/30 backdrop-blur-md">
         <table class="w-full text-left text-sm border-collapse min-w-[800px]">
           <thead>

--- a/src/lib/components/RightPanel.svelte
+++ b/src/lib/components/RightPanel.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { playerStore } from "../stores/player.svelte";
   import { themeStore } from "../stores/theme.svelte";
-  import { Music, Clock, Volume2 } from "lucide-svelte";
+  import { Music, Clock } from "lucide-svelte";
 
   interface Props {
     isOpen?: boolean;
@@ -11,27 +11,12 @@
 
   let { isOpen = true, width = 288, onClose }: Props = $props();
 
-  function formatDuration(nanosec: number): string {
-    if (!nanosec) return "0:00";
-    const totalSeconds = Math.floor(nanosec / 1_000_000_000);
-    const minutes = Math.floor(totalSeconds / 60);
-    const seconds = totalSeconds % 60;
-    return `${minutes}:${seconds.toString().padStart(2, "0")}`;
-  }
-
   let currentSong = $derived(playerStore.currentSong);
-  let position = $derived(playerStore.positionNanosec);
-  let volume = $derived(playerStore.volume);
-  let isPlaying = $derived(playerStore.state === "playing");
-
-  let progressPercent = $derived(
-    currentSong?.length_nanosec ? (position / currentSong.length_nanosec) * 100 : 0
-  );
 </script>
 
 <aside
   style="width: {width}px;"
-  class="relative bg-brand-sidebar border-l border-brand-border flex flex-col h-full text-brand-text-secondary select-none flex-shrink-0 overflow-hidden"
+  class="relative bg-brand-sidebar border-l border-brand-border flex flex-col h-full text-brand-text-secondary select-none flex-shrink-0 overflow-hidden rounded-tl-2xl rounded-bl-2xl"
   class:glass-surface={themeStore.isGlassTheme}
 >
   <!-- Header -->
@@ -63,33 +48,8 @@
         </div>
       </div>
 
-      <!-- Progress Bar -->
-      <div class="space-y-2">
-        <div class="w-full bg-brand-border rounded-full h-1 overflow-hidden">
-          <div
-            class="bg-brand-accent h-1 rounded-full transition-all duration-300"
-            style="width: {progressPercent}%"
-          ></div>
-        </div>
-        <div class="flex justify-between text-xs text-brand-text-secondary/70">
-          <span>{formatDuration(position)}</span>
-          <span>{formatDuration(currentSong.length_nanosec || 0)}</span>
-        </div>
-      </div>
-
       <!-- Playback Info -->
       <div class="space-y-2 bg-brand-main/40 rounded-lg p-3">
-        <div class="flex items-center justify-between text-xs">
-          <span class="text-brand-text-secondary/60">Status</span>
-          <span class="text-brand-accent font-semibold capitalize">{isPlaying ? "Playing" : "Paused"}</span>
-        </div>
-        <div class="flex items-center justify-between text-xs">
-          <span class="flex items-center gap-1 text-brand-text-secondary/60">
-            <Volume2 class="w-3 h-3" />
-            Volume
-          </span>
-          <span class="text-brand-text-primary font-semibold">{Math.round(volume * 100)}%</span>
-        </div>
         {#if currentSong.bitrate}
           <div class="flex items-center justify-between text-xs">
             <span class="text-brand-text-secondary/60">Bitrate</span>

--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -36,7 +36,7 @@
   }
 </script>
 
-<aside style="width: {width}px;" class="bg-brand-sidebar border-r border-brand-border flex flex-col h-full text-brand-text-secondary select-none flex-shrink-0" class:glass-surface={themeStore.isGlassTheme}>
+<aside style="width: {width}px;" class="bg-brand-sidebar border-r border-brand-border flex flex-col h-full text-brand-text-secondary select-none flex-shrink-0 overflow-hidden rounded-tr-2xl rounded-br-2xl" class:glass-surface={themeStore.isGlassTheme}>
   <!-- Navigation -->
   <nav class="{isCollapsed ? 'p-2' : 'p-4'} space-y-1 flex flex-col items-center">
     <button
@@ -140,7 +140,7 @@
   {/if}
 
   <!-- Scanning status / trigger -->
-  <div class="{isCollapsed ? 'p-2 flex justify-center' : 'p-4'} border-t border-brand-border bg-brand-main/40 text-xs flex-shrink-0">
+  <div class="{isCollapsed ? 'p-2 flex justify-center' : 'p-4'} mb-24 border-t border-brand-border bg-brand-main/40 text-xs flex-shrink-0">
     {#if collectionStore.isScanning}
       {#if isCollapsed}
         <div 

--- a/src/lib/components/TopNavigation.svelte
+++ b/src/lib/components/TopNavigation.svelte
@@ -85,7 +85,7 @@
 
 <svelte:window on:keydown={handleKeyDown} />
 
-<header in:fade={{ duration: 600 }} class="w-full h-20 bg-brand-sidebar border-b border-brand-border flex items-center px-6 gap-6 z-40" class:glass-surface={themeStore.isGlassTheme}>
+<header in:fade={{ duration: 600 }} class="w-full h-20 bg-brand-sidebar border-b border-brand-border flex items-center px-6 gap-6 z-40 overflow-hidden rounded-bl-2xl rounded-br-2xl" class:glass-surface={themeStore.isGlassTheme}>
   <!-- History Navigation Controls -->
   <div class="flex items-center gap-2">
     <button

--- a/src/lib/stores/theme.svelte.ts
+++ b/src/lib/stores/theme.svelte.ts
@@ -1,7 +1,7 @@
 import { invoke } from "@tauri-apps/api/core";
 import { getCoverArtUrl } from "../types";
 import type { Song } from "../types";
-import { hexToRgb, rgbToHex, pickAccessibleOnColor } from "../utils/colorUtils";
+import { hexToRgb, rgbToHex, pickAccessibleOnColor, isLightColor } from "../utils/colorUtils";
 
 export interface ThemeColors {
   "bg-main": string;
@@ -396,7 +396,9 @@ class ThemeStore {
   }
 
   get isGlassTheme(): boolean {
-    return this.activeThemeId === "system";
+    // Every theme gets the glass treatment now — chrome panels always
+    // render translucent/blurred, computed from whichever theme is active.
+    return true;
   }
 
   get currentTheme(): Theme {
@@ -476,8 +478,17 @@ class ThemeStore {
   }
 
   async updateArtworkColors(song: Song | undefined) {
+    // Extracted artwork colors only drive rendering (--logo-stop-*,
+    // --color-artwork-*) when the Dynamic Artwork theme is actually
+    // active — otherwise every track change would stomp whatever
+    // applyActiveTheme() correctly set for the current theme. The
+    // extraction itself still runs so artworkColors is ready the moment
+    // the user switches to Dynamic Artwork.
+    const isDynamicArtwork = this.currentTheme.id === "dynamic-artwork";
+
     if (!song) {
-      this.resetArtworkColors();
+      if (isDynamicArtwork) this.resetArtworkColors();
+      else this.artworkColors = null;
       return;
     }
 
@@ -508,16 +519,19 @@ class ThemeStore {
     }
 
     if (!url) {
-      this.resetArtworkColors();
+      if (isDynamicArtwork) this.resetArtworkColors();
+      else this.artworkColors = null;
       return;
     }
 
     try {
       const colors = await extractColorsFromImage(url);
-      this.applyArtworkColors(colors);
+      if (isDynamicArtwork) this.applyArtworkColors(colors);
+      else this.artworkColors = colors;
     } catch (e) {
       console.error("Failed to extract artwork colors:", e);
-      this.resetArtworkColors();
+      if (isDynamicArtwork) this.resetArtworkColors();
+      else this.artworkColors = null;
     }
   }
 
@@ -604,24 +618,35 @@ class ThemeStore {
     `;
 
     const root = document.documentElement;
-    root.classList.toggle("theme-glass", isLuminous);
+    root.classList.toggle("theme-glass", true);
 
-    if (isLuminous) {
-      const isDark = this.systemColorScheme === "dark";
-      // These are rendering-only, separate from the opaque `colors` above —
-      // alpha never reaches a color picker, see hexToRgbaString().
-      root.style.setProperty("--glass-bg-sidebar", hexToRgbaString(colors["bg-sidebar"], isDark ? 0.5 : 0.6));
-      root.style.setProperty("--glass-bg-playerbar", hexToRgbaString(colors["bg-playerbar"], isDark ? 0.55 : 0.65));
-      root.style.setProperty("--glass-border-color", isDark ? "rgba(255, 255, 255, 0.10)" : "rgba(15, 15, 20, 0.08)");
+    // Glass rendering vars — computed for every theme (not just System) so
+    // all four chrome panels get the blur/tint/shine treatment regardless
+    // of which theme is active. isDark comes from this theme's own
+    // bg-main luminance rather than systemColorScheme, since only System
+    // tracks the OS scheme — every other theme has fixed colors.
+    // Rendering-only, separate from the opaque `colors` above — alpha
+    // never reaches a color picker, see hexToRgbaString().
+    const isDark = !isLightColor(colors["bg-main"]);
+    root.style.setProperty("--glass-bg-sidebar", hexToRgbaString(colors["bg-sidebar"], isDark ? 0.5 : 0.6));
+    root.style.setProperty("--glass-bg-playerbar", hexToRgbaString(colors["bg-playerbar"], isDark ? 0.78 : 0.85));
+    root.style.setProperty("--glass-border-color", isDark ? "rgba(255, 255, 255, 0.10)" : "rgba(15, 15, 20, 0.08)");
 
-      const elevation = isDark ? "0 8px 32px rgba(0, 0, 0, 0.45)" : "0 8px 32px rgba(15, 15, 20, 0.10)";
-      // Two-layer glow (tight bright core + wide soft halo) reads as an
-      // actual glow rather than a flat blurred outline.
-      const glowNear = `0 0 24px 2px ${hexToRgbaString(colors["color-accent"], isDark ? 0.45 : 0.28)}`;
-      const glowFar = `0 0 90px 10px ${hexToRgbaString(colors["color-accent"], isDark ? 0.28 : 0.16)}`;
-      const highlight = isDark ? "inset 0 1px 0 rgba(255, 255, 255, 0.14)" : "inset 0 1px 0 rgba(255, 255, 255, 0.9)";
-      root.style.setProperty("--glass-shadow", `${elevation}, ${glowNear}, ${glowFar}, ${highlight}`);
-    }
+    const elevation = isDark ? "0 8px 32px rgba(0, 0, 0, 0.45)" : "0 8px 32px rgba(15, 15, 20, 0.10)";
+    const highlight = isDark ? "inset 0 1px 0 rgba(255, 255, 255, 0.14)" : "inset 0 1px 0 rgba(255, 255, 255, 0.9)";
+    root.style.setProperty("--glass-shadow", `${elevation}, ${highlight}`);
+
+    // PlayDock-only accent glow — kept out of --glass-shadow above since
+    // the other three panels don't get it. Two-layer glow (tight bright
+    // core + wide soft halo) reads as an actual glow rather than a flat
+    // blurred outline. Reuses resolvedAccent (computed above), not
+    // colors["color-accent"] directly: for Dynamic Artwork that's a CSS
+    // var() reference string, and hexToRgbaString() needs a literal hex —
+    // fed the reference string, hexToRgb()'s regex fails and silently
+    // falls back to black, rendering as an invisible glow.
+    const glowNear = `0 0 24px 2px ${hexToRgbaString(resolvedAccent, isDark ? 0.45 : 0.28)}`;
+    const glowFar = `0 0 90px 10px ${hexToRgbaString(resolvedAccent, isDark ? 0.28 : 0.16)}`;
+    root.style.setProperty("--glass-glow", `${glowNear}, ${glowFar}`);
 
     // Apply logo stops based on active theme or dynamic colors. The
     // System theme always uses the true brand orange/gold here — never

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -101,8 +101,10 @@
   }
 </script>
 
-<div class="flex flex-col h-screen overflow-hidden bg-brand-main">
-  <!-- 3D Flip Container for everything above the PlayerBar -->
+<div class="relative flex flex-col h-screen overflow-hidden bg-brand-main">
+  <!-- 3D Flip Container fills the full window height; the PlayerBar floats
+       on top of it (absolute, below) so scrolled content passes underneath
+       the glass footer instead of stopping above it. -->
   <div class="flex-1 relative overflow-hidden flip-perspective" class:no-3d={isLinux}>
     <!-- Inner Card Wrapper -->
     <div class="w-full h-full relative flip-card" class:flipped={collectionStore.immersiveMode}>
@@ -232,8 +234,10 @@
     </div>
   </div>
 
-  <!-- Full-Width Player Bar at Bottom (Always Visible, mt-auto keeps bottom-aligned) -->
-  <div class="flex-shrink-0 z-40 overflow-hidden mt-auto">
+  <!-- Floating PlayDock: inset from all edges (not flush) so it reads as a
+       floating glass dock, and the content behind it can still scroll
+       underneath the gap for the blur to have something to blur. -->
+  <div class="absolute inset-x-4 bottom-4 z-40">
     <PlayerBar />
   </div>
 </div>
@@ -268,7 +272,15 @@
     transform: rotateY(180deg);
   }
 
-  /* Disable 3D flip on Linux/WebKit and use simple, clean opacity cross-fade */
+  /* Disable 3D flip on Linux/WebKit and use simple, clean opacity cross-fade.
+     `perspective` alone (with no rotation left to apply) still forces its
+     subtree into a separate 3D compositing layer, which is enough to break
+     WebKitGTK's backdrop-filter sampling for elements outside that subtree
+     (e.g. the glass PlayerBar) — so drop it here too, not just the transform. */
+  .flip-perspective.no-3d {
+    perspective: none;
+  }
+
   .no-3d .flip-card {
     transform-style: flat;
     transform: none !important;


### PR DESCRIPTION
## Summary

- Turns the PlayerBar into a floating, rounded "PlayDock" (inset margin, elevation shadow, specular shine layer, dock-only accent glow) instead of a flush edge-to-edge bar — modeled on the tint/shine half of [this liquid-glass CodePen](https://codepen.io/lassiterda/pen/vEOpqMa), intentionally dropping its SVG turbulence-distortion filter (fragile combined with `backdrop-filter` in WebKitGTK).
- Extends the glass blur/tint treatment to every theme (previously System-only), computed from each theme's own colors.
- Fixes a WebKitGTK compositing bug where `backdrop-filter` silently failed to render at all — a leftover `perspective` on the Linux 3D-flip workaround was fragmenting the compositing layer tree.
- Fixes the accent glow rendering as invisible black on the Dynamic Artwork theme (`hexToRgbaString()` fed a CSS `var()` reference instead of a literal hex).
- Fixes the reactive logo always taking the *playing song's* artwork colors instead of the active theme's colors on every track change.
- Adds bottom clearance (`pb-24`) to every scrollable view and the Sidebar's Rescan Library button so nothing ends up hidden behind the floating dock.
- Rounds the inner corners of Sidebar/TopNav/RightPanel (facing the content area, not the window edges) to match the dock's rounded language.
- Removes RightPanel's duplicate progress bar / Status / Volume rows (already shown in the PlayerBar).
- Removes the unused `@tanstack/svelte-table` dependency — dead since the initial scaffold, and its Svelte 3/4-only peer requirement was breaking `npm install` with an ERESOLVE conflict against the project's Svelte 5.

## Test plan

- [x] `npm run check` — no new errors (same 4 pre-existing, unrelated ones in `vite.config.js` / `CollectionView.benchmark.ts`)
- [x] `npm install` and `bun install` both resolve cleanly with no ERESOLVE conflict
- [x] Verified dock geometry, corner radii, and glass CSS vars via computed styles/bounding rects in a Chromium-based browser against mocked data (no real Tauri backend available there)
- [x] Verified the Rescan Library button and dock no longer overlap (16px gap confirmed via bounding rects)
- [ ] Needs a check in the actual WebKitGTK app window: the `backdrop-filter` compositing fix and the liquid-glass shine/glow layers were only verifiable structurally (computed styles), not visually, from this environment — WebKitGTK is a different rendering engine than the Chromium-based tooling available here, so the actual blur/shine rendering hasn't been eyeballed on the real target platform yet.

Co-Authored-By: Claude <noreply@anthropic.com>