### PR TITLE
Context-aware Recently Played / Most Frequently Played

### DIFF
--- a/src-tauri/src/collection.rs
+++ b/src-tauri/src/collection.rs
@@ -726,9 +726,9 @@ impl CollectionScanner {
         let rows: Vec<(Song, i64, String, Option<i64>)> = stmt
             .query_map(params![query_limit], |row| {
                 let song = row_to_song(row)?;
-                let album_track_count: i64 = row.get(55)?;
-                let context_type: String = row.get(56)?;
-                let playlist_id: Option<i64> = row.get(57)?;
+                let album_track_count: i64 = row.get(56)?;
+                let context_type: String = row.get(57)?;
+                let playlist_id: Option<i64> = row.get(58)?;
                 Ok((song, album_track_count, context_type, playlist_id))
             })?
             .filter_map(|r| r.ok())
@@ -754,29 +754,77 @@ impl CollectionScanner {
         ))
     }
 
+    /// Most frequently played, grouped the same way as `get_recently_played`
+    /// (Album/Playlist/Song by recorded context) but ordered by total play
+    /// count per context instead of recency.
     pub fn get_most_frequently_played(&self, limit: i64) -> Result<Vec<HomeItem>> {
         let conn = self.db.pool.get()?;
-        let query_limit = limit * 20;
-        let sql = format!(
-            "SELECT {HOME_ITEM_SELECT_COLS}
-             FROM songs s
-             WHERE s.source IN (1, 2) AND s.unavailable = 0
-             ORDER BY s.playcount DESC, s.lastplayed DESC NULLS LAST
-             LIMIT ?1"
-        );
-        let mut stmt = conn.prepare(&sql)?;
-        let songs_with_counts: Vec<(Song, i64)> = stmt
-            .query_map(params![query_limit], |row| {
-                let song = row_to_song(row)?;
-                let count: i64 = row.get(55)?;
-                Ok((song, count))
+        let sql = "
+            SELECT
+                ph.context_type,
+                ph.playlist_id,
+                COUNT(*) as play_count,
+                MAX(ph.played_at) as last_played,
+                MAX(ph.song_id) as representative_song_id
+            FROM play_history ph
+            JOIN songs s ON s.id = ph.song_id
+            WHERE s.source IN (1, 2) AND s.unavailable = 0
+            GROUP BY
+                ph.context_type,
+                CASE ph.context_type WHEN 'playlist' THEN ph.playlist_id END,
+                CASE ph.context_type WHEN 'album' THEN s.album END,
+                CASE ph.context_type WHEN 'album' THEN COALESCE(s.album_artist, s.artist) END,
+                CASE ph.context_type WHEN 'song' THEN ph.song_id END
+            ORDER BY play_count DESC, last_played DESC
+            LIMIT ?1
+        ";
+        let mut stmt = conn.prepare(sql)?;
+        struct AggRow {
+            context_type: String,
+            playlist_id: Option<i64>,
+            representative_song_id: i64,
+        }
+        let agg_rows: Vec<AggRow> = stmt
+            .query_map(params![limit], |row| {
+                Ok(AggRow {
+                    context_type: row.get(0)?,
+                    playlist_id: row.get(1)?,
+                    representative_song_id: row.get(4)?,
+                })
             })?
             .filter_map(|r| r.ok())
             .collect();
-        Ok(group_songs_into_home_items(
-            songs_with_counts,
-            limit as usize,
-        ))
+
+        let playlist_ids: Vec<i64> = {
+            use std::collections::HashSet;
+            agg_rows
+                .iter()
+                .filter(|r| r.context_type == "playlist")
+                .filter_map(|r| r.playlist_id)
+                .collect::<HashSet<_>>()
+                .into_iter()
+                .collect()
+        };
+        let playlists_by_id = get_playlists_by_ids(&conn, &playlist_ids)?;
+
+        let song_ids: Vec<i64> = agg_rows.iter().map(|r| r.representative_song_id).collect();
+        let songs_by_id = get_songs_by_ids(&conn, &song_ids)?;
+
+        let items = agg_rows
+            .into_iter()
+            .filter_map(|row| {
+                let (song, album_track_count) =
+                    songs_by_id.get(&row.representative_song_id)?.clone();
+                Some(home_item_for_context(
+                    &row.context_type,
+                    row.playlist_id,
+                    song,
+                    album_track_count,
+                    &playlists_by_id,
+                ))
+            })
+            .collect();
+        Ok(items)
     }
 
     pub fn get_recently_added(&self, limit: i64) -> Result<Vec<HomeItem>> {
@@ -793,7 +841,7 @@ impl CollectionScanner {
         let songs_with_counts: Vec<(Song, i64)> = stmt
             .query_map(params![query_limit], |row| {
                 let song = row_to_song(row)?;
-                let count: i64 = row.get(55)?;
+                let count: i64 = row.get(56)?;
                 Ok((song, count))
             })?
             .filter_map(|r| r.ok())
@@ -889,39 +937,61 @@ fn group_by_play_context(
         if seen.contains(&key) {
             continue;
         }
-        seen.insert(key.clone());
+        seen.insert(key);
 
-        match key {
-            PlayContextKey::Playlist(id) => match playlists_by_id.get(&id) {
-                Some(playlist) => items.push(HomeItem::Playlist {
-                    playlist: playlist.clone(),
-                }),
-                None => items.push(HomeItem::Song {
-                    song: Box::new(song),
-                }),
-            },
-            PlayContextKey::Album(album_name, artist_name) => {
-                items.push(HomeItem::Album {
-                    album: AlbumItem {
-                        artist: Some(artist_name),
-                        album: Some(album_name),
-                        year: song.year,
-                        track_count: album_track_count as i32,
-                        art_embedded: song.art_embedded,
-                        art_automatic: song.art_automatic.clone(),
-                        art_manual: song.art_manual.clone(),
-                    },
-                });
-            }
-            PlayContextKey::Song(_) => {
-                items.push(HomeItem::Song {
-                    song: Box::new(song),
-                });
-            }
-        }
+        items.push(home_item_for_context(
+            &context_type,
+            playlist_id,
+            song,
+            album_track_count,
+            playlists_by_id,
+        ));
     }
 
     items
+}
+
+/// Build the HomeItem a play-history context maps to: a Playlist card when
+/// resolvable, an Album card when the representative song carries an album
+/// tag, otherwise a standalone Song card.
+fn home_item_for_context(
+    context_type: &str,
+    playlist_id: Option<i64>,
+    song: Song,
+    album_track_count: i64,
+    playlists_by_id: &std::collections::HashMap<i64, Playlist>,
+) -> HomeItem {
+    match context_type {
+        "playlist" => match playlist_id.and_then(|id| playlists_by_id.get(&id)) {
+            Some(playlist) => HomeItem::Playlist {
+                playlist: playlist.clone(),
+            },
+            None => HomeItem::Song {
+                song: Box::new(song),
+            },
+        },
+        "album" if song.album.as_deref().is_some_and(|a| !a.trim().is_empty()) => {
+            let artist_name = song
+                .album_artist
+                .clone()
+                .or_else(|| song.artist.clone())
+                .unwrap_or_default();
+            HomeItem::Album {
+                album: AlbumItem {
+                    artist: Some(artist_name),
+                    album: song.album.clone(),
+                    year: song.year,
+                    track_count: album_track_count as i32,
+                    art_embedded: song.art_embedded,
+                    art_automatic: song.art_automatic.clone(),
+                    art_manual: song.art_manual.clone(),
+                },
+            }
+        }
+        _ => HomeItem::Song {
+            song: Box::new(song),
+        },
+    }
 }
 
 fn get_playlists_by_ids(
@@ -953,6 +1023,27 @@ fn get_playlists_by_ids(
                 track_count: row.get(8)?,
             };
             Ok((playlist.id, playlist))
+        })?
+        .filter_map(|r| r.ok())
+        .collect();
+    Ok(map)
+}
+
+fn get_songs_by_ids(
+    conn: &rusqlite::Connection,
+    ids: &[i64],
+) -> Result<std::collections::HashMap<i64, (Song, i64)>> {
+    if ids.is_empty() {
+        return Ok(std::collections::HashMap::new());
+    }
+    let placeholders = ids.iter().map(|_| "?").collect::<Vec<_>>().join(",");
+    let sql = format!("SELECT {HOME_ITEM_SELECT_COLS} FROM songs s WHERE s.id IN ({placeholders})");
+    let mut stmt = conn.prepare(&sql)?;
+    let map = stmt
+        .query_map(rusqlite::params_from_iter(ids.iter()), |row| {
+            let song = row_to_song(row)?;
+            let album_track_count: i64 = row.get(56)?;
+            Ok((song.id, (song, album_track_count)))
         })?
         .filter_map(|r| r.ok())
         .collect();
@@ -1778,6 +1869,110 @@ mod tests {
         let songs_80s = scanner.get_songs_by_decade("1980s", 10).unwrap();
         assert_eq!(songs_80s.len(), 1);
         assert_eq!(songs_80s[0].title.as_deref(), Some("80s Song"));
+
+        let _ = std::fs::remove_dir_all(temp_dir);
+    }
+
+    #[test]
+    fn test_get_recently_played_groups_by_play_context() {
+        let temp_dir = std::env::temp_dir().join(format!(
+            "luminous_recent_played_test_{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let db = Arc::new(Database::new(temp_dir.clone()).unwrap());
+        let scanner = CollectionScanner::new(db.clone());
+        let conn = db.pool.get().unwrap();
+
+        let insert_song = |path: &str, title: &str, album: Option<&str>| {
+            let song = Song {
+                path: Some(path.to_string()),
+                title: Some(title.to_string()),
+                artist: Some("Artist".to_string()),
+                album: album.map(|s| s.to_string()),
+                album_artist: album.map(|_| "Artist".to_string()),
+                source: SongSource::LocalFile,
+                filetype: FileType::Mp3,
+                unavailable: false,
+                ..Default::default()
+            };
+            upsert_song(&conn, &song).unwrap();
+            conn.query_row("SELECT id FROM songs WHERE path = ?1", params![path], |r| {
+                r.get::<_, i64>(0)
+            })
+            .unwrap()
+        };
+
+        let standalone_id = insert_song("path/standalone.mp3", "Standalone", None);
+        let album_track_1 = insert_song("path/album_a1.mp3", "Album Track 1", Some("Album A"));
+        let album_track_2 = insert_song("path/album_a2.mp3", "Album Track 2", Some("Album A"));
+        let playlist_track = insert_song("path/playlist_track.mp3", "Playlist Track", None);
+
+        conn.execute(
+            "INSERT INTO playlists (name) VALUES ('My Playlist')",
+            params![],
+        )
+        .unwrap();
+        let playlist_id = conn.last_insert_rowid();
+
+        // played_at ascending: standalone (oldest) -> two album plays -> playlist play (newest)
+        conn.execute(
+            "INSERT INTO play_history (context_type, song_id, playlist_id, played_at) VALUES ('song', ?1, NULL, 100)",
+            params![standalone_id],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO play_history (context_type, song_id, playlist_id, played_at) VALUES ('album', ?1, NULL, 200)",
+            params![album_track_1],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO play_history (context_type, song_id, playlist_id, played_at) VALUES ('album', ?1, NULL, 201)",
+            params![album_track_2],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO play_history (context_type, song_id, playlist_id, played_at) VALUES ('playlist', ?1, ?2, 300)",
+            params![playlist_track, playlist_id],
+        )
+        .unwrap();
+
+        let recent = scanner.get_recently_played(10).unwrap();
+        assert_eq!(recent.len(), 3, "album plays should collapse into one card");
+        match &recent[0] {
+            HomeItem::Playlist { playlist } => assert_eq!(playlist.id, playlist_id),
+            other => panic!("expected Playlist as most recent, got {other:?}"),
+        }
+        match &recent[1] {
+            HomeItem::Album { album } => assert_eq!(album.album.as_deref(), Some("Album A")),
+            other => panic!("expected Album next, got {other:?}"),
+        }
+        match &recent[2] {
+            HomeItem::Song { song } => assert_eq!(song.id, standalone_id),
+            other => panic!("expected standalone Song last, got {other:?}"),
+        }
+
+        // Most frequently played: play the standalone song two more times so it
+        // outranks the (2-play) album and (1-play) playlist contexts.
+        conn.execute(
+            "INSERT INTO play_history (context_type, song_id, playlist_id, played_at) VALUES ('song', ?1, NULL, 400)",
+            params![standalone_id],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO play_history (context_type, song_id, playlist_id, played_at) VALUES ('song', ?1, NULL, 500)",
+            params![standalone_id],
+        )
+        .unwrap();
+
+        let frequent = scanner.get_most_frequently_played(10).unwrap();
+        assert_eq!(frequent.len(), 3);
+        match &frequent[0] {
+            HomeItem::Song { song } => assert_eq!(song.id, standalone_id),
+            other => panic!("expected most-played standalone Song first, got {other:?}"),
+        }
 
         let _ = std::fs::remove_dir_all(temp_dir);
     }

--- a/src-tauri/src/collection.rs
+++ b/src-tauri/src/collection.rs
@@ -4,8 +4,8 @@ use crate::{
     covermanager::CoverManager,
     db::Database,
     models::{
-        AlbumItem, FileType, HomeItem, LibraryStats, MusicDirectory, ScanPhase, ScanProgress, Song,
-        SongSource,
+        AlbumItem, FileType, HomeItem, LibraryStats, MusicDirectory, Playlist, ScanPhase,
+        ScanProgress, Song, SongSource,
     },
 };
 use anyhow::{Context, Result};
@@ -707,28 +707,50 @@ impl CollectionScanner {
         Ok(stats)
     }
 
+    /// Recently played, grouped by what the user actually played from —
+    /// an Album card if they were browsing an album, a Playlist card if
+    /// they played from a playlist, or a Song card for a standalone pick.
+    /// See `play_history` (migration 10) and `PlayContext`.
     pub fn get_recently_played(&self, limit: i64) -> Result<Vec<HomeItem>> {
         let conn = self.db.pool.get()?;
         let query_limit = limit * 20;
         let sql = format!(
-            "SELECT {HOME_ITEM_SELECT_COLS}
-             FROM songs s
+            "SELECT {HOME_ITEM_SELECT_COLS}, ph.context_type, ph.playlist_id
+             FROM play_history ph
+             JOIN songs s ON s.id = ph.song_id
              WHERE s.source IN (1, 2) AND s.unavailable = 0
-             ORDER BY s.lastplayed DESC NULLS LAST, s.mtime DESC
+             ORDER BY ph.played_at DESC
              LIMIT ?1"
         );
         let mut stmt = conn.prepare(&sql)?;
-        let songs_with_counts: Vec<(Song, i64)> = stmt
+        let rows: Vec<(Song, i64, String, Option<i64>)> = stmt
             .query_map(params![query_limit], |row| {
                 let song = row_to_song(row)?;
-                let count: i64 = row.get(55)?;
-                Ok((song, count))
+                let album_track_count: i64 = row.get(55)?;
+                let context_type: String = row.get(56)?;
+                let playlist_id: Option<i64> = row.get(57)?;
+                Ok((song, album_track_count, context_type, playlist_id))
             })?
             .filter_map(|r| r.ok())
             .collect();
-        Ok(group_songs_into_home_items(
-            songs_with_counts,
+
+        let playlist_ids: Vec<i64> = {
+            use std::collections::HashSet;
+            rows.iter()
+                .filter(|(_, _, context_type, playlist_id)| {
+                    context_type == "playlist" && playlist_id.is_some()
+                })
+                .filter_map(|(_, _, _, playlist_id)| *playlist_id)
+                .collect::<HashSet<_>>()
+                .into_iter()
+                .collect()
+        };
+        let playlists_by_id = get_playlists_by_ids(&conn, &playlist_ids)?;
+
+        Ok(group_by_play_context(
+            rows,
             limit as usize,
+            &playlists_by_id,
         ))
     }
 
@@ -826,6 +848,115 @@ fn group_songs_into_home_items(songs_with_counts: Vec<(Song, i64)>, limit: usize
     }
 
     items
+}
+
+/// Dedup key for context-aware Recently Played — one entry per album,
+/// playlist, or standalone song, keeping only the most recent occurrence.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+enum PlayContextKey {
+    Playlist(i64),
+    Album(String, String),
+    Song(i64),
+}
+
+fn group_by_play_context(
+    rows: Vec<(Song, i64, String, Option<i64>)>,
+    limit: usize,
+    playlists_by_id: &std::collections::HashMap<i64, Playlist>,
+) -> Vec<HomeItem> {
+    use std::collections::HashSet;
+    let mut items = Vec::new();
+    let mut seen = HashSet::new();
+
+    for (song, album_track_count, context_type, playlist_id) in rows {
+        if items.len() >= limit {
+            break;
+        }
+
+        let key = match context_type.as_str() {
+            "playlist" if playlist_id.is_some() => PlayContextKey::Playlist(playlist_id.unwrap()),
+            "album" if song.album.as_deref().is_some_and(|a| !a.trim().is_empty()) => {
+                let artist_name = song
+                    .album_artist
+                    .clone()
+                    .or_else(|| song.artist.clone())
+                    .unwrap_or_default();
+                PlayContextKey::Album(song.album.clone().unwrap(), artist_name)
+            }
+            _ => PlayContextKey::Song(song.id),
+        };
+
+        if seen.contains(&key) {
+            continue;
+        }
+        seen.insert(key.clone());
+
+        match key {
+            PlayContextKey::Playlist(id) => match playlists_by_id.get(&id) {
+                Some(playlist) => items.push(HomeItem::Playlist {
+                    playlist: playlist.clone(),
+                }),
+                None => items.push(HomeItem::Song {
+                    song: Box::new(song),
+                }),
+            },
+            PlayContextKey::Album(album_name, artist_name) => {
+                items.push(HomeItem::Album {
+                    album: AlbumItem {
+                        artist: Some(artist_name),
+                        album: Some(album_name),
+                        year: song.year,
+                        track_count: album_track_count as i32,
+                        art_embedded: song.art_embedded,
+                        art_automatic: song.art_automatic.clone(),
+                        art_manual: song.art_manual.clone(),
+                    },
+                });
+            }
+            PlayContextKey::Song(_) => {
+                items.push(HomeItem::Song {
+                    song: Box::new(song),
+                });
+            }
+        }
+    }
+
+    items
+}
+
+fn get_playlists_by_ids(
+    conn: &rusqlite::Connection,
+    ids: &[i64],
+) -> Result<std::collections::HashMap<i64, Playlist>> {
+    if ids.is_empty() {
+        return Ok(std::collections::HashMap::new());
+    }
+    let placeholders = ids.iter().map(|_| "?").collect::<Vec<_>>().join(",");
+    let sql = format!(
+        "SELECT p.id, p.name, p.dynamic_enabled, p.dynamic_spec, p.auto_play,
+                p.last_played_row, p.created, p.updated,
+                (SELECT COUNT(*) FROM playlist_items pi WHERE pi.playlist_id = p.id) as track_count
+         FROM playlists p WHERE p.id IN ({placeholders})"
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let map = stmt
+        .query_map(rusqlite::params_from_iter(ids.iter()), |row| {
+            let playlist = Playlist {
+                id: row.get(0)?,
+                name: row.get(1)?,
+                dynamic_enabled: row.get(2)?,
+                dynamic_spec: row.get(3)?,
+                auto_play: row.get::<_, Option<bool>>(4)?.unwrap_or(false),
+                last_played_row: row.get(5)?,
+                created: row.get(6)?,
+                updated: row.get::<_, Option<i64>>(7)?.unwrap_or(0),
+                track_count: row.get(8)?,
+            };
+            Ok((playlist.id, playlist))
+        })?
+        .filter_map(|r| r.ok())
+        .collect();
+    Ok(map)
 }
 
 // ---------------------------------------------------------------------------

--- a/src-tauri/src/commands/player.rs
+++ b/src-tauri/src/commands/player.rs
@@ -1,5 +1,5 @@
 use crate::{
-    models::{PlaybackState, PlaylistItem, RepeatMode, ShuffleMode},
+    models::{PlayContext, PlaybackState, PlaylistItem, RepeatMode, ShuffleMode},
     AppState,
 };
 use tauri::State;
@@ -20,7 +20,7 @@ pub async fn play_song(song_id: i64, state: State<'_, AppState>) -> Result<(), S
     let item = PlaylistItem::new_song(0, 0, song);
     let mut player = state.player.lock().await;
     player
-        .play_playlist(vec![item], 0, 0)
+        .play_playlist(vec![item], 0, 0, Some(PlayContext::Song))
         .await
         .map_err(|e| e.to_string())
 }
@@ -30,6 +30,7 @@ pub async fn play_songs(
     song_ids: Vec<i64>,
     start_index: usize,
     playlist_id: Option<i64>,
+    context: Option<PlayContext>,
     state: State<'_, AppState>,
 ) -> Result<(), String> {
     use rusqlite::params;
@@ -127,7 +128,7 @@ pub async fn play_songs(
 
     let mut player = state.player.lock().await;
     player
-        .play_playlist(items, start_index, pid)
+        .play_playlist(items, start_index, pid, context)
         .await
         .map_err(|e| e.to_string())
 }
@@ -146,7 +147,7 @@ pub async fn play_playlist_item(
     };
     let mut player = state.player.lock().await;
     player
-        .play_playlist(items, item_index, playlist_id)
+        .play_playlist(items, item_index, playlist_id, None)
         .await
         .map_err(|e| e.to_string())
 }
@@ -415,7 +416,7 @@ pub async fn open_and_play(paths: Vec<String>, state: State<'_, AppState>) -> Re
 
     let mut player = state.player.lock().await;
     player
-        .play_playlist(items, 0, 0)
+        .play_playlist(items, 0, 0, Some(PlayContext::Song))
         .await
         .map_err(|e| e.to_string())
 }

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 pub type DbPool = Pool<SqliteConnectionManager>;
 
 /// Current schema version. Increment when adding migrations.
-const CURRENT_SCHEMA_VERSION: i32 = 9;
+const CURRENT_SCHEMA_VERSION: i32 = 10;
 
 #[derive(Debug)]
 pub struct Database {
@@ -142,6 +142,15 @@ impl Database {
             conn.execute(
                 "INSERT OR REPLACE INTO schema_version (version) VALUES (?1)",
                 params![9],
+            )?;
+        }
+
+        if version < 10 {
+            log::info!("Running migration 10: play_history for context-aware Recently Played");
+            conn.execute_batch(MIGRATION_10)?;
+            conn.execute(
+                "INSERT OR REPLACE INTO schema_version (version) VALUES (?1)",
+                params![10],
             )?;
         }
 
@@ -409,6 +418,21 @@ ALTER TABLE songs ADD COLUMN is_instrumental BOOLEAN NOT NULL DEFAULT 0;
 const MIGRATION_9: &str = "
 ALTER TABLE playlists ADD COLUMN auto_play BOOLEAN NOT NULL DEFAULT 1;
 UPDATE playlists SET auto_play = 1 WHERE dynamic_enabled = 1;
+";
+
+// ---------------------------------------------------------------------------
+// Migration 10: play_history for context-aware Recently Played
+// ---------------------------------------------------------------------------
+
+const MIGRATION_10: &str = "
+CREATE TABLE IF NOT EXISTS play_history (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    context_type TEXT NOT NULL,
+    song_id INTEGER NOT NULL REFERENCES songs(id) ON DELETE CASCADE,
+    playlist_id INTEGER REFERENCES playlists(id) ON DELETE CASCADE,
+    played_at INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_play_history_played_at ON play_history(played_at DESC);
 ";
 
 #[cfg(test)]

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -315,6 +315,22 @@ impl PlaylistItem {
     }
 }
 
+/// Where a play was initiated from, recorded alongside each scrobble so
+/// "Recently Played" can reflect what the user actually clicked into
+/// (an album, a playlist, or an individual song) rather than a heuristic.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "camelCase")]
+pub enum PlayContext {
+    Song,
+    Album {
+        album: String,
+        album_artist: Option<String>,
+    },
+    Playlist {
+        playlist_id: i64,
+    },
+}
+
 /// A named playlist.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Playlist {
@@ -521,10 +537,11 @@ pub struct AlbumItem {
     pub art_manual: Option<String>,
 }
 
-/// Represents a dynamic item in the Home curation carousels (either a Song or an Album).
+/// Represents a dynamic item in the Home curation carousels (a Song, an Album, or a Playlist).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "camelCase")]
 pub enum HomeItem {
     Song { song: Box<Song> },
     Album { album: AlbumItem },
+    Playlist { playlist: Playlist },
 }

--- a/src-tauri/src/player.rs
+++ b/src-tauri/src/player.rs
@@ -6,7 +6,9 @@
 use crate::{
     audio::AudioEngine,
     db::Database,
-    models::{LoudnessGainSource, PlaybackState, PlaylistItem, RepeatMode, ShuffleMode, Song},
+    models::{
+        LoudnessGainSource, PlayContext, PlaybackState, PlaylistItem, RepeatMode, ShuffleMode, Song,
+    },
     stats,
 };
 use anyhow::{anyhow, Result};
@@ -39,6 +41,10 @@ pub struct Player {
     pub current_song: Option<Song>,
     pub current_playlist_id: Option<i64>,
     pub current_item_uuid: Option<String>,
+    /// What the user was inside (album/playlist/standalone) when this
+    /// playback queue was started — recorded at the scrobble point for
+    /// context-aware "Recently Played".
+    current_play_context: Option<PlayContext>,
 
     // Playback mode
     pub shuffle_mode: ShuffleMode,
@@ -264,6 +270,7 @@ impl Player {
             current_song: restored_song.clone(),
             current_playlist_id: restored_playlist_id,
             current_item_uuid: restored_item_uuid,
+            current_play_context: None,
             shuffle_mode,
             repeat_mode,
             stop_after_current: false,
@@ -296,9 +303,12 @@ impl Player {
         items: Vec<PlaylistItem>,
         start_index: usize,
         playlist_id: i64,
+        context: Option<PlayContext>,
     ) -> Result<()> {
         self.playlist_items = items;
         self.current_playlist_id = Some(playlist_id);
+        self.current_play_context =
+            context.or_else(|| (playlist_id > 0).then_some(PlayContext::Playlist { playlist_id }));
         self.played_indices.clear();
         self.queue.clear();
         self.scrobbled = false;
@@ -1043,7 +1053,16 @@ impl Player {
         let song_id = self.current_song.as_ref()?.id;
         match self._db.pool.get() {
             Ok(conn) => match stats::record_play(&conn, song_id) {
-                Ok(()) => Some(stats::stats_payload(&conn, song_id)),
+                Ok(()) => {
+                    let context = self
+                        .current_play_context
+                        .clone()
+                        .unwrap_or(PlayContext::Song);
+                    if let Err(e) = stats::record_play_context(&conn, &context, song_id) {
+                        log::warn!("Failed to record play context for song {song_id}: {e}");
+                    }
+                    Some(stats::stats_payload(&conn, song_id))
+                }
                 Err(e) => {
                     log::warn!("Failed to record play for song {song_id}: {e}");
                     None
@@ -1190,7 +1209,7 @@ mod tests {
 
         // Simulate an ad-hoc selection (album/artist/search — playlist_id 0)
         // starting on the middle track, then "quitting" mid-playback.
-        player.play_playlist(items, 1, 0).await.unwrap();
+        player.play_playlist(items, 1, 0, None).await.unwrap();
         assert_eq!(player.current_song.as_ref().unwrap().id, 2);
 
         // Reopening the app re-runs Player::new against the same DB.

--- a/src-tauri/src/stats.rs
+++ b/src-tauri/src/stats.rs
@@ -1,6 +1,7 @@
 //! Play statistics & ratings — write paths for playcount, skipcount,
 //! lastplayed, and the user rating stored on `songs`.
 
+use crate::models::PlayContext;
 use anyhow::Result;
 use rusqlite::{params, Connection};
 
@@ -15,6 +16,23 @@ pub fn record_play(conn: &Connection, song_id: i64) -> Result<()> {
              lastplayed = strftime('%s', 'now')
          WHERE id = ?1",
         params![song_id],
+    )?;
+    Ok(())
+}
+
+/// Record what the user was inside (album/playlist/standalone song) when a
+/// listen completed, so "Recently Played" can reflect that context instead
+/// of a post-hoc heuristic.
+pub fn record_play_context(conn: &Connection, context: &PlayContext, song_id: i64) -> Result<()> {
+    let (context_type, playlist_id) = match context {
+        PlayContext::Song => ("song", None),
+        PlayContext::Album { .. } => ("album", None),
+        PlayContext::Playlist { playlist_id } => ("playlist", Some(*playlist_id)),
+    };
+    conn.execute(
+        "INSERT INTO play_history (context_type, song_id, playlist_id, played_at)
+         VALUES (?1, ?2, ?3, strftime('%s','now'))",
+        params![context_type, song_id, playlist_id],
     )?;
     Ok(())
 }
@@ -122,6 +140,52 @@ mod tests {
         assert_eq!(playcount, 2);
         assert_eq!(skipcount, 0);
         assert!(lastplayed.is_some());
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn test_record_play_context_persists_by_type() {
+        let (db, dir) = test_db();
+        let conn = db.pool.get().unwrap();
+        let id = insert_song(&conn, "/tmp/context.flac");
+        conn.execute(
+            "INSERT INTO playlists (name) VALUES ('Test Playlist')",
+            params![],
+        )
+        .unwrap();
+        let playlist_id = conn.last_insert_rowid();
+
+        record_play_context(&conn, &PlayContext::Song, id).unwrap();
+        record_play_context(
+            &conn,
+            &PlayContext::Album {
+                album: "Test Album".into(),
+                album_artist: Some("Test Artist".into()),
+            },
+            id,
+        )
+        .unwrap();
+        record_play_context(&conn, &PlayContext::Playlist { playlist_id }, id).unwrap();
+
+        let rows: Vec<(String, Option<i64>)> = conn
+            .prepare(
+                "SELECT context_type, playlist_id FROM play_history WHERE song_id = ?1 ORDER BY id",
+            )
+            .unwrap()
+            .query_map(params![id], |row| Ok((row.get(0)?, row.get(1)?)))
+            .unwrap()
+            .map(|r| r.unwrap())
+            .collect();
+
+        assert_eq!(
+            rows,
+            vec![
+                ("song".to_string(), None),
+                ("album".to_string(), None),
+                ("playlist".to_string(), Some(playlist_id)),
+            ]
+        );
 
         let _ = std::fs::remove_dir_all(dir);
     }

--- a/src/lib/components/AlbumCard.svelte
+++ b/src/lib/components/AlbumCard.svelte
@@ -40,7 +40,11 @@
       songs = songs.filter(song => !collectionStore.isFormatExcluded(song.filetype));
       if (songs.length > 0) {
         const songIds = songs.map((s) => s.id);
-        playerStore.playSongs(songIds, 0);
+        playerStore.playSongs(songIds, 0, undefined, {
+          type: "album",
+          album: album.album || "",
+          albumArtist: album.artist ?? undefined,
+        });
       }
     } catch (err) {
       console.error("Failed to play album:", err);

--- a/src/lib/components/AlbumDetailView.svelte
+++ b/src/lib/components/AlbumDetailView.svelte
@@ -10,7 +10,7 @@
   import TagEditor from "./TagEditor.svelte";
   import SongContextMenu from "./SongContextMenu.svelte";
   import { Play, Shuffle, Plus, Edit3, Clock, Music } from "lucide-svelte";
-  import type { Song, AlbumItem } from "../types";
+  import type { Song, AlbumItem, PlayContext } from "../types";
   import { i18n } from "../stores/i18n.svelte";
 
   let { albumName }: { albumName: string } = $props();
@@ -96,11 +96,15 @@
     }
   }
 
+  function albumPlayContext(): PlayContext {
+    return { type: "album", album: albumName, albumArtist: artistName || undefined };
+  }
+
   function handlePlaySelected() {
     if (selectedSongIds.size === 0) return;
     const selectedList = songs.filter((s) => selectedSongIds.has(s.id));
     if (selectedList.length > 0) {
-      playerStore.playSongs(selectedList.map((s) => s.id), 0);
+      playerStore.playSongs(selectedList.map((s) => s.id), 0, undefined, albumPlayContext());
     }
   }
 
@@ -232,13 +236,13 @@
   function handlePlaySong(song: Song) {
     const index = songs.findIndex((s) => s.id === song.id);
     const songIds = songs.map((s) => s.id);
-    playerStore.playSongs(songIds, index >= 0 ? index : 0);
+    playerStore.playSongs(songIds, index >= 0 ? index : 0, undefined, albumPlayContext());
   }
 
   async function handlePlayAll() {
     if (songs.length === 0) return;
     await playerStore.setShuffleMode("off");
-    await playerStore.playSongs(songs.map((s) => s.id), 0);
+    await playerStore.playSongs(songs.map((s) => s.id), 0, undefined, albumPlayContext());
   }
 
   async function handleShufflePlay() {
@@ -246,7 +250,7 @@
     const ids = songs.map((s) => s.id);
     const randomIndex = Math.floor(Math.random() * ids.length);
     await playerStore.setShuffleMode("all");
-    await playerStore.playSongs(ids, randomIndex);
+    await playerStore.playSongs(ids, randomIndex, undefined, albumPlayContext());
   }
 
   async function handleAddSongToPlaylist(songId: number) {

--- a/src/lib/components/ArtistDetailView.svelte
+++ b/src/lib/components/ArtistDetailView.svelte
@@ -10,7 +10,7 @@
   import AlbumContextMenu from "./AlbumContextMenu.svelte";
   import HorizontalScrollRow from "./HorizontalScrollRow.svelte";
   import { Play, Shuffle } from "lucide-svelte";
-  import type { Song, Playlist, AlbumItem } from "../types";
+  import type { Song, Playlist, AlbumItem, PlayContext } from "../types";
   import { getArtistAlbums } from "../utils/artist";
   import { i18n } from "../stores/i18n.svelte";
 
@@ -285,7 +285,8 @@
       let songs = await invoke<Song[]>("get_songs_by_album", { album: album.album || "" });
       songs = songs.filter(s => !collectionStore.isFormatExcluded(s.filetype));
       if (songs.length > 0) {
-        playerStore.playSongs(songs.map(s => s.id), 0);
+        const context: PlayContext = { type: "album", album: album.album || "", albumArtist: album.artist || undefined };
+        playerStore.playSongs(songs.map(s => s.id), 0, undefined, context);
       }
     }}
     onAddToPlaylist={async () => {

--- a/src/lib/components/CarouselCard.svelte
+++ b/src/lib/components/CarouselCard.svelte
@@ -1,12 +1,33 @@
 <script lang="ts">
   import type { HomeItem } from "../types";
   import { playerStore } from "../stores/player.svelte";
+  import { playlistsStore } from "../stores/playlists.svelte";
+  import { collectionStore } from "../stores/collection.svelte";
   import CoverArt from "./CoverArt.svelte";
   import AlbumCard from "./AlbumCard.svelte";
+  import PlaylistCard from "./PlaylistCard.svelte";
   import { Play } from "lucide-svelte";
   import { i18n } from "../stores/i18n.svelte";
 
   let { item }: { item: HomeItem } = $props();
+
+  // Mirrors ArtistDetailView's openPlaylist: genre/decade auto-playlists open
+  // in AutoPlaylistDetailView, custom playlists open in the regular PlaylistView.
+  function openPlaylist() {
+    if (item.type !== "playlist") return;
+    const playlist = item.playlist;
+    if (playlist.dynamic_enabled) {
+      const isDecade = playlist.dynamic_spec?.startsWith("decade:") ?? false;
+      collectionStore.viewAutoPlaylist(
+        isDecade
+          ? { kind: "decade", decade: playlist.dynamic_spec?.replace(/^decade:/, "") ?? playlist.name, playlistId: playlist.id, updated: playlist.updated }
+          : { kind: "genre", genre: playlist.dynamic_spec?.replace(/^genre:/, "") ?? playlist.name, playlistId: playlist.id, updated: playlist.updated }
+      );
+      return;
+    }
+    playlistsStore.selectPlaylist(playlist.id);
+    collectionStore.viewPlaylist(playlist.id);
+  }
 
   function formatDuration(ns: number | undefined): string {
     if (!ns) return "0:00";
@@ -26,6 +47,8 @@
 
 {#if item.type === "album"}
   <AlbumCard album={item.album} widthClass="w-48 shrink-0" />
+{:else if item.type === "playlist"}
+  <PlaylistCard playlist={item.playlist} widthClass="w-48 shrink-0" onClick={openPlaylist} />
 {:else}
   <!-- svelte-ignore a11y_click_events_have_key_events -->
   <!-- svelte-ignore a11y_no_static_element_interactions -->

--- a/src/lib/components/CurationCarousel.svelte
+++ b/src/lib/components/CurationCarousel.svelte
@@ -9,10 +9,16 @@
   }
 
   let { title, items }: Props = $props();
+
+  function keyFor(item: HomeItem): string {
+    if (item.type === "song") return "s_" + item.song.id;
+    if (item.type === "playlist") return "p_" + item.playlist.id;
+    return "a_" + (item.album.album || "") + "_" + (item.album.artist || "");
+  }
 </script>
 
 <HorizontalScrollRow {title}>
-  {#each items as item (item.type === 'song' ? 's_' + item.song.id : 'a_' + (item.album.album || '') + '_' + (item.album.artist || ''))}
+  {#each items as item (keyFor(item))}
     <CarouselCard {item} />
   {/each}
 </HorizontalScrollRow>

--- a/src/lib/stores/player.svelte.ts
+++ b/src/lib/stores/player.svelte.ts
@@ -1,6 +1,6 @@
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
-import type { PlaybackState, Playlist, Song, ShuffleMode, RepeatMode, PlayState, LoudnessGainSource } from "../types";
+import type { PlaybackState, Playlist, Song, ShuffleMode, RepeatMode, PlayState, LoudnessGainSource, PlayContext } from "../types";
 import { applySongStats, type SongStatsPayload } from "../utils/stats";
 import { themeStore } from "./theme.svelte";
 
@@ -153,8 +153,8 @@ export class PlayerStore {
     await invoke("open_and_play", { paths });
   }
 
-  async playSongs(songIds: number[], startIndex: number, playlistId?: number) {
-    await invoke("play_songs", { songIds, startIndex, playlistId: playlistId ?? null });
+  async playSongs(songIds: number[], startIndex: number, playlistId?: number, context?: PlayContext) {
+    await invoke("play_songs", { songIds, startIndex, playlistId: playlistId ?? null, context: context ?? null });
   }
 
   async playPlaylistItem(playlistId: number, itemIndex: number) {

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -261,4 +261,12 @@ export function getCoverArtUrl(uri: string | null | undefined): string | null {
 
 export type HomeItem =
   | { type: "song"; song: Song }
-  | { type: "album"; album: AlbumItem };
+  | { type: "album"; album: AlbumItem }
+  | { type: "playlist"; playlist: Playlist };
+
+// What the user was inside when a play started — lets "Recently Played"
+// show an Album/Playlist card instead of always collapsing to a Song.
+export type PlayContext =
+  | { type: "song" }
+  | { type: "album"; album: string; albumArtist?: string }
+  | { type: "playlist"; playlistId: number };


### PR DESCRIPTION
## 📋 Summary
"Recently Played" and "Most Frequently Played" previously derived entirely from `songs.lastplayed`/`playcount`, with a post-hoc heuristic that grouped same-album songs into an Album card based on library composition — not on what the user actually clicked. There was also no Playlist support in the Home carousels at all. This adds a `play_history` table that records what the user was inside (an Album, a Playlist, or a standalone song) at the moment each play scrobbles, and rewrites both carousels to group by that recorded context instead of guessing.

## 🔍 Implementation Notes
- New `play_history` table (migration 10, `src-tauri/src/db.rs`) logs `context_type`/`song_id`/`playlist_id`/`played_at` per scrobble.
- `PlayContext` enum (`src-tauri/src/models.rs`) threads through `Player::play_playlist` (`src-tauri/src/player.rs`) and the `play_songs` command (`src-tauri/src/commands/player.rs`). Playlist context is inferred automatically from the existing `playlist_id` argument — no frontend change needed for playlist-driven plays. Album context is threaded explicitly from the handful of frontend call sites that know they're inside an album view (`AlbumCard.svelte`, `AlbumDetailView.svelte`, one spot in `ArtistDetailView.svelte`).
- `get_recently_played` and `get_most_frequently_played` (`src-tauri/src/collection.rs`) now query `play_history` and dedupe by context — recency-ordered for the former, count-ordered for the latter — sharing a new `home_item_for_context` helper. `HomeItem` gained a `Playlist` variant; `CarouselCard.svelte`/`CurationCarousel.svelte` render it by reusing `PlaylistCard.svelte`.
- `get_recently_added` is intentionally left on its original heuristic — it's driven by library scan time (`songs.added`), which has no play context to key off (confirmed with the user this should stay as-is).
- While rewiring the SQL, found and fixed a pre-existing off-by-one bug: `HOME_ITEM_SELECT_COLS`'s `album_track_count` subquery is column **56**, not 55 (55 is `is_instrumental`). Reading it as `i64` silently returned `is_instrumental`'s 0/1 value instead of erroring, so the old ">1 tracks" album-grouping heuristic never actually fired on any Home carousel — likely the real root cause of the original "shows songs instead of albums" report. This also fixes `get_recently_added`'s grouping as a side effect.
- Known minor gap, intentionally out of scope here and flagged separately: "play selected" bulk-selection handlers in `PlaylistView.svelte`/`AutoPlaylistDetailView.svelte` don't pass `playlistId` through, so a playlist-selection play falls back to Song context.

## 🧪 Test Plan
- [x] `bun run check` (svelte-check) — 0 errors
- [x] `bun run test -- --run` (frontend) — 219 passed
- [x] `cargo test` (src-tauri) — 50 passed (includes a new `get_recently_played`/`get_most_frequently_played` context-grouping test and a `record_play_context` unit test)
- [x] Manually verified in the app — played from inside an album, from a playlist, and standalone; confirmed Recently Played and Most Frequently Played show the right card type and dedupe correctly; playlist card navigation confirmed working.

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed — not needed; this changes carousel *content* (live play history) not static layout, so the existing screenshots aren't stale.