### PR TITLE
Show user guide in-app via Help sidebar item

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ scripts/mock-config.json
 .cargo/
 *.cargo/config.toml
 
+# Synced from docs/luminous-user-guide.html by `bun run sync-docs`
+/static/luminous-user-guide.html
+

--- a/package.json
+++ b/package.json
@@ -6,8 +6,9 @@
   "license": "MIT",
   "type": "module",
   "scripts": {
-    "dev": "svelte-kit sync && vite dev",
-    "build": "svelte-kit sync && vite build",
+    "dev": "bun run sync-docs && svelte-kit sync && vite dev",
+    "build": "bun run sync-docs && svelte-kit sync && vite build",
+    "sync-docs": "node -e \"require('fs').copyFileSync('docs/luminous-user-guide.html','static/luminous-user-guide.html')\"",
     "preview": "vite preview",
     "prepare": "svelte-kit sync",
     "install:git-hooks": "git config core.hooksPath .githooks",

--- a/src/lib/components/HelpView.svelte
+++ b/src/lib/components/HelpView.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import { LoaderCircle } from "lucide-svelte";
+  import { i18n } from "../stores/i18n.svelte";
+
+  let isLoading = $state(true);
+</script>
+
+<div class="relative flex flex-col h-full overflow-hidden bg-brand-main">
+  {#if isLoading}
+    <div class="absolute inset-0 z-10 flex flex-col items-center justify-center gap-3 bg-brand-main">
+      <LoaderCircle class="w-8 h-8 animate-spin text-brand-accent-text" />
+      <span class="text-xs text-brand-text-secondary/60 font-medium">{i18n.t('help.loading', {}, "Loading user guide...")}</span>
+    </div>
+  {/if}
+  <iframe
+    src="/luminous-user-guide.html"
+    title={i18n.t('sidebar.help')}
+    class="flex-1 w-full h-full border-0 transition-opacity duration-150 {isLoading ? 'opacity-0' : 'opacity-100'}"
+    onload={() => { isLoading = false; }}
+  ></iframe>
+</div>

--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -46,14 +46,6 @@
     collectionStore.selectedAutoPlaylist = null;
   }
 
-  async function openHelp() {
-    try {
-      const { openUrl } = await import("@tauri-apps/plugin-opener");
-      await openUrl("https://github.com/esoltys/luminous");
-    } catch {
-      window.open("https://github.com/esoltys/luminous", "_blank");
-    }
-  }
 </script>
 
 <aside style="width: {width}px;" class="bg-brand-sidebar flex flex-col h-full text-brand-text-secondary select-none flex-shrink-0 overflow-hidden {themeStore.isGlassTheme ? 'glass-surface' : ''}">
@@ -202,8 +194,8 @@
     </button>
 
     <button
-      onclick={openHelp}
-      class="flex items-center gap-3 transition-all duration-150 text-brand-text-secondary hover:bg-brand-accent/10 hover:text-brand-accent-text-hover {isCollapsed ? 'justify-center w-10 h-10 rounded-xl p-0' : 'w-full px-3 py-2 rounded-lg text-sm font-medium'}"
+      onclick={() => { collectionStore.activeTab = "help"; }}
+      class="flex items-center gap-3 transition-all duration-150 {collectionStore.activeTab === 'help' ? 'bg-brand-accent text-brand-accent-contrast shadow-lg shadow-brand-accent/20' : 'text-brand-text-secondary hover:bg-brand-accent/10 hover:text-brand-accent-text-hover'} {isCollapsed ? 'justify-center w-10 h-10 rounded-xl p-0' : 'w-full px-3 py-2 rounded-lg text-sm font-medium'}"
       title={i18n.t('sidebar.help')}
     >
       <HelpCircle class={isCollapsed ? "w-5 h-5" : "w-4 h-4"} />

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -412,6 +412,9 @@ export const en = {
     editorPlaceholder: "Paste synced LRC or plain text lyrics here...",
     saveFailedPrefix: "Failed to save lyrics: "
   },
+  help: {
+    loading: "Loading user guide..."
+  },
   playerBar: {
     previous: "Previous Track",
     play: "Play",

--- a/src/lib/locales/fr.ts
+++ b/src/lib/locales/fr.ts
@@ -411,6 +411,9 @@ export const fr = {
     editorPlaceholder: "Coller les paroles au format LRC synchronisé ou texte brut ici...",
     saveFailedPrefix: "Échec de l'enregistrement des paroles : "
   },
+  help: {
+    loading: "Chargement du guide d'utilisation..."
+  },
   playerBar: {
     previous: "Piste précédente",
     play: "Lire",

--- a/src/lib/stores/collection.svelte.ts
+++ b/src/lib/stores/collection.svelte.ts
@@ -13,7 +13,7 @@ import type {
 import { applySongStats, type SongStatsPayload } from "../utils/stats";
 import { playlistsStore } from "./playlists.svelte";
 
-export type ActiveTab = "home" | "collection" | "playlists" | "settings" | "lyrics";
+export type ActiveTab = "home" | "collection" | "playlists" | "settings" | "lyrics" | "help";
 export type ActiveSubTab = "songs" | "albums" | "artists";
 
 /** Which grid is shown under the Playlists tab (mirrors `ActiveSubTab` for Collection). */

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -312,7 +312,7 @@
          underneath the gap for the blur to have something to blur. Hidden
          whenever there's no current song, so it doesn't linger showing
          "Nothing playing" after the queue ends. -->
-    {#if playerStore.currentSong}
+    {#if playerStore.currentSong && collectionStore.activeTab !== 'help'}
       <div class="absolute inset-x-4 bottom-4 z-40">
         <PlayerBar />
       </div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -6,6 +6,7 @@
   import PlaylistsCollectionView from "../lib/components/PlaylistsCollectionView.svelte";
   import FoldersView from "../lib/components/FoldersView.svelte";
   import LyricsView from "../lib/components/LyricsView.svelte";
+  import HelpView from "../lib/components/HelpView.svelte";
   import { themeStore } from "../lib/stores/theme.svelte";
   import { collectionStore, type ActiveTab, type ActiveSubTab } from "../lib/stores/collection.svelte";
   import { playerStore } from "../lib/stores/player.svelte";
@@ -127,6 +128,8 @@
       <FoldersView />
     {:else if collectionStore.activeTab === "lyrics"}
       <LyricsView />
+    {:else if collectionStore.activeTab === "help"}
+      <HelpView />
     {/if}
   </div>
 </div>


### PR DESCRIPTION
## Summary
- Clicking **Help** in the sidebar now opens the self-contained user guide (`docs/luminous-user-guide.html`) inline in the central view, instead of opening the GitHub repo in an external browser.
- The guide is synced into `static/` at dev/build time (`bun run sync-docs`) so SvelteKit bundles it and it's servable at `/luminous-user-guide.html` in both dev and the packaged Tauri app. `docs/` stays the single source of truth.
- Shows a loading spinner while the guide (large, with embedded screenshot blobs) loads, to avoid a visible flutter.
- The floating playbar is hidden while the Help view is active.

## Test plan
- [x] `bun run check` (svelte-check) passes
- [x] `Sidebar.test.ts` passes
- [ ] Manually verified in `bun run tauri dev`: Help nav highlights, guide loads with spinner then fades in, playbar hidden while on Help tab and reappears on other tabs