### PR TITLE
feat: song/album tag editor screenshots, fix Favourites mock data

### DIFF
--- a/scripts/mock-config.example.json
+++ b/scripts/mock-config.example.json
@@ -8,70 +8,91 @@
     "sidebarOpen": true,
     "rightPanelOpen": false,
     "sidebarWidth": 64,
-    "positionSeconds": 111,
-    "featuredSong": "You Wreck Me",
-    "featuredArtist": "Eric Soltys",
-    "featuredAlbum": "Wildflowers"
+    "positionSeconds": 176,
+    "featuredSong": "I Get Weak",
+    "featuredArtist": "Cannons",
+    "featuredAlbum": "Everything Glows",
+    "subTab": ""
   },
   "screenshots": [
     {
       "name": "home",
       "filename": "home.png",
       "tab": "home",
-      "subTab": "",
-      "language": "fr"
+      "sidebarWidth": 220
     },
     {
       "name": "songs",
       "filename": "songs.png",
       "tab": "collection",
-      "subTab": "songs"
+      "subTab": "songs",
+      "sidebarWidth": 220
     },
     {
       "name": "albums",
       "filename": "albums.png",
       "tab": "collection",
-      "subTab": "albums"
+      "subTab": "albums",
+      "sidebarWidth": 220
     },
     {
       "name": "artists",
       "filename": "artists.png",
       "tab": "collection",
-      "subTab": "artists"
+      "subTab": "artists",
+      "sidebarWidth": 220
     },
     {
       "name": "artist-detail",
       "filename": "artist-detail.png",
       "tab": "collection",
       "subTab": "artists",
-      "action": "click-artist"
+      "action": "click-artist",
+      "featuredArtist": "Eric Soltys",
+      "sidebarWidth": 220
     },
     {
       "name": "album-detail",
       "filename": "album-detail.png",
       "tab": "collection",
       "subTab": "albums",
-      "action": "click-album"
+      "action": "click-album",
+      "sidebarWidth": 220,
+      "rightPanelOpen": true,
+      "positionSeconds": 79
+    },
+    {
+      "name": "song-tag-editor",
+      "filename": "song-tag-editor.png",
+      "tab": "collection",
+      "subTab": "songs",
+      "action": "click-song-tag-editor",
+      "sidebarWidth": 220
+    },
+    {
+      "name": "album-tag-editor",
+      "filename": "album-tag-editor.png",
+      "tab": "collection",
+      "subTab": "albums",
+      "action": "click-album-tag-editor",
+      "sidebarWidth": 220
     },
     {
       "name": "settings-general",
       "filename": "settings-general.png",
-      "tab": "settings",
-      "subTab": ""
+      "tab": "settings"
     },
     {
       "name": "settings-folders",
       "filename": "settings-folders.png",
       "tab": "settings",
-      "subTab": "",
       "action": "click-settings-folders",
       "viewportHeight": 1100
     },
     {
-      "name": "organize-files",
-      "filename": "organize-files.png",
+      "name": "settings-tools",
+      "filename": "settings-tools.png",
       "tab": "settings",
-      "subTab": "",
       "action": "click-settings-tools",
       "viewportHeight": 1220
     },
@@ -79,28 +100,26 @@
       "name": "themes",
       "filename": "themes.png",
       "tab": "settings",
-      "subTab": "",
       "action": "click-themes"
     },
     {
       "name": "equalizer",
       "filename": "equalizer.png",
       "tab": "settings",
-      "subTab": "",
-      "action": "click-equalizer"
+      "action": "click-equalizer",
+      "positionSeconds": 79
     },
     {
       "name": "equalizer-parametric",
       "filename": "equalizer-parametric.png",
       "tab": "settings",
-      "subTab": "",
-      "action": "click-equalizer-parametric"
+      "action": "click-equalizer-parametric",
+      "positionSeconds": 79
     },
     {
       "name": "settings-about",
       "filename": "settings-about.png",
       "tab": "settings",
-      "subTab": "",
       "action": "click-settings-about",
       "viewportHeight": 950
     },
@@ -109,41 +128,81 @@
       "filename": "now-playing.png",
       "tab": "collection",
       "subTab": "songs",
-      "isImmersive": true
+      "isImmersive": true,
+      "theme": "dynamic-artwork",
+      "positionSeconds": 79
     },
     {
       "name": "moodbar",
       "filename": "moodbar.png",
       "tab": "collection",
       "subTab": "songs",
-      "action": "click-moodbar-toggle"
+      "action": "click-moodbar-toggle",
+      "sidebarWidth": 220,
+      "positionSeconds": 79
     },
     {
       "name": "lyrics",
       "filename": "lyrics.png",
       "tab": "lyrics",
-      "subTab": ""
+      "positionSeconds": 79
     },
     {
-      "name": "playlist",
-      "filename": "playlist.png",
+      "name": "playlist-auto",
+      "filename": "playlist-auto.png",
       "tab": "playlists",
       "subTab": "auto",
-      "sidebarWidth": 260
+      "sidebarWidth": 220
     },
     {
       "name": "playlist-auto-detail",
       "filename": "playlist-auto-detail.png",
       "tab": "playlists",
       "subTab": "auto",
-      "action": "click-playlist"
+      "action": "click-playlist",
+      "sidebarWidth": 220,
+      "positionSeconds": 79
     },
     {
-      "name": "smart-playlist-editor",
-      "filename": "smart-playlist-editor.png",
+      "name": "playlist",
+      "filename": "playlist.png",
       "tab": "playlists",
       "subTab": "custom",
-      "action": "click-smart-playlist"
+      "sidebarWidth": 220
+    },
+    {
+      "name": "playlist-smart-edit",
+      "filename": "playlist-smart-edit.png",
+      "tab": "playlists",
+      "subTab": "custom",
+      "action": "click-smart-playlist-edit",
+      "sidebarWidth": 220
+    },
+    {
+      "name": "miniplayer",
+      "filename": "miniplayer.png",
+      "tab": "collection",
+      "subTab": "songs",
+      "action": "toggle-miniplayer",
+      "theme": "dynamic-artwork",
+      "viewportWidth": 340,
+      "viewportHeight": 420
+    },
+    {
+      "name": "miniplayer-hover",
+      "filename": "miniplayer-hover.png",
+      "tab": "collection",
+      "subTab": "songs",
+      "action": "toggle-miniplayer-hover",
+      "theme": "dynamic-artwork",
+      "viewportWidth": 340,
+      "viewportHeight": 420
+    },
+    {
+      "name": "search",
+      "filename": "search.png",
+      "tab": "home",
+      "action": "type-search"
     }
   ]
 }

--- a/scripts/take-screenshots.ts
+++ b/scripts/take-screenshots.ts
@@ -295,6 +295,31 @@ async function main() {
         }
       }, featured.album ?? featured.song?.album);
     },
+    "click-song-tag-editor": async (page) => {
+      await page.getByTitle("Edit tags").first().click();
+      await page.waitForTimeout(500);
+    },
+    "click-album-tag-editor": async (page, featured) => {
+      await page.evaluate((albumName) => {
+        const cards = Array.from(document.querySelectorAll(".bg-brand-sidebar"));
+        let targetCard = cards.find((c: Element) => {
+          const titleBtn = c.querySelector("button.font-semibold");
+          return titleBtn && titleBtn.textContent?.trim() === albumName;
+        });
+        if (!targetCard && cards.length > 0) {
+          targetCard = cards[0];
+        }
+        if (targetCard) {
+          const titleBtn = targetCard.querySelector("button.font-semibold");
+          if (titleBtn) {
+            (titleBtn as HTMLElement).click();
+          }
+        }
+      }, featured.album ?? featured.song?.album);
+      await page.waitForTimeout(500);
+      await page.getByTitle("Edit album info", { exact: true }).click();
+      await page.waitForTimeout(400);
+    },
     "click-themes": async (page) => {
       await page.evaluate(() => {
         const btns = Array.from(document.querySelectorAll("button"));

--- a/scripts/tauri-ipc-mock.ts
+++ b/scripts/tauri-ipc-mock.ts
@@ -508,11 +508,33 @@ function getIpcCallback(id: number | undefined): IpcCallback | undefined {
     get_songs_by_artist: (args) =>
       library.songs.filter((s) => s.artist === args.artist || s.album_artist === args.artist),
 
+    get_song_details: (args) => {
+      const songId = args.songId as number;
+      const song = library.songs.find((s) => s.id === songId) ?? featuredSong;
+      return {
+        id: song.id,
+        path: song.path,
+        title: song.title,
+        artist: song.artist,
+        album: song.album,
+        album_artist: song.album_artist ?? song.artist ?? "",
+        composer: song.composer ?? "",
+        genre: song.genre ?? "",
+        track: song.track ?? null,
+        disc: song.disc ?? null,
+        year: song.year ?? null,
+        rating: song.rating ?? -1,
+      };
+    },
+
     get_playlists_by_artist: () => [],
     get_playlists: () => library.playlists,
     sync_genre_auto_playlists: () => null,
     sync_decade_auto_playlists: () => null,
-    get_favourite_songs: () => library.songs.slice(0, 5),
+    get_favourite_songs: () => {
+      const cannonsSongs = library.songs.filter((s) => s.artist === "Cannons" || s.album_artist === "Cannons");
+      return (cannonsSongs.length > 0 ? cannonsSongs : library.songs).slice(0, 20);
+    },
     get_recently_added_songs: () => library.songs.slice(0, 5),
     get_songs_by_genre: (args) => library.songs.filter((s) => s.genre === args.genre),
     get_songs_by_decade: (args) => {
@@ -671,6 +693,7 @@ function getIpcCallback(id: number | undefined): IpcCallback | undefined {
     "next_track", "previous_track", "seek_to", "set_volume", "set_shuffle_mode", "set_repeat_mode",
     "get_startup_file",
     "enter_miniplayer_mode", "exit_miniplayer_mode", "resize_miniplayer", "start_window_drag", "start_window_resize",
+    "save_song_tags", "save_album_tags", "lookup_acoustid_tags",
   ];
   for (const cmd of NOOP_COMMANDS) commands[cmd] = noop;
 


### PR DESCRIPTION
## 📋 Summary
Follow-up to #139 (already merged). Adds two more screenshot capture actions requested for the user guide, plus fixes to the mock IPC layer that were needed to make them work correctly.

## 🔍 Implementation Notes
- `scripts/take-screenshots.ts`: added `click-song-tag-editor` (opens the "Edit Metadata Tags" modal from the first song row) and `click-album-tag-editor` (opens "Edit Album Tags" from an album's detail view).
- `scripts/tauri-ipc-mock.ts`: `get_song_details` was never mocked, so the song tag editor modal rendered a "Failed to read tags" error instead of populated fields. Added a mock that resolves it from the mock library by `songId`. Also added `save_song_tags`, `save_album_tags`, and `lookup_acoustid_tags` as no-ops so Save/Lookup never throws if a future flow exercises them.
- `scripts/tauri-ipc-mock.ts`: `get_favourite_songs` previously returned `library.songs.slice(0, 5)`, which happened to surface an unrelated artist's tracks in the Favourites auto-playlist screenshots. Now filters for artist/album-artist `"Cannons"` (falling back to the raw slice if no match).
- `scripts/mock-config.example.json`: kept byte-for-byte identical to the local (gitignored) `mock-config.json` used to drive the actual capture — no real PII in it, just mock library selectors — so the full screenshot set stays versioned with no drift.

## 🧪 Test Plan
- [x] Ran `bun run take-screenshots --name=song-tag-editor` and `--name=album-tag-editor` against the real local library and visually verified both modals render fully populated.
- [x] Re-ran `--name=playlist-auto` and `--name=playlist-auto-detail` and confirmed Favourites now shows Cannons tracks.
- [ ] `bun run check` / `cargo test` — no Svelte/Rust component changes, only the screenshot script and mock IPC layer.

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots harness updated for new user-facing views