### PR TITLE
Extract artwork colors via Median Cut + archetype scoring, seed-based predefined themes (#61)

### DIFF
--- a/src/lib/stores/theme.svelte.ts
+++ b/src/lib/stores/theme.svelte.ts
@@ -10,6 +10,7 @@ import {
   quantizeMedianCut,
   extractArchetypes,
   checkWcagCompliance,
+  generatePaletteFromSeed,
   type ColorCount
 } from "../utils/colorUtils";
 
@@ -121,6 +122,20 @@ export function hexToRgbaString(hex: string, alpha: number): string {
   return `rgba(${r}, ${g}, ${b}, ${alpha})`;
 }
 
+/**
+ * Ruby Red / Nordic Blue / Retro Amber are each defined as a single seed
+ * hue (their accent color) run through generatePaletteFromSeed()
+ * (colorUtils.ts) rather than 8 hand-picked hexes — "bake-once": computed
+ * from the seed every time this module loads, not hand-tuned per value, so
+ * every derived surface automatically keeps the WCAG guarantees
+ * generatePaletteFromSeed() enforces (#61). The seed is just the theme's
+ * previously hand-picked accent hex, chosen to preserve each theme's
+ * identifying hue rather than introduce a new one.
+ */
+const RUBY_RED_SEED = "#e11d48";
+const NORDIC_BLUE_SEED = "#88c0d0";
+const RETRO_AMBER_SEED = "#d97706";
+
 export const PREDEFINED_THEMES: Theme[] = [
   {
     id: "system",
@@ -130,44 +145,17 @@ export const PREDEFINED_THEMES: Theme[] = [
   {
     id: "ruby-red",
     name: "Ruby Red",
-    colors: {
-      "bg-main": "#1a0f12",
-      "bg-sidebar": "#10090a",
-      "bg-playerbar": "#150c0e",
-      "color-accent": "#e11d48",
-      "color-accent-hover": "#f43f5e",
-      "color-text-primary": "#f9fafb",
-      "color-text-secondary": "#d1d5db",
-      "color-border": "#281b1e"
-    }
+    colors: generatePaletteFromSeed(RUBY_RED_SEED)
   },
   {
     id: "nordic-blue",
     name: "Nordic Blue",
-    colors: {
-      "bg-main": "#2e3440",
-      "bg-sidebar": "#242933",
-      "bg-playerbar": "#2b303c",
-      "color-accent": "#88c0d0",
-      "color-accent-hover": "#8fbcbb",
-      "color-text-primary": "#eceff4",
-      "color-text-secondary": "#d8dee9",
-      "color-border": "#3b4252"
-    }
+    colors: generatePaletteFromSeed(NORDIC_BLUE_SEED)
   },
   {
     id: "retro-amber",
     name: "Retro Amber",
-    colors: {
-      "bg-main": "#0d0a00",
-      "bg-sidebar": "#060500",
-      "bg-playerbar": "#0a0800",
-      "color-accent": "#d97706",
-      "color-accent-hover": "#f59e0b",
-      "color-text-primary": "#fef3c7",
-      "color-text-secondary": "#b45309",
-      "color-border": "#1e1700"
-    }
+    colors: generatePaletteFromSeed(RETRO_AMBER_SEED)
   },
   {
     id: "dynamic-artwork",

--- a/src/lib/stores/theme.svelte.ts
+++ b/src/lib/stores/theme.svelte.ts
@@ -1,7 +1,17 @@
 import { invoke } from "@tauri-apps/api/core";
 import { getCoverArtUrl } from "../types";
 import type { Song } from "../types";
-import { hexToRgb, rgbToHex, pickAccessibleOnColor } from "../utils/colorUtils";
+import {
+  hexToRgb,
+  rgbToHex,
+  pickAccessibleOnColor,
+  rgbToHsl,
+  hslToRgb,
+  quantizeMedianCut,
+  extractArchetypes,
+  checkWcagCompliance,
+  type ColorCount
+} from "../utils/colorUtils";
 
 export interface ThemeColors {
   "bg-main": string;
@@ -175,6 +185,84 @@ export const PREDEFINED_THEMES: Theme[] = [
   }
 ];
 
+// The Dynamic Artwork theme (PREDEFINED_THEMES below) hardcodes these as its
+// text colors regardless of the extracted background, so every background
+// surface buildExtractedColors() produces must stay readable against both.
+const ARTWORK_TEXT_PRIMARY = "#ffffff";
+const ARTWORK_TEXT_SECONDARY = "#e2e8f0";
+
+type Rgb = { r: number; g: number; b: number };
+
+/** Re-lightens/darkens an RGB color in HSL space, holding hue+saturation fixed. */
+function withLightness(rgb: Rgb, l: number): Rgb {
+  const hsl = rgbToHsl(rgb.r, rgb.g, rgb.b);
+  return hslToRgb(hsl.h, hsl.s, Math.min(1, Math.max(0, l)));
+}
+
+function clampLightness(rgb: Rgb, minL: number, maxL: number): Rgb {
+  const hsl = rgbToHsl(rgb.r, rgb.g, rgb.b);
+  if (hsl.l >= minL && hsl.l <= maxL) return rgb;
+  return withLightness(rgb, Math.min(Math.max(hsl.l, minL), maxL));
+}
+
+/** Steps lightness down in HSL space until both fixed artwork text colors clear WCAG AA, or L bottoms out. */
+function darkenUntilReadable(rgb: Rgb): Rgb {
+  let candidate = rgb;
+  let hsl = rgbToHsl(rgb.r, rgb.g, rgb.b);
+  for (let i = 0; i < 30; i++) {
+    const hex = rgbToHex(candidate.r, candidate.g, candidate.b);
+    const primaryOk = checkWcagCompliance(ARTWORK_TEXT_PRIMARY, hex).wcagAA;
+    const secondaryOk = checkWcagCompliance(ARTWORK_TEXT_SECONDARY, hex).wcagAA;
+    if (primaryOk && secondaryOk) return candidate;
+    if (hsl.l <= 0) return candidate;
+    hsl = { ...hsl, l: Math.max(0, hsl.l - 0.02) };
+    candidate = hslToRgb(hsl.h, hsl.s, hsl.l);
+  }
+  return candidate;
+}
+
+/**
+ * Derives the full artwork palette from a weighted color histogram using
+ * Median Cut quantization + Android Palette-style archetype scoring (#61),
+ * replacing flat population-dominance picking. That approach loses small,
+ * vibrant accent clusters on covers dominated by a huge neutral background
+ * (e.g. a mostly-black album with a tiny neon accent) because population
+ * alone decides the winner; scoring candidates by role (vibrant vs. muted,
+ * light vs. dark) instead keeps the accent regardless of how few pixels it
+ * covers. Every derived background surface is then validated with
+ * checkWcagCompliance() against the fixed Dynamic Artwork text colors,
+ * mirroring the pickAccessibleOnColor() pattern already used for text-on-accent.
+ */
+export function buildExtractedColors(colorCounts: ColorCount[]): ExtractedColors {
+  const swatches = quantizeMedianCut(colorCounts, 24);
+  const archetypes = extractArchetypes(swatches);
+  const dominant = swatches.reduce((max, s) => (s.population > max.population ? s : max), swatches[0]);
+
+  const primaryBase = archetypes.darkVibrant || archetypes.darkMuted || dominant;
+  const primaryRgb = darkenUntilReadable(clampLightness(primaryBase, 0, 0.35));
+  const primaryHsl = rgbToHsl(primaryRgb.r, primaryRgb.g, primaryRgb.b);
+
+  // extractArchetypes() always backfills vibrant with the dominant swatch
+  // when nothing clears its guard rails, so this is never null here.
+  const accentBase = archetypes.vibrant as (typeof swatches)[number];
+  const accentRgb = clampLightness(accentBase, 0.35, 0.75);
+  const accentHsl = rgbToHsl(accentRgb.r, accentRgb.g, accentRgb.b);
+
+  const sidebarRgb = withLightness(primaryRgb, primaryHsl.l - 0.025);
+  const playerbarRgb = withLightness(primaryRgb, primaryHsl.l - 0.012);
+  const borderRgb = withLightness(primaryRgb, primaryHsl.l + 0.14);
+  const accentHoverRgb = withLightness(accentRgb, Math.min(0.85, accentHsl.l + 0.1));
+
+  return {
+    primary: rgbToHex(primaryRgb.r, primaryRgb.g, primaryRgb.b),
+    sidebar: rgbToHex(sidebarRgb.r, sidebarRgb.g, sidebarRgb.b),
+    playerbar: rgbToHex(playerbarRgb.r, playerbarRgb.g, playerbarRgb.b),
+    accent: rgbToHex(accentRgb.r, accentRgb.g, accentRgb.b),
+    accentHover: rgbToHex(accentHoverRgb.r, accentHoverRgb.g, accentHoverRgb.b),
+    border: rgbToHex(borderRgb.r, borderRgb.g, borderRgb.b)
+  };
+}
+
 export function extractColorsFromImage(imgUrl: string): Promise<ExtractedColors> {
   return new Promise((resolve) => {
     const img = new Image();
@@ -208,7 +296,8 @@ export function extractColorsFromImage(imgUrl: string): Promise<ExtractedColors>
 
           count++;
 
-          // Quantize color
+          // Pre-quantize to a 16-step RGB grid so Median Cut works over a
+          // manageable candidate pool instead of up to 1600 raw pixels.
           const qr = Math.floor(r / 16) * 16;
           const qg = Math.floor(g / 16) * 16;
           const qb = Math.floor(b / 16) * 16;
@@ -222,82 +311,12 @@ export function extractColorsFromImage(imgUrl: string): Promise<ExtractedColors>
           return;
         }
 
-        const sortedColors = Array.from(colorBuckets.entries())
-          .sort((a, b) => b[1] - a[1])
-          .map(([key]) => {
-            const [r, g, b] = key.split(",").map(Number);
-            return { r, g, b };
-          });
-
-        const dominant = sortedColors[0] || { r: 139, g: 92, b: 246 };
-
-        // Find a saturated accent color
-        let accent = dominant;
-        let maxSaturation = 0;
-
-        for (const color of sortedColors) {
-          const { r, g, b } = color;
-          const max = Math.max(r, g, b);
-          const min = Math.min(r, g, b);
-          const chroma = max - min;
-          const saturation = max === 0 ? 0 : chroma / max;
-          const brightness = max / 255;
-
-          if (saturation > maxSaturation && brightness > 0.3 && brightness < 0.99) {
-            maxSaturation = saturation;
-            accent = color;
-          }
-        }
-
-        if (maxSaturation < 0.15) {
-          accent = dominant;
-        }
-
-        const toHex = (c: number) => {
-          const hex = Math.min(255, Math.max(0, Math.round(c))).toString(16);
-          return hex.length === 1 ? "0" + hex : hex;
-        };
-
-        const rgbToHex = (r: number, g: number, b: number) => `#${toHex(r)}${toHex(g)}${toHex(b)}`;
-
-        const adjustBrightness = (color: { r: number, g: number, b: number }, factor: number) => {
-          return {
-            r: Math.min(255, Math.max(0, color.r * factor)),
-            g: Math.min(255, Math.max(0, color.g * factor)),
-            b: Math.min(255, Math.max(0, color.b * factor))
-          };
-        };
-
-        // Darken primary background for dark-mode readability
-        let primaryColor = { ...dominant };
-        const primaryBrightness = (primaryColor.r * 0.299 + primaryColor.g * 0.587 + primaryColor.b * 0.114) / 255;
-        if (primaryBrightness > 0.15) {
-          primaryColor = adjustBrightness(primaryColor, 0.10 / primaryBrightness);
-        } else if (primaryBrightness < 0.05) {
-          primaryColor = adjustBrightness(primaryColor, 1.5);
-        }
-
-        const sidebarColor = adjustBrightness(primaryColor, 0.6);
-        const playerbarColor = adjustBrightness(primaryColor, 0.8);
-
-        // Normalize accent brightness
-        let accentColor = { ...accent };
-        const accentBrightness = (accentColor.r * 0.299 + accentColor.g * 0.587 + accentColor.b * 0.114) / 255;
-        if (accentBrightness < 0.45) {
-          accentColor = adjustBrightness(accentColor, 0.6 / Math.max(0.1, accentBrightness));
-        }
-
-        const accentHoverColor = adjustBrightness(accentColor, 1.2);
-        const borderColor = adjustBrightness(primaryColor, 2.2);
-
-        resolve({
-          primary: rgbToHex(primaryColor.r, primaryColor.g, primaryColor.b),
-          sidebar: rgbToHex(sidebarColor.r, sidebarColor.g, sidebarColor.b),
-          playerbar: rgbToHex(playerbarColor.r, playerbarColor.g, playerbarColor.b),
-          accent: rgbToHex(accentColor.r, accentColor.g, accentColor.b),
-          accentHover: rgbToHex(accentHoverColor.r, accentHoverColor.g, accentHoverColor.b),
-          border: rgbToHex(borderColor.r, borderColor.g, borderColor.b)
+        const colorCounts: ColorCount[] = Array.from(colorBuckets.entries()).map(([key, bucketCount]) => {
+          const [r, g, b] = key.split(",").map(Number);
+          return { r, g, b, count: bucketCount };
         });
+
+        resolve(buildExtractedColors(colorCounts));
       } catch (e) {
         console.error("Failed to process image colors:", e);
         resolve(getFallbackColors());

--- a/src/lib/stores/theme.test.ts
+++ b/src/lib/stores/theme.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { PREDEFINED_THEMES, LUMINOUS_DARK_COLORS, LUMINOUS_LIGHT_COLORS } from "./theme.svelte";
-import { checkWcagCompliance, pickAccessibleOnColor } from "../utils/colorUtils";
+import { PREDEFINED_THEMES, LUMINOUS_DARK_COLORS, LUMINOUS_LIGHT_COLORS, buildExtractedColors } from "./theme.svelte";
+import { checkWcagCompliance, pickAccessibleOnColor, hexToRgb, rgbToHsl } from "../utils/colorUtils";
 
 describe("PREDEFINED_THEMES", () => {
   it("does not include the removed Luminous Violet theme", () => {
@@ -79,5 +79,46 @@ describe("on-accent text contrast (heuristically derived, not hand-picked)", () 
   it("picks white for a dark accent and black for a light accent", () => {
     expect(pickAccessibleOnColor("#1a1a2e")).toBe("#ffffff");
     expect(pickAccessibleOnColor("#f5f5f5")).toBe("#000000");
+  });
+});
+
+describe("buildExtractedColors (archetype-based artwork color extraction, #61)", () => {
+  // The failure mode #61 exists to fix: a moody-rock-album stand-in that's
+  // ~99.5% near-black background with a tiny neon-blue accent cluster.
+  // Flat population-dominance extraction loses the neon entirely.
+  const darkCoverWithNeonAccent = [
+    { r: 5, g: 5, b: 5, count: 1000 },
+    { r: 20, g: 40, b: 255, count: 5 }
+  ];
+
+  it("picks the small neon cluster as the accent instead of losing it to the black background", () => {
+    const colors = buildExtractedColors(darkCoverWithNeonAccent);
+    const accentRgb = hexToRgb(colors.accent);
+    expect(accentRgb.b).toBeGreaterThan(150);
+  });
+
+  it("keeps the primary background dark enough for the fixed Dynamic Artwork text colors", () => {
+    const colors = buildExtractedColors(darkCoverWithNeonAccent);
+    expect(checkWcagCompliance("#ffffff", colors.primary).wcagAA).toBe(true);
+    expect(checkWcagCompliance("#e2e8f0", colors.primary).wcagAA).toBe(true);
+  });
+
+  it("keeps sidebar/playerbar darker than, and border lighter than, the primary background", () => {
+    const colors = buildExtractedColors([{ r: 80, g: 40, b: 160, count: 1000 }]);
+    const luminanceOf = (hex: string) => checkWcagCompliance("#000000", hex).ratio;
+    expect(luminanceOf(colors.sidebar)).toBeLessThanOrEqual(luminanceOf(colors.primary));
+    expect(luminanceOf(colors.playerbar)).toBeLessThanOrEqual(luminanceOf(colors.primary));
+    expect(luminanceOf(colors.border)).toBeGreaterThanOrEqual(luminanceOf(colors.primary));
+  });
+
+  it("keeps the accent in a visible lightness range even for a fully desaturated dominant color", () => {
+    // No candidate clears any archetype's saturation guard rail here, so
+    // extractArchetypes() falls back to the dominant swatch for vibrant —
+    // this proves that fallback still gets lightness-normalized rather
+    // than handed back near-black.
+    const colors = buildExtractedColors([{ r: 8, g: 8, b: 8, count: 1000 }]);
+    const rgb = hexToRgb(colors.accent);
+    const hsl = rgbToHsl(rgb.r, rgb.g, rgb.b);
+    expect(hsl.l).toBeGreaterThanOrEqual(0.3);
   });
 });

--- a/src/lib/stores/theme.test.ts
+++ b/src/lib/stores/theme.test.ts
@@ -16,10 +16,21 @@ describe("PREDEFINED_THEMES", () => {
   });
 });
 
+const rubyRedColors = PREDEFINED_THEMES.find(t => t.id === "ruby-red")!.colors;
+const nordicBlueColors = PREDEFINED_THEMES.find(t => t.id === "nordic-blue")!.colors;
+const retroAmberColors = PREDEFINED_THEMES.find(t => t.id === "retro-amber")!.colors;
+
 describe.each([
   ["dark", LUMINOUS_DARK_COLORS],
-  ["light", LUMINOUS_LIGHT_COLORS]
-] as const)("Luminous %s palette accessibility", (_scheme, palette) => {
+  ["light", LUMINOUS_LIGHT_COLORS],
+  // Ruby Red / Nordic Blue / Retro Amber are generatePaletteFromSeed()
+  // output (#61 step 3), not hand-picked — this coverage is what "stay
+  // consistent if the generation heuristic improves later" (the issue's
+  // own rationale for the seed+generator move) actually guards.
+  ["Ruby Red (generated)", rubyRedColors],
+  ["Nordic Blue (generated)", nordicBlueColors],
+  ["Retro Amber (generated)", retroAmberColors]
+] as const)("%s palette accessibility", (_scheme, palette) => {
   const surfaces: (keyof typeof palette)[] = ["bg-main", "bg-sidebar", "bg-playerbar"];
 
   it.each(surfaces)("primary text meets WCAG AA against %s", (surface) => {
@@ -30,6 +41,17 @@ describe.each([
   it.each(surfaces)("secondary text meets WCAG AA against %s", (surface) => {
     const result = checkWcagCompliance(palette["color-text-secondary"], palette[surface]);
     expect(result.wcagAA).toBe(true);
+  });
+});
+
+describe("generated predefined themes' accent contrast against bg-main (WCAG 1.4.11 3:1 non-text threshold)", () => {
+  it.each([
+    ["Ruby Red", rubyRedColors],
+    ["Nordic Blue", nordicBlueColors],
+    ["Retro Amber", retroAmberColors]
+  ] as const)("%s", (_name, colors) => {
+    const result = checkWcagCompliance(colors["color-accent"], colors["bg-main"]);
+    expect(result.ratio).toBeGreaterThanOrEqual(3);
   });
 });
 

--- a/src/lib/utils/colorUtils.test.ts
+++ b/src/lib/utils/colorUtils.test.ts
@@ -10,7 +10,14 @@ import {
   getColorMetrics,
   formatLuminance,
   getWcagBadgeColor,
-  getWcagBadgeText
+  getWcagBadgeText,
+  rgbToHsl,
+  hslToRgb,
+  scoreSwatch,
+  ARCHETYPE_TARGETS,
+  quantizeMedianCut,
+  extractArchetypes,
+  type Swatch
 } from "./colorUtils";
 
 describe("hexToRgb", () => {
@@ -163,5 +170,152 @@ describe("getWcagBadgeText", () => {
     expect(getWcagBadgeText("AAA")).toBe("✓ WCAG AAA");
     expect(getWcagBadgeText("AA")).toBe("✓ WCAG AA");
     expect(getWcagBadgeText("fail")).toBe("✗ Below AA");
+  });
+});
+
+describe("rgbToHsl", () => {
+  it("converts pure red to 0deg hue, full saturation, 50% lightness", () => {
+    expect(rgbToHsl(255, 0, 0)).toEqual({ h: 0, s: 1, l: 0.5 });
+  });
+
+  it("converts white to 0 saturation, 100% lightness", () => {
+    expect(rgbToHsl(255, 255, 255)).toEqual({ h: 0, s: 0, l: 1 });
+  });
+
+  it("converts black to 0 saturation, 0% lightness", () => {
+    expect(rgbToHsl(0, 0, 0)).toEqual({ h: 0, s: 0, l: 0 });
+  });
+
+  it("converts a neon blue accent to high saturation, mid lightness", () => {
+    const hsl = rgbToHsl(30, 60, 255);
+    expect(hsl.s).toBeGreaterThan(0.8);
+    expect(hsl.l).toBeGreaterThan(0.4);
+    expect(hsl.l).toBeLessThan(0.6);
+  });
+});
+
+describe("hslToRgb", () => {
+  it("round-trips with rgbToHsl for a saturated color", () => {
+    const hsl = rgbToHsl(30, 60, 255);
+    const rgb = hslToRgb(hsl.h, hsl.s, hsl.l);
+    expect(rgb.r).toBeCloseTo(30, 0);
+    expect(rgb.g).toBeCloseTo(60, 0);
+    expect(rgb.b).toBeCloseTo(255, 0);
+  });
+
+  it("converts 0 saturation to a gray regardless of hue", () => {
+    expect(hslToRgb(200, 0, 0.5)).toEqual({ r: 128, g: 128, b: 128 });
+  });
+
+  it("converts full lightness to white and zero lightness to black", () => {
+    expect(hslToRgb(120, 0.8, 1)).toEqual({ r: 255, g: 255, b: 255 });
+    expect(hslToRgb(120, 0.8, 0)).toEqual({ r: 0, g: 0, b: 0 });
+  });
+});
+
+describe("scoreSwatch", () => {
+  it("scores 0 for a swatch outside the archetype's saturation guard rail", () => {
+    // A pure gray (s=0) can never be VIBRANT (minS 0.35) no matter its population
+    const gray = { h: 0, s: 0, l: 0.5 };
+    expect(scoreSwatch(gray, 100, 100, ARCHETYPE_TARGETS.vibrant)).toBe(0);
+  });
+
+  it("scores higher for a swatch closer to the archetype's target saturation", () => {
+    const close = { h: 200, s: 0.9, l: 0.5 };
+    const far = { h: 200, s: 0.4, l: 0.5 };
+    const scoreClose = scoreSwatch(close, 50, 100, ARCHETYPE_TARGETS.vibrant);
+    const scoreFar = scoreSwatch(far, 50, 100, ARCHETYPE_TARGETS.vibrant);
+    expect(scoreClose).toBeGreaterThan(scoreFar);
+  });
+
+  it("gives a higher-population swatch a higher score, all else equal", () => {
+    const hsl = { h: 200, s: 0.9, l: 0.5 };
+    const scoreLow = scoreSwatch(hsl, 10, 100, ARCHETYPE_TARGETS.vibrant);
+    const scoreHigh = scoreSwatch(hsl, 90, 100, ARCHETYPE_TARGETS.vibrant);
+    expect(scoreHigh).toBeGreaterThan(scoreLow);
+  });
+});
+
+describe("quantizeMedianCut", () => {
+  it("returns a single swatch spanning the whole population for a flat-color input", () => {
+    const swatches = quantizeMedianCut([{ r: 10, g: 10, b: 10, count: 500 }], 8);
+    expect(swatches).toEqual([{ r: 10, g: 10, b: 10, population: 500 }]);
+  });
+
+  it("keeps a tiny neon accent as its own swatch instead of averaging it into a huge black background", () => {
+    // A moody-rock-album stand-in: near-black dominates by population,
+    // a small neon-blue cluster is the only accent — this is the exact
+    // case flat population-dominance quantization loses.
+    const swatches = quantizeMedianCut(
+      [
+        { r: 5, g: 5, b: 5, count: 1000 },
+        { r: 20, g: 40, b: 255, count: 5 }
+      ],
+      8
+    );
+    const neon = swatches.find(s => s.b > 200);
+    expect(neon).toBeDefined();
+    expect(neon?.population).toBe(5);
+    const black = swatches.find(s => s.b <= 10);
+    expect(black?.population).toBe(1000);
+  });
+
+  it("conserves total population across all output swatches", () => {
+    const input = [
+      { r: 5, g: 5, b: 5, count: 1000 },
+      { r: 20, g: 40, b: 255, count: 5 },
+      { r: 200, g: 200, b: 200, count: 50 },
+      { r: 128, g: 64, b: 32, count: 20 }
+    ];
+    const swatches = quantizeMedianCut(input, 8);
+    const totalIn = input.reduce((sum, c) => sum + c.count, 0);
+    const totalOut = swatches.reduce((sum, s) => sum + s.population, 0);
+    expect(totalOut).toBe(totalIn);
+  });
+
+  it("never returns more swatches than requested", () => {
+    const input = Array.from({ length: 40 }, (_, i) => ({
+      r: (i * 6) % 256,
+      g: (i * 11) % 256,
+      b: (i * 17) % 256,
+      count: 1
+    }));
+    const swatches = quantizeMedianCut(input, 8);
+    expect(swatches.length).toBeLessThanOrEqual(8);
+  });
+
+  it("returns an empty array for empty input", () => {
+    expect(quantizeMedianCut([], 8)).toEqual([]);
+  });
+});
+
+describe("extractArchetypes", () => {
+  it("picks the neon accent as vibrant, not the dominant black background", () => {
+    const swatches = quantizeMedianCut(
+      [
+        { r: 5, g: 5, b: 5, count: 1000 },
+        { r: 20, g: 40, b: 255, count: 5 }
+      ],
+      8
+    );
+    const archetypes = extractArchetypes(swatches);
+    expect(archetypes.vibrant).toBeTruthy();
+    expect(archetypes.vibrant?.b).toBeGreaterThan(200);
+  });
+
+  it("falls back vibrant to the dominant-by-population swatch when nothing clears the guard rails", () => {
+    // Two flat grays (s=0): neither can satisfy any archetype's minS
+    const swatches: Swatch[] = [
+      { r: 200, g: 200, b: 200, population: 100 },
+      { r: 10, g: 10, b: 10, population: 900 }
+    ];
+    const archetypes = extractArchetypes(swatches);
+    expect(archetypes.vibrant).toEqual({ r: 10, g: 10, b: 10, population: 900 });
+  });
+
+  it("returns null for an archetype no candidate satisfies", () => {
+    const swatches: Swatch[] = [{ r: 10, g: 10, b: 10, population: 900 }];
+    const archetypes = extractArchetypes(swatches);
+    expect(archetypes.lightVibrant).toBeNull();
   });
 });

--- a/src/lib/utils/colorUtils.test.ts
+++ b/src/lib/utils/colorUtils.test.ts
@@ -17,6 +17,7 @@ import {
   ARCHETYPE_TARGETS,
   quantizeMedianCut,
   extractArchetypes,
+  generatePaletteFromSeed,
   type Swatch
 } from "./colorUtils";
 
@@ -317,5 +318,60 @@ describe("extractArchetypes", () => {
     const swatches: Swatch[] = [{ r: 10, g: 10, b: 10, population: 900 }];
     const archetypes = extractArchetypes(swatches);
     expect(archetypes.lightVibrant).toBeNull();
+  });
+});
+
+describe("generatePaletteFromSeed", () => {
+  const seeds = ["#e11d48", "#88c0d0", "#d97706"];
+
+  it("returns all 8 ThemeColors keys", () => {
+    const palette = generatePaletteFromSeed("#e11d48");
+    expect(Object.keys(palette).sort()).toEqual(
+      [
+        "bg-main",
+        "bg-playerbar",
+        "bg-sidebar",
+        "color-accent",
+        "color-accent-hover",
+        "color-border",
+        "color-text-primary",
+        "color-text-secondary"
+      ].sort()
+    );
+  });
+
+  it("is deterministic for the same seed", () => {
+    expect(generatePaletteFromSeed("#88c0d0")).toEqual(generatePaletteFromSeed("#88c0d0"));
+  });
+
+  it("keeps both text colors at WCAG AA against every background surface", () => {
+    for (const seed of seeds) {
+      const p = generatePaletteFromSeed(seed);
+      for (const bg of [p["bg-main"], p["bg-sidebar"], p["bg-playerbar"]]) {
+        expect(checkWcagCompliance(p["color-text-primary"], bg).wcagAA).toBe(true);
+        expect(checkWcagCompliance(p["color-text-secondary"], bg).wcagAA).toBe(true);
+      }
+    }
+  });
+
+  it("keeps the accent at WCAG 1.4.11's 3:1 non-text threshold against bg-main", () => {
+    for (const seed of seeds) {
+      const p = generatePaletteFromSeed(seed);
+      expect(checkWcagCompliance(p["color-accent"], p["bg-main"]).ratio).toBeGreaterThanOrEqual(3);
+    }
+  });
+
+  it("tints the dark background family toward the seed's hue instead of collapsing to gray", () => {
+    const redHue = rgbToHsl(...(Object.values(hexToRgb(generatePaletteFromSeed("#e11d48")["bg-main"])) as [number, number, number])).h;
+    const blueHue = rgbToHsl(...(Object.values(hexToRgb(generatePaletteFromSeed("#3b82f6")["bg-main"])) as [number, number, number])).h;
+    expect(Math.abs(redHue - blueHue)).toBeGreaterThan(30);
+  });
+
+  it("keeps bg-sidebar darkest, bg-playerbar in between, and border lighter than bg-main", () => {
+    const p = generatePaletteFromSeed("#d97706");
+    const lumOf = (hex: string) => calculateLuminance(hex);
+    expect(lumOf(p["bg-sidebar"])).toBeLessThanOrEqual(lumOf(p["bg-playerbar"]));
+    expect(lumOf(p["bg-playerbar"])).toBeLessThanOrEqual(lumOf(p["bg-main"]));
+    expect(lumOf(p["color-border"])).toBeGreaterThanOrEqual(lumOf(p["bg-main"]));
   });
 });

--- a/src/lib/utils/colorUtils.ts
+++ b/src/lib/utils/colorUtils.ts
@@ -214,3 +214,265 @@ export function getWcagBadgeText(level: 'fail' | 'AA' | 'AAA'): string {
       return '✗ Below AA';
   }
 }
+
+export interface HSL {
+  h: number; // degrees, 0-360
+  s: number; // 0-1
+  l: number; // 0-1
+}
+
+/**
+ * Convert RGB (0-255) to HSL. Used to score candidate swatches against the
+ * Android Palette-style archetypes below — HSL's saturation/lightness axes
+ * map directly onto "vibrant vs muted" and "light vs dark" in a way RGB
+ * doesn't.
+ */
+export function rgbToHsl(r: number, g: number, b: number): HSL {
+  r /= 255;
+  g /= 255;
+  b /= 255;
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  const l = (max + min) / 2;
+
+  if (max === min) {
+    return { h: 0, s: 0, l };
+  }
+
+  const d = max - min;
+  const s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+  let h: number;
+  switch (max) {
+    case r:
+      h = (g - b) / d + (g < b ? 6 : 0);
+      break;
+    case g:
+      h = (b - r) / d + 2;
+      break;
+    default:
+      h = (r - g) / d + 4;
+      break;
+  }
+  return { h: (h / 6) * 360, s, l };
+}
+
+/**
+ * Inverse of rgbToHsl. Used to derive a family of related shades (surface
+ * background, sidebar, border, accent hover, ...) from a single seed color
+ * by stepping lightness in HSL space while holding hue/saturation fixed —
+ * unlike naive RGB brightness multiplication, this can't drift the hue.
+ */
+export function hslToRgb(h: number, s: number, l: number): { r: number; g: number; b: number } {
+  if (s === 0) {
+    const v = Math.round(l * 255);
+    return { r: v, g: v, b: v };
+  }
+
+  const hueToRgb = (p: number, q: number, t: number): number => {
+    let tt = t;
+    if (tt < 0) tt += 1;
+    if (tt > 1) tt -= 1;
+    if (tt < 1 / 6) return p + (q - p) * 6 * tt;
+    if (tt < 1 / 2) return q;
+    if (tt < 2 / 3) return p + (q - p) * (2 / 3 - tt) * 6;
+    return p;
+  };
+
+  const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+  const p = 2 * l - q;
+  const hNorm = h / 360;
+
+  return {
+    r: Math.round(hueToRgb(p, q, hNorm + 1 / 3) * 255),
+    g: Math.round(hueToRgb(p, q, hNorm) * 255),
+    b: Math.round(hueToRgb(p, q, hNorm - 1 / 3) * 255)
+  };
+}
+
+/** One of the six Android Palette / Spotify-style UI color roles. */
+export type Archetype = 'vibrant' | 'lightVibrant' | 'darkVibrant' | 'muted' | 'lightMuted' | 'darkMuted';
+
+interface ArchetypeTarget {
+  targetS: number;
+  minS: number;
+  maxS: number;
+  targetL: number;
+  minL: number;
+  maxL: number;
+}
+
+/**
+ * Aesthetic benchmarks each archetype is scored against. Guard rails
+ * (min/max) reject a candidate outright; target values shape the score of
+ * whatever passes the guard rails.
+ */
+export const ARCHETYPE_TARGETS: Record<Archetype, ArchetypeTarget> = {
+  vibrant: { targetS: 1.0, minS: 0.35, maxS: 1.0, targetL: 0.5, minL: 0.3, maxL: 0.7 },
+  lightVibrant: { targetS: 1.0, minS: 0.35, maxS: 1.0, targetL: 0.74, minL: 0.55, maxL: 1.0 },
+  darkVibrant: { targetS: 1.0, minS: 0.35, maxS: 1.0, targetL: 0.26, minL: 0.0, maxL: 0.45 },
+  muted: { targetS: 0.3, minS: 0.0, maxS: 0.4, targetL: 0.5, minL: 0.3, maxL: 0.7 },
+  lightMuted: { targetS: 0.3, minS: 0.0, maxS: 0.4, targetL: 0.74, minL: 0.55, maxL: 1.0 },
+  darkMuted: { targetS: 0.3, minS: 0.0, maxS: 0.4, targetL: 0.26, minL: 0.0, maxL: 0.45 }
+};
+
+const WEIGHT_SATURATION = 0.6;
+const WEIGHT_LUMINANCE = 0.3;
+const WEIGHT_POPULATION = 0.1;
+
+/**
+ * Scores how well a candidate swatch fits an archetype: 0 if it falls
+ * outside the archetype's saturation/lightness guard rails, otherwise a
+ * weighted blend of closeness-to-target and population (so a huge but
+ * off-target background can't outscore a smaller, better-matching swatch —
+ * the exact failure mode that made naive dominant-color extraction lose
+ * small vibrant accents on mostly-black covers).
+ */
+export function scoreSwatch(hsl: HSL, population: number, maxPopulation: number, target: ArchetypeTarget): number {
+  const { s, l } = hsl;
+  if (s < target.minS || s > target.maxS || l < target.minL || l > target.maxL) {
+    return 0;
+  }
+  const satScore = (1 - Math.abs(s - target.targetS)) * WEIGHT_SATURATION;
+  const lumScore = (1 - Math.abs(l - target.targetL)) * WEIGHT_LUMINANCE;
+  const popScore = (population / maxPopulation) * WEIGHT_POPULATION;
+  return satScore + lumScore + popScore;
+}
+
+export interface ColorCount {
+  r: number;
+  g: number;
+  b: number;
+  count: number;
+}
+
+export interface Swatch {
+  r: number;
+  g: number;
+  b: number;
+  population: number;
+}
+
+type RgbChannel = 'r' | 'g' | 'b';
+
+function widestChannel(box: ColorCount[]): { axis: RgbChannel; range: number } {
+  let minR = 255, maxR = 0, minG = 255, maxG = 0, minB = 255, maxB = 0;
+  for (const c of box) {
+    if (c.r < minR) minR = c.r;
+    if (c.r > maxR) maxR = c.r;
+    if (c.g < minG) minG = c.g;
+    if (c.g > maxG) maxG = c.g;
+    if (c.b < minB) minB = c.b;
+    if (c.b > maxB) maxB = c.b;
+  }
+  const ranges: Record<RgbChannel, number> = { r: maxR - minR, g: maxG - minG, b: maxB - minB };
+  const axis = (Object.keys(ranges) as RgbChannel[]).reduce((a, b) => (ranges[b] > ranges[a] ? b : a));
+  return { axis, range: ranges[axis] };
+}
+
+/**
+ * Median Cut color quantization: reduces a weighted color histogram down to
+ * at most `maxSwatches` representative colors. Chosen over flat/K-Means
+ * bucketing because each split is driven by color *range*, not population —
+ * a box containing both a huge near-black background and a handful of
+ * neon-blue pixels has a huge range on the blue channel, so it keeps
+ * getting split until the neon cluster is isolated into its own swatch,
+ * rather than being averaged away into "dark gray".
+ */
+export function quantizeMedianCut(colors: ColorCount[], maxSwatches: number): Swatch[] {
+  if (colors.length === 0) return [];
+
+  const boxes: ColorCount[][] = [colors.slice()];
+
+  while (boxes.length < maxSwatches) {
+    let splitIdx = -1;
+    let splitAxis: RgbChannel = 'r';
+    let widestRange = 0;
+
+    for (let i = 0; i < boxes.length; i++) {
+      if (boxes[i].length <= 1) continue;
+      const { axis, range } = widestChannel(boxes[i]);
+      if (range > widestRange) {
+        widestRange = range;
+        splitIdx = i;
+        splitAxis = axis;
+      }
+    }
+
+    if (splitIdx === -1) break; // no box left with more than one distinct color
+
+    const box = boxes[splitIdx];
+    box.sort((a, b) => a[splitAxis] - b[splitAxis]);
+    const totalCount = box.reduce((sum, c) => sum + c.count, 0);
+
+    let cumulative = 0;
+    let cutAt = 1;
+    for (let i = 0; i < box.length; i++) {
+      cumulative += box[i].count;
+      if (cumulative >= totalCount / 2) {
+        cutAt = i + 1;
+        break;
+      }
+    }
+    cutAt = Math.min(Math.max(cutAt, 1), box.length - 1);
+
+    boxes.splice(splitIdx, 1, box.slice(0, cutAt), box.slice(cutAt));
+  }
+
+  return boxes
+    .map(box => {
+      let rSum = 0, gSum = 0, bSum = 0, population = 0;
+      for (const c of box) {
+        rSum += c.r * c.count;
+        gSum += c.g * c.count;
+        bSum += c.b * c.count;
+        population += c.count;
+      }
+      return {
+        r: Math.round(rSum / population),
+        g: Math.round(gSum / population),
+        b: Math.round(bSum / population),
+        population
+      };
+    })
+    .sort((a, b) => b.population - a.population);
+}
+
+/**
+ * Evaluates every candidate swatch against all six archetype targets and
+ * returns the best match for each. If no candidate clears "vibrant"'s
+ * guard rails at all (e.g. an entirely desaturated cover), vibrant falls
+ * back to the dominant-by-population swatch so the UI always has an accent
+ * rather than nothing. Other archetypes are left null when unmatched —
+ * callers chain their own role-appropriate fallbacks (e.g. darkVibrant →
+ * darkMuted → dominant) since "no good light-vibrant swatch" isn't
+ * necessarily a problem the way "no accent at all" is.
+ */
+export function extractArchetypes(swatches: Swatch[]): Record<Archetype, Swatch | null> {
+  const result = {} as Record<Archetype, Swatch | null>;
+  if (swatches.length === 0) {
+    for (const key of Object.keys(ARCHETYPE_TARGETS) as Archetype[]) result[key] = null;
+    return result;
+  }
+
+  const maxPopulation = Math.max(...swatches.map(s => s.population));
+
+  for (const [key, target] of Object.entries(ARCHETYPE_TARGETS) as [Archetype, ArchetypeTarget][]) {
+    let best: Swatch | null = null;
+    let bestScore = 0;
+    for (const swatch of swatches) {
+      const hsl = rgbToHsl(swatch.r, swatch.g, swatch.b);
+      const score = scoreSwatch(hsl, swatch.population, maxPopulation, target);
+      if (score > bestScore) {
+        bestScore = score;
+        best = swatch;
+      }
+    }
+    result[key] = best;
+  }
+
+  if (!result.vibrant) {
+    result.vibrant = swatches.reduce((max, s) => (s.population > max.population ? s : max), swatches[0]);
+  }
+
+  return result;
+}

--- a/src/lib/utils/colorUtils.ts
+++ b/src/lib/utils/colorUtils.ts
@@ -476,3 +476,90 @@ export function extractArchetypes(swatches: Swatch[]): Record<Archetype, Swatch 
 
   return result;
 }
+
+/** The 8-value palette shape every predefined/custom theme uses (structurally identical to theme.svelte.ts's ThemeColors — kept separate here to avoid a circular import). */
+export interface GeneratedThemePalette {
+  "bg-main": string;
+  "bg-sidebar": string;
+  "bg-playerbar": string;
+  "color-accent": string;
+  "color-accent-hover": string;
+  "color-text-primary": string;
+  "color-text-secondary": string;
+  "color-border": string;
+}
+
+const BG_MAIN_LIGHTNESS = 0.12;
+const BG_SIDEBAR_DELTA = -0.045;
+const BG_PLAYERBAR_DELTA = -0.02;
+const BORDER_DELTA = 0.13;
+const ACCENT_HOVER_DELTA = 0.12;
+
+function toHex(rgb: { r: number; g: number; b: number }): string {
+  return rgbToHex(rgb.r, rgb.g, rgb.b);
+}
+
+/**
+ * Derives a full 8-value theme palette from a single seed color using HSL
+ * lightness/saturation steps, validated against the same WCAG thresholds
+ * the hand-picked Luminous palettes already use: 4.5:1 ("normal text") for
+ * both text colors against every background surface, and WCAG 1.4.11's
+ * 3:1 ("non-text/UI-component") threshold for the accent against bg-main —
+ * the same trade-off `LUMINOUS_LIGHT_ACCENT` documents, since the accent is
+ * used almost entirely as icon/button/badge color, not paragraph text.
+ *
+ * The background family is tinted toward the seed's hue at low saturation
+ * (a moody near-black, not pure gray) rather than derived from the accent's
+ * exact lightness, mirroring the relationship already present across Ruby
+ * Red / Nordic Blue / Retro Amber: bg-sidebar darkest, bg-playerbar
+ * between it and bg-main, border lighter than bg-main.
+ */
+export function generatePaletteFromSeed(seedHex: string): GeneratedThemePalette {
+  const seedHsl = rgbToHsl(...(Object.values(hexToRgb(seedHex)) as [number, number, number]));
+
+  const bgSaturation = Math.min(seedHsl.s * 0.35, 0.25);
+  const bgMain = { h: seedHsl.h, s: bgSaturation, l: BG_MAIN_LIGHTNESS };
+  const bgSidebar = { h: seedHsl.h, s: bgSaturation, l: Math.max(0, BG_MAIN_LIGHTNESS + BG_SIDEBAR_DELTA) };
+  const bgPlayerbar = { h: seedHsl.h, s: bgSaturation, l: Math.max(0, BG_MAIN_LIGHTNESS + BG_PLAYERBAR_DELTA) };
+  const border = { h: seedHsl.h, s: bgSaturation, l: Math.min(1, BG_MAIN_LIGHTNESS + BORDER_DELTA) };
+
+  const accentSaturation = Math.max(seedHsl.s, 0.55);
+  const accentLightness = Math.min(Math.max(seedHsl.l, 0.45), 0.65);
+  const accent = { h: seedHsl.h, s: accentSaturation, l: accentLightness };
+  const accentHover = { h: seedHsl.h, s: accentSaturation, l: Math.min(0.85, accentLightness + ACCENT_HOVER_DELTA) };
+
+  let textPrimary = { h: seedHsl.h, s: 0.15, l: 0.97 };
+  let textSecondary = { h: seedHsl.h, s: 0.12, l: 0.82 };
+
+  const backgroundHexes = [toHex(hslToRgb(bgMain.h, bgMain.s, bgMain.l)), toHex(hslToRgb(bgSidebar.h, bgSidebar.s, bgSidebar.l)), toHex(hslToRgb(bgPlayerbar.h, bgPlayerbar.s, bgPlayerbar.l))];
+
+  const meetsAA = (hsl: HSL) => {
+    const hex = toHex(hslToRgb(hsl.h, hsl.s, hsl.l));
+    return backgroundHexes.every(bg => checkWcagCompliance(hex, bg).wcagAA);
+  };
+
+  for (let i = 0; i < 20 && !meetsAA(textPrimary); i++) {
+    textPrimary = { ...textPrimary, l: Math.min(1, textPrimary.l + 0.02) };
+  }
+  for (let i = 0; i < 20 && !meetsAA(textSecondary); i++) {
+    textSecondary = { ...textSecondary, l: Math.min(1, textSecondary.l + 0.02) };
+  }
+
+  let accentAdjusted = accent;
+  for (let i = 0; i < 20; i++) {
+    const accentHex = toHex(hslToRgb(accentAdjusted.h, accentAdjusted.s, accentAdjusted.l));
+    if (checkWcagCompliance(accentHex, backgroundHexes[0]).ratio >= 3) break;
+    accentAdjusted = { ...accentAdjusted, l: Math.min(0.85, accentAdjusted.l + 0.02) };
+  }
+
+  return {
+    "bg-main": backgroundHexes[0],
+    "bg-sidebar": backgroundHexes[1],
+    "bg-playerbar": backgroundHexes[2],
+    "color-accent": toHex(hslToRgb(accentAdjusted.h, accentAdjusted.s, accentAdjusted.l)),
+    "color-accent-hover": toHex(hslToRgb(accentHover.h, accentHover.s, accentHover.l)),
+    "color-text-primary": toHex(hslToRgb(textPrimary.h, textPrimary.s, textPrimary.l)),
+    "color-text-secondary": toHex(hslToRgb(textSecondary.h, textSecondary.s, textSecondary.l)),
+    "color-border": toHex(hslToRgb(border.h, border.s, border.l))
+  };
+}


### PR DESCRIPTION
## Summary

**Artwork extraction (steps 1, 2 partial, 4):**
- Replaces `extractColorsFromImage()`'s flat population-dominance color picking (theme.svelte.ts) with a Median Cut quantizer + Android Palette/Spotify-style archetype scoring, so a small vibrant accent cluster on a cover dominated by a huge neutral background (e.g. a mostly-black album with a tiny neon-blue accent) no longer gets lost to gray/black.
- Adds `rgbToHsl`, `hslToRgb`, `ARCHETYPE_TARGETS`, `scoreSwatch`, `quantizeMedianCut`, `extractArchetypes` to `colorUtils.ts` — pure, unit-tested color-science primitives.
- New `buildExtractedColors()` assigns palette roles (background/sidebar/playerbar/accent/accentHover/border) by archetype (darkVibrant/darkMuted → background, vibrant → accent) instead of ad hoc RGB brightness multiplication, validated against the Dynamic Artwork theme's fixed text colors via `checkWcagCompliance()`.

**Predefined themes as seed + generator (step 3):**
- New `generatePaletteFromSeed()` in `colorUtils.ts` derives a full 8-value `ThemeColors` palette from a single seed hue via HSL lightness/saturation steps, validated against 4.5:1 text-on-background and WCAG 1.4.11's 3:1 accent-on-background thresholds — the same trade-offs the hand-picked Luminous palettes already document.
- Ruby Red, Nordic Blue, and Retro Amber now compute their `colors` from `generatePaletteFromSeed(seed)` at module load ("bake-once" — no data-model or theme-builder change), seeded from each theme's previous accent hex to preserve its identifying hue.

Closes #61.

## Test plan

- [x] `bunx vitest run` — 112/112 tests pass, including a regression test replicating the "mostly-black cover with a tiny neon accent" case, and full WCAG contrast coverage for the three now-generated predefined themes
- [x] `bun run check` — svelte-check reports 0 errors
- [ ] Manual verification in a running Tauri build (not done here — the artwork extraction path depends on `invoke()` calls into the Rust backend, so a plain `vite dev` preview doesn't exercise it; the predefined-theme output was spot-checked by generating and inspecting the hex values directly)