### PR TITLE
docs: sync DESIGN.md with recent theming changes

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,5 +1,5 @@
 ---
-version: 0.67
+version: 0.90
 name: Luminous
 description: >
   Dark-first desktop music player UI. Tokens below describe the default
@@ -123,7 +123,7 @@ Luminous is a dense, dark-first desktop music player (Tauri v2 + Svelte 5 Runes)
 
 The UI is built almost entirely from panels: a collapsible **Sidebar**, a **TopNavigation** ribbon, the main content canvas, a multi-tab **RightPanel** (Synced Lyrics, Queue Drawer, Liner Notes), and a persistent **PlayerBar** transport dock. All chrome and content surfaces read colors exclusively from CSS custom properties (`--bg-main`, `--color-accent`, etc., wired through `@theme` in `src/app.css`) rather than literal hex values in components — enabling seamless runtime theme switching and dynamic artwork color extraction.
 
-Theming is **not static**: users can switch between several built-in themes (Luminous, Ruby Red, Nordic Blue, Retro Amber, System light/dark), derive themes dynamically from playing cover art, or build a custom theme in the in-app Custom Theme Builder (`DesignTools.svelte`). Every theme is generated or validated against a **WCAG AA 4.5:1 contrast guarantee** between accent and background (`clampForContrast()` / `generatePaletteFromSeed()` in `src/lib/utils/colorUtils.ts`). This document describes the shipped default theme; treat its *structure and rules* (spacing, radii, elevation approach, contrast discipline) as normative for new UI.
+Theming is **not static**: users can switch between several built-in themes (Luminous, Ruby Red, Nordic Blue, Retro Amber, System light/dark, Dynamic Artwork), derive themes dynamically from playing cover art, or build a custom theme in the in-app Custom Theme Builder (Settings → Themes tab, in `FoldersView.svelte`; the previous standalone `DesignTools.svelte` panel was folded into Settings). Every theme is generated or validated against a **WCAG AA 4.5:1 contrast guarantee** between accent and background (`clampForContrast()` / `generatePaletteFromSeed()` in `src/lib/utils/colorUtils.ts`). This document describes the shipped default theme; treat its *structure and rules* (spacing, radii, elevation approach, contrast discipline) as normative for new UI.
 
 ## Colors
 
@@ -181,7 +181,7 @@ Luminous is largely **flat**: hierarchy comes from background tone steps (`bg-ma
 - `shadow-sm`/`shadow-xs` mark subtle resting state on interactive chrome.
 - `shadow-md`/`shadow-lg` mark active/hover elevation, tinted with the accent color (`shadow-brand-accent/20`, `shadow-brand-accent/10`) for a soft accent glow.
 - `shadow-xl`/`shadow-2xl` mark modal-like overlays (`TagEditor`, `SmartPlaylistModal`) and hero album art.
-- **Glassmorphism surface**: Applied via `.glass-surface` (`backdrop-filter: blur(20px) saturate(180%)`) when the System auto-theme is active.
+- **Glassmorphism surface**: Applied via `.glass-surface` (`backdrop-filter: blur(20px) saturate(180%)`) on all chrome panels (Sidebar, TopNavigation, RightPanel, PlayerBar, Miniplayer). This is no longer System-theme-exclusive — every theme now gets the glass treatment (`themeStore.isGlassTheme` is unconditionally `true`), with the `--glass-*` custom properties recomputed per-theme from that theme's own resolved hex colors.
 
 ## Shapes
 
@@ -209,5 +209,6 @@ Rounded corners scale with component visual weight:
 - Do use `accent-text` (contrast-clamped token), not raw `accent`, for text/icons sitting directly on `bg-main`/`bg-sidebar` to guarantee WCAG AA compliance.
 - Do tint elevation shadows with the accent color on interactive elements.
 - Do reserve `rounded-full` for circular controls and pill chips — avoid using it on rectangular cards or panels.
+- Do use full-strength `text-brand-text-secondary` for metadata/captions — never dilute it with opacity modifiers (`/40`–`/90`). An accessibility audit swept these out app-wide because diluted secondary text failed contrast checks; `border` opacity modifiers are unaffected and remain the normal pattern.
 - Don't introduce a second typeface; hierarchy comes strictly from size and weight.
-- Don't add heavy drop shadows to flat chrome panels outside of the System theme's glass treatment.
+- Don't add heavy drop shadows to flat chrome panels beyond the standard glass treatment (now applied to all themes, not just System).


### PR DESCRIPTION
## 📋 Summary
- `DESIGN.md` had drifted from the actual theming implementation. This brings it back in sync:
  - Version bumped `0.67` → `0.90` to match `package.json`.
  - The Custom Theme Builder was relocated from a standalone `DesignTools.svelte` into the Settings → Themes tab (`FoldersView.svelte`) as of `515373f` — updated the reference.
  - Glassmorphism (`.glass-surface`) is no longer System-theme-exclusive; `themeStore.isGlassTheme` is now unconditionally `true`, so every theme gets the glass chrome treatment on Sidebar/TopNavigation/RightPanel/PlayerBar/Miniplayer — updated the Elevation & Depth section.
  - Added a Do/Don't rule documenting the accessibility audit (`515373f`, resolves #17) that removed opacity-diluted `text-brand-text-secondary` usage app-wide, so future UI work doesn't reintroduce it.
- Also filed [#118](https://github.com/esoltys/luminous/issues/118) separately for the Home page layout redesign (Top Artists carousel + Most Played/Recently Added row columns) discussed alongside this — no code changes for that yet, this PR is docs-only.

## 🔍 Implementation Notes
Doc-only change, no source touched. Findings verified against `git log`/`git show` on the relevant commits (`515373f`, `739bf3b`, `532db85`) and current `theme.svelte.ts`/`app.css`/`FoldersView.svelte` source.

## 🧪 Test Plan
- [ ] `bun run check` (svelte-check) — n/a, no source changed
- [ ] `bun run test -- --run` (frontend) — n/a, no source changed
- [ ] `cargo test` (src-tauri, if Rust changed) — n/a, no Rust changed
- [x] Manually verified — read the current `theme.svelte.ts`, `app.css`, and `FoldersView.svelte` to confirm each corrected claim against source

## 📸 Screenshots
N/A — documentation only, no UI changes.

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs updated to reflect current user-facing behavior (this PR *is* the docs update)

---
_Generated by [Claude Code](https://claude.ai/code/session_0156dM71GuMSrFvHAUf4paTS)_