### PR TITLE
Add song rating widget to miniplayer

### DIFF
--- a/src/lib/components/Miniplayer.svelte
+++ b/src/lib/components/Miniplayer.svelte
@@ -7,6 +7,7 @@
   import { i18n } from "../stores/i18n.svelte";
   import CoverArt from "./CoverArt.svelte";
   import WaveformSeekBar from "./WaveformSeekBar.svelte";
+  import SongRating from "./SongRating.svelte";
   import {
     Play,
     Pause,
@@ -189,6 +190,15 @@
       <span class="text-xs text-brand-text-secondary/80 truncate w-full" title={playerStore.currentSong?.artist}>
         {playerStore.currentSong?.artist || (playerStore.currentSong ? i18n.t('collection.unknownArtist') : '')}
       </span>
+      {#if playerStore.currentSong}
+        <div class="mt-1.5">
+          <SongRating
+            rating={playerStore.currentSong.rating}
+            onRate={(r) => playerStore.rateCurrent(r)}
+            size="md"
+          />
+        </div>
+      {/if}
     </div>
 
     <!-- CENTER PLAYBACK CONTROLS & WAVEFORM PROGRESS (Grouped together with tight spacing) -->

--- a/src/lib/components/Miniplayer.test.ts
+++ b/src/lib/components/Miniplayer.test.ts
@@ -91,6 +91,17 @@ describe("Miniplayer.svelte", () => {
     expect(getByText("AL")).toBeInTheDocument();
   });
 
+  it("renders the song rating widget and rates the current song", async () => {
+    playerStore.currentSong = mockSong; // rating: 5 -> favorited under the default heart style
+    const rateSpy = vi.spyOn(playerStore, "rateCurrent").mockResolvedValue(undefined as any);
+
+    const { getByTitle } = render(Miniplayer);
+    const heartBtn = getByTitle("Remove from favorites");
+    await fireEvent.click(heartBtn);
+
+    expect(rateSpy).toHaveBeenCalledWith(-1);
+  });
+
   it("exits miniplayer mode when restore button is clicked or Escape is pressed", async () => {
     playerStore.currentSong = mockSong;
     const exitSpy = vi.spyOn(collectionStore, "exitMiniplayerMode");


### PR DESCRIPTION
## 📋 Summary
- Adds the heart/star rating widget to the miniplayer, next to the artist name in the hover control mask, matching the same spot requested in the screenshot (between artist name and transport controls).

## 🔍 Implementation Notes
- Reuses the existing `SongRating` component (already used in `PlayerBar.svelte` and `TagEditor.svelte`), which renders either `HeartToggle` or `StarRating` depending on the user's `prefs.ratingStyle` setting — no new rating UI or icon was introduced, keeping it consistent with the rest of the app.
- Wired to `playerStore.rateCurrent(rating)`, same store action the full player bar uses.
- Placed in `Miniplayer.svelte`'s "Song Metadata Info in Hover Mask" block, below the artist name.

## 🧪 Test Plan
- [x] `npm run check` (svelte-check) — 0 errors
- [x] `npx vitest run src/lib/components/Miniplayer.test.ts` — all 5 tests pass (added a new test covering the rating widget's render + click-to-rate behavior)
- [ ] `cargo test` (src-tauri, if Rust changed) — no Rust changes
- [ ] Manually verified in the app — not run in this environment (no display); verified via component tests and svelte-check instead

## 📸 Screenshots
Not captured in this environment; behavior matches the existing `SongRating`/`HeartToggle`/`StarRating` components already used elsewhere in the app.

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed — no docs changes needed; widget reuses existing components


---
_Generated by [Claude Code](https://claude.ai/code/session_01PmqPAkgVNVXmzrFv86Po6z)_