### PR TITLE
Fix cover art for real, and remove the fix that didn't work

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -22,6 +22,7 @@
         "@testing-library/svelte": "^5.4.2",
         "@types/node": "^26.1.1",
         "jsdom": "^29.1.1",
+        "music-metadata": "^11.14.0",
         "playwright": "^1.61.1",
         "svelte": "^5.0.0",
         "svelte-check": "^4.0.0",
@@ -47,6 +48,8 @@
     "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
 
     "@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
+
+    "@borewit/text-codec": ["@borewit/text-codec@0.2.2", "", {}, "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ=="],
 
     "@bramus/specificity": ["@bramus/specificity@2.4.2", "", { "dependencies": { "css-tree": "^3.0.0" }, "bin": { "specificity": "bin/cli.js" } }, "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw=="],
 
@@ -260,6 +263,10 @@
 
     "@testing-library/svelte-core": ["@testing-library/svelte-core@1.1.3", "", { "peerDependencies": { "svelte": "^3 || ^4 || ^5 || ^5.0.0-next.0" } }, "sha512-KkMAvXeWorxN2Yn0kdC1lfoAItxpoj4uOWzxK5leDrNxonLvS5nwBFvztrroyTszQ0Wf/EU6iLT8JhY5qcn22g=="],
 
+    "@tokenizer/inflate": ["@tokenizer/inflate@0.4.1", "", { "dependencies": { "debug": "^4.4.3", "token-types": "^6.1.1" } }, "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA=="],
+
+    "@tokenizer/token": ["@tokenizer/token@0.3.0", "", {}, "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="],
+
     "@types/aria-query": ["@types/aria-query@5.0.4", "", {}, "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="],
 
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
@@ -308,6 +315,8 @@
 
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
 
+    "content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
+
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
     "cookie": ["cookie@0.6.0", "", {}, "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw=="],
@@ -350,11 +359,15 @@
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
+    "file-type": ["file-type@21.3.4", "", { "dependencies": { "@tokenizer/inflate": "^0.4.1", "strtok3": "^10.3.4", "token-types": "^6.1.1", "uint8array-extras": "^1.4.0" } }, "sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g=="],
+
     "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
     "html-encoding-sniffer": ["html-encoding-sniffer@6.0.0", "", { "dependencies": { "@exodus/bytes": "^1.6.0" } }, "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg=="],
+
+    "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
 
     "indent-string": ["indent-string@4.0.0", "", {}, "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="],
 
@@ -406,6 +419,8 @@
 
     "mdn-data": ["mdn-data@2.27.1", "", {}, "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ=="],
 
+    "media-typer": ["media-typer@2.0.0", "", {}, "sha512-kOy3OxT2HH39N70UnKgu4NWDZjLOz8W/mfyvniHjRH/DrL3f2pOfvWQ4p60offbbtDAnXWp0v9LfMIqMec269Q=="],
+
     "min-indent": ["min-indent@1.0.1", "", {}, "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="],
 
     "mri": ["mri@1.2.0", "", {}, "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="],
@@ -413,6 +428,8 @@
     "mrmime": ["mrmime@2.0.1", "", {}, "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "music-metadata": ["music-metadata@11.14.0", "", { "dependencies": { "@borewit/text-codec": "^0.2.2", "@tokenizer/token": "^0.3.0", "content-type": "^2.0.0", "debug": "^4.4.3", "file-type": "^21.3.4", "media-typer": "^2.0.0", "strtok3": "^10.3.5", "token-types": "^6.1.2", "uint8array-extras": "^1.5.0", "win-guid": "^0.2.1" } }, "sha512-RyOSq98kuVfXB1emJ+NjBF0av8Ph3oBuqNy+Z5sFFfLhjYrkBQEB53V8u+U0RNTVwNo20WoPUwNkfKwZfrOqmQ=="],
 
     "nanoid": ["nanoid@3.3.15", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA=="],
 
@@ -464,6 +481,8 @@
 
     "strip-indent": ["strip-indent@3.0.0", "", { "dependencies": { "min-indent": "^1.0.0" } }, "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ=="],
 
+    "strtok3": ["strtok3@10.3.5", "", { "dependencies": { "@tokenizer/token": "^0.3.0" } }, "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA=="],
+
     "svelte": ["svelte@5.56.4", "", { "dependencies": { "@jridgewell/remapping": "^2.3.4", "@jridgewell/sourcemap-codec": "^1.5.0", "@sveltejs/acorn-typescript": "^1.0.10", "@types/estree": "^1.0.5", "@types/trusted-types": "^2.0.7", "acorn": "^8.12.1", "aria-query": "5.3.1", "axobject-query": "^4.1.0", "clsx": "^2.1.1", "devalue": "^5.8.1", "esm-env": "^1.2.1", "esrap": "^2.2.12", "is-reference": "^3.0.3", "locate-character": "^3.0.0", "magic-string": "^0.30.11", "zimmerframe": "^1.1.2" } }, "sha512-/d0QHehmRuJW8gVz395MTkPcPozxzdjBMBE8oEYGz8O3b9KTMzzQ9ZHJQLuFKOHOPQbU6kx/X4iid/EBBzH7iw=="],
 
     "svelte-check": ["svelte-check@4.7.2", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.25", "@sveltejs/load-config": "^0.2.0", "chokidar": "^4.0.1", "fdir": "^6.2.0", "picocolors": "^1.0.0", "sade": "^1.7.4" }, "peerDependencies": { "svelte": "^4.0.0 || ^5.0.0-next.0", "typescript": ">=5.0.0" }, "bin": { "svelte-check": "bin/svelte-check" } }, "sha512-GoS4XJdGswlq0rIT1vtFLzJY1bvHtY37McY9H9Gkm1Ggw/ICdZYn8J/Z8Yi0BEL0i3R4+jtaWVePjyppMlij/A=="],
@@ -488,6 +507,8 @@
 
     "tldts-core": ["tldts-core@7.4.7", "", {}, "sha512-rNlAI8fKn/JckBMUSbNL/ES2kmDiurWaE49l+ikwEc9A6lFR7gMx9AhgQMQKBK4H5w4pKLH64JzZfB99uRsGNQ=="],
 
+    "token-types": ["token-types@6.1.2", "", { "dependencies": { "@borewit/text-codec": "^0.2.1", "@tokenizer/token": "^0.3.0", "ieee754": "^1.2.1" } }, "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww=="],
+
     "totalist": ["totalist@3.0.1", "", {}, "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ=="],
 
     "tough-cookie": ["tough-cookie@6.0.2", "", { "dependencies": { "tldts": "^7.0.5" } }, "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA=="],
@@ -495,6 +516,8 @@
     "tr46": ["tr46@6.0.0", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw=="],
 
     "typescript": ["typescript@5.6.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw=="],
+
+    "uint8array-extras": ["uint8array-extras@1.5.0", "", {}, "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A=="],
 
     "undici": ["undici@7.28.0", "", {}, "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA=="],
 
@@ -515,6 +538,8 @@
     "whatwg-url": ["whatwg-url@16.0.1", "", { "dependencies": { "@exodus/bytes": "^1.11.0", "tr46": "^6.0.0", "webidl-conversions": "^8.0.1" } }, "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw=="],
 
     "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
+
+    "win-guid": ["win-guid@0.2.1", "", {}, "sha512-gEIQU4mkgl2OPeoNrWflcJFJ3Ae2BPd4eCsHHA/XikslkIVms/nHhvnvzIZV7VLmBvtFlDOzLt9rrZT+n6D67A=="],
 
     "xml-name-validator": ["xml-name-validator@5.0.0", "", {}, "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg=="],
 

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@testing-library/svelte": "^5.4.2",
     "@types/node": "^26.1.1",
     "jsdom": "^29.1.1",
+    "music-metadata": "^11.14.0",
     "playwright": "^1.61.1",
     "svelte": "^5.0.0",
     "svelte-check": "^4.0.0",

--- a/scripts/embedded-art-cache.ts
+++ b/scripts/embedded-art-cache.ts
@@ -1,0 +1,80 @@
+// Extracts embedded cover art (ID3 APIC / FLAC PICTURE / etc.) straight from
+// the audio files themselves. The real backend only does this on demand, via
+// the get_cover_art_uri command (see src-tauri/src/covermanager.rs) — that
+// command doesn't exist in the browser-only mock, so any song whose
+// art_automatic/art_manual are both null (the common case for embedded art
+// that was never pre-cached to a file) would otherwise show the placeholder
+// icon forever.
+//
+// Extracted images are cached under the OS temp dir — deliberately *not*
+// the real app's covers/ cache, so this tooling never writes into your
+// actual Luminous app data. Filenames are given an "album-" prefix so
+// CoverArt.svelte's `artAutomatic.startsWith("album-")` check treats them
+// as a cache-relative filename (`luminous-art://album-mockembed-<id>.jpg`)
+// rather than an absolute path — which matters because an absolute POSIX
+// path starts with "/", and CoverArt.svelte treats *any* "/"-prefixed
+// artAutomatic as an already-servable URL, bypassing the luminous-art
+// scheme (and this tooling's route interception) entirely.
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { Song } from "../src/lib/types/index";
+
+export const EMBEDDED_ART_CACHE_DIR = path.join(os.tmpdir(), "luminous-mock-embedded-art");
+const FILENAME_PREFIX = "album-mockembed-";
+
+const EXTENSION_BY_MIME: Record<string, string> = {
+  "image/jpeg": "jpg",
+  "image/jpg": "jpg",
+  "image/png": "png",
+  "image/gif": "gif",
+  "image/webp": "webp",
+};
+
+/**
+ * Returns the luminous-art cache filename (e.g. "album-mockembed-123.jpg")
+ * for `song`'s embedded cover art, or undefined if the file has no embedded
+ * picture (or can't be read at all — a Windows-recorded path that no longer
+ * resolves, corrupt tags, etc). Never throws; a failure here should just
+ * mean "no art", not abort the whole mock library load.
+ */
+export async function resolveEmbeddedArt(song: Song): Promise<string | undefined> {
+  if (!song.path || !existsSync(song.path)) return undefined;
+
+  for (const ext of ["jpg", "png"]) {
+    const filename = `${FILENAME_PREFIX}${song.id}.${ext}`;
+    if (existsSync(path.join(EMBEDDED_ART_CACHE_DIR, filename))) return filename;
+  }
+
+  try {
+    const { parseFile } = await import("music-metadata");
+    const metadata = await parseFile(song.path);
+    const picture = metadata.common.picture?.[0];
+    if (!picture) return undefined;
+
+    const ext = EXTENSION_BY_MIME[picture.format.toLowerCase()] ?? "jpg";
+    const filename = `${FILENAME_PREFIX}${song.id}.${ext}`;
+    mkdirSync(EMBEDDED_ART_CACHE_DIR, { recursive: true });
+    writeFileSync(path.join(EMBEDDED_ART_CACHE_DIR, filename), picture.data);
+    return filename;
+  } catch (err) {
+    console.warn(`[Mock Library] Could not read embedded art from "${song.path}":`, (err as Error).message);
+    return undefined;
+  }
+}
+
+/** Runs `resolveEmbeddedArt` over `songs` with bounded concurrency, mutating art_automatic in place. */
+export async function hydrateEmbeddedArt(songs: Song[], concurrency = 8): Promise<void> {
+  const candidates = songs.filter((s) => s.art_embedded && !s.art_automatic && !s.art_manual && s.path);
+  if (candidates.length === 0) return;
+
+  let cursor = 0;
+  async function worker() {
+    while (cursor < candidates.length) {
+      const song = candidates[cursor++];
+      const filename = await resolveEmbeddedArt(song);
+      if (filename) song.art_automatic = filename;
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(concurrency, candidates.length) }, worker));
+}

--- a/scripts/mock-library.ts
+++ b/scripts/mock-library.ts
@@ -6,6 +6,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { AlbumItem, ArtistItem, Playlist, Song } from "../src/lib/types/index";
+import { hydrateEmbeddedArt } from "./embedded-art-cache";
 import { FALLBACK_LYRICS, FALLBACK_PLAYLISTS, FALLBACK_SONGS } from "./mock-data";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -280,16 +281,36 @@ async function loadFromDatabase(dbPath: string, limit: number, silentIfMissing =
   }
 }
 
+/**
+ * The db path a given config actually resolves to: an explicit `dbPath`
+ * wins, otherwise the auto-detected default (see defaultDbPath above).
+ * Exported so anything else that needs to find the sibling covers/
+ * directory (e.g. the vite dev middleware serving /covers/*) resolves the
+ * exact same path loadMockLibrary used, instead of re-deriving it and
+ * silently diverging when dbPath is left unset.
+ */
+export function resolveDbPath(config: MockConfig): string | undefined {
+  return config.dbPath || defaultDbPath();
+}
+
 export async function loadMockLibrary(config: MockConfig = loadMockConfig()): Promise<MockLibrary> {
   const limit = config.songLimit ?? 2000;
   // An explicit dbPath is a firm request — warn if it's wrong. Falling back
   // to the auto-detected Tauri app-data location is best-effort and should
   // stay quiet when nothing's there (e.g. CI, or no desktop app installed).
-  const dbPath = config.dbPath || defaultDbPath();
+  const dbPath = resolveDbPath(config);
   const fromDb = dbPath ? await loadFromDatabase(dbPath, limit, !config.dbPath) : null;
 
   const songs = fromDb?.songs ?? FALLBACK_SONGS;
   const playlists = fromDb?.playlists ?? FALLBACK_PLAYLISTS;
+
+  // Real songs with embedded (but never pre-cached) art would otherwise show
+  // the placeholder icon forever — the mock has no get_cover_art_uri command
+  // to extract it on demand like the real backend does. Do it upfront instead,
+  // before deriving albums/artists so their art_automatic picks it up too.
+  if (fromDb) {
+    await hydrateEmbeddedArt(songs);
+  }
 
   return {
     songs,

--- a/scripts/take-screenshots.ts
+++ b/scripts/take-screenshots.ts
@@ -18,49 +18,6 @@ function parseNameFilter(argv: string[]): string | undefined {
   return undefined;
 }
 
-/**
- * Resolves a `luminous-art://...` (or its Windows rewrite,
- * `http://luminous-art.localhost/...`) request to a file under coversDir,
- * mirroring the custom protocol handler in src-tauri/src/lib.rs exactly —
- * there's no real Tauri backend in the browser to answer these requests, so
- * without this every cover art image 404s.
- */
-function resolveCoverArtPath(requestUrl: string, coversDir: string): string {
-  let trimmed = requestUrl;
-  if (requestUrl.startsWith("http://luminous-art.localhost/")) {
-    trimmed = requestUrl.slice("http://luminous-art.localhost/".length);
-  } else if (requestUrl.startsWith("luminous-art://")) {
-    trimmed = requestUrl.slice("luminous-art://".length);
-  }
-  if (trimmed.startsWith("localhost/")) {
-    trimmed = trimmed.slice("localhost/".length);
-  }
-  trimmed = trimmed.replace(/\/+$/, "");
-
-  if (trimmed.startsWith("local/")) {
-    return decodeURIComponent(trimmed.slice("local/".length));
-  }
-  return path.join(coversDir, decodeURIComponent(trimmed));
-}
-
-async function registerCoverArtRoute(page: import("playwright").Page, coversDir: string | undefined) {
-  if (!coversDir) return;
-  const handler = async (route: import("playwright").Route) => {
-    const filePath = resolveCoverArtPath(route.request().url(), coversDir);
-    if (fs.existsSync(filePath) && fs.statSync(filePath).isFile()) {
-      await route.fulfill({
-        status: 200,
-        contentType: filePath.toLowerCase().endsWith(".png") ? "image/png" : "image/jpeg",
-        body: fs.readFileSync(filePath),
-      });
-    } else {
-      await route.fulfill({ status: 404, body: Buffer.alloc(0) });
-    }
-  };
-  await page.route("http://luminous-art.localhost/**", handler);
-  await page.route("luminous-art://**", handler);
-}
-
 async function main() {
   if (process.env.CI) {
     console.log("[Screenshot Automation] Running in CI environment. Skipping screenshot generation.");
@@ -164,7 +121,6 @@ async function main() {
   // the "featured" selection and UI settings vary per-screenshot.
   const libraryJson = JSON.stringify(mockLibrary);
   const mockCode = compileMockScript();
-  const coversDir = mockLibrary.dbPath ? path.join(path.dirname(mockLibrary.dbPath), "covers") : undefined;
 
   interface CaptureOptions {
     tab: string;
@@ -198,7 +154,6 @@ async function main() {
     console.log(`[Screenshot Automation] Capturing ${filename} (Tab: ${tab}, SubTab: ${subTab}, Theme: ${theme}, Language: ${language}, Immersive: ${isImmersive})...`);
     const page = await browser.newPage();
     await page.setViewportSize({ width: 1280, height: 800 });
-    await registerCoverArtRoute(page, coversDir);
     page.on("console", (msg) => {
       if (msg.type() === "error" || msg.type() === "warning") {
         console.warn(`[Page ${msg.type()}] ${msg.text()}`);

--- a/scripts/vite-mock-plugin.ts
+++ b/scripts/vite-mock-plugin.ts
@@ -1,8 +1,22 @@
 import type { Plugin } from "vite";
 import { compileMockScript } from "./compile-mock-script";
-import { loadMockConfig, loadMockLibrary, resolveFeatured } from "./mock-library";
+import { EMBEDDED_ART_CACHE_DIR } from "./embedded-art-cache";
+import { loadMockConfig, loadMockLibrary, resolveDbPath, resolveFeatured } from "./mock-library";
 import { existsSync, readFileSync } from "fs";
 import { join, dirname } from "path";
+
+/** Tries `dir/filename`, then `dir/<filename without extension>.{jpg,png}`. */
+function findCoverFile(dir: string, filename: string): string | undefined {
+  const direct = join(dir, filename);
+  if (existsSync(direct)) return direct;
+
+  const baseName = filename.replace(/\.(jpg|jpeg|png)$/i, "");
+  for (const ext of ["jpg", "png"]) {
+    const candidate = join(dir, `${baseName}.${ext}`);
+    if (existsSync(candidate)) return candidate;
+  }
+  return undefined;
+}
 
 export function tauriIpcMockPlugin(): Plugin {
   return {
@@ -14,29 +28,20 @@ export function tauriIpcMockPlugin(): Plugin {
 
         if (url.startsWith("/covers/")) {
           try {
-            const config = loadMockConfig();
-            const dbPath = config.dbPath || "";
-            const coversDir = dbPath ? join(dirname(dbPath), "covers") : "";
-            if (!coversDir) {
-              res.statusCode = 404;
-              res.end("No dbPath configured");
-              return;
-            }
-            const filename = decodeURIComponent(url.slice(8));
-            const baseName = filename.replace(/\.(jpg|png|jpeg)$/i, "");
-            
-            let filePath = join(coversDir, filename);
-            if (!existsSync(filePath)) {
-              const jpgPath = join(coversDir, `${baseName}.jpg`);
-              const pngPath = join(coversDir, `${baseName}.png`);
-              if (existsSync(jpgPath)) {
-                filePath = jpgPath;
-              } else if (existsSync(pngPath)) {
-                filePath = pngPath;
-              }
-            }
+            const filename = decodeURIComponent(url.slice("/covers/".length));
 
-            if (existsSync(filePath)) {
+            // Check the mock-only embedded-art extraction cache first (see
+            // embedded-art-cache.ts — it has no real-app equivalent), then
+            // fall back to the real app's covers/ directory alongside the
+            // resolved db (explicit dbPath or the auto-detected default —
+            // *not* the raw config value, which is empty whenever dbPath is
+            // left unset for auto-detection).
+            const dbPath = resolveDbPath(loadMockConfig());
+            const coversDir = dbPath ? join(dirname(dbPath), "covers") : undefined;
+            const filePath =
+              findCoverFile(EMBEDDED_ART_CACHE_DIR, filename) ?? (coversDir ? findCoverFile(coversDir, filename) : undefined);
+
+            if (filePath) {
               const mime = filePath.endsWith(".png") ? "image/png" : "image/jpeg";
               res.setHeader("Content-Type", mime);
               res.end(readFileSync(filePath));


### PR DESCRIPTION
## Summary

Follow-up to #74. That PR claimed to fix cover art by having Playwright intercept `luminous-art://` requests, but the app doesn't generate those URLs in mock mode at all — `getCoverArtUrl()` (`src/lib/types/index.ts`) has a mock-aware branch that rewrites straight to same-origin `/covers/`, `/local-art/`, or `/fixtures/` paths, served by a Vite dev middleware in `scripts/vite-mock-plugin.ts` that already existed. The Playwright routing in #74 never fired — the one screenshot that "worked" during that PR's verification did so via the pre-existing middleware, not the code under test. **This PR removes that dead code** and fixes the two real bugs, found this time by tracing actual `<img src>` values and `invoke()` calls in a live page instead of trusting a screenshot:

1. **`/covers/` middleware ignored dbPath auto-detection.** It read `config.dbPath` directly, which is empty whenever `dbPath` is left unset for auto-detection (the now-recommended setup from #73) — every cover request 404'd regardless of anything else. `mock-library.ts` now exports `resolveDbPath()` as the single place that combines an explicit `dbPath` with the auto-detected default, and both `loadMockLibrary()` and the middleware use it — no more silently diverging.

2. **No mock equivalent of `get_cover_art_uri` for embedded art.** Real songs whose embedded cover was never pre-cached to a file (`art_automatic` and `art_manual` both null in the DB — the common case) have no way to resolve art in the mock; the real backend extracts it on demand via a Tauri command that doesn't exist here. `scripts/embedded-art-cache.ts` now extracts embedded pictures directly from the audio files with `music-metadata`, caches them under the OS temp dir (deliberately *not* the real app's `covers/`, so this tooling never writes into your actual Luminous data), and the `/covers/` middleware checks that cache before the real one.

## Test plan

- [x] `bun run check` — 0 errors
- [x] `bun run test:run` — 121/121 passing
- [x] Hand-built a minimal ID3v2.3 MP3 with an embedded APIC frame (no full audio codec available in the sandbox), pointed a throwaway db's song at it with `art_automatic`/`art_manual` both null, and confirmed:
  - `music-metadata` extracts the embedded picture correctly
  - the extraction cache file gets written
  - the actual `<img>` element in a live page resolves to the real image (verified via `page.evaluate` reading `img.src`, not just the final screenshot)
  - `resolveDbPath()` behaves correctly whether `dbPath` is explicit or left unset for auto-detection


---
_Generated by [Claude Code](https://claude.ai/code/session_018U8RrTszfm4HG7yJBDjYHc)_