### PR TITLE
fix: docs-screenshot harness — add Settings/Collection/moodbar actions, fix stale ones

### DIFF
--- a/scripts/mock-config.example.json
+++ b/scripts/mock-config.example.json
@@ -22,6 +22,12 @@
       "language": "fr"
     },
     {
+      "name": "songs",
+      "filename": "songs.png",
+      "tab": "collection",
+      "subTab": "songs"
+    },
+    {
       "name": "albums",
       "filename": "albums.png",
       "tab": "collection",
@@ -48,6 +54,28 @@
       "action": "click-album"
     },
     {
+      "name": "settings-general",
+      "filename": "settings-general.png",
+      "tab": "settings",
+      "subTab": ""
+    },
+    {
+      "name": "settings-folders",
+      "filename": "settings-folders.png",
+      "tab": "settings",
+      "subTab": "",
+      "action": "click-settings-folders",
+      "viewportHeight": 1100
+    },
+    {
+      "name": "organize-files",
+      "filename": "organize-files.png",
+      "tab": "settings",
+      "subTab": "",
+      "action": "click-settings-tools",
+      "viewportHeight": 1220
+    },
+    {
       "name": "themes",
       "filename": "themes.png",
       "tab": "settings",
@@ -69,11 +97,12 @@
       "action": "click-equalizer-parametric"
     },
     {
-      "name": "organize-files",
-      "filename": "organize-files.png",
+      "name": "settings-about",
+      "filename": "settings-about.png",
       "tab": "settings",
       "subTab": "",
-      "action": "click-organize-files"
+      "action": "click-settings-about",
+      "viewportHeight": 950
     },
     {
       "name": "now-playing",
@@ -101,6 +130,13 @@
       "tab": "playlists",
       "subTab": "auto",
       "sidebarWidth": 260
+    },
+    {
+      "name": "playlist-auto-detail",
+      "filename": "playlist-auto-detail.png",
+      "tab": "playlists",
+      "subTab": "auto",
+      "action": "click-playlist"
     },
     {
       "name": "smart-playlist-editor",

--- a/scripts/take-screenshots.ts
+++ b/scripts/take-screenshots.ts
@@ -315,6 +315,24 @@ async function main() {
       await page.getByRole("button", { name: "20-band parametric", exact: true }).click();
       await page.waitForTimeout(400);
     },
+    "click-settings-folders": async (page) => {
+      await page.getByRole("button", { name: "Folders", exact: true }).click();
+      await page.waitForTimeout(400);
+    },
+    "click-settings-tools": async (page) => {
+      await page.getByRole("button", { name: "Organize", exact: true }).click();
+      await page.waitForTimeout(400);
+      // Swap in a template that actually changes the mock library's paths
+      // (the default template already matches how the mock data is laid
+      // out, so every row would show "Unchanged" otherwise).
+      const templateInput = page.locator("#template-input");
+      await templateInput.fill("%albumartist/{%album/}{Disc %disc/}{%track }%title");
+      await page.waitForTimeout(600);
+    },
+    "click-settings-about": async (page) => {
+      await page.getByRole("button", { name: "About & Credits", exact: true }).click();
+      await page.waitForTimeout(400);
+    },
     "click-moodbar-toggle": async (page) => {
       await page.getByTitle("Waveform mode — click to switch to moodbar").click();
       await page.waitForTimeout(400);
@@ -325,18 +343,6 @@ async function main() {
         if (card) (card as HTMLElement).click();
       });
       await page.waitForTimeout(400);
-    },
-    "click-organize-files": async (page) => {
-      await page.getByRole("button", { name: "Watched Folders", exact: true }).click();
-      await page.waitForTimeout(300);
-      await page.getByRole("button", { name: "Organize Entire Library...", exact: true }).click();
-      await page.waitForTimeout(400);
-      // Swap in a template that actually changes the mock library's paths
-      // (the default template already matches how the mock data is laid
-      // out, so every row would show "Unchanged" otherwise).
-      const templateInput = page.locator("#template-input");
-      await templateInput.fill("%albumartist/{%album/}{Disc %disc/}{%track }%title");
-      await page.waitForTimeout(600);
     },
     "click-smart-playlist": async (page) => {
       await page.getByRole("button", { name: "New Playlist", exact: true }).click();
@@ -373,9 +379,10 @@ async function main() {
       await page.waitForTimeout(100);
       await valInputs.nth(2).fill("1989");
 
-      const toggle = page.locator('form input[type="checkbox"]');
-      if (!(await toggle.isChecked())) {
-        await toggle.check();
+      // Toggle is a <button role="switch" aria-checked>, not a real checkbox input.
+      const toggle = page.getByRole("switch", { name: "Auto-Refill Batch Playback" });
+      if ((await toggle.getAttribute("aria-checked")) !== "true") {
+        await toggle.click();
       }
       await page.waitForTimeout(400);
     },


### PR DESCRIPTION
## 📋 Summary
Extends the `bun run take-screenshots` harness so it can capture every Settings sub-tab, the Collection Songs overview, and an auto-playlist detail view for the Luminous user guide — and fixes two existing screenshot actions that had gone stale as the underlying UI changed.

## 🔍 Implementation Notes
- `scripts/take-screenshots.ts`: added `click-settings-folders`, `click-settings-tools`, `click-settings-about` actions to reach the Folders/Organize/About & Credits Settings sub-tabs (General, Themes, and Equalizer sub-tabs were already reachable).
- Removed the dead `click-organize-files` action — it clicked a `"Watched Folders"` button and an `"Organize Entire Library..."` button that no longer exist now that Organize is its own Settings sub-tab. Its useful bit (filling in a template so the dry-run preview shows real path diffs instead of all "Unchanged") was folded into `click-settings-tools`.
- Fixed `click-smart-playlist-edit`'s Auto-Refill toggle check: it targeted `input[type="checkbox"]`, but `Toggle.svelte` renders a `<button role="switch" aria-checked>`, so the locator timed out after 30s and crashed the whole batch run. Now checks `aria-checked` on the switch role instead.
- `scripts/mock-config.example.json`: added matching entries (`songs`, `settings-general`, `settings-folders`, `organize-files`, `settings-about`, `playlist-auto-detail`) so a future full regen documents and produces them. Kept the `organize-files` name/filename (now pointed at the fixed `click-settings-tools` action) since `README.md` already references `docs/screenshots/organize-files.png`.
- Tuned `viewportHeight` on the taller/shorter Settings sub-tabs based on actual rendered output (Organize needs more room for its "Apply Changes" footer; About & Credits was previously over-tall with dead space below the content).

## 🧪 Test Plan
- [x] Ran `bun run take-screenshots --name=<entry>` for each new/changed entry (`settings-general`, `settings-folders`, `settings-tools`, `settings-about`, `equalizer-parametric`, `songs`, `moodbar`, `playlist-auto-detail`, `playlist-smart-edit`, `lyrics`) against the real local library and visually verified each output.
- [ ] `bun run check` (svelte-check) — no Svelte/TS component changes in this PR, only the screenshot script and its example config.
- [ ] `cargo test` — no Rust changes.

## 📸 Screenshots
N/A — this PR changes the screenshot *generation* tooling, not app UI. See `docs/screenshots/organize-files.png`, `settings-about.png`, `settings-tools.png`, and `lyrics.png` after regenerating for the corrected output.

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots harness updated for new user-facing views (per `.claude/CLAUDE.md`)