### PR TITLE
UI polish: margins, volume tooltip, table ellipsis, album categories

### DIFF
--- a/scripts/mock-data.ts
+++ b/scripts/mock-data.ts
@@ -200,6 +200,7 @@ export const FALLBACK_PLAYLISTS: Playlist[] = [
   { id: 2, name: "Heavy Riffs", dynamic_enabled: false, created: 1782810000000, updated: 1782810000000, track_count: 2 },
   { id: 3, name: "Acoustic Morning", dynamic_enabled: false, created: 1782820000000, updated: 1782820000000, track_count: 6 },
   { id: 4, name: "Indie Rock", dynamic_enabled: true, dynamic_spec: "Indie Rock", created: 1782830000000, updated: 1782830000000, track_count: 8 },
+  { id: 5, name: "Queue", dynamic_enabled: false, created: 1782840000000, updated: 1782840000000, track_count: 4 },
 ];
 
 export const FEATURED_YOU_WRECK_ME_LYRICS = `[00:00.00] Tom Petty - You Wreck Me

--- a/scripts/mock-library.ts
+++ b/scripts/mock-library.ts
@@ -172,6 +172,7 @@ export function deriveAlbums(songs: Song[]): AlbumItem[] {
     const existing = byKey.get(key);
     if (existing) {
       existing.track_count += 1;
+      existing.disc_count = Math.max(existing.disc_count, song.disc ?? 1);
       existing.year = existing.year ?? song.year ?? null;
       existing.art_embedded = existing.art_embedded || song.art_embedded;
       existing.art_automatic = existing.art_automatic ?? song.art_automatic ?? null;
@@ -182,6 +183,7 @@ export function deriveAlbums(songs: Song[]): AlbumItem[] {
         artist,
         year: song.year ?? null,
         track_count: 1,
+        disc_count: song.disc ?? 1,
         art_embedded: song.art_embedded,
         art_automatic: song.art_automatic ?? null,
         art_manual: song.art_manual ?? null,

--- a/scripts/tauri-ipc-mock.ts
+++ b/scripts/tauri-ipc-mock.ts
@@ -282,9 +282,10 @@ function getIpcCallback(id: number | undefined): IpcCallback | undefined {
       const albumName = song.album?.trim();
       if (albumName) {
         const artistName = song.album_artist || song.artist || "";
-        const albumTrackCount = library.songs.filter(
+        const albumSongs = library.songs.filter(
           (s) => s.album === song.album && (s.album_artist || s.artist || "") === artistName
-        ).length;
+        );
+        const albumTrackCount = albumSongs.length;
 
         if (albumTrackCount > 1) {
           const albumKey = `${song.album}::${artistName}`;
@@ -297,6 +298,7 @@ function getIpcCallback(id: number | undefined): IpcCallback | undefined {
                 album: song.album,
                 year: song.year ?? null,
                 track_count: albumTrackCount,
+                disc_count: Math.max(1, ...albumSongs.map((s) => s.disc ?? 1)),
                 art_embedded: song.art_embedded,
                 art_automatic: song.art_automatic ?? null,
                 art_manual: song.art_manual ?? null,

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2947,7 +2947,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "luminous"
-version = "0.75.0"
+version = "0.90.0"
 dependencies = [
  "anyhow",
  "bs1770",

--- a/src-tauri/src/collection.rs
+++ b/src-tauri/src/collection.rs
@@ -643,6 +643,7 @@ impl CollectionScanner {
                 album,
                 MIN(year) AS year,
                 COUNT(*) AS track_count,
+                MAX(COALESCE(disc, 1)) AS disc_count,
                 MAX(CAST(art_embedded AS INTEGER)) AS art_embedded,
                 MAX(art_automatic) AS art_automatic,
                 MAX(art_manual) AS art_manual
@@ -658,9 +659,10 @@ impl CollectionScanner {
                     "album": row.get::<_, Option<String>>(1)?,
                     "year": row.get::<_, Option<i32>>(2)?,
                     "track_count": row.get::<_, i32>(3)?,
-                    "art_embedded": row.get::<_, bool>(4)?,
-                    "art_automatic": row.get::<_, Option<String>>(5)?,
-                    "art_manual": row.get::<_, Option<String>>(6)?,
+                    "disc_count": row.get::<_, i32>(4)?,
+                    "art_embedded": row.get::<_, bool>(5)?,
+                    "art_automatic": row.get::<_, Option<String>>(6)?,
+                    "art_manual": row.get::<_, Option<String>>(7)?,
                 }))
             })?
             .filter_map(|r| r.ok())
@@ -750,13 +752,14 @@ impl CollectionScanner {
              LIMIT ?1"
         );
         let mut stmt = conn.prepare(&sql)?;
-        let rows: Vec<(Song, i64, String, Option<i64>)> = stmt
+        let rows: Vec<(Song, i64, i64, String, Option<i64>)> = stmt
             .query_map(params![query_limit], |row| {
                 let song = row_to_song(row)?;
                 let album_track_count: i64 = row.get(56)?;
-                let context_type: String = row.get(57)?;
-                let playlist_id: Option<i64> = row.get(58)?;
-                Ok((song, album_track_count, context_type, playlist_id))
+                let album_disc_count: i64 = row.get(57)?;
+                let context_type: String = row.get(58)?;
+                let playlist_id: Option<i64> = row.get(59)?;
+                Ok((song, album_track_count, album_disc_count, context_type, playlist_id))
             })?
             .filter_map(|r| r.ok())
             .collect();
@@ -764,10 +767,10 @@ impl CollectionScanner {
         let playlist_ids: Vec<i64> = {
             use std::collections::HashSet;
             rows.iter()
-                .filter(|(_, _, context_type, playlist_id)| {
+                .filter(|(_, _, _, context_type, playlist_id)| {
                     context_type == "playlist" && playlist_id.is_some()
                 })
-                .filter_map(|(_, _, _, playlist_id)| *playlist_id)
+                .filter_map(|(_, _, _, _, playlist_id)| *playlist_id)
                 .collect::<HashSet<_>>()
                 .into_iter()
                 .collect()
@@ -840,13 +843,14 @@ impl CollectionScanner {
         let items = agg_rows
             .into_iter()
             .filter_map(|row| {
-                let (song, album_track_count) =
+                let (song, album_track_count, album_disc_count) =
                     songs_by_id.get(&row.representative_song_id)?.clone();
                 Some(home_item_for_context(
                     &row.context_type,
                     row.playlist_id,
                     song,
                     album_track_count,
+                    album_disc_count,
                     &playlists_by_id,
                 ))
             })
@@ -865,11 +869,12 @@ impl CollectionScanner {
              LIMIT ?1"
         );
         let mut stmt = conn.prepare(&sql)?;
-        let songs_with_counts: Vec<(Song, i64)> = stmt
+        let songs_with_counts: Vec<(Song, i64, i64)> = stmt
             .query_map(params![query_limit], |row| {
                 let song = row_to_song(row)?;
                 let count: i64 = row.get(56)?;
-                Ok((song, count))
+                let disc_count: i64 = row.get(57)?;
+                Ok((song, count, disc_count))
             })?
             .filter_map(|r| r.ok())
             .collect();
@@ -880,12 +885,12 @@ impl CollectionScanner {
     }
 }
 
-fn group_songs_into_home_items(songs_with_counts: Vec<(Song, i64)>, limit: usize) -> Vec<HomeItem> {
+fn group_songs_into_home_items(songs_with_counts: Vec<(Song, i64, i64)>, limit: usize) -> Vec<HomeItem> {
     use std::collections::HashSet;
     let mut items = Vec::new();
     let mut seen_albums = HashSet::new();
 
-    for (song, album_track_count) in songs_with_counts {
+    for (song, album_track_count, album_disc_count) in songs_with_counts {
         if items.len() >= limit {
             break;
         }
@@ -907,6 +912,7 @@ fn group_songs_into_home_items(songs_with_counts: Vec<(Song, i64)>, limit: usize
                             album: Some(album_name.clone()),
                             year: song.year,
                             track_count: album_track_count as i32,
+                            disc_count: album_disc_count as i32,
                             art_embedded: song.art_embedded,
                             art_automatic: song.art_automatic.clone(),
                             art_manual: song.art_manual.clone(),
@@ -935,7 +941,7 @@ enum PlayContextKey {
 }
 
 fn group_by_play_context(
-    rows: Vec<(Song, i64, String, Option<i64>)>,
+    rows: Vec<(Song, i64, i64, String, Option<i64>)>,
     limit: usize,
     playlists_by_id: &std::collections::HashMap<i64, Playlist>,
 ) -> Vec<HomeItem> {
@@ -943,7 +949,7 @@ fn group_by_play_context(
     let mut items = Vec::new();
     let mut seen = HashSet::new();
 
-    for (song, album_track_count, context_type, playlist_id) in rows {
+    for (song, album_track_count, album_disc_count, context_type, playlist_id) in rows {
         if items.len() >= limit {
             break;
         }
@@ -971,6 +977,7 @@ fn group_by_play_context(
             playlist_id,
             song,
             album_track_count,
+            album_disc_count,
             playlists_by_id,
         ));
     }
@@ -986,6 +993,7 @@ fn home_item_for_context(
     playlist_id: Option<i64>,
     song: Song,
     album_track_count: i64,
+    album_disc_count: i64,
     playlists_by_id: &std::collections::HashMap<i64, Playlist>,
 ) -> HomeItem {
     match context_type {
@@ -1009,6 +1017,7 @@ fn home_item_for_context(
                     album: song.album.clone(),
                     year: song.year,
                     track_count: album_track_count as i32,
+                    disc_count: album_disc_count as i32,
                     art_embedded: song.art_embedded,
                     art_automatic: song.art_automatic.clone(),
                     art_manual: song.art_manual.clone(),
@@ -1059,7 +1068,7 @@ fn get_playlists_by_ids(
 fn get_songs_by_ids(
     conn: &rusqlite::Connection,
     ids: &[i64],
-) -> Result<std::collections::HashMap<i64, (Song, i64)>> {
+) -> Result<std::collections::HashMap<i64, (Song, i64, i64)>> {
     if ids.is_empty() {
         return Ok(std::collections::HashMap::new());
     }
@@ -1070,7 +1079,8 @@ fn get_songs_by_ids(
         .query_map(rusqlite::params_from_iter(ids.iter()), |row| {
             let song = row_to_song(row)?;
             let album_track_count: i64 = row.get(56)?;
-            Ok((song.id, (song, album_track_count)))
+            let album_disc_count: i64 = row.get(57)?;
+            Ok((song.id, (song, album_track_count, album_disc_count)))
         })?
         .filter_map(|r| r.ok())
         .collect();
@@ -1339,8 +1349,8 @@ pub(crate) const SONG_SELECT_COLS: &str = "
     is_vbr, is_instrumental
 ";
 
-/// Song columns qualified with the `s` alias, plus a correlated `album_track_count`
-/// subquery. Shared by the home-screen queries (`get_recently_played`,
+/// Song columns qualified with the `s` alias, plus correlated `album_track_count`
+/// and `album_disc_count` subqueries. Shared by the home-screen queries (`get_recently_played`,
 /// `get_most_frequently_played`, `get_recently_added`), which all join on `songs s`.
 const HOME_ITEM_SELECT_COLS: &str = "s.id, s.source, s.filetype, s.path, s.url, s.stream_url,
     s.title, s.titlesort, s.artist, s.artistsort,
@@ -1359,7 +1369,10 @@ const HOME_ITEM_SELECT_COLS: &str = "s.id, s.source, s.filetype, s.path, s.url, 
     s.is_vbr, s.is_instrumental,
     (SELECT COUNT(*) FROM songs s2
      WHERE s2.source IN (1, 2) AND s2.unavailable = 0 AND s2.album = s.album AND COALESCE(s2.album_artist, s2.artist) = COALESCE(s.album_artist, s.artist)
-    ) AS album_track_count";
+    ) AS album_track_count,
+    (SELECT COALESCE(MAX(COALESCE(s2.disc, 1)), 1) FROM songs s2
+     WHERE s2.source IN (1, 2) AND s2.unavailable = 0 AND s2.album = s.album AND COALESCE(s2.album_artist, s2.artist) = COALESCE(s.album_artist, s.artist)
+    ) AS album_disc_count";
 
 const SONG_INSERT_COLS: &str = "
     source, filetype, path, title, artist, album, album_artist,

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -532,6 +532,7 @@ pub struct AlbumItem {
     pub album: Option<String>,
     pub year: Option<i32>,
     pub track_count: i32,
+    pub disc_count: i32,
     pub art_embedded: bool,
     pub art_automatic: Option<String>,
     pub art_manual: Option<String>,

--- a/src-tauri/src/player.rs
+++ b/src-tauri/src/player.rs
@@ -691,9 +691,18 @@ impl Player {
     }
 
     pub async fn previous_track(&mut self) -> Result<()> {
-        // In shuffle mode, walk back through history (skip unavailable)
+        // In shuffle mode, walk back through history (skip unavailable).
+        // `play_at_index` pushes every track it plays onto `played_indices`,
+        // including the current one — so the entry on top of the stack right
+        // now is the current track's own history entry, not the prior track.
+        // Discard it (and any other stale entries matching current_index)
+        // before treating a popped entry as the destination, or Previous
+        // just replays the current song instead of moving back (#105).
         if self.shuffle_mode != ShuffleMode::Off {
             while let Some(prev_index) = self.played_indices.pop() {
+                if Some(prev_index) == self.current_index {
+                    continue;
+                }
                 let item_index = self
                     .shuffle_order
                     .get(prev_index)
@@ -1326,6 +1335,75 @@ mod tests {
             "previous should move to the prior playlist track, not replay the current one"
         );
         assert_eq!(player.current_index, Some(1));
+
+        let _ = std::fs::remove_dir_all(temp_dir);
+    }
+
+    /// Root-caused #105's "Previous restarts the current song instead of
+    /// moving to the prior one" report: it only reproduces with Shuffle on.
+    /// `play_at_index` pushes every played (virtual) index onto
+    /// `played_indices`, including the current track's own entry, so the
+    /// naive top-of-stack pop in `previous_track` just replayed it.
+    #[tokio::test]
+    async fn test_previous_track_in_shuffle_mode_does_not_replay_current() {
+        let (db, temp_dir) = setup_test_db();
+        let db_arc = Arc::new(db);
+
+        {
+            let conn = db_arc.pool.get().unwrap();
+            for id in 1..=4i64 {
+                conn.execute(
+                    &format!(
+                        "INSERT INTO songs (id, path, title, artist, album, length_nanosec) VALUES ({id}, '/fake/path{id}.mp3', 'Track {id}', 'Artist', 'Album', 180000000000)"
+                    ),
+                    [],
+                )
+                .unwrap();
+            }
+        }
+
+        let audio = Arc::new(Mutex::new(AudioEngine::new()));
+        let mut player = Player::new(db_arc.clone(), audio.clone());
+
+        let items = (1..=4i64)
+            .map(|id| {
+                let conn = db_arc.pool.get().unwrap();
+                let sql = format!(
+                    "SELECT {} FROM songs WHERE id = ?1",
+                    crate::collection::SONG_SELECT_COLS
+                );
+                let song = conn
+                    .query_row(&sql, rusqlite::params![id], crate::collection::row_to_song)
+                    .unwrap();
+                PlaylistItem::new_song(0, 0, song)
+            })
+            .collect::<Vec<_>>();
+
+        player.set_shuffle_mode(ShuffleMode::All);
+        player.play_playlist(items, 0, 0, None).await.unwrap();
+        let first_song_id = player.current_song.as_ref().unwrap().id;
+
+        // Advance forward twice so there's real history to walk back through.
+        player.next_track().await.unwrap();
+        let second_song_id = player.current_song.as_ref().unwrap().id;
+        player.next_track().await.unwrap();
+        let third_song_id = player.current_song.as_ref().unwrap().id;
+        assert_ne!(second_song_id, first_song_id);
+        assert_ne!(third_song_id, second_song_id);
+
+        player.previous_track().await.unwrap();
+        assert_eq!(
+            player.current_song.as_ref().unwrap().id,
+            second_song_id,
+            "previous should move to the prior shuffled track, not replay the current one"
+        );
+
+        player.previous_track().await.unwrap();
+        assert_eq!(
+            player.current_song.as_ref().unwrap().id,
+            first_song_id,
+            "a second previous press should keep walking back, not stay put"
+        );
 
         let _ = std::fs::remove_dir_all(temp_dir);
     }

--- a/src-tauri/src/player.rs
+++ b/src-tauri/src/player.rs
@@ -1220,4 +1220,59 @@ mod tests {
 
         let _ = std::fs::remove_dir_all(temp_dir);
     }
+
+    #[tokio::test]
+    async fn test_previous_track_walks_back_through_playlist() {
+        let (db, temp_dir) = setup_test_db();
+        let db_arc = Arc::new(db);
+
+        {
+            let conn = db_arc.pool.get().unwrap();
+            for id in 1..=3i64 {
+                conn.execute(
+                    &format!(
+                        "INSERT INTO songs (id, path, title, artist, album, length_nanosec) VALUES ({id}, '/fake/path{id}.mp3', 'Track {id}', 'Artist', 'Album', 180000000000)"
+                    ),
+                    [],
+                )
+                .unwrap();
+            }
+        }
+
+        let audio = Arc::new(Mutex::new(AudioEngine::new()));
+        let mut player = Player::new(db_arc.clone(), audio.clone());
+
+        let items = (1..=3i64)
+            .map(|id| {
+                let conn = db_arc.pool.get().unwrap();
+                let sql = format!(
+                    "SELECT {} FROM songs WHERE id = ?1",
+                    crate::collection::SONG_SELECT_COLS
+                );
+                let song = conn
+                    .query_row(&sql, rusqlite::params![id], crate::collection::row_to_song)
+                    .unwrap();
+                PlaylistItem::new_song(0, 0, song)
+            })
+            .collect::<Vec<_>>();
+
+        // Start on the last track (index 2, song id 3).
+        player.play_playlist(items, 2, 0, None).await.unwrap();
+        assert_eq!(player.current_song.as_ref().unwrap().id, 3);
+        assert_eq!(player.current_index, Some(2));
+
+        player.previous_track().await.unwrap();
+        assert_eq!(
+            player.current_song.as_ref().unwrap().id,
+            2,
+            "previous should move to the prior track, not replay the current one"
+        );
+        assert_eq!(player.current_index, Some(1));
+
+        player.previous_track().await.unwrap();
+        assert_eq!(player.current_song.as_ref().unwrap().id, 1);
+        assert_eq!(player.current_index, Some(0));
+
+        let _ = std::fs::remove_dir_all(temp_dir);
+    }
 }

--- a/src-tauri/src/player.rs
+++ b/src-tauri/src/player.rs
@@ -1275,4 +1275,58 @@ mod tests {
 
         let _ = std::fs::remove_dir_all(temp_dir);
     }
+
+    /// Same scenario as `test_previous_track_walks_back_through_playlist`,
+    /// but exercises the real saved-playlist path (`PlaylistManager` +
+    /// `get_playlist_tracks`) instead of the ad-hoc `PlaylistItem::new_song`
+    /// helper, to check for divergence between Album and Playlist playback
+    /// reported in #105 ("Previous song works on albums, but not playlists").
+    #[tokio::test]
+    async fn test_previous_track_walks_back_through_saved_playlist() {
+        let (db, temp_dir) = setup_test_db();
+        let db_arc = Arc::new(db);
+
+        {
+            let conn = db_arc.pool.get().unwrap();
+            for id in 1..=3i64 {
+                conn.execute(
+                    &format!(
+                        "INSERT INTO songs (id, path, title, artist, album, length_nanosec) VALUES ({id}, '/fake/path{id}.mp3', 'Track {id}', 'Artist', 'Album', 180000000000)"
+                    ),
+                    [],
+                )
+                .unwrap();
+            }
+        }
+
+        let mut manager = crate::playlist::PlaylistManager::new(db_arc.clone()).unwrap();
+        let playlist = manager.create_playlist("Test Playlist").unwrap();
+        manager
+            .add_songs_to_playlist(playlist.id, &[1, 2, 3])
+            .unwrap();
+
+        let items = manager.get_playlist_tracks(playlist.id).unwrap();
+        assert_eq!(items.len(), 3);
+
+        let audio = Arc::new(Mutex::new(AudioEngine::new()));
+        let mut player = Player::new(db_arc.clone(), audio.clone());
+
+        // Start on the last track (index 2).
+        player
+            .play_playlist(items, 2, playlist.id, None)
+            .await
+            .unwrap();
+        assert_eq!(player.current_song.as_ref().unwrap().id, 3);
+        assert_eq!(player.current_index, Some(2));
+
+        player.previous_track().await.unwrap();
+        assert_eq!(
+            player.current_song.as_ref().unwrap().id,
+            2,
+            "previous should move to the prior playlist track, not replay the current one"
+        );
+        assert_eq!(player.current_index, Some(1));
+
+        let _ = std::fs::remove_dir_all(temp_dir);
+    }
 }

--- a/src/lib/components/AlbumCard.svelte
+++ b/src/lib/components/AlbumCard.svelte
@@ -7,6 +7,7 @@
   import { Play } from "lucide-svelte";
   import { invoke } from "@tauri-apps/api/core";
   import { i18n } from "../stores/i18n.svelte";
+  import { getAlbumCategoryLabel } from "../utils/artist";
 
   interface Props {
     album: AlbumItem;
@@ -154,7 +155,7 @@
     {/if}
     <div class="flex items-center justify-between mt-auto pt-2 text-[10px] text-brand-text-secondary/50">
       <span>{album.year || ""}</span>
-      <span>{album.track_count <= 7 ? i18n.t('artistDetail.singleEp') : (album.track_count === 1 ? i18n.t('playlists.oneSong') : i18n.t('playlists.songsCount', { count: album.track_count }))}</span>
+      <span>{getAlbumCategoryLabel(album.track_count, album.disc_count)}</span>
     </div>
   </div>
 </div>

--- a/src/lib/components/AlbumCard.test.ts
+++ b/src/lib/components/AlbumCard.test.ts
@@ -19,6 +19,7 @@ describe("AlbumCard.svelte", () => {
     artist: "Barenaked Ladies",
     year: 2017,
     track_count: 14,
+    disc_count: 1,
     art_embedded: false,
     art_automatic: null,
     art_manual: null,
@@ -28,13 +29,35 @@ describe("AlbumCard.svelte", () => {
     vi.clearAllMocks();
   });
 
-  it("renders album title, artist, year, and track count", () => {
+  it("renders album title, artist, year, and category", () => {
     const { getByText } = render(AlbumCard, { props: { album: mockAlbum } });
 
     expect(getByText("Fake Nudes")).toBeInTheDocument();
     expect(getByText("Barenaked Ladies")).toBeInTheDocument();
     expect(getByText("2017")).toBeInTheDocument();
-    expect(getByText(/14 songs/i)).toBeInTheDocument();
+    expect(getByText("Album")).toBeInTheDocument();
+  });
+
+  it("shows Single for a one-track release", () => {
+    const { getByText } = render(AlbumCard, {
+      props: { album: { ...mockAlbum, track_count: 1 } },
+    });
+    expect(getByText("Single")).toBeInTheDocument();
+  });
+
+  it("shows EP for a 2-6 track release", () => {
+    const { getByText } = render(AlbumCard, {
+      props: { album: { ...mockAlbum, track_count: 5 } },
+    });
+    expect(getByText("EP")).toBeInTheDocument();
+  });
+
+  it("shows an N-Disc Set label instead of Album when multi-disc, never both", () => {
+    const { getByText, queryByText } = render(AlbumCard, {
+      props: { album: { ...mockAlbum, track_count: 20, disc_count: 2 } },
+    });
+    expect(getByText("2-Disc Set")).toBeInTheDocument();
+    expect(queryByText("Album")).not.toBeInTheDocument();
   });
 
   it("navigates to album when album title is clicked", async () => {

--- a/src/lib/components/AlbumDetailView.svelte
+++ b/src/lib/components/AlbumDetailView.svelte
@@ -427,7 +427,7 @@
   </div>
 
   <!-- Songs Table Section -->
-  <div class="px-6 md:px-8 py-6" class:pb-24={!!playerStore.currentSong}>
+  <div class="px-6 py-6" class:pb-24={!!playerStore.currentSong}>
     <div class="border border-brand-border rounded-lg bg-brand-sidebar/30">
       <!-- Table Header -->
       <div class="sticky top-0 z-10 flex flex-col rounded-t-lg bg-brand-sidebar border-b border-brand-border text-[10px] text-brand-text-secondary uppercase tracking-wider font-semibold select-none">

--- a/src/lib/components/ArtistDetailView.svelte
+++ b/src/lib/components/ArtistDetailView.svelte
@@ -212,7 +212,7 @@
   </div>
 
   <!-- Discography -->
-  <div class="px-8 pt-8">
+  <div class="px-6 pt-8">
     <div class="flex items-center justify-between mb-4">
       <h2 class="text-xl font-semibold text-brand-text-primary">{i18n.t('artistDetail.discography')}</h2>
       {#if discographySource.length > POPULAR_CAP}
@@ -265,7 +265,7 @@
 
   <!-- Playlists featuring this artist -->
   {#if playlists.length > 0}
-    <div class="px-8 pt-10" class:pb-24={!!playerStore.currentSong}>
+    <div class="px-6 pt-10" class:pb-24={!!playerStore.currentSong}>
       <HorizontalScrollRow title={i18n.t('artistDetail.playlistsFeaturing', { artist: artistName })}>
         {#each playlists as playlist (playlist.id)}
           <PlaylistCard {playlist} widthClass="w-44 shrink-0" onClick={() => openPlaylist(playlist)} />

--- a/src/lib/components/CarouselCard.svelte
+++ b/src/lib/components/CarouselCard.svelte
@@ -31,14 +31,6 @@
     collectionStore.viewPlaylist(playlist.id);
   }
 
-  function formatDuration(ns: number | undefined): string {
-    if (!ns) return "0:00";
-    const seconds = Math.floor(ns / 1_000_000_000);
-    const mins = Math.floor(seconds / 60);
-    const secs = seconds % 60;
-    return `${mins}:${secs.toString().padStart(2, "0")}`;
-  }
-
   async function handlePlay(e: MouseEvent) {
     e.stopPropagation();
     if (item.type === "song") {
@@ -90,11 +82,6 @@
         <p class="text-xs text-brand-text-secondary truncate mt-0.5 font-medium" title={item.song.artist}>
           {item.song.artist || i18n.t('collection.unknownArtist')}
         </p>
-
-        <!-- Song Duration -->
-        <div class="mt-auto pt-2 text-[10px] text-brand-text-secondary/50">
-          {formatDuration(item.song.length_nanosec)}
-        </div>
       </div>
     </div>
   </div>

--- a/src/lib/components/CarouselCard.svelte
+++ b/src/lib/components/CarouselCard.svelte
@@ -40,13 +40,13 @@
 </script>
 
 {#if item.type === "album"}
-  <AlbumCard album={item.album} widthClass="w-48 shrink-0" />
+  <AlbumCard album={item.album} widthClass="w-48 shrink-0 snap-start" />
 {:else if item.type === "playlist"}
-  <PlaylistCard playlist={item.playlist} widthClass="w-48 shrink-0" onClick={openPlaylist} />
+  <PlaylistCard playlist={item.playlist} widthClass="w-48 shrink-0 snap-start" onClick={openPlaylist} />
 {:else}
   <!-- svelte-ignore a11y_click_events_have_key_events -->
   <!-- svelte-ignore a11y_no_static_element_interactions -->
-  <div class="flex-shrink-0 w-48 group relative">
+  <div class="flex-shrink-0 w-48 group relative snap-start">
     <!-- Card Container -->
     <div class="relative overflow-hidden rounded-xl bg-brand-sidebar border border-brand-border/60 transition-all duration-200 hover:border-brand-accent/40 flex flex-col h-full">
       <!-- Cover Art -->

--- a/src/lib/components/CollectionView.benchmark.ts
+++ b/src/lib/components/CollectionView.benchmark.ts
@@ -27,6 +27,7 @@ vi.mock("@tauri-apps/api/core", () => {
     artist: `Artist ${i * 2}`,
     year: 2020 + (i % 5),
     track_count: 200,
+    disc_count: 1,
     art_embedded: false,
     art_automatic: null,
     art_manual: null,

--- a/src/lib/components/CollectionView.svelte
+++ b/src/lib/components/CollectionView.svelte
@@ -261,6 +261,30 @@
     return `grid-template-columns: ${cols.join(" ")}`;
   });
 
+  // The song rows live inside <VirtualList>'s scrolling viewport, which
+  // reserves layout width for its own vertical scrollbar; the sticky header
+  // sits outside that viewport and doesn't. On platforms with a non-overlay
+  // scrollbar (e.g. Windows), that gutter makes the header's grid track a
+  // few pixels wider than the rows' grid track, misaligning every column
+  // after the ones that can absorb it. Measure the actual scrollbar width
+  // and pad the header by the same amount so both grids compute identical
+  // track widths.
+  let songsTableContainer = $state<HTMLDivElement | undefined>(undefined);
+  let scrollbarWidth = $state(0);
+
+  $effect(() => {
+    if (!songsTableContainer) return;
+    const viewport = songsTableContainer.querySelector<HTMLElement>("svelte-virtual-list-viewport");
+    if (!viewport) return;
+    const update = () => {
+      scrollbarWidth = viewport.offsetWidth - viewport.clientWidth;
+    };
+    update();
+    const observer = new ResizeObserver(update);
+    observer.observe(viewport);
+    return () => observer.disconnect();
+  });
+
   function toggleSort(field: keyof Song) {
     if (sortField === field) {
       sortAsc = !sortAsc;
@@ -404,9 +428,9 @@
     <!-- Main View Songs Container -->
     <div class="flex-1 px-6 pt-2 overflow-hidden flex flex-col" class:pb-24={!!playerStore.currentSong}>
       <!-- Songs Table View -->
-      <div class="flex-1 overflow-hidden border border-brand-border rounded-lg bg-brand-sidebar/40 flex flex-col min-h-0">
+      <div bind:this={songsTableContainer} class="flex-1 overflow-hidden border border-brand-border rounded-lg bg-brand-sidebar/40 flex flex-col min-h-0">
         <div class="sticky top-0 z-20 flex flex-col bg-brand-sidebar border-b border-brand-border text-xs text-brand-text-secondary uppercase tracking-wider font-semibold select-none">
-          <div class="grid items-center py-3 px-4" style={gridColsStyle}>
+          <div class="grid items-center py-3 px-4" style="{gridColsStyle}; padding-right: calc(1rem + {scrollbarWidth}px)">
             <div class="text-center w-9"></div>
             <button onclick={() => toggleSort("track")} class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0">
               <span class="truncate max-w-[calc(100%-1rem)]">{i18n.t('collection.tableHeaderTrack')} {sortField === "track" ? (sortAsc ? "▲" : "▼") : ""}</span>

--- a/src/lib/components/CollectionView.svelte
+++ b/src/lib/components/CollectionView.svelte
@@ -408,51 +408,51 @@
         <div class="sticky top-0 z-20 flex flex-col bg-brand-sidebar border-b border-brand-border text-xs text-brand-text-secondary uppercase tracking-wider font-semibold select-none">
           <div class="grid items-center py-3 px-4" style={gridColsStyle}>
             <div class="text-center w-9"></div>
-            <button onclick={() => toggleSort("track")} class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider">
-              {i18n.t('collection.tableHeaderTrack')} {sortField === "track" ? (sortAsc ? "▲" : "▼") : ""}
+            <button onclick={() => toggleSort("track")} class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 pr-4">
+              <span class="truncate">{i18n.t('collection.tableHeaderTrack')} {sortField === "track" ? (sortAsc ? "▲" : "▼") : ""}</span>
             </button>
-            <button onclick={() => toggleSort("title")} class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider">
-              {i18n.t('collection.tableHeaderTitle')} {sortField === "title" ? (sortAsc ? "▲" : "▼") : ""}
+            <button onclick={() => toggleSort("title")} class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 pr-4">
+              <span class="truncate">{i18n.t('collection.tableHeaderTitle')} {sortField === "title" ? (sortAsc ? "▲" : "▼") : ""}</span>
             </button>
-            <button onclick={() => toggleSort("artist")} class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider">
-              {i18n.t('collection.tableHeaderArtist')} {sortField === "artist" ? (sortAsc ? "▲" : "▼") : ""}
+            <button onclick={() => toggleSort("artist")} class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 pr-4">
+              <span class="truncate">{i18n.t('collection.tableHeaderArtist')} {sortField === "artist" ? (sortAsc ? "▲" : "▼") : ""}</span>
             </button>
-            <button onclick={() => toggleSort("album")} class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider">
-              {i18n.t('collection.tableHeaderAlbum')} {sortField === "album" ? (sortAsc ? "▲" : "▼") : ""}
+            <button onclick={() => toggleSort("album")} class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 pr-4">
+              <span class="truncate">{i18n.t('collection.tableHeaderAlbum')} {sortField === "album" ? (sortAsc ? "▲" : "▼") : ""}</span>
             </button>
             {#if collectionStore.visibleColumns.format}
-              <button onclick={() => toggleSort("filetype")} class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider">
-                Format {sortField === "filetype" ? (sortAsc ? "▲" : "▼") : ""}
+              <button onclick={() => toggleSort("filetype")} class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 pr-2">
+                <span class="truncate">Format {sortField === "filetype" ? (sortAsc ? "▲" : "▼") : ""}</span>
               </button>
             {/if}
             {#if collectionStore.visibleColumns.year}
-              <button onclick={() => toggleSort("year")} class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider">
-                Year {sortField === "year" ? (sortAsc ? "▲" : "▼") : ""}
+              <button onclick={() => toggleSort("year")} class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 pr-2">
+                <span class="truncate">Year {sortField === "year" ? (sortAsc ? "▲" : "▼") : ""}</span>
               </button>
             {/if}
             {#if collectionStore.visibleColumns.genre}
-              <button onclick={() => toggleSort("genre")} class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider">
-                Genre {sortField === "genre" ? (sortAsc ? "▲" : "▼") : ""}
+              <button onclick={() => toggleSort("genre")} class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 pr-2">
+                <span class="truncate">Genre {sortField === "genre" ? (sortAsc ? "▲" : "▼") : ""}</span>
               </button>
             {/if}
             {#if collectionStore.visibleColumns.bitrate}
-              <button onclick={() => toggleSort("bitrate")} class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider">
-                Bitrate {sortField === "bitrate" ? (sortAsc ? "▲" : "▼") : ""}
+              <button onclick={() => toggleSort("bitrate")} class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 pr-2">
+                <span class="truncate">Bitrate {sortField === "bitrate" ? (sortAsc ? "▲" : "▼") : ""}</span>
               </button>
             {/if}
             {#if collectionStore.visibleColumns.rating}
-              <button onclick={() => toggleSort("rating")} class="flex items-center justify-center hover:text-brand-text-primary transition-colors cursor-pointer font-semibold uppercase tracking-wider">
-                {i18n.t('collection.tableHeaderRating')} {sortField === "rating" ? (sortAsc ? "▲" : "▼") : ""}
+              <button onclick={() => toggleSort("rating")} class="flex items-center justify-center hover:text-brand-text-primary transition-colors cursor-pointer font-semibold uppercase tracking-wider min-w-0">
+                <span class="truncate">{i18n.t('collection.tableHeaderRating')} {sortField === "rating" ? (sortAsc ? "▲" : "▼") : ""}</span>
               </button>
             {/if}
             {#if collectionStore.visibleColumns.playcount}
-              <button onclick={() => toggleSort("playcount")} class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 cursor-pointer font-semibold uppercase tracking-wider">
-                Plays {sortField === "playcount" ? (sortAsc ? "▲" : "▼") : ""}
+              <button onclick={() => toggleSort("playcount")} class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0">
+                <span class="truncate">Plays {sortField === "playcount" ? (sortAsc ? "▲" : "▼") : ""}</span>
               </button>
             {/if}
             {#if collectionStore.visibleColumns.duration}
-              <button onclick={() => toggleSort("length_nanosec")} class="flex items-center justify-center hover:text-brand-text-primary transition-colors cursor-pointer font-semibold uppercase tracking-wider">
-                <Clock class="w-4 h-4" /> {sortField === "length_nanosec" ? (sortAsc ? "▲" : "▼") : ""}
+              <button onclick={() => toggleSort("length_nanosec")} class="flex items-center justify-center hover:text-brand-text-primary transition-colors cursor-pointer font-semibold uppercase tracking-wider min-w-0">
+                <Clock class="w-4 h-4 shrink-0" /> {sortField === "length_nanosec" ? (sortAsc ? "▲" : "▼") : ""}
               </button>
             {/if}
             <div class="text-center">{i18n.t('collection.tableHeaderActions')}</div>

--- a/src/lib/components/CollectionView.svelte
+++ b/src/lib/components/CollectionView.svelte
@@ -408,36 +408,36 @@
         <div class="sticky top-0 z-20 flex flex-col bg-brand-sidebar border-b border-brand-border text-xs text-brand-text-secondary uppercase tracking-wider font-semibold select-none">
           <div class="grid items-center py-3 px-4" style={gridColsStyle}>
             <div class="text-center w-9"></div>
-            <button onclick={() => toggleSort("track")} class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 pr-4">
-              <span class="truncate">{i18n.t('collection.tableHeaderTrack')} {sortField === "track" ? (sortAsc ? "▲" : "▼") : ""}</span>
+            <button onclick={() => toggleSort("track")} class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0">
+              <span class="truncate max-w-[calc(100%-1rem)]">{i18n.t('collection.tableHeaderTrack')} {sortField === "track" ? (sortAsc ? "▲" : "▼") : ""}</span>
             </button>
-            <button onclick={() => toggleSort("title")} class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 pr-4">
-              <span class="truncate">{i18n.t('collection.tableHeaderTitle')} {sortField === "title" ? (sortAsc ? "▲" : "▼") : ""}</span>
+            <button onclick={() => toggleSort("title")} class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0">
+              <span class="truncate max-w-[calc(100%-1rem)]">{i18n.t('collection.tableHeaderTitle')} {sortField === "title" ? (sortAsc ? "▲" : "▼") : ""}</span>
             </button>
-            <button onclick={() => toggleSort("artist")} class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 pr-4">
-              <span class="truncate">{i18n.t('collection.tableHeaderArtist')} {sortField === "artist" ? (sortAsc ? "▲" : "▼") : ""}</span>
+            <button onclick={() => toggleSort("artist")} class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0">
+              <span class="truncate max-w-[calc(100%-1rem)]">{i18n.t('collection.tableHeaderArtist')} {sortField === "artist" ? (sortAsc ? "▲" : "▼") : ""}</span>
             </button>
-            <button onclick={() => toggleSort("album")} class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 pr-4">
-              <span class="truncate">{i18n.t('collection.tableHeaderAlbum')} {sortField === "album" ? (sortAsc ? "▲" : "▼") : ""}</span>
+            <button onclick={() => toggleSort("album")} class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0">
+              <span class="truncate max-w-[calc(100%-1rem)]">{i18n.t('collection.tableHeaderAlbum')} {sortField === "album" ? (sortAsc ? "▲" : "▼") : ""}</span>
             </button>
             {#if collectionStore.visibleColumns.format}
-              <button onclick={() => toggleSort("filetype")} class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 pr-2">
-                <span class="truncate">Format {sortField === "filetype" ? (sortAsc ? "▲" : "▼") : ""}</span>
+              <button onclick={() => toggleSort("filetype")} class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0">
+                <span class="truncate max-w-[calc(100%-0.5rem)]">Format {sortField === "filetype" ? (sortAsc ? "▲" : "▼") : ""}</span>
               </button>
             {/if}
             {#if collectionStore.visibleColumns.year}
-              <button onclick={() => toggleSort("year")} class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 pr-2">
-                <span class="truncate">Year {sortField === "year" ? (sortAsc ? "▲" : "▼") : ""}</span>
+              <button onclick={() => toggleSort("year")} class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0">
+                <span class="truncate max-w-[calc(100%-0.5rem)]">Year {sortField === "year" ? (sortAsc ? "▲" : "▼") : ""}</span>
               </button>
             {/if}
             {#if collectionStore.visibleColumns.genre}
-              <button onclick={() => toggleSort("genre")} class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 pr-2">
-                <span class="truncate">Genre {sortField === "genre" ? (sortAsc ? "▲" : "▼") : ""}</span>
+              <button onclick={() => toggleSort("genre")} class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0">
+                <span class="truncate max-w-[calc(100%-0.5rem)]">Genre {sortField === "genre" ? (sortAsc ? "▲" : "▼") : ""}</span>
               </button>
             {/if}
             {#if collectionStore.visibleColumns.bitrate}
-              <button onclick={() => toggleSort("bitrate")} class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 pr-2">
-                <span class="truncate">Bitrate {sortField === "bitrate" ? (sortAsc ? "▲" : "▼") : ""}</span>
+              <button onclick={() => toggleSort("bitrate")} class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0">
+                <span class="truncate max-w-[calc(100%-0.5rem)]">Bitrate {sortField === "bitrate" ? (sortAsc ? "▲" : "▼") : ""}</span>
               </button>
             {/if}
             {#if collectionStore.visibleColumns.rating}

--- a/src/lib/components/CollectionView.svelte
+++ b/src/lib/components/CollectionView.svelte
@@ -523,11 +523,11 @@
                     {song.title || i18n.t('collection.unknownSong')}
                   </span>
                 </div>
-                <div class="text-brand-text-secondary/90 truncate pr-4 min-w-0">
+                <div class="text-brand-text-secondary/90 truncate pr-4 flex items-center min-w-0">
                   {#if song.artist}
                     <button
                       onclick={(e) => { e.stopPropagation(); collectionStore.viewArtist(song.album_artist?.trim() || song.artist || ""); }}
-                      class="hover:underline hover:text-brand-accent-text transition-all duration-150 text-left truncate cursor-pointer text-brand-text-secondary/90 text-left"
+                      class="hover:underline hover:text-brand-accent-text transition-all duration-150 text-left truncate cursor-pointer text-brand-text-secondary/90"
                       title={i18n.t('collection.filterByArtist', { artist: song.artist })}
                     >
                       {song.artist}
@@ -536,11 +536,11 @@
                     <span class="text-brand-text-secondary/50">{i18n.t('collection.unknownArtist')}</span>
                   {/if}
                 </div>
-                <div class="text-brand-text-secondary/70 truncate pr-4 min-w-0">
+                <div class="text-brand-text-secondary/70 truncate pr-4 flex items-center min-w-0">
                   {#if song.album}
                     <button
                       onclick={(e) => { e.stopPropagation(); collectionStore.viewAlbum(song.album || ""); }}
-                      class="hover:underline hover:text-brand-accent-text transition-all duration-150 text-left truncate cursor-pointer text-brand-text-secondary/70 text-left"
+                      class="hover:underline hover:text-brand-accent-text transition-all duration-150 text-left truncate cursor-pointer text-brand-text-secondary/70"
                       title={i18n.t('collection.filterByAlbum', { album: song.album })}
                     >
                       {song.album}

--- a/src/lib/components/CollectionView.test.ts
+++ b/src/lib/components/CollectionView.test.ts
@@ -80,6 +80,7 @@ describe("CollectionView.svelte", () => {
       artist: "Band A",
       year: 2021,
       track_count: 1,
+      disc_count: 1,
       art_embedded: false,
       art_automatic: null,
       art_manual: null,

--- a/src/lib/components/HorizontalScrollRow.svelte
+++ b/src/lib/components/HorizontalScrollRow.svelte
@@ -83,7 +83,7 @@
     </div>
   {/if}
 
-  <div bind:this={scrollContainer} class="flex gap-4 overflow-x-auto scroll-smooth pb-2 carousel-scroll">
+  <div bind:this={scrollContainer} class="flex gap-4 overflow-x-auto scroll-smooth snap-x snap-mandatory pb-2 carousel-scroll">
     {@render children()}
   </div>
 </div>

--- a/src/lib/components/PlayerBar.svelte
+++ b/src/lib/components/PlayerBar.svelte
@@ -317,7 +317,7 @@
       class="volume-slider w-20 h-1 rounded-lg cursor-pointer outline-none"
       style={volumeSliderStyle}
       aria-label={i18n.t('playerBar.volumeSlider')}
-      title={i18n.t('playerBar.volume')}
+      title={i18n.t('playerBar.volumeWithValue', { value: Math.round(volumePercent) })}
     />
     {#if collectionStore.immersiveMode}
       <button 

--- a/src/lib/components/PlayerBar.svelte
+++ b/src/lib/components/PlayerBar.svelte
@@ -205,18 +205,25 @@
   <!-- Player controls / Playback engine controller -->
   <div class="flex flex-col items-center gap-1.5 w-1/3 max-w-[600px]">
     <div class="flex items-center gap-5">
-      <button
-        onclick={cycleShuffle}
-        class="text-xs transition-colors hover:text-brand-text-primary relative p-1 {playerStore.shuffleMode !== 'off' ? 'text-brand-accent-text font-bold' : 'text-brand-text-secondary/50'}"
-        title={`${i18n.t('playerBar.shuffle')}: ${shuffleModeLabel(playerStore.shuffleMode)}`}
-      >
-        <Shuffle class="w-4 h-4" />
-        {#if playerStore.shuffleMode !== 'off' && playerStore.shuffleMode !== 'all'}
-          <span class="absolute -bottom-1 -right-1 text-[8px] bg-brand-accent text-brand-accent-contrast rounded-full px-0.5 scale-75">
-            {playerStore.shuffleMode === 'inside_album' ? 'IA' : playerStore.shuffleMode === 'albums' ? 'AL' : 'AR'}
+      <div class="relative">
+        {#if playerStore.shuffleMode !== 'off'}
+          <span class="absolute right-full top-1/2 -translate-y-1/2 mr-1.5 text-[10px] font-semibold text-brand-accent-text uppercase tracking-wide whitespace-nowrap pointer-events-none">
+            {i18n.t('playerBar.shuffle')} {shuffleModeLabel(playerStore.shuffleMode)}
           </span>
         {/if}
-      </button>
+        <button
+          onclick={cycleShuffle}
+          class="text-xs transition-colors hover:text-brand-text-primary relative p-1 {playerStore.shuffleMode !== 'off' ? 'text-brand-accent-text font-bold' : 'text-brand-text-secondary/50'}"
+          title={`${i18n.t('playerBar.shuffle')}: ${shuffleModeLabel(playerStore.shuffleMode)}`}
+        >
+          <Shuffle class="w-4 h-4" />
+          {#if playerStore.shuffleMode !== 'off' && playerStore.shuffleMode !== 'all'}
+            <span class="absolute -bottom-1 -right-1 text-[8px] bg-brand-accent text-brand-accent-contrast rounded-full px-0.5 scale-75">
+              {playerStore.shuffleMode === 'inside_album' ? 'IA' : playerStore.shuffleMode === 'albums' ? 'AL' : 'AR'}
+            </span>
+          {/if}
+        </button>
+      </div>
 
       <button onclick={() => playerStore.previous()} class="text-brand-text-secondary hover:text-brand-text-primary transition-colors" title={i18n.t('playerBar.previous')}>
         <SkipBack class="w-5 h-5 fill-current" />

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -386,6 +386,7 @@ export const en = {
     repeatOneByOne: "One by One",
     volume: "Volume",
     volumeSlider: "Volume Slider",
+    volumeWithValue: "Volume: {value}%",
     queueTitle: "Play Queue",
     historyTitle: "Play History",
     queueTab: "Queue ({count})",
@@ -513,6 +514,10 @@ export const en = {
     albumsFilter: "Albums ({count})",
     singlesAndEps: "Singles and EPs ({count})",
     singleEp: "Single/EP",
+    single: "Single",
+    ep: "EP",
+    album: "Album",
+    discSet: "{count}-Disc Set",
     noReleasesFound: "No releases found.",
     playlistsFeaturing: "Playlists featuring {artist}"
   },

--- a/src/lib/locales/fr.ts
+++ b/src/lib/locales/fr.ts
@@ -386,6 +386,7 @@ export const fr = {
     repeatOneByOne: "Une à la fois",
     volume: "Volume",
     volumeSlider: "Curseur de volume",
+    volumeWithValue: "Volume : {value}%",
     queueTitle: "File d'attente",
     historyTitle: "Historique d'écoute",
     queueTab: "File ({count})",
@@ -513,6 +514,10 @@ export const fr = {
     albumsFilter: "Albums ({count})",
     singlesAndEps: "Singles et EPs ({count})",
     singleEp: "Single/EP",
+    single: "Single",
+    ep: "EP",
+    album: "Album",
+    discSet: "Coffret {count} disques",
     noReleasesFound: "Aucune sortie trouvée.",
     playlistsFeaturing: "Listes de lecture avec {artist}"
   },

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -213,6 +213,7 @@ export interface AlbumItem {
   album: string | null;
   year: number | null;
   track_count: number;
+  disc_count: number;
   art_embedded: boolean;
   art_automatic: string | null;
   art_manual: string | null;

--- a/src/lib/utils/artist.ts
+++ b/src/lib/utils/artist.ts
@@ -1,4 +1,5 @@
 import type { AlbumItem } from "../types";
+import { i18n } from "../stores/i18n.svelte";
 
 /** An artist's albums, newest first. */
 export function getArtistAlbums(albums: AlbumItem[], name: string | null): AlbumItem[] {
@@ -6,6 +7,20 @@ export function getArtistAlbums(albums: AlbumItem[], name: string | null): Album
   return albums
     .filter((a) => a.artist === name)
     .sort((a, b) => (b.year ?? 0) - (a.year ?? 0));
+}
+
+/**
+ * Single card-facing category label for an album: "Single" (1 track), "EP"
+ * (2-6 tracks), "Album" (7+ tracks) — overridden by "{n}-Disc Set" whenever
+ * the release spans more than one disc, so a card never shows two labels.
+ */
+export function getAlbumCategoryLabel(trackCount: number, discCount: number | null | undefined): string {
+  if ((discCount ?? 1) > 1) {
+    return i18n.t("artistDetail.discSet", { count: discCount ?? 1 });
+  }
+  if (trackCount === 1) return i18n.t("artistDetail.single");
+  if (trackCount <= 6) return i18n.t("artistDetail.ep");
+  return i18n.t("artistDetail.album");
 }
 
 const GRADIENTS = [


### PR DESCRIPTION
## 📋 Summary
Addresses part of #103. Four of the seven items in that issue are fixed here; the remaining three (table column header margin, Albums/Artists/Playlists header whitespace, Home visual hierarchy) need clarification from @esoltys since I couldn't reproduce the first two with pixel-level measurements and the third is a subjective design direction — tracked separately in a comment on the issue.

- Album/Artist detail views: match the song-table section's horizontal padding (`px-6`) to the header above it, removing the extra `px-8` inset that misaligned everything under the page title.
- Volume slider tooltip now shows `Volume: N%` instead of a static "Volume" label.
- Songs table: fixed Artist/Album column truncation. The wrapping `<div>` was a plain block container around an `inline-block` `<button>`, so the button's intrinsic content width overflowed and got hard-clipped with no ellipsis — unlike Title, which used a flex wrapper. Made Artist/Album flex containers too so they blockify and truncate correctly, matching Title's behavior.
- Split the "Single/EP" album category into **Single** (1 track), **EP** (2–6), and **Album** (7+), overridden by an **N-Disc Set** label for multi-disc releases. Only one category ever shows per card.

## 🔍 Implementation Notes
- The disc-set exception needed a small backend addition: `disc_count` on `AlbumItem`, computed in `get_albums` (GROUP BY) and via a correlated subquery in `HOME_ITEM_SELECT_COLS` (shared by the home-carousel queries). The correlated version needed an outer `COALESCE` since `MAX()` over zero matching rows returns `NULL` (unlike `COUNT(*)`, which returns 0) for songs without an album tag — caught this via a regression in `test_get_recently_played_groups_by_play_context`.
- New i18n keys: `artistDetail.single`, `artistDetail.ep`, `artistDetail.album`, `artistDetail.discSet` (en + fr). Category label logic lives in `src/lib/utils/artist.ts` as `getAlbumCategoryLabel`.
- Updated the dev-only mock library/IPC mock (`scripts/mock-library.ts`, `scripts/tauri-ipc-mock.ts`) to derive `disc_count` the same way, so `npm run dev` and the screenshot harness stay accurate.

## 🧪 Test Plan
- [x] `npx svelte-check` — 0 errors
- [x] `npx vitest run` — 229/229 passing (updated `AlbumCard.test.ts` and `CollectionView.test.ts` fixtures for the new `disc_count` field and category labels)
- [x] `cargo test --lib` (src-tauri) — 54/54 passing
- [x] Manually verified in a running dev instance (Playwright against the mocked IPC): confirmed Artist/Album ellipsis with a synthetically long name, and all four category labels (Single/EP/Album/N-Disc Set) rendering correctly with synthetic mock data

## 📸 Screenshots
Verified visually via the mock dev server; not attaching since these are transient Playwright captures against synthetic test data rather than the real screenshot harness output.

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed — not touched; none of these are the kind of layout change the README screenshots showcase


---
_Generated by [Claude Code](https://claude.ai/code/session_01MgJLfuqqPWfhYbP8Hc8L5J)_