### PR TITLE
docs: add pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+## 📋 Summary
+<!-- What changed and why. Link the issue this addresses, e.g. "Addresses #86" or "Fixes #71". -->
+
+## 🔍 Implementation Notes
+<!-- Anything a reviewer should know: key files/components touched, design decisions, tradeoffs, or things intentionally left out of scope. -->
+
+## 🧪 Test Plan
+<!-- How this was verified. Check what applies, add commands/output where useful. -->
+- [ ] `bun run check` (svelte-check)
+- [ ] `bun run test -- --run` (frontend)
+- [ ] `cargo test` (src-tauri, if Rust changed)
+- [ ] Manually verified in the app (describe what you did)
+
+## 📸 Screenshots
+<!-- For UI changes, before/after screenshots or a short clip. Delete this section if not applicable. -->
+
+## ✅ Checklist
+- [ ] No unrelated changes bundled in
+- [ ] Docs/screenshots updated if user-facing behavior changed (see `.claude/CLAUDE.md` for the screenshot harness)


### PR DESCRIPTION
## Summary
Adds `.github/PULL_REQUEST_TEMPLATE.md`, matching the emoji-header style already used by `.github/ISSUE_TEMPLATE/bug_report.md` and `feature_request.md`. Sections: Summary, Implementation Notes, Test Plan (with the repo's standard `bun run check` / `bun run test` / `cargo test` checks pre-filled), Screenshots, and a pre-merge checklist.

## Why
No PR template existed, so PR descriptions had no consistent structure. This gives contributors (and future me) a starting checklist that mirrors the conventions already established by the issue templates.