### PR TITLE
Sync app to new design system, logo, and playlist card gradients

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -15,6 +15,10 @@
   --color-brand-border: var(--color-border);
   /* Heuristically derived (not hand-picked) — see ThemeStore.applyActiveTheme() */
   --color-brand-accent-contrast: var(--color-accent-contrast);
+  /* Fixed brand color, not theme-swappable — borrowed from the logo's
+     eclipse ring. Reserved for rare highlight moments (Featured badge,
+     premium marker, milestone toast); never wired through ThemeStore. */
+  --color-brand-gold: var(--color-accent-gold);
 }
 
 @layer base {
@@ -35,6 +39,8 @@
        further clamping needed for this fallback — see clampForContrast(). */
     --color-accent-text: #6f7ea9;
     --color-accent-text-hover: #8c98ba;
+    /* Fixed brand gold, never overridden per-theme (see @theme block above) */
+    --color-accent-gold: #ffb648;
 
     /* Artwork extracted colors defaults */
     --color-artwork-primary: #2e3440;

--- a/src/lib/components/AlbumCard.svelte
+++ b/src/lib/components/AlbumCard.svelte
@@ -108,7 +108,7 @@
   onclick={handleCardClick}
   ondblclick={handleCardDblClick}
   oncontextmenu={(e) => customContextMenu?.(e)}
-  class="{widthClass} bg-brand-sidebar border border-brand-border/60 rounded-xl overflow-hidden flex flex-col group hover:border-brand-accent/40 transition-all duration-200 cursor-pointer select-none"
+  class="{widthClass} bg-brand-sidebar border border-brand-border/60 rounded-b-xl overflow-hidden flex flex-col group hover:border-brand-accent/40 transition-all duration-200 cursor-pointer select-none"
 >
   <div
     class="aspect-square bg-brand-main flex items-center justify-center text-brand-accent-text relative overflow-hidden w-full"

--- a/src/lib/components/AutoPlaylistCard.svelte
+++ b/src/lib/components/AutoPlaylistCard.svelte
@@ -93,27 +93,27 @@
 >
   <div class="aspect-square w-full mb-3 bg-brand-main relative flex items-center justify-center">
     {#if (kind === "genre" || kind === "decade") && topCovers.length > 0}
-      <div class="w-full h-full bg-gradient-to-br {kind === 'decade' ? 'from-cyan-600 to-blue-600' : 'from-emerald-600 to-teal-600'} flex items-center justify-center overflow-hidden border border-brand-border/60 rounded-lg relative">
+      <div class="w-full h-full bg-gradient-to-br {kind === 'decade' ? 'from-[#2563EB] to-[#38BDF8]' : 'from-[#059669] to-[#34D399]'} flex items-center justify-center overflow-hidden border border-brand-border/60 relative">
         <CoverStack covers={topCovers} hoverEffect={true} sizeClass="w-[82%] h-[82%]" />
       </div>
     {:else if kind === "favourites"}
-      <div class="w-full h-full bg-gradient-to-br from-purple-600 to-indigo-600 flex items-center justify-center overflow-hidden border border-brand-border/60 rounded-lg">
+      <div class="w-full h-full bg-gradient-to-br from-[#DB2777] to-[#F43F5E] flex items-center justify-center overflow-hidden border border-brand-border/60">
         <Heart class="w-10 h-10 text-white/90 fill-current" />
       </div>
     {:else if kind === "recently_added"}
-      <div class="w-full h-full bg-gradient-to-br from-amber-500 to-orange-600 flex items-center justify-center overflow-hidden border border-brand-border/60 rounded-lg">
+      <div class="w-full h-full bg-gradient-to-br from-[#CA8A04] to-[#FACC15] flex items-center justify-center overflow-hidden border border-brand-border/60">
         <Clock class="w-10 h-10 text-white/90" />
       </div>
     {:else if kind === "decade"}
-      <div class="w-full h-full bg-gradient-to-br from-cyan-600 to-blue-600 flex items-center justify-center overflow-hidden border border-brand-border/60 rounded-lg">
+      <div class="w-full h-full bg-gradient-to-br from-[#2563EB] to-[#38BDF8] flex items-center justify-center overflow-hidden border border-brand-border/60">
         <Calendar class="w-10 h-10 text-white/90" />
       </div>
     {:else if kind === "genre"}
-      <div class="w-full h-full bg-gradient-to-br from-emerald-600 to-teal-600 flex items-center justify-center overflow-hidden border border-brand-border/60 rounded-lg">
+      <div class="w-full h-full bg-gradient-to-br from-[#059669] to-[#34D399] flex items-center justify-center overflow-hidden border border-brand-border/60">
         <Music class="w-10 h-10 text-white/90" />
       </div>
     {:else}
-      <div class="w-full h-full bg-gradient-to-br from-slate-700 to-slate-900 flex items-center justify-center overflow-hidden border border-brand-border/60 rounded-lg">
+      <div class="w-full h-full bg-gradient-to-br from-slate-700 to-slate-900 flex items-center justify-center overflow-hidden border border-brand-border/60">
         <ListMusic class="w-10 h-10 text-white/90" />
       </div>
     {/if}

--- a/src/lib/components/AutoPlaylistDetailView.svelte
+++ b/src/lib/components/AutoPlaylistDetailView.svelte
@@ -497,7 +497,7 @@
       <!-- Right: Cover Stack -->
       <div class="relative w-40 h-40 hidden sm:block shrink-0">
         {#if topCovers.length > 0}
-          <div class="w-full h-full bg-gradient-to-br {kind === 'decade' ? 'from-cyan-600 to-blue-600' : 'from-emerald-600 to-teal-600'} flex items-center justify-center overflow-hidden border border-brand-border/60 rounded-lg relative shadow-2xl">
+          <div class="w-full h-full bg-gradient-to-br {kind === 'decade' ? 'from-[#2563EB] to-[#38BDF8]' : 'from-[#059669] to-[#34D399]'} flex items-center justify-center overflow-hidden border border-brand-border/60 relative shadow-2xl">
             <CoverStack covers={topCovers} sizeClass="w-[82%] h-[82%]" />
           </div>
         {:else}

--- a/src/lib/components/CarouselCard.svelte
+++ b/src/lib/components/CarouselCard.svelte
@@ -48,7 +48,7 @@
   <!-- svelte-ignore a11y_no_static_element_interactions -->
   <div class="flex-shrink-0 w-48 group relative snap-start">
     <!-- Card Container -->
-    <div class="relative overflow-hidden rounded-xl bg-brand-sidebar border border-brand-border/60 transition-all duration-200 hover:border-brand-accent/40 flex flex-col h-full">
+    <div class="relative overflow-hidden rounded-b-xl bg-brand-sidebar border border-brand-border/60 transition-all duration-200 hover:border-brand-accent/40 flex flex-col h-full">
       <!-- Cover Art -->
       <div class="relative aspect-square overflow-hidden bg-brand-sidebar w-full">
         <CoverArt

--- a/src/lib/components/HomeRowList.svelte
+++ b/src/lib/components/HomeRowList.svelte
@@ -148,7 +148,7 @@
           </span>
         {/if}
 
-        <div class="relative shrink-0 rounded-md overflow-hidden">
+        <div class="relative shrink-0 overflow-hidden">
           {#if item.type === "song"}
             <CoverArt
               songId={item.song.id}

--- a/src/lib/components/PlaylistCard.svelte
+++ b/src/lib/components/PlaylistCard.svelte
@@ -2,7 +2,6 @@
   import { invoke } from "@tauri-apps/api/core";
   import { ListMusic, Play, Calendar, Music, Radio, Layers, Sparkles } from "lucide-svelte";
   import type { Playlist, PlaylistItem } from "../types";
-  import { getArtistGradient } from "../utils/artist";
   import { songsToCoverStack } from "../utils/covers";
   import { playerStore } from "../stores/player.svelte";
   import { playlistsStore } from "../stores/playlists.svelte";
@@ -70,19 +69,19 @@
   onclick={onClick}
   class="{widthClass} bg-brand-sidebar border border-brand-border/60 rounded-xl p-4 flex flex-col text-left hover:border-brand-accent/40 transition-all duration-200 cursor-pointer group relative"
 >
-  <div class="aspect-square w-full mb-3 bg-brand-main relative flex items-center justify-center rounded-lg overflow-hidden">
+  <div class="aspect-square w-full mb-3 bg-brand-main relative flex items-center justify-center overflow-hidden">
     {#if isQueue}
-      <div class="w-full h-full bg-gradient-to-br from-indigo-600 via-purple-600 to-pink-600 flex items-center justify-center overflow-hidden border border-brand-border/60 rounded-lg">
+      <div class="w-full h-full bg-gradient-to-br from-[#4338CA] to-[#7C3AED] flex items-center justify-center overflow-hidden border border-brand-border/60">
         <Layers class="w-10 h-10 text-white/90" />
       </div>
     {:else if topAlbums.length > 0 && autoKind}
-      <div class="w-full h-full bg-gradient-to-br {autoKind === 'decade' ? 'from-cyan-600 to-blue-600' : autoKind === 'genre' ? 'from-emerald-600 to-teal-600' : 'from-amber-500 via-orange-500 to-orange-600'} flex items-center justify-center overflow-hidden border border-brand-border/60 rounded-lg">
+      <div class="w-full h-full bg-gradient-to-br {autoKind === 'decade' ? 'from-[#2563EB] to-[#38BDF8]' : autoKind === 'genre' ? 'from-[#059669] to-[#34D399]' : 'from-[#C2410C] to-[#F59E0B]'} flex items-center justify-center overflow-hidden border border-brand-border/60">
         <CoverStack covers={topAlbums} hoverEffect={true} sizeClass="w-[82%] h-[82%]" />
       </div>
     {:else if topAlbums.length > 0}
       <CoverStack covers={topAlbums} hoverEffect={true} sizeClass="w-[82%] h-[82%]" />
     {:else if autoKind}
-      <div class="w-full h-full bg-gradient-to-br {autoKind === 'decade' ? 'from-cyan-600 to-blue-600' : autoKind === 'genre' ? 'from-emerald-600 to-teal-600' : 'from-amber-500 via-orange-500 to-orange-600'} flex items-center justify-center overflow-hidden border border-brand-border/60 rounded-lg">
+      <div class="w-full h-full bg-gradient-to-br {autoKind === 'decade' ? 'from-[#2563EB] to-[#38BDF8]' : autoKind === 'genre' ? 'from-[#059669] to-[#34D399]' : 'from-[#C2410C] to-[#F59E0B]'} flex items-center justify-center overflow-hidden border border-brand-border/60">
         {#if autoKind === "decade"}
           <Calendar class="w-10 h-10 text-white/90" />
         {:else if autoKind === "genre"}
@@ -92,9 +91,10 @@
         {/if}
       </div>
     {:else}
-      <div class="w-full h-full bg-gradient-to-br {getArtistGradient(playlist.name)} flex items-center justify-center overflow-hidden border border-brand-border/60">
-        <ListMusic class="w-10 h-10 text-white/80" />
-      </div>
+      <!-- Custom (user-made) playlist with no art yet: flat, no gradient —
+           gradient/frame treatment is reserved for app-generated playlists
+           (see Luminous Playlist Card System). -->
+      <ListMusic class="w-10 h-10 text-brand-text-secondary" />
     {/if}
 
     {#if (autoKind === "decade" || autoKind === "genre") && playlist.auto_play}

--- a/src/lib/components/PlaylistView.svelte
+++ b/src/lib/components/PlaylistView.svelte
@@ -685,7 +685,7 @@
 
         <!-- Right: 3D Stacked Album Cover Preview Header or Special Queue Banner -->
         {#if isQueue}
-          <div class="w-32 h-32 hidden sm:flex shrink-0 bg-gradient-to-br from-indigo-600 via-purple-600 to-pink-600 items-center justify-center overflow-hidden border border-brand-border/60 rounded-2xl shadow-xl">
+          <div class="w-32 h-32 hidden sm:flex shrink-0 bg-gradient-to-br from-[#4338CA] to-[#7C3AED] items-center justify-center overflow-hidden border border-brand-border/60 shadow-xl">
             <Layers class="w-14 h-14 text-white/90" />
           </div>
         {:else if topAlbums.length > 0}

--- a/src/lib/components/ReactiveLogoBrand.svelte
+++ b/src/lib/components/ReactiveLogoBrand.svelte
@@ -92,14 +92,30 @@
 
   let isPlaying = $derived(playerStore.state === "playing");
 
-  // Derive element opacities, glow radii, and saturation based on play and specific band intensities
-  let bgOpacity = $derived(!isPlaying || !isPulsingEnabled ? 0.35 : 0.0 + midIntensity * 0.8);
-  let ringOpacity = $derived(!isPlaying || !isPulsingEnabled ? 0.8 : 0.05 + coronalIntensity * 0.9);
-  let burstOpacity = $derived(!isPlaying || !isPulsingEnabled ? 0.65 : 0.05 + bassIntensity * 0.95);
+  // Geometry and resting values below mirror the static mark
+  // (assets/luminous-mark.svg / app-icon.svg) exactly: centered at (100,100),
+  // disc r=68, indigo inner rim r=77, gold eclipse ring r=92, burst at
+  // (152,57). When paused/pulsing-disabled these derive to that mark's own
+  // literal opacity/width values, so the logo is indistinguishable from the
+  // static icon at rest.
 
-  let bgRadius = $derived(!isPlaying || !isPulsingEnabled ? 115 : 105 + midIntensity * 40);
-  let ringRadius = $derived(!isPlaying || !isPulsingEnabled ? 120 : 110 + coronalIntensity * 30);
-  let burstRadius = $derived(!isPlaying || !isPulsingEnabled ? 32 : 24 + bassIntensity * 16);
+  // Ambient glow (mid-driven): the blurred halo plus its crisp inner rim —
+  // both re-target to the active theme's accent color, per the Luminous
+  // Logo System spec.
+  let glowRadius = $derived(!isPlaying || !isPulsingEnabled ? 104 : 92 + midIntensity * 38);
+  let glowOpacity = $derived(!isPlaying || !isPulsingEnabled ? 0.3 : 0.15 + midIntensity * 0.75);
+  let innerRimWidth = $derived(!isPlaying || !isPulsingEnabled ? 14 : 10 + midIntensity * 10);
+  let innerRimOpacity = $derived(!isPlaying || !isPulsingEnabled ? 1.0 : 0.6 + midIntensity * 0.4);
+
+  // Eclipse ring (treble-driven): re-targets to the active theme's
+  // accent-hover, one step brighter than the glow.
+  let ringWidth = $derived(!isPlaying || !isPulsingEnabled ? 8 : 4 + coronalIntensity * 14);
+  let ringOpacity = $derived(!isPlaying || !isPulsingEnabled ? 0.9 : 0.4 + coronalIntensity * 0.6);
+
+  // Coronal burst (bass-driven): the halo pulses; the small core dot stays
+  // fixed, matching the static mark's always-visible white highlight.
+  let burstRadius = $derived(!isPlaying || !isPulsingEnabled ? 20 : 14 + bassIntensity * 22);
+  let burstOpacity = $derived(!isPlaying || !isPulsingEnabled ? 0.28 : 0.1 + bassIntensity * 0.6);
 
   let maxIntensity = $derived(Math.max(bassIntensity, midIntensity, coronalIntensity));
   let saturationVal = $derived(!isPlaying || !isPulsingEnabled ? 1.0 : 0.15 + maxIntensity * 2.35);
@@ -114,23 +130,11 @@
 >
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    viewBox="70 66 380 380"
+    viewBox="-50 -50 300 300"
     class="{sizeMap[size]} {className} select-none"
     aria-hidden="true"
   >
     <defs>
-      <!-- Mid Gradient (Ambient Glow): Deep Accent to Accent -->
-      <linearGradient id="midGradient" x1="0%" y1="50%" x2="100%" y2="50%">
-        <stop offset="0%" stop-color="var(--logo-stop-1, #3a0d00)" />
-        <stop offset="100%" stop-color="var(--logo-stop-3, #ff7300)" />
-      </linearGradient>
-
-      <!-- Treble Gradient (Eclipse Ring): Deep Accent Hover to Accent Hover -->
-      <linearGradient id="trebleGradient" x1="0%" y1="50%" x2="100%" y2="50%">
-        <stop offset="0%" stop-color="var(--logo-stop-2, #5a1d00)" />
-        <stop offset="100%" stop-color="var(--logo-stop-4, #ffcc00)" />
-      </linearGradient>
-
       <!-- Adaptive glow filter, region clamped to the logo's own bounding box
            so blurred primitives can't be composited past the viewBox -->
       <filter id="adaptiveGlow" x="-20%" y="-20%" width="140%" height="140%">
@@ -148,34 +152,52 @@
     <g
       style="filter: saturate({saturationVal}); transition: filter 0.05s ease-out;"
     >
-      <!-- Ambient backplate glow -->
+      <!-- Ambient glow (mid-driven): soft blurred halo -->
       <circle
-        cx="280"
-        cy="256"
-        r={bgRadius}
-        fill="url(#midGradient)"
-        opacity={bgOpacity}
+        cx="100"
+        cy="100"
+        r={glowRadius}
+        fill="var(--color-accent)"
+        opacity={glowOpacity}
         filter="url(#adaptiveGlow)"
         style="transition: r 0.05s ease-out;"
       />
 
-      <!-- Reactive eclipse ring (thickened) -->
+      <!-- Ambient glow inner rim (mid-driven): crisp ring right at the disc's edge -->
       <circle
-        cx="256"
-        cy="256"
-        r={ringRadius}
-        stroke="url(#trebleGradient)"
-        stroke-width="26"
+        cx="100"
+        cy="100"
+        r="77"
+        stroke="var(--color-accent)"
+        stroke-width={innerRimWidth}
+        fill="none"
+        opacity={innerRimOpacity}
+        style="transition: stroke-width 0.05s ease-out;"
+      />
+
+      <!-- Eclipse ring (treble-driven): re-targets to the active theme's
+           accent-hover, one step brighter than the glow -->
+      <circle
+        cx="100"
+        cy="100"
+        r="92"
+        stroke="var(--color-accent-hover)"
+        stroke-width={ringWidth}
         fill="none"
         opacity={ringOpacity}
-        filter="url(#adaptiveGlow)"
-        style="transition: r 0.05s ease-out;"
+        style="transition: stroke-width 0.05s ease-out;"
       />
 
-      <!-- White-hot sunrise burst (opacity increases when playing) -->
+      <!-- The planet disc -->
+      <circle cx="100" cy="100" r="68" fill="#0A0A0D" />
+
+      <!-- Inner border separating core disc from corona -->
+      <circle cx="100" cy="100" r="68" stroke="var(--bg-main)" stroke-width="1.5" fill="none" />
+
+      <!-- Coronal burst halo (bass-driven) -->
       <circle
-        cx="368"
-        cy="256"
+        cx="152"
+        cy="57"
         r={burstRadius}
         fill="#ffffff"
         filter="url(#adaptiveGlow)"
@@ -183,11 +205,8 @@
         style="transition: r 0.05s ease-out;"
       />
 
-      <!-- The planet disc -->
-      <circle cx="252" cy="256" r="107" fill="#101015" />
-
-      <!-- Inner border separating core disc from corona -->
-      <circle cx="252" cy="256" r="107" stroke="var(--bg-main)" stroke-width="1.5" fill="none" />
+      <!-- Coronal burst core: fixed, always-visible white highlight -->
+      <circle cx="152" cy="57" r="11" fill="#ffffff" />
     </g>
   </svg>
 </button>

--- a/src/lib/components/TopNavigation.svelte
+++ b/src/lib/components/TopNavigation.svelte
@@ -422,7 +422,7 @@
                         artManual={album.art_manual}
                         artAutomatic={album.art_automatic}
                         artEmbedded={album.art_embedded}
-                        sizeClass="w-8 h-8 rounded-md"
+                        sizeClass="w-8 h-8"
                       />
                       <div class="flex flex-col min-w-0 flex-1">
                         <span class="text-sm font-medium text-brand-text-primary truncate group-hover:text-brand-accent-text transition-colors">
@@ -472,7 +472,7 @@
                     class="group flex items-center justify-between p-2 rounded-lg hover:bg-brand-main/80 transition-colors cursor-pointer"
                   >
                     <div class="flex items-center gap-3 min-w-0 flex-1">
-                      <div class="w-8 h-8 rounded-md flex-shrink-0 flex items-center justify-center bg-brand-main/60 border border-brand-border/40 overflow-hidden">
+                      <div class="w-8 h-8 flex-shrink-0 flex items-center justify-center bg-brand-main/60 border border-brand-border/40 overflow-hidden">
                         <ListMusic class="w-4 h-4 text-brand-text-secondary" />
                       </div>
                       <div class="flex flex-col min-w-0 flex-1">
@@ -524,7 +524,7 @@
                         artManual={song.art_manual}
                         artAutomatic={song.art_automatic}
                         artEmbedded={song.art_embedded}
-                        sizeClass="w-8 h-8 rounded-md"
+                        sizeClass="w-8 h-8"
                       />
                       <div class="flex flex-col min-w-0 flex-1">
                         <span class="text-sm font-medium text-brand-text-primary truncate group-hover:text-brand-accent-text transition-colors">
@@ -579,10 +579,10 @@
                       songId={typeof item.entityId === 'number' ? item.entityId : undefined}
                       artManual={item.artUrl}
                       artAutomatic={item.artUrl}
-                      sizeClass="w-9 h-9 {item.kind === 'artist' ? 'rounded-full' : 'rounded-md'}"
+                      sizeClass="w-9 h-9 {item.kind === 'artist' ? 'rounded-full' : ''}"
                     />
                   {:else}
-                    <div class="w-9 h-9 flex-shrink-0 flex items-center justify-center bg-brand-main/60 border border-brand-border/40 overflow-hidden {item.kind === 'artist' ? 'rounded-full' : 'rounded-md'}">
+                    <div class="w-9 h-9 flex-shrink-0 flex items-center justify-center bg-brand-main/60 border border-brand-border/40 overflow-hidden {item.kind === 'artist' ? 'rounded-full' : ''}">
                       {#if item.kind === 'artist'}
                         <User class="w-4 h-4 text-brand-text-secondary" />
                       {:else if item.kind === 'album'}

--- a/src/lib/stores/theme.svelte.ts
+++ b/src/lib/stores/theme.svelte.ts
@@ -51,26 +51,13 @@ export interface ExtractedColors {
 }
 
 /**
- * Reserved for ReactiveLogoBrand's gradient only (see calculateLogoStops()
- * below) — pulled from app-icon.svg's own sunrise gradient ("Vibrant Zest
- * Orange core" / "golden horizon" stops) so the in-app logo always matches
- * the real icon shown in the OS taskbar/dock, independent of whatever UI
- * accent the active theme uses. Not extracted programmatically from the
- * SVG at build/runtime — overkill for a static, rarely-changing asset, and
- * would still require guessing which of five gradient stops is "the" brand
- * color; using the exact hex the icon's own source comments already label
- * as the core color is simpler and unambiguous.
- */
-const BRAND_ORANGE = "#ff7300";
-const BRAND_GOLD = "#ffcc00";
-
-/**
- * Dusty slate blue, chosen over the original BRAND_ORANGE for the dark
- * theme's UI accent (badges, buttons, sliders, active states) — clears the
- * same strict 4.5:1 WCAG text-contrast threshold against the near-black
- * canvas (~4.96:1) that BRAND_ORANGE cleared. Deliberately independent of
- * BRAND_ORANGE/BRAND_GOLD, which stay logo-only (see above) so this swap
- * doesn't touch the app-icon-matched logo gradient.
+ * Dusty slate blue, the dark theme's UI accent (badges, buttons, sliders,
+ * active states) — clears the strict 4.5:1 WCAG text-contrast threshold
+ * against the near-black canvas (~4.96:1). Per the Luminous Logo System
+ * (docs/Luminous Logo System.dc.html), the in-app reactive logo's glow/ring
+ * re-target to this same active-theme accent/accent-hover pair — the fixed
+ * Indigo/Gold brand colors in app-icon.svg are reserved for the static
+ * "at rest" mark (app icon, marketing) only.
  */
 const LUMINOUS_DARK_ACCENT = "#6f7ea9";
 
@@ -379,26 +366,6 @@ function getFallbackColors(): ExtractedColors {
   };
 }
 
-function calculateLogoStops(accentHex: string, accentHoverHex: string) {
-  const darken = (hex: string, amount: number): string => {
-    if (!hex || !hex.startsWith("#")) return hex || "";
-    const usePound = hex[0] === "#";
-    const col = usePound ? hex.slice(1) : hex;
-    const num = parseInt(col, 16);
-    const r = Math.max(0, Math.floor(((num / 65536) % 256) * (1 - amount)));
-    const g = Math.max(0, Math.floor(((num / 256) % 256) * (1 - amount)));
-    const b = Math.max(0, Math.floor((num % 256) * (1 - amount)));
-    return (usePound ? "#" : "") + (0x1000000 + r * 0x10000 + g * 0x100 + b).toString(16).slice(1);
-  };
-
-  return {
-    stop1: darken(accentHex, 0.6),
-    stop2: darken(accentHex, 0.2),
-    stop3: accentHex,
-    stop4: accentHoverHex
-  };
-}
-
 export class ThemeStore {
   activeThemeId = $state<string>("system");
   customThemes = $state<Theme[]>([]);
@@ -590,13 +557,6 @@ export class ThemeStore {
     root.style.setProperty("--color-artwork-accent-hover", colors.accentHover);
     root.style.setProperty("--color-artwork-border", colors.border);
 
-    // Apply logo stop variables
-    const stops = calculateLogoStops(colors.accent, colors.accentHover);
-    root.style.setProperty("--logo-stop-1", stops.stop1);
-    root.style.setProperty("--logo-stop-2", stops.stop2);
-    root.style.setProperty("--logo-stop-3", stops.stop3);
-    root.style.setProperty("--logo-stop-4", stops.stop4);
-
     if (!skipApplyActiveTheme && this.activeThemeId === "dynamic-artwork") {
       this.applyActiveTheme(true);
     }
@@ -612,13 +572,6 @@ export class ThemeStore {
     root.style.setProperty("--color-artwork-accent", "#88c0d0");
     root.style.setProperty("--color-artwork-accent-hover", "#8fbcbb");
     root.style.setProperty("--color-artwork-border", "#3b4252");
-
-    // Apply logo stop variables
-    const stops = calculateLogoStops("#88c0d0", "#8fbcbb");
-    root.style.setProperty("--logo-stop-1", stops.stop1);
-    root.style.setProperty("--logo-stop-2", stops.stop2);
-    root.style.setProperty("--logo-stop-3", stops.stop3);
-    root.style.setProperty("--logo-stop-4", stops.stop4);
 
     if (!skipApplyActiveTheme && this.activeThemeId === "dynamic-artwork") {
       this.applyActiveTheme(true);
@@ -798,32 +751,6 @@ export class ThemeStore {
     const glowNear = `0 0 24px 2px ${hexToRgbaString(resolvedAccent, isDark ? 0.45 : 0.28)}`;
     const glowFar = `0 0 90px 10px ${hexToRgbaString(resolvedAccent, isDark ? 0.28 : 0.16)}`;
     root.style.setProperty("--glass-glow", `${glowNear}, ${glowFar}`);
-
-    // Apply logo stops based on active theme or dynamic colors. The
-    // System theme always uses the true brand orange/gold here — never
-    // the scheme-adjusted UI accent, which in light mode is deliberately
-    // darkened for text contrast and would make the logo look muddy/wrong
-    // instead of matching the real app icon.
-    if (theme.id === "dynamic-artwork") {
-      const artColors = this.artworkColors || getFallbackColors();
-      const stops = calculateLogoStops(artColors.accent, artColors.accentHover);
-      root.style.setProperty("--logo-stop-1", stops.stop1);
-      root.style.setProperty("--logo-stop-2", stops.stop2);
-      root.style.setProperty("--logo-stop-3", stops.stop3);
-      root.style.setProperty("--logo-stop-4", stops.stop4);
-    } else if (isLuminous) {
-      const stops = calculateLogoStops(BRAND_ORANGE, BRAND_GOLD);
-      root.style.setProperty("--logo-stop-1", stops.stop1);
-      root.style.setProperty("--logo-stop-2", stops.stop2);
-      root.style.setProperty("--logo-stop-3", stops.stop3);
-      root.style.setProperty("--logo-stop-4", stops.stop4);
-    } else {
-      const stops = calculateLogoStops(colors["color-accent"], colors["color-accent-hover"]);
-      root.style.setProperty("--logo-stop-1", stops.stop1);
-      root.style.setProperty("--logo-stop-2", stops.stop2);
-      root.style.setProperty("--logo-stop-3", stops.stop3);
-      root.style.setProperty("--logo-stop-4", stops.stop4);
-    }
   }
 }
 

--- a/static/app-icon.svg
+++ b/static/app-icon.svg
@@ -1,46 +1,19 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="100 96 320 320" width="100%" height="100%">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
   <defs>
-    <!-- Master App Canvas Shape Definition -->
-    <clipPath id="squircle">
-      <rect x="32" y="32" width="448" height="448" rx="105" ry="105" />
-    </clipPath>
-    
-    <!-- Symmetrical Sunrise Gradient: Deep Left Shadow to Right White-Heat -->
-    <linearGradient id="sunriseGradient" x1="0%" y1="50%" x2="100%" y2="50%">
-      <stop offset="0%" stop-color="#3a0d00" />    <!-- Muted, deep shadow silhouette red -->
-      <stop offset="30%" stop-color="#c83200" />   <!-- Rich mid-glow orange-red -->
-      <stop offset="65%" stop-color="#ff7300" />   <!-- Vibrant Zest Orange core -->
-      <stop offset="88%" stop-color="#ffcc00" />   <!-- High-intensity golden horizon -->
-      <stop offset="100%" stop-color="#ffffff" />  <!-- Blazing white-hot sunrise peak -->
-    </linearGradient>
-
-    <!-- Heavy Coronal Diffusion Filters for Scaled Visibility -->
-    <filter id="heavyGlow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="12" result="blur1" />
-      <feGaussianBlur stdDeviation="4" result="blur2" />
-      <feMerge>
-        <feMergeNode in="blur1" />
-        <feMergeNode in="blur2" />
-        <feMergeNode in="SourceGraphic" />
-      </feMerge>
+    <filter id="glowBlurOuter" x="-60%" y="-60%" width="220%" height="220%">
+      <feGaussianBlur stdDeviation="16"></feGaussianBlur>
+    </filter>
+    <filter id="glowBlurInner" x="-60%" y="-60%" width="220%" height="220%">
+      <feGaussianBlur stdDeviation="1.5"></feGaussianBlur>
+    </filter>
+    <filter id="burstBlur" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="6"></feGaussianBlur>
     </filter>
   </defs>
-
-  <!-- Base Container without Squircle Background -->
-  <g>
-    <!-- Ambient Backplate Glow (Shifted Eastward to throw light behind the planet) -->
-    <circle cx="280" cy="256" r="115" fill="url(#sunriseGradient)" opacity="0.35" filter="url(#heavyGlow)" />
-
-    <!-- Beefed-up Eclipse Ring (Thickened from 8px to 26px for extreme small-scale parity) -->
-    <circle cx="256" cy="256" r="120" stroke="url(#sunriseGradient)" stroke-width="26" fill="none" filter="url(#heavyGlow)" />
-
-    <!-- The White-Hot Sunrise Burst (Placed right over the eastern ring centerline) -->
-    <circle cx="368" cy="256" r="32" fill="#ffffff" filter="url(#heavyGlow)" opacity="0.65" />
-
-    <!-- The "Planet" Disc (Shifted 4px Left to naturally thin the western rim and thicken the sunrise) -->
-    <circle cx="252" cy="256" r="107" fill="#101015" />
-    
-    <!-- Razor-thin inner border to cleanly separate the core disc from the corona -->
-    <circle cx="252" cy="256" r="107" stroke="#101015" stroke-width="1.5" fill="none" />
-  </g>
+  <circle cx="100" cy="100" r="104" fill="#626FE8" opacity="0.3" filter="url(#glowBlurOuter)"></circle>
+  <circle cx="100" cy="100" r="77" fill="none" stroke="#626FE8" stroke-width="14" opacity="1"></circle>
+  <circle cx="100" cy="100" r="92" fill="none" stroke="#FFB648" stroke-width="8" opacity="0.9"></circle>
+  <circle cx="100" cy="100" r="68" fill="#0A0A0D"></circle>
+  <circle cx="152" cy="57" r="20" fill="#FFFFFF" opacity="0.28" filter="url(#burstBlur)"></circle>
+  <circle cx="152" cy="57" r="11" fill="#FFFFFF"></circle>
 </svg>


### PR DESCRIPTION
## Summary
- Colors already matched the new `DESIGN.md`; adds the missing `accent-gold` fixed brand token.
- Rebuilds the reactive logo around the new `app-icon.svg`: removes the hardcoded brand-orange/gold gradient special-case (now re-targets flat `--color-accent`/`--color-accent-hover` for every theme, including the default), and reworks the layer geometry to match the redesigned icon's actual structure (centered composition, indigo inner rim, gold eclipse ring, split burst halo/core).
- Syncs the stale `static/app-icon.svg` (used in Settings → About) with the already-updated root `app-icon.svg`.
- Corrects playlist card frame/tile gradients (Decades, Genres, Smart, Favourites, Recently Added, Queue) to the exact hex stops documented in the Playlist Card System spec.
- Drops the gradient treatment on empty custom (user-made) playlists — the spec says flat is what marks a playlist as custom.
- Removes rounded corners from album cover art app-wide, per follow-up design feedback.

## Test plan
- [x] `bun run check` — 0 errors
- [x] `bun run test:run` — 259 tests passed
- [x] Manually verify in `bun run tauri dev`: reactive logo at rest/while playing, Settings → About icon, and Decades/Genres/Smart/Favourites/Recently Added/Queue playlist cards (needs real Tauri IPC, can't be previewed in a plain browser)