### PR TITLE
Serve real cover art during screenshot generation from a real database

### DIFF
--- a/scripts/mock-library.ts
+++ b/scripts/mock-library.ts
@@ -129,6 +129,8 @@ export interface MockLibrary {
   playlistTracks: Record<number, Song[]>;
   lyrics: string;
   source: "database" | "fallback";
+  /** The db file actually used, when source is "database" — covers/ lives alongside it. */
+  dbPath?: string;
 }
 
 function readJsonConfig(configPath: string): MockConfig {
@@ -297,6 +299,7 @@ export async function loadMockLibrary(config: MockConfig = loadMockConfig()): Pr
     playlistTracks: fromDb?.playlistTracks ?? {},
     lyrics: FALLBACK_LYRICS,
     source: fromDb ? "database" : "fallback",
+    dbPath: fromDb ? dbPath : undefined,
   };
 }
 

--- a/scripts/take-screenshots.ts
+++ b/scripts/take-screenshots.ts
@@ -18,6 +18,49 @@ function parseNameFilter(argv: string[]): string | undefined {
   return undefined;
 }
 
+/**
+ * Resolves a `luminous-art://...` (or its Windows rewrite,
+ * `http://luminous-art.localhost/...`) request to a file under coversDir,
+ * mirroring the custom protocol handler in src-tauri/src/lib.rs exactly —
+ * there's no real Tauri backend in the browser to answer these requests, so
+ * without this every cover art image 404s.
+ */
+function resolveCoverArtPath(requestUrl: string, coversDir: string): string {
+  let trimmed = requestUrl;
+  if (requestUrl.startsWith("http://luminous-art.localhost/")) {
+    trimmed = requestUrl.slice("http://luminous-art.localhost/".length);
+  } else if (requestUrl.startsWith("luminous-art://")) {
+    trimmed = requestUrl.slice("luminous-art://".length);
+  }
+  if (trimmed.startsWith("localhost/")) {
+    trimmed = trimmed.slice("localhost/".length);
+  }
+  trimmed = trimmed.replace(/\/+$/, "");
+
+  if (trimmed.startsWith("local/")) {
+    return decodeURIComponent(trimmed.slice("local/".length));
+  }
+  return path.join(coversDir, decodeURIComponent(trimmed));
+}
+
+async function registerCoverArtRoute(page: import("playwright").Page, coversDir: string | undefined) {
+  if (!coversDir) return;
+  const handler = async (route: import("playwright").Route) => {
+    const filePath = resolveCoverArtPath(route.request().url(), coversDir);
+    if (fs.existsSync(filePath) && fs.statSync(filePath).isFile()) {
+      await route.fulfill({
+        status: 200,
+        contentType: filePath.toLowerCase().endsWith(".png") ? "image/png" : "image/jpeg",
+        body: fs.readFileSync(filePath),
+      });
+    } else {
+      await route.fulfill({ status: 404, body: Buffer.alloc(0) });
+    }
+  };
+  await page.route("http://luminous-art.localhost/**", handler);
+  await page.route("luminous-art://**", handler);
+}
+
 async function main() {
   if (process.env.CI) {
     console.log("[Screenshot Automation] Running in CI environment. Skipping screenshot generation.");
@@ -121,6 +164,7 @@ async function main() {
   // the "featured" selection and UI settings vary per-screenshot.
   const libraryJson = JSON.stringify(mockLibrary);
   const mockCode = compileMockScript();
+  const coversDir = mockLibrary.dbPath ? path.join(path.dirname(mockLibrary.dbPath), "covers") : undefined;
 
   interface CaptureOptions {
     tab: string;
@@ -154,6 +198,7 @@ async function main() {
     console.log(`[Screenshot Automation] Capturing ${filename} (Tab: ${tab}, SubTab: ${subTab}, Theme: ${theme}, Language: ${language}, Immersive: ${isImmersive})...`);
     const page = await browser.newPage();
     await page.setViewportSize({ width: 1280, height: 800 });
+    await registerCoverArtRoute(page, coversDir);
     page.on("console", (msg) => {
       if (msg.type() === "error" || msg.type() === "warning") {
         console.warn(`[Page ${msg.type()}] ${msg.text()}`);


### PR DESCRIPTION
## Summary

Follow-up to #73. With DB auto-detection working, running `take-screenshots` against a real library produced a wall of `Failed to load resource: 404` errors and every cover art image fell back to the placeholder icon.

`CoverArt.svelte` requests images through the `luminous-art://` custom protocol (rewritten to `http://luminous-art.localhost/...` on Windows). That protocol only exists inside the real Tauri app — `src-tauri/src/lib.rs` registers a `register_uri_scheme_protocol` handler that reads files from `{app_data_dir}/covers/`. In the browser-only mock there's nothing answering those requests at all.

- `scripts/take-screenshots.ts` now intercepts `luminous-art://**` and `http://luminous-art.localhost/**` via Playwright's `page.route()` and serves the real files straight off disk.
- `resolveCoverArtPath()` mirrors the Rust handler's resolution exactly: strip the scheme/`localhost/` prefix, trim a trailing slash, and either treat the remainder as an absolute path (`local/` prefix) or look it up under `covers/`.
- `mock-library.ts`'s `loadMockLibrary()` now returns the `dbPath` it actually used (explicit or auto-detected), so the screenshot script can derive `{dbPath's directory}/covers` without duplicating the path-detection logic.

## Test plan

- [x] `bun run check` — 0 errors
- [x] `bun run test:run` — 121/121 passing
- [x] Built a throwaway SQLite db + `covers/` directory with a synthetic test image, pointed `dbPath` at it, and confirmed the captured screenshot shows the real image instead of the placeholder icon — verified end-to-end even where the scheme stays as raw `luminous-art://` (not rewritten to `http://luminous-art.localhost/`, i.e. non-Windows), since Playwright's routing intercepts custom schemes too


---
_Generated by [Claude Code](https://claude.ai/code/session_018U8RrTszfm4HG7yJBDjYHc)_