### PR TITLE
Fix: restore playback context and album/artist detail view across restart

### DIFF
--- a/src-tauri/src/player.rs
+++ b/src-tauri/src/player.rs
@@ -195,6 +195,40 @@ impl Player {
                                 }
                             }
                         }
+                    } else {
+                        // Ad-hoc queue (album/artist/search selection played via
+                        // play_song/play_songs/open_and_play — not a saved DB
+                        // playlist). Its track order only lives in the
+                        // `last_adhoc_song_ids` snapshot; without it we'd only
+                        // know the single current song and nothing to advance to.
+                        if let Ok(ids_json) = conn.query_row(
+                            "SELECT value FROM app_state WHERE key = 'last_adhoc_song_ids'",
+                            [],
+                            |row| row.get::<_, String>(0),
+                        ) {
+                            if let Ok(song_ids) = serde_json::from_str::<Vec<i64>>(&ids_json) {
+                                let sql = format!(
+                                    "SELECT {} FROM songs WHERE id = ?1 AND unavailable = 0",
+                                    crate::collection::SONG_SELECT_COLS
+                                );
+                                let mut items = Vec::with_capacity(song_ids.len());
+                                for (i, sid) in song_ids.iter().enumerate() {
+                                    if let Ok(s) = conn.query_row(
+                                        &sql,
+                                        rusqlite::params![sid],
+                                        crate::collection::row_to_song,
+                                    ) {
+                                        items.push(PlaylistItem::new_song(0, i as i32, s));
+                                    }
+                                }
+                                if !items.is_empty() {
+                                    playlist_items = items;
+                                    current_index = playlist_items.iter().position(|i| {
+                                        i.song.as_ref().map(|s| s.id) == Some(song.id)
+                                    });
+                                }
+                            }
+                        }
                     }
                 }
 
@@ -268,6 +302,8 @@ impl Player {
         self.played_indices.clear();
         self.queue.clear();
         self.scrobbled = false;
+
+        self.persist_adhoc_queue();
 
         // Build shuffle order if needed
         self.rebuild_shuffle_order();
@@ -374,6 +410,34 @@ impl Player {
         self.apply_loudness_gain(&song).await;
         let audio = self.audio.lock().await;
         audio.play(Box::new(song), start_ns)
+    }
+
+    /// Persist the ordered song-id list for ad-hoc queues (`playlist_id ==
+    /// 0` — album/artist/search selections, not a saved DB playlist) so a
+    /// restart can rebuild the full playback context instead of just the
+    /// current song. Saved playlists don't need this: they're reloaded from
+    /// the `playlists`/`playlist_items` tables via `last_playlist_id`.
+    fn persist_adhoc_queue(&self) {
+        if let Ok(conn) = self._db.pool.get() {
+            if self.current_playlist_id == Some(0) {
+                let song_ids: Vec<i64> = self
+                    .playlist_items
+                    .iter()
+                    .filter_map(|i| i.song.as_ref().map(|s| s.id))
+                    .collect();
+                if let Ok(json) = serde_json::to_string(&song_ids) {
+                    let _ = conn.execute(
+                        "INSERT OR REPLACE INTO app_state (key, value) VALUES ('last_adhoc_song_ids', ?1)",
+                        rusqlite::params![json],
+                    );
+                }
+            } else {
+                let _ = conn.execute(
+                    "DELETE FROM app_state WHERE key = 'last_adhoc_song_ids'",
+                    [],
+                );
+            }
+        }
     }
 
     pub fn persist_current_song(&self) {
@@ -995,6 +1059,55 @@ mod tests {
             |r| r.get(0),
         );
         assert!(song_id_exists.is_err());
+
+        let _ = std::fs::remove_dir_all(temp_dir);
+    }
+
+    #[tokio::test]
+    async fn test_adhoc_queue_survives_restart() {
+        let (db, temp_dir) = setup_test_db();
+        let db_arc = Arc::new(db);
+
+        {
+            let conn = db_arc.pool.get().unwrap();
+            for id in 1..=3i64 {
+                conn.execute(
+                    &format!(
+                        "INSERT INTO songs (id, path, title, artist, album, length_nanosec) VALUES ({id}, '/fake/path{id}.mp3', 'Track {id}', 'Artist', 'Album', 180000000000)"
+                    ),
+                    [],
+                )
+                .unwrap();
+            }
+        }
+
+        let audio = Arc::new(Mutex::new(AudioEngine::new()));
+        let mut player = Player::new(db_arc.clone(), audio.clone());
+
+        let items = (1..=3i64)
+            .map(|id| {
+                let conn = db_arc.pool.get().unwrap();
+                let sql = format!(
+                    "SELECT {} FROM songs WHERE id = ?1",
+                    crate::collection::SONG_SELECT_COLS
+                );
+                let song = conn
+                    .query_row(&sql, rusqlite::params![id], crate::collection::row_to_song)
+                    .unwrap();
+                PlaylistItem::new_song(0, 0, song)
+            })
+            .collect::<Vec<_>>();
+
+        // Simulate an ad-hoc selection (album/artist/search — playlist_id 0)
+        // starting on the middle track, then "quitting" mid-playback.
+        player.play_playlist(items, 1, 0).await.unwrap();
+        assert_eq!(player.current_song.as_ref().unwrap().id, 2);
+
+        // Reopening the app re-runs Player::new against the same DB.
+        let restarted = Player::new(db_arc.clone(), audio.clone());
+        assert_eq!(restarted.current_song.as_ref().unwrap().id, 2);
+        assert_eq!(restarted.playlist_items.len(), 3);
+        assert_eq!(restarted.current_index, Some(1));
 
         let _ = std::fs::remove_dir_all(temp_dir);
     }

--- a/src/lib/stores/collection.svelte.ts
+++ b/src/lib/stores/collection.svelte.ts
@@ -45,6 +45,29 @@ class CollectionStore {
     }
   }
 
+  private _selectedArtistName = $state<string | null>(null);
+  private _selectedAlbumName = $state<string | null>(null);
+
+  /** Selected artist for the Artist Detail view (rendered inside CollectionView). */
+  get selectedArtistName() { return this._selectedArtistName; }
+  set selectedArtistName(val) {
+    this._selectedArtistName = val;
+    if (typeof window !== "undefined") {
+      if (val) localStorage.setItem("navigation_selectedArtistName", val);
+      else localStorage.removeItem("navigation_selectedArtistName");
+    }
+  }
+
+  /** Selected album for the Album Detail view (rendered inside CollectionView). */
+  get selectedAlbumName() { return this._selectedAlbumName; }
+  set selectedAlbumName(val) {
+    this._selectedAlbumName = val;
+    if (typeof window !== "undefined") {
+      if (val) localStorage.setItem("navigation_selectedAlbumName", val);
+      else localStorage.removeItem("navigation_selectedAlbumName");
+    }
+  }
+
   // Layout panel states
   sidebarOpen = $state<boolean>(true);
   rightPanelOpen = $state<boolean>(true);
@@ -84,6 +107,14 @@ class CollectionStore {
 
         const savedSubTab = localStorage.getItem("navigation_activeSubTab");
         if (savedSubTab) this._activeSubTab = savedSubTab as ActiveSubTab;
+
+        // Restore the last-viewed Album/Artist detail view (mutually
+        // exclusive — CollectionView prefers the album when both are set).
+        const savedAlbum = localStorage.getItem("navigation_selectedAlbumName");
+        if (savedAlbum) this._selectedAlbumName = savedAlbum;
+
+        const savedArtist = localStorage.getItem("navigation_selectedArtistName");
+        if (savedArtist) this._selectedArtistName = savedArtist;
       }
 
       await this.refreshDirectories();
@@ -238,12 +269,6 @@ class CollectionStore {
       this.searchQuery = query;
     }
   }
-
-  /** Selected artist for the Artist Detail view (rendered inside CollectionView). */
-  selectedArtistName = $state<string | null>(null);
-
-  /** Selected album for the Album Detail view (rendered inside CollectionView). */
-  selectedAlbumName = $state<string | null>(null);
 
   viewArtist(name: string) {
     this.searchQuery = "";

--- a/src/lib/stores/collection.test.ts
+++ b/src/lib/stores/collection.test.ts
@@ -202,6 +202,19 @@ describe("CollectionStore", () => {
     expect(collectionStore.selectedArtistName).toBeNull();
   });
 
+  it("persists the selected album/artist detail view to localStorage so a relaunch restores it", () => {
+    collectionStore.viewAlbum("Dark Side of the Moon");
+    expect(localStorage.getItem("navigation_selectedAlbumName")).toBe("Dark Side of the Moon");
+    expect(localStorage.getItem("navigation_selectedArtistName")).toBeNull();
+
+    collectionStore.viewArtist("Pink Floyd");
+    expect(localStorage.getItem("navigation_selectedArtistName")).toBe("Pink Floyd");
+    expect(localStorage.getItem("navigation_selectedAlbumName")).toBeNull();
+
+    collectionStore.selectedArtistName = null;
+    expect(localStorage.getItem("navigation_selectedArtistName")).toBeNull();
+  });
+
   it("toggles and persists layout states (sidebar, right panel, immersive mode)", () => {
     const initialSidebar = collectionStore.sidebarOpen;
     collectionStore.toggleSidebar();


### PR DESCRIPTION
## Summary
- Ad-hoc queues (album/artist/search selections — not a saved DB playlist) only persisted the current song and position, so relaunching the app could finish the restored track but had nothing to advance to. `Player::play_playlist` now snapshots the ordered song-id list to `app_state.last_adhoc_song_ids`, and `Player::new` reconstructs the full queue and current index from it on restart.
- Separately, `selectedAlbumName`/`selectedArtistName` (which drive the Album/Artist detail views) were in-memory only, so relaunching always dropped back to the grid instead of restoring the detail view you were on. They're now persisted to `localStorage` and restored alongside `activeTab`/`activeSubTab`.

## Test plan
- [x] `cargo test --lib` — 33 passed (added `test_adhoc_queue_survives_restart`)
- [x] `cargo clippy --lib` — clean
- [x] `bun run test` — 200 passed (added localStorage persistence assertions to `collection.test.ts`)
- [x] Manually verified on dev server: relaunch restores the Album detail view, and playback of a playlist continues to the next track after restart