### PR TITLE
Update Milestone 1.0 description to reflect completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![TypeScript](https://img.shields.io/badge/TypeScript-3178c6?style=flat-square&logo=typescript&logoColor=white)](https://www.typescriptlang.org)
 [![Svelte](https://img.shields.io/badge/Svelte-ff3e00?style=flat-square&logo=svelte&logoColor=white)](https://svelte.dev)
 [![Release](https://img.shields.io/badge/Release-0.90.0-blue?style=flat-square)](https://github.com/esoltys/luminous/releases/latest)
-[![Milestone 1.0](https://img.shields.io/badge/Milestone%201.0-91%25-green?style=flat-square)](https://github.com/esoltys/luminous/milestone/1)
+[![Milestone 1.0](https://img.shields.io/badge/Milestone%201.0-Complete-brightgreen?style=flat-square)](https://github.com/esoltys/luminous/milestone/1)
 [![Roadmap](https://img.shields.io/badge/Roadmap-v1.0--v4.0-purple?style=flat-square)](ROADMAP.md)
 
 Luminous is a high-performance desktop music player designed for modern local audio listening. Built with **Rust**, **Tauri v2**, **TypeScript**, and **Svelte 5 (Runes)**, it offers a lightweight, premium desktop experience with a beautiful dynamic user interface. Made in Canada 🍁 and available in both English and French.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -40,7 +40,7 @@ timeline
 *   **Modern Desktop Interface**:
     *   Resizable 3-column layout (sidebar navigation, central core canvas, right context pane) with a universal top search & navigation ribbon.
     *   Adaptive Information Density matrix (Compact, Balanced, Expanded).
-    *   Personalized Home Hub, Category Explorer, album parallax views, artist profiles, and instant database search with auto-suggestions.
+    *   Personalized Home Hub, Category Explorer, album hero detail views, artist profiles, and instant database search with auto-suggestions.
     *   Synchronized `.LRC` scrolling lyrics and detached Picture-in-Picture miniplayer.
     *   Dynamic theme engine with glassmorphism effects, artwork-based accent extraction, and a Custom Theme Builder.
     *   Bilingual (English/French) interface and full session state preservation on reopen.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -27,25 +27,32 @@ timeline
 
 ## Milestones Detail
 
-### [Milestone 1.0 — Core Desktop Player & Local Collection](https://github.com/esoltys/luminous/milestone/1)
+### ✅ [Milestone 1.0 — Core Desktop Player & Local Collection](https://github.com/esoltys/luminous/milestone/1) — Complete
 
-**Focus**: Establishing a high-performance desktop music player for local audio collections with an audiophile playback engine and modern Svelte 5 user interface.
+**Focus**: A high-performance desktop music player for local audio collections, pairing an audiophile playback engine with a modern Svelte 5 user interface. All planned features have shipped and the milestone is closed (84/84 issues resolved).
 
 *   **Audiophile Audio Pipeline**:
     *   Symphonia decoding + CPAL output thread with allocation-free playback loop.
     *   True gapless playback with double-buffered audio streaming.
-    *   Dual-mode Equalizer: 10-band graphic equalizer & 20-band parametric DSP filters.
+    *   Dual-mode Equalizer: 10-band graphic equalizer & 20-band parametric DSP filters, with custom pre-amp.
     *   EBU R128 loudness normalization and ReplayGain fallback.
+    *   Real-time FFT spectrum analyzer and colorized moodbar/waveform seek bars.
 *   **Modern Desktop Interface**:
-    *   Resizable 3-column layout (sidebar navigation, central core canvas, right context pane).
+    *   Resizable 3-column layout (sidebar navigation, central core canvas, right context pane) with a universal top search & navigation ribbon.
     *   Adaptive Information Density matrix (Compact, Balanced, Expanded).
-    *   Personalized Home Hub, Category Explorer, and instant database search.
+    *   Personalized Home Hub, Category Explorer, album parallax views, artist profiles, and instant database search with auto-suggestions.
     *   Synchronized `.LRC` scrolling lyrics and detached Picture-in-Picture miniplayer.
+    *   Dynamic theme engine with glassmorphism effects, artwork-based accent extraction, and a Custom Theme Builder.
+    *   Bilingual (English/French) interface and full session state preservation on reopen.
 *   **Local Collection & Metadata Engine**:
     *   Incremental filesystem scanner and file watcher powered by `lofty`.
     *   SQLite database with full-text search (FTS5).
     *   AcoustID audio fingerprinting (`fpcalc`) and tag reader/writer.
-    *   Smart Playlists GUI rule builder with type-safe SQL query translation.
+    *   Smart Cover Art engine with multi-layered stack previews and duplicate cleanup.
+    *   Smart Playlists GUI rule builder with type-safe SQL query translation, plus decade-based auto-playlists and 5-star/heart ratings.
+*   **Quality Assurance**:
+    *   Frontend unit & integration tests (Vitest) and backend unit tests (Rust/Cargo).
+    *   BDD feature specifications under [`features/`](features) covering end-to-end behavior.
 
 ---
 


### PR DESCRIPTION
## 📋 Summary
GitHub Milestone 1.0 is closed (84/84 issues resolved), but `ROADMAP.md` and the README badge still described it as an in-progress 91% milestone with a forward-looking feature list. This updates both to reflect completion and to fill in shipped features that weren't previously listed (moodbar/waveform visualizers, theme builder, cover art engine, ratings, bilingual UI, state preservation, QA section).

Note: this only updates the in-repo documentation (README.md / ROADMAP.md). The available tooling in this session doesn't include a way to edit the GitHub Milestone object's own description field directly — if that field also needs updating, it'll need to be done manually in the Milestones UI.

## 🔍 Implementation Notes
- `README.md`: swapped the `Milestone 1.0 - 91%` badge for a `Milestone 1.0 - Complete` badge.
- `ROADMAP.md`: marked the Milestone 1.0 heading as complete, expanded the feature bullets to match what's actually shipped (per README's Product Highlights), and added a Quality Assurance bullet.

## 🧪 Test Plan
- [ ] `bun run check` (svelte-check)
- [ ] `bun run test -- --run` (frontend)
- [ ] `cargo test` (src-tauri, if Rust changed)
- [x] Docs-only change, no app behavior affected

## 📸 Screenshots
N/A — documentation only.

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed

---
_Generated by [Claude Code](https://claude.ai/code/session_018bhpkK5Xx7kdjXhA2MU12b)_