### PR TITLE
fix: contain ReactiveLogoBrand glow filter to prevent sidebar bleed

### DIFF
--- a/src/lib/components/ReactiveLogoBrand.svelte
+++ b/src/lib/components/ReactiveLogoBrand.svelte
@@ -108,7 +108,7 @@
 <button
   type="button"
   onclick={togglePulsing}
-  class="bg-transparent border-none p-0 cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-accent rounded-full transition-shadow duration-300"
+  class="bg-transparent border-none p-0 cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-accent rounded-full overflow-hidden isolate transition-shadow duration-300"
   title={isPulsingEnabled ? i18n.t('common.disableLogoPulse') : i18n.t('common.enableLogoPulse')}
   aria-label={i18n.t('common.toggleLogoPulsing')}
 >
@@ -131,8 +131,9 @@
         <stop offset="100%" stop-color="var(--logo-stop-4, #ffcc00)" />
       </linearGradient>
 
-      <!-- Adaptive glow filter -->
-      <filter id="adaptiveGlow" x="-50%" y="-50%" width="200%" height="200%">
+      <!-- Adaptive glow filter, region clamped to the logo's own bounding box
+           so blurred primitives can't be composited past the viewBox -->
+      <filter id="adaptiveGlow" x="-20%" y="-20%" width="140%" height="140%">
         <feGaussianBlur stdDeviation="12" result="blur1" />
         <feGaussianBlur stdDeviation="4" result="blur2" />
         <feMerge>
@@ -193,6 +194,8 @@
 
 <style>
   svg {
+    overflow: hidden;
+    isolation: isolate;
     transition: filter 0.3s ease;
   }
 

--- a/src/lib/components/TopNavigation.svelte
+++ b/src/lib/components/TopNavigation.svelte
@@ -654,7 +654,10 @@
   </div>
 
   <!-- Reactive Logo Brand -->
-  <div class="flex items-center justify-center flex-shrink-0">
+  <!-- overflow-hidden + isolate scoped to just this wrapper (not the header,
+       which needs overflow-visible for the search dropdown popover) so the
+       logo's SVG glow filter can never bleed into the sidebar/header layers -->
+  <div class="flex items-center justify-center flex-shrink-0 overflow-hidden isolate">
     <ReactiveLogoBrand size="lg" />
   </div>
 </header>


### PR DESCRIPTION
## 📋 Summary
Fixes #113. The `ReactiveLogoBrand` logo's SVG glow filter (`#adaptiveGlow`, using a 200% filter region + 12px Gaussian blur) had no explicit clipping bounds, letting the blurred glow primitives composite past the logo's own box. Combined with `TopNavigation`'s header needing `overflow-visible` (for its search dropdown popover), the glow leaked into the neighboring sidebar's glass backdrop-filter, producing 3 pulsing spots in sync with the bass/mid/treble spectrum bands.

## 🔍 Implementation Notes
- `ReactiveLogoBrand.svelte`: clamped the `#adaptiveGlow` filter region from `-50%/-50%/200%/200%` to `-20%/-20%/140%/140%`, and added `overflow: hidden` + `isolation: isolate` to the `<svg>` and its wrapping `<button>` so the glow can never render outside the logo's own bounding box.
- `TopNavigation.svelte`: added `overflow-hidden isolate` to just the logo's wrapper `<div>` — not the `<header>` itself, since the header intentionally keeps `overflow-visible` for its `top-full` search dropdown popover. Scoping the clip to the logo wrapper contains the glow without clipping the dropdown.
- `Sidebar.svelte` already has `overflow-hidden`; no change needed there — it was only receiving bleed from the unclipped logo layer above it.

## 🧪 Test Plan
- [x] `npm run check` (svelte-check) — 0 errors, 0 warnings
- [x] `npm run test:run` (frontend) — 255 tests passed
- [ ] `cargo test` (src-tauri) — not applicable, no Rust changed
- [x] `npm run build` — production build succeeds

## 📸 Screenshots
Not applicable — fix is a containment/clipping change for a visual artifact tied to live audio playback; no static screenshot diff.

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed — n/a, no visible design change, only a bug fix


---
_Generated by [Claude Code](https://claude.ai/code/session_01SAFY7txkuhWdK4rZ72xgpC)_