### PR TITLE
Extract magic numbers into named constants

### DIFF
--- a/src/lib/components/AlbumContextMenu.svelte
+++ b/src/lib/components/AlbumContextMenu.svelte
@@ -5,6 +5,7 @@
   import { playerStore } from "../stores/player.svelte";
   import { playlistsStore } from "../stores/playlists.svelte";
   import { portal } from "../utils/portal";
+  import { CONTEXT_MENU_WIDTH_PX, VIEWPORT_EDGE_PADDING_PX, PLAYER_DOCK_CLEARANCE_PX } from "../constants";
 
   let {
     x,
@@ -30,18 +31,16 @@
 
   let adjustedX = $derived.by(() => {
     if (typeof window === "undefined") return x;
-    const menuWidth = 200;
-    return Math.min(x, window.innerWidth - menuWidth - 10);
+    return Math.min(x, window.innerWidth - CONTEXT_MENU_WIDTH_PX - VIEWPORT_EDGE_PADDING_PX);
   });
 
   let adjustedY = $derived.by(() => {
     if (typeof window === "undefined") return y;
     const menuHeight = 180;
-    // The floating PlayerBar dock (h-20 + bottom-4 inset ≈ 96px) sits on top
-    // of page content whenever a song is loaded — clamp above it so the
-    // menu's lower items aren't hidden underneath it.
-    const dockClearance = playerStore.currentSong ? 96 : 0;
-    return Math.min(y, window.innerHeight - menuHeight - dockClearance - 10);
+    // Clamp above the floating PlayerBar dock so the menu's lower items
+    // aren't hidden underneath it.
+    const dockClearance = playerStore.currentSong ? PLAYER_DOCK_CLEARANCE_PX : 0;
+    return Math.min(y, window.innerHeight - menuHeight - dockClearance - VIEWPORT_EDGE_PADDING_PX);
   });
 
   function handleWindowClick(e: MouseEvent) {

--- a/src/lib/components/CoverStack.svelte
+++ b/src/lib/components/CoverStack.svelte
@@ -1,6 +1,13 @@
 <script lang="ts">
   import CoverArt from "./CoverArt.svelte";
   import { getArtistGradient } from "../utils/artist";
+  import {
+    COVER_STACK_OFFSET_X_PX,
+    COVER_STACK_OFFSET_Y_PX,
+    COVER_STACK_ROTATION_DEG,
+    COVER_STACK_SCALE_STEP,
+    COVER_STACK_OPACITY_STEP,
+  } from "../constants";
 
   export interface CoverItem {
     songId?: number;
@@ -43,17 +50,17 @@
       return `translate(${x}px, ${y}px) rotate(${rot}deg) scale(${scale})`;
     } else {
       // Left stack (used in ArtistDetailView hero header)
-      const x = i * -18;
-      const y = i * -10;
-      const rot = i * -5;
-      const scale = 1 - i * 0.05;
+      const x = i * COVER_STACK_OFFSET_X_PX;
+      const y = i * COVER_STACK_OFFSET_Y_PX;
+      const rot = i * COVER_STACK_ROTATION_DEG;
+      const scale = 1 - i * COVER_STACK_SCALE_STEP;
       return `translate(${x}px, ${y}px) rotate(${rot}deg) scale(${scale})`;
     }
   }
 
   function getOpacity(i: number, count: number): number {
     if (count <= 1) return 1;
-    return 1 - i * (direction === "left" ? 0.07 : 0.09);
+    return 1 - i * (direction === "left" ? COVER_STACK_OPACITY_STEP : 0.09);
   }
 </script>
 

--- a/src/lib/components/FoldersView.svelte
+++ b/src/lib/components/FoldersView.svelte
@@ -13,6 +13,9 @@
   import OrganizeFiles from "./OrganizeFiles.svelte";
   import Toggle from "./Toggle.svelte";
 
+  const COPY_FEEDBACK_DURATION_MS = 1500;
+  const PRUNE_MESSAGE_DURATION_MS = 8000;
+
   let settingsTab = $state<"general" | "folders" | "tools" | "themes" | "equalizer" | "about">("general");
   let appVersion = $state("");
   let versionCopied = $state(false);
@@ -21,7 +24,7 @@
     try {
       await navigator.clipboard.writeText(appVersion);
       versionCopied = true;
-      setTimeout(() => { versionCopied = false; }, 1500);
+      setTimeout(() => { versionCopied = false; }, COPY_FEEDBACK_DURATION_MS);
     } catch (e) {
       console.error("Failed to copy version to clipboard:", e);
     }
@@ -59,7 +62,7 @@
     pruneMsg = removedFolders > 0
       ? i18n.t('settings.pruneCompleteMsgWithFolders', { count: deletedSongs, folders: removedFolders })
       : i18n.t('settings.pruneCompleteMsg', { count: deletedSongs });
-    setTimeout(() => { pruneMsg = null; }, 8000);
+    setTimeout(() => { pruneMsg = null; }, PRUNE_MESSAGE_DURATION_MS);
   }
 
   onMount(async () => {

--- a/src/lib/components/HorizontalScrollRow.svelte
+++ b/src/lib/components/HorizontalScrollRow.svelte
@@ -11,6 +11,9 @@
 
   let { title, headerExtra, children }: Props = $props();
 
+  const SCROLL_END_BUFFER_PX = 10;
+  const SCROLL_STEP_PX = 600; // approximate 3 card-widths including gap
+
   let scrollContainer = $state<HTMLDivElement | undefined>(undefined);
   let canScrollLeft = $state(false);
   let canScrollRight = $state(false);
@@ -19,12 +22,12 @@
     if (!scrollContainer) return;
     canScrollLeft = scrollContainer.scrollLeft > 0;
     canScrollRight =
-      scrollContainer.scrollLeft < scrollContainer.scrollWidth - scrollContainer.clientWidth - 10;
+      scrollContainer.scrollLeft < scrollContainer.scrollWidth - scrollContainer.clientWidth - SCROLL_END_BUFFER_PX;
   }
 
   function scroll(direction: "left" | "right") {
     if (!scrollContainer) return;
-    const scrollAmount = 200 * 3; // approximate card width including gap
+    const scrollAmount = SCROLL_STEP_PX;
     scrollContainer.scrollBy({
       left: direction === "left" ? -scrollAmount : scrollAmount,
       behavior: "smooth",

--- a/src/lib/components/Miniplayer.svelte
+++ b/src/lib/components/Miniplayer.svelte
@@ -21,6 +21,9 @@
     Scaling
   } from "lucide-svelte";
 
+  const MINIPLAYER_MIN_SIZE_PX = 220;
+  const MINIPLAYER_MAX_SIZE_PX = 650;
+
   function cycleShuffle() {
     const modes: import("../types").ShuffleMode[] = ["off", "all", "inside_album", "albums", "artists"];
     const currentIdx = modes.indexOf(playerStore.shuffleMode);
@@ -66,8 +69,8 @@
     function onPointerMove(moveEvent: PointerEvent) {
       const deltaX = moveEvent.clientX - startX;
       const deltaY = moveEvent.clientY - startY;
-      const newWidth = Math.max(220, Math.min(650, startWidth + deltaX));
-      const newHeight = Math.max(220, Math.min(650, startHeight + deltaY));
+      const newWidth = Math.max(MINIPLAYER_MIN_SIZE_PX, Math.min(MINIPLAYER_MAX_SIZE_PX, startWidth + deltaX));
+      const newHeight = Math.max(MINIPLAYER_MIN_SIZE_PX, Math.min(MINIPLAYER_MAX_SIZE_PX, startHeight + deltaY));
       invoke("resize_miniplayer", { width: newWidth, height: newHeight }).catch(() => {});
     }
 

--- a/src/lib/components/OrganizeFiles.svelte
+++ b/src/lib/components/OrganizeFiles.svelte
@@ -8,6 +8,13 @@
   import { VirtualList } from "svelte-virtual-list-ts";
   import Toggle from "./Toggle.svelte";
 
+  const PREVIEW_DEBOUNCE_MS = 300;
+  const COL_MIN_WIDTH_PX = 150;
+  const COL_MAX_WIDTH_PX = 1000;
+  const AUTO_FIT_MIN_FROM_WIDTH_PX = 250;
+  const AUTO_FIT_MIN_TO_WIDTH_PX = 300;
+  const PX_PER_CHAR_ESTIMATE = 7.5;
+
   export interface OrganizePreviewItem {
     song_id: number;
     from_path: string;
@@ -161,9 +168,9 @@
     if (!isResizing) return;
     const diff = e.clientX - resizeStartX;
     if (isResizing === "from") {
-      fromColWidth = Math.max(150, resizeStartWidth + diff);
+      fromColWidth = Math.max(COL_MIN_WIDTH_PX, resizeStartWidth + diff);
     } else {
-      toColWidth = Math.max(150, resizeStartWidth + diff);
+      toColWidth = Math.max(COL_MIN_WIDTH_PX, resizeStartWidth + diff);
     }
   }
 
@@ -174,15 +181,15 @@
   }
 
   function autoFitColumns() {
-    let maxFrom = 250;
-    let maxTo = 300;
+    let maxFrom = AUTO_FIT_MIN_FROM_WIDTH_PX;
+    let maxTo = AUTO_FIT_MIN_TO_WIDTH_PX;
     for (const raw of items) {
       const i = getItemObj(raw);
-      if (i.from_path) maxFrom = Math.max(maxFrom, i.from_path.length * 7.5);
-      if (i.to_path) maxTo = Math.max(maxTo, i.to_path.length * 7.5);
+      if (i.from_path) maxFrom = Math.max(maxFrom, i.from_path.length * PX_PER_CHAR_ESTIMATE);
+      if (i.to_path) maxTo = Math.max(maxTo, i.to_path.length * PX_PER_CHAR_ESTIMATE);
     }
-    fromColWidth = Math.min(1000, Math.max(250, maxFrom));
-    toColWidth = Math.min(1000, Math.max(300, maxTo));
+    fromColWidth = Math.min(COL_MAX_WIDTH_PX, Math.max(AUTO_FIT_MIN_FROM_WIDTH_PX, maxFrom));
+    toColWidth = Math.min(COL_MAX_WIDTH_PX, Math.max(AUTO_FIT_MIN_TO_WIDTH_PX, maxTo));
   }
 
   let collisionCount = $derived(items.filter((i) => getItemStatus(i) === "collision").length);
@@ -271,7 +278,7 @@
       if (debounceTimer) clearTimeout(debounceTimer);
       debounceTimer = setTimeout(() => {
         fetchPreview();
-      }, 300);
+      }, PREVIEW_DEBOUNCE_MS);
     }
     return () => {
       if (debounceTimer) clearTimeout(debounceTimer);

--- a/src/lib/components/PlaylistContextMenu.svelte
+++ b/src/lib/components/PlaylistContextMenu.svelte
@@ -4,6 +4,7 @@
   import { i18n } from "../stores/i18n.svelte";
   import { playerStore } from "../stores/player.svelte";
   import { portal } from "../utils/portal";
+  import { CONTEXT_MENU_WIDTH_PX, VIEWPORT_EDGE_PADDING_PX, PLAYER_DOCK_CLEARANCE_PX } from "../constants";
 
   let {
     x,
@@ -32,18 +33,16 @@
   // Keep menu inside viewport boundaries
   let adjustedX = $derived.by(() => {
     if (typeof window === "undefined") return x;
-    const menuWidth = 200;
-    return Math.min(x, window.innerWidth - menuWidth - 10);
+    return Math.min(x, window.innerWidth - CONTEXT_MENU_WIDTH_PX - VIEWPORT_EDGE_PADDING_PX);
   });
 
   let adjustedY = $derived.by(() => {
     if (typeof window === "undefined") return y;
     const menuHeight = 220;
-    // The floating PlayerBar dock (h-20 + bottom-4 inset ≈ 96px) sits on top
-    // of page content whenever a song is loaded — clamp above it so the
-    // menu's lower items aren't hidden underneath it.
-    const dockClearance = playerStore.currentSong ? 96 : 0;
-    return Math.min(y, window.innerHeight - menuHeight - dockClearance - 10);
+    // Clamp above the floating PlayerBar dock so the menu's lower items
+    // aren't hidden underneath it.
+    const dockClearance = playerStore.currentSong ? PLAYER_DOCK_CLEARANCE_PX : 0;
+    return Math.min(y, window.innerHeight - menuHeight - dockClearance - VIEWPORT_EDGE_PADDING_PX);
   });
 
   function handleWindowClick(e: MouseEvent) {

--- a/src/lib/components/PlaylistView.svelte
+++ b/src/lib/components/PlaylistView.svelte
@@ -36,6 +36,15 @@
   import PlaylistContextMenu from "./PlaylistContextMenu.svelte";
   import ConfirmDialog from "./ConfirmDialog.svelte";
   import { portal } from "../utils/portal";
+  import {
+    COVER_STACK_OFFSET_X_PX,
+    COVER_STACK_OFFSET_Y_PX,
+    COVER_STACK_ROTATION_DEG,
+    COVER_STACK_SCALE_STEP,
+    COVER_STACK_OPACITY_STEP,
+  } from "../constants";
+
+  const DRAG_RESET_DELAY_MS = 100;
 
   let editingSongId = $state<number | null>(null);
 
@@ -502,7 +511,7 @@
     dragOverIndex = null;
     setTimeout(() => {
       draggedIndex = null;
-    }, 100);
+    }, DRAG_RESET_DELAY_MS);
   }
 
   function handleDrop(event: DragEvent, targetIndex: number) {
@@ -693,7 +702,7 @@
             {#each topAlbums.slice(0, 6) as album, i (i)}
               <div
                 class="absolute bottom-0 right-0 w-28 h-28 overflow-hidden border border-brand-border/60 shadow-xl transition-all duration-300"
-                style="z-index: {10 - i}; transform: translate({i * -18}px, {i * -10}px) rotate({i * -5}deg) scale({1 - i * 0.05}); opacity: {1 - i * 0.07};"
+                style="z-index: {10 - i}; transform: translate({i * COVER_STACK_OFFSET_X_PX}px, {i * COVER_STACK_OFFSET_Y_PX}px) rotate({i * COVER_STACK_ROTATION_DEG}deg) scale({1 - i * COVER_STACK_SCALE_STEP}); opacity: {1 - i * COVER_STACK_OPACITY_STEP};"
               >
                 <CoverArt
                   songId={album.songId}

--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -8,6 +8,7 @@
   import { Library, ListMusic, Sparkles, Settings, FileText, Home, Mic2, DiscAlbum, Music, ArrowUp, HelpCircle } from "lucide-svelte";
   import { open } from "@tauri-apps/plugin-dialog";
   import { isSmartPlaylistSpec } from "../utils/filterParser";
+  import { SIDEBAR_MIN_WIDTH_PX } from "../constants";
 
   import { invoke } from "@tauri-apps/api/core";
 
@@ -15,7 +16,7 @@
 
   let showAddDirModal = $state(false);
 
-  let isCollapsed = $derived(width < 180);
+  let isCollapsed = $derived(width < SIDEBAR_MIN_WIDTH_PX);
 
   function navigateToFoldersSettings() {
     collectionStore.activeTab = "settings";

--- a/src/lib/components/SmartPlaylistBuilderModal.svelte
+++ b/src/lib/components/SmartPlaylistBuilderModal.svelte
@@ -9,6 +9,7 @@
   import type { QueuePopulationMode } from "../types";
   import PopulationModeTabs from "./PopulationModeTabs.svelte";
   import Toggle from "./Toggle.svelte";
+  import { PLAYER_DOCK_CLEARANCE_PX } from "../constants";
 
   interface Props {
     initialRules?: Rule[];
@@ -211,10 +212,9 @@
     }
   }
 
-  // The floating PlayerBar dock (h-20 + bottom-4 inset ≈ 96px) sits on top of
-  // page content whenever a song is loaded — reserve room for it so the modal
-  // shrinks and its form scrolls internally instead of sliding underneath it.
-  let dockClearance = $derived(playerStore.currentSong ? 96 : 0);
+  // Reserve room for the floating PlayerBar dock so the modal shrinks and its
+  // form scrolls internally instead of sliding underneath it.
+  let dockClearance = $derived(playerStore.currentSong ? PLAYER_DOCK_CLEARANCE_PX : 0);
 </script>
 
 <svelte:window onkeydown={handleKeydown} />

--- a/src/lib/components/SongContextMenu.svelte
+++ b/src/lib/components/SongContextMenu.svelte
@@ -6,6 +6,7 @@
   import { playlistsStore } from "../stores/playlists.svelte";
   import type { Song } from "../types";
   import { portal } from "../utils/portal";
+  import { CONTEXT_MENU_WIDTH_PX, VIEWPORT_EDGE_PADDING_PX, PLAYER_DOCK_CLEARANCE_PX } from "../constants";
 
   let {
     x,
@@ -38,15 +39,14 @@
   // Keep menu inside viewport boundaries
   let adjustedX = $derived.by(() => {
     if (typeof window === "undefined") return x;
-    const menuWidth = 200;
-    return Math.min(x, window.innerWidth - menuWidth - 10);
+    return Math.min(x, window.innerWidth - CONTEXT_MENU_WIDTH_PX - VIEWPORT_EDGE_PADDING_PX);
   });
 
   let adjustedY = $derived.by(() => {
     if (typeof window === "undefined") return y;
     const menuHeight = 250;
-    const dockClearance = playerStore.currentSong ? 96 : 0;
-    return Math.min(y, window.innerHeight - menuHeight - dockClearance - 10);
+    const dockClearance = playerStore.currentSong ? PLAYER_DOCK_CLEARANCE_PX : 0;
+    return Math.min(y, window.innerHeight - menuHeight - dockClearance - VIEWPORT_EDGE_PADDING_PX);
   });
 
   function handleWindowClick(e: MouseEvent) {

--- a/src/lib/components/TopNavigation.svelte
+++ b/src/lib/components/TopNavigation.svelte
@@ -12,6 +12,7 @@
   import CoverArt from "./CoverArt.svelte";
   import ReactiveLogoBrand from "./ReactiveLogoBrand.svelte";
   import { fade } from "svelte/transition";
+  import { MAX_SEARCH_SUGGESTIONS_PER_CATEGORY } from "../constants";
 
   let searchInput: HTMLInputElement | undefined;
   let searchContainerRef: HTMLDivElement | undefined;
@@ -343,7 +344,7 @@
             {:else}
               <div class="flex flex-col gap-1">
                 <!-- Matching Artists (Top 3) -->
-                {#each collectionStore.filteredArtists.slice(0, 3) as artist (artist.name)}
+                {#each collectionStore.filteredArtists.slice(0, MAX_SEARCH_SUGGESTIONS_PER_CATEGORY) as artist (artist.name)}
                   <div
                     role="button"
                     tabindex="0"
@@ -379,7 +380,7 @@
                 {/each}
 
                 <!-- Matching Albums (Top 3) -->
-                {#each collectionStore.filteredAlbums.slice(0, 3) as album (album.album)}
+                {#each collectionStore.filteredAlbums.slice(0, MAX_SEARCH_SUGGESTIONS_PER_CATEGORY) as album (album.album)}
                   <div
                     role="button"
                     tabindex="0"
@@ -420,7 +421,7 @@
                 {/each}
 
                 <!-- Matching Playlists & Auto-playlists (Top 3) -->
-                {#each matchingPlaylists.slice(0, 3) as item (item.id)}
+                {#each matchingPlaylists.slice(0, MAX_SEARCH_SUGGESTIONS_PER_CATEGORY) as item (item.id)}
                   <div
                     role="button"
                     tabindex="0"
@@ -471,7 +472,7 @@
                 {/each}
 
                 <!-- Matching Songs (Top 3) -->
-                {#each collectionStore.searchResults.slice(0, 3) as song (song.id)}
+                {#each collectionStore.searchResults.slice(0, MAX_SEARCH_SUGGESTIONS_PER_CATEGORY) as song (song.id)}
                   <div
                     role="button"
                     tabindex="0"

--- a/src/lib/components/WaveformSeekBar.svelte
+++ b/src/lib/components/WaveformSeekBar.svelte
@@ -5,6 +5,10 @@
   import { prefs } from "../stores/prefs.svelte";
   import { i18n } from "../stores/i18n.svelte";
 
+  const CANVAS_BAR_HEIGHT_PX = 28;
+  const NARROW_WIDTH_BREAKPOINT_PX = 450;
+  const MOODBAR_SEGMENT_COUNT = 40;
+
   let containerEl = $state<HTMLDivElement | null>(null);
   let canvas = $state<HTMLCanvasElement | null>(null);
   let waveformData = $state<number[]>([]);
@@ -138,7 +142,7 @@
 
     const dpr = window.devicePixelRatio || 1;
     const width = containerEl.clientWidth || 300;
-    const height = 28;
+    const height = CANVAS_BAR_HEIGHT_PX;
 
     if (canvas.width !== width * dpr || canvas.height !== height * dpr) {
       canvas.width = width * dpr;
@@ -178,7 +182,7 @@
     const isPlaceholder = isLoadingWaveform || waveformData.length === 0;
     const data = isPlaceholder ? Array(150).fill(0) : waveformData;
     const numBars = data.length;
-    const barGap = width < 450 ? 0.5 : 1.0;
+    const barGap = width < NARROW_WIDTH_BREAKPOINT_PX ? 0.5 : 1.0;
     const barWidth = Math.max(1, (width - (numBars - 1) * barGap) / numBars);
 
     // Premium gradients for played part
@@ -242,7 +246,7 @@
     // ~40 wider contiguous blocks reveals the track's actual color
     // structure (verse/chorus-scale regions) the way a real moodbar strip
     // is meant to read at a glance.
-    const segmentCount = Math.min(40, totalPoints);
+    const segmentCount = Math.min(MOODBAR_SEGMENT_COUNT, totalPoints);
     const groupSize = Math.max(1, Math.ceil(totalPoints / segmentCount));
     const segCount = Math.ceil(totalPoints / groupSize);
     const segWidth = width / segCount;

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,0 +1,49 @@
+// Shared numeric constants used across multiple components/stores.
+// File-local magic numbers that only ever appear in one place stay named
+// inline near their usage instead of being centralized here.
+
+/** Estimated width of a floating context menu, used to keep it inside the viewport. */
+export const CONTEXT_MENU_WIDTH_PX = 200;
+
+/** Minimum gap kept between a floating menu/modal and the edge of the viewport. */
+export const VIEWPORT_EDGE_PADDING_PX = 10;
+
+/**
+ * The floating PlayerBar dock (h-20 + bottom-4 inset ≈ 96px) sits on top of
+ * page content whenever a song is loaded. Anything that positions itself
+ * near the bottom of the viewport (context menus, modals) needs to clamp
+ * above it so it isn't hidden underneath.
+ */
+export const PLAYER_DOCK_CLEARANCE_PX = 96;
+
+/** Sidebar width bounds (routes/+layout.svelte resize handle, Sidebar.svelte collapse threshold). */
+export const SIDEBAR_MIN_WIDTH_PX = 180;
+export const SIDEBAR_MAX_WIDTH_PX = 400;
+export const SIDEBAR_COLLAPSED_WIDTH_PX = 64;
+
+/** Right panel width bounds (routes/+layout.svelte resize handle). */
+export const RIGHT_PANEL_MIN_WIDTH_PX = 220;
+export const RIGHT_PANEL_MAX_WIDTH_PX = 480;
+
+/** Step size used by the keyboard-accessible resize handles for the sidebar/right panel. */
+export const PANEL_RESIZE_STEP_PX = 10;
+
+/**
+ * Per-cover offset/scale/opacity step used to fan out a stack of album
+ * covers into a 3D-ish pile, for the "left" stacking direction shared by
+ * CoverStack.svelte and the playlist header's inline cover stack.
+ */
+export const COVER_STACK_OFFSET_X_PX = -18;
+export const COVER_STACK_OFFSET_Y_PX = -10;
+export const COVER_STACK_ROTATION_DEG = -5;
+export const COVER_STACK_SCALE_STEP = 0.05;
+export const COVER_STACK_OPACITY_STEP = 0.07;
+
+/** Number of matches shown per category in the search-suggestions dropdown. */
+export const MAX_SEARCH_SUGGESTIONS_PER_CATEGORY = 3;
+
+/** Number of entries kept in the recent-searches history. */
+export const MAX_RECENT_SEARCHES = 10;
+
+/** Lightness step used when nudging a color's HSL lightness to reach a target contrast ratio. */
+export const LIGHTNESS_STEP = 0.02;

--- a/src/lib/stores/collection.svelte.ts
+++ b/src/lib/stores/collection.svelte.ts
@@ -12,6 +12,7 @@ import type {
 } from "../types";
 import { applySongStats, type SongStatsPayload } from "../utils/stats";
 import { playlistsStore } from "./playlists.svelte";
+import { MAX_RECENT_SEARCHES } from "../constants";
 
 export type ActiveTab = "home" | "collection" | "playlists" | "settings" | "lyrics" | "help";
 export type ActiveSubTab = "songs" | "albums" | "artists";
@@ -572,8 +573,8 @@ class CollectionStore {
     };
 
     this.recentSearches.unshift(newItem);
-    if (this.recentSearches.length > 10) {
-      this.recentSearches = this.recentSearches.slice(0, 10);
+    if (this.recentSearches.length > MAX_RECENT_SEARCHES) {
+      this.recentSearches = this.recentSearches.slice(0, MAX_RECENT_SEARCHES);
     }
     this.saveRecentSearches();
   }

--- a/src/lib/stores/theme.svelte.ts
+++ b/src/lib/stores/theme.svelte.ts
@@ -15,6 +15,9 @@ import {
   generatePaletteFromSeed,
   type ColorCount
 } from "../utils/colorUtils";
+import { LIGHTNESS_STEP } from "../constants";
+
+const MAX_READABILITY_ADJUST_STEPS = 30;
 
 export interface ThemeColors {
   "bg-main": string;
@@ -194,13 +197,13 @@ function clampLightness(rgb: Rgb, minL: number, maxL: number): Rgb {
 function darkenUntilReadable(rgb: Rgb): Rgb {
   let candidate = rgb;
   let hsl = rgbToHsl(rgb.r, rgb.g, rgb.b);
-  for (let i = 0; i < 30; i++) {
+  for (let i = 0; i < MAX_READABILITY_ADJUST_STEPS; i++) {
     const hex = rgbToHex(candidate.r, candidate.g, candidate.b);
     const primaryOk = checkWcagCompliance(ARTWORK_TEXT_PRIMARY_DARK, hex).wcagAA;
     const secondaryOk = checkWcagCompliance(ARTWORK_TEXT_SECONDARY_DARK, hex).wcagAA;
     if (primaryOk && secondaryOk) return candidate;
     if (hsl.l <= 0) return candidate;
-    hsl = { ...hsl, l: Math.max(0, hsl.l - 0.02) };
+    hsl = { ...hsl, l: Math.max(0, hsl.l - LIGHTNESS_STEP) };
     candidate = hslToRgb(hsl.h, hsl.s, hsl.l);
   }
   return candidate;
@@ -210,13 +213,13 @@ function darkenUntilReadable(rgb: Rgb): Rgb {
 function lightenUntilReadable(rgb: Rgb): Rgb {
   let candidate = rgb;
   let hsl = rgbToHsl(rgb.r, rgb.g, rgb.b);
-  for (let i = 0; i < 30; i++) {
+  for (let i = 0; i < MAX_READABILITY_ADJUST_STEPS; i++) {
     const hex = rgbToHex(candidate.r, candidate.g, candidate.b);
     const primaryOk = checkWcagCompliance(ARTWORK_TEXT_PRIMARY_LIGHT, hex).wcagAA;
     const secondaryOk = checkWcagCompliance(ARTWORK_TEXT_SECONDARY_LIGHT, hex).wcagAA;
     if (primaryOk && secondaryOk) return candidate;
     if (hsl.l >= 1) return candidate;
-    hsl = { ...hsl, l: Math.min(1, hsl.l + 0.02) };
+    hsl = { ...hsl, l: Math.min(1, hsl.l + LIGHTNESS_STEP) };
     candidate = hslToRgb(hsl.h, hsl.s, hsl.l);
   }
   return candidate;

--- a/src/lib/stores/updater.svelte.ts
+++ b/src/lib/stores/updater.svelte.ts
@@ -8,6 +8,8 @@ export interface InstallFormatInfo {
 
 export type CheckStatus = "idle" | "checking" | "available" | "up-to-date" | "error";
 
+const UPDATE_CHECK_INTERVAL_MS = 4 * 60 * 60 * 1000; // 4 hours
+
 class UpdaterStore {
   updateCheckEnabled = $state(false);
   updateAutoInstall = $state(false);
@@ -86,12 +88,11 @@ class UpdaterStore {
 
   startPeriodicCheck() {
     this.stopPeriodicCheck();
-    // Check every 4 hours (14,400,000 ms) while app is running
     this.intervalTimer = setInterval(() => {
       if (this.updateCheckEnabled) {
         this.checkForUpdates();
       }
-    }, 4 * 60 * 60 * 1000);
+    }, UPDATE_CHECK_INTERVAL_MS);
   }
 
   stopPeriodicCheck() {

--- a/src/lib/utils/colorUtils.ts
+++ b/src/lib/utils/colorUtils.ts
@@ -1,6 +1,11 @@
 // CIE Color Science and Accessibility Utilities
 // Based on International Commission on Illumination (CIE) standards
 
+import { LIGHTNESS_STEP } from "../constants";
+
+const MAX_CONTRAST_ADJUST_STEPS = 50;
+const MAX_PALETTE_TEXT_ADJUST_STEPS = 20;
+
 export interface ColorMetrics {
   hex: string;
   rgb: { r: number; g: number; b: number };
@@ -180,8 +185,8 @@ export function clampForContrast(hex: string, backgroundHex: string, minRatio = 
   let hsl = rgbToHsl(rgb.r, rgb.g, rgb.b);
   let candidateHex = hex;
 
-  for (let i = 0; i < 50; i++) {
-    const nextL = bgIsLight ? hsl.l - 0.02 : hsl.l + 0.02;
+  for (let i = 0; i < MAX_CONTRAST_ADJUST_STEPS; i++) {
+    const nextL = bgIsLight ? hsl.l - LIGHTNESS_STEP : hsl.l + LIGHTNESS_STEP;
     if (nextL < 0 || nextL > 1) break;
     hsl = { ...hsl, l: nextL };
     const candidateRgb = hslToRgb(hsl.h, hsl.s, hsl.l);
@@ -573,18 +578,18 @@ export function generatePaletteFromSeed(seedHex: string): GeneratedThemePalette 
     return backgroundHexes.every(bg => checkWcagCompliance(hex, bg).wcagAA);
   };
 
-  for (let i = 0; i < 20 && !meetsAA(textPrimary); i++) {
-    textPrimary = { ...textPrimary, l: Math.min(1, textPrimary.l + 0.02) };
+  for (let i = 0; i < MAX_PALETTE_TEXT_ADJUST_STEPS && !meetsAA(textPrimary); i++) {
+    textPrimary = { ...textPrimary, l: Math.min(1, textPrimary.l + LIGHTNESS_STEP) };
   }
-  for (let i = 0; i < 20 && !meetsAA(textSecondary); i++) {
-    textSecondary = { ...textSecondary, l: Math.min(1, textSecondary.l + 0.02) };
+  for (let i = 0; i < MAX_PALETTE_TEXT_ADJUST_STEPS && !meetsAA(textSecondary); i++) {
+    textSecondary = { ...textSecondary, l: Math.min(1, textSecondary.l + LIGHTNESS_STEP) };
   }
 
   let accentAdjusted = accent;
-  for (let i = 0; i < 20; i++) {
+  for (let i = 0; i < MAX_PALETTE_TEXT_ADJUST_STEPS; i++) {
     const accentHex = toHex(hslToRgb(accentAdjusted.h, accentAdjusted.s, accentAdjusted.l));
     if (checkWcagCompliance(accentHex, backgroundHexes[0]).ratio >= 3) break;
-    accentAdjusted = { ...accentAdjusted, l: Math.min(0.85, accentAdjusted.l + 0.02) };
+    accentAdjusted = { ...accentAdjusted, l: Math.min(0.85, accentAdjusted.l + LIGHTNESS_STEP) };
   }
 
   return {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -16,6 +16,14 @@
   import { i18n } from '../lib/stores/i18n.svelte';
   import { prefs } from '../lib/stores/prefs.svelte';
   import { onMount } from 'svelte';
+  import {
+    SIDEBAR_MIN_WIDTH_PX,
+    SIDEBAR_MAX_WIDTH_PX,
+    SIDEBAR_COLLAPSED_WIDTH_PX,
+    RIGHT_PANEL_MIN_WIDTH_PX,
+    RIGHT_PANEL_MAX_WIDTH_PX,
+    PANEL_RESIZE_STEP_PX,
+  } from '../lib/constants';
 
   let { children } = $props();
   let isLinux = $state(false);
@@ -93,9 +101,9 @@
       const deltaX = moveEvent.clientX - startX;
       let newWidth = startWidth + deltaX;
       if (newWidth < 120) {
-        newWidth = 64;
+        newWidth = SIDEBAR_COLLAPSED_WIDTH_PX;
       } else {
-        newWidth = Math.max(180, Math.min(400, newWidth));
+        newWidth = Math.max(SIDEBAR_MIN_WIDTH_PX, Math.min(SIDEBAR_MAX_WIDTH_PX, newWidth));
       }
       collectionStore.setSidebarWidth(newWidth);
     }
@@ -117,7 +125,7 @@
 
     function onPointerMove(moveEvent: PointerEvent) {
       const deltaX = moveEvent.clientX - startX;
-      collectionStore.setRightPanelWidth(Math.max(220, Math.min(480, startWidth - deltaX)));
+      collectionStore.setRightPanelWidth(Math.max(RIGHT_PANEL_MIN_WIDTH_PX, Math.min(RIGHT_PANEL_MAX_WIDTH_PX, startWidth - deltaX)));
     }
 
     function onPointerUp() {
@@ -135,19 +143,19 @@
       e.preventDefault();
       e.stopPropagation();
       const currentWidth = collectionStore.sidebarWidth;
-      if (currentWidth === 180) {
-        collectionStore.setSidebarWidth(64);
-      } else if (currentWidth > 180) {
-        collectionStore.setSidebarWidth(Math.max(180, currentWidth - 10));
+      if (currentWidth === SIDEBAR_MIN_WIDTH_PX) {
+        collectionStore.setSidebarWidth(SIDEBAR_COLLAPSED_WIDTH_PX);
+      } else if (currentWidth > SIDEBAR_MIN_WIDTH_PX) {
+        collectionStore.setSidebarWidth(Math.max(SIDEBAR_MIN_WIDTH_PX, currentWidth - PANEL_RESIZE_STEP_PX));
       }
     } else if (e.key === "ArrowRight") {
       e.preventDefault();
       e.stopPropagation();
       const currentWidth = collectionStore.sidebarWidth;
-      if (currentWidth === 64) {
-        collectionStore.setSidebarWidth(180);
+      if (currentWidth === SIDEBAR_COLLAPSED_WIDTH_PX) {
+        collectionStore.setSidebarWidth(SIDEBAR_MIN_WIDTH_PX);
       } else {
-        collectionStore.setSidebarWidth(Math.min(400, currentWidth + 10));
+        collectionStore.setSidebarWidth(Math.min(SIDEBAR_MAX_WIDTH_PX, currentWidth + PANEL_RESIZE_STEP_PX));
       }
     }
   }
@@ -157,11 +165,11 @@
     if (e.key === "ArrowLeft") {
       e.preventDefault();
       e.stopPropagation();
-      collectionStore.setRightPanelWidth(Math.min(480, collectionStore.rightPanelWidth + 10));
+      collectionStore.setRightPanelWidth(Math.min(RIGHT_PANEL_MAX_WIDTH_PX, collectionStore.rightPanelWidth + PANEL_RESIZE_STEP_PX));
     } else if (e.key === "ArrowRight") {
       e.preventDefault();
       e.stopPropagation();
-      collectionStore.setRightPanelWidth(Math.max(220, collectionStore.rightPanelWidth - 10));
+      collectionStore.setRightPanelWidth(Math.max(RIGHT_PANEL_MIN_WIDTH_PX, collectionStore.rightPanelWidth - PANEL_RESIZE_STEP_PX));
     }
   }
 </script>
@@ -199,8 +207,8 @@
                 <div 
                   role="separator"
                   aria-valuenow={collectionStore.sidebarWidth}
-                  aria-valuemin={64}
-                  aria-valuemax={400}
+                  aria-valuemin={SIDEBAR_COLLAPSED_WIDTH_PX}
+                  aria-valuemax={SIDEBAR_MAX_WIDTH_PX}
                   aria-label={i18n.t('topNav.resizeSidebar')}
                   tabindex="0"
                   class="relative w-1 hover:w-1.5 active:w-1.5 bg-brand-border hover:bg-brand-accent/50 active:bg-brand-accent cursor-col-resize transition-all self-stretch flex-shrink-0 z-30 touch-none focus:outline-none focus:bg-brand-accent focus:w-1.5"
@@ -227,8 +235,8 @@
                 <div 
                   role="separator"
                   aria-valuenow={collectionStore.rightPanelWidth}
-                  aria-valuemin={220}
-                  aria-valuemax={480}
+                  aria-valuemin={RIGHT_PANEL_MIN_WIDTH_PX}
+                  aria-valuemax={RIGHT_PANEL_MAX_WIDTH_PX}
                   aria-label={i18n.t('topNav.resizeRightPanel')}
                   tabindex="0"
                   class="relative w-1 hover:w-1.5 active:w-1.5 bg-brand-border hover:bg-brand-accent/50 active:bg-brand-accent cursor-col-resize transition-all self-stretch flex-shrink-0 z-30 touch-none focus:outline-none focus:bg-brand-accent focus:w-1.5"


### PR DESCRIPTION
## 📋 Summary
Part of a code-smell audit (magic numbers). Extracts unnamed numeric literals into named constants — either a shared `src/lib/constants.ts` for values duplicated across files, or file-local `const` declarations for values used once but embedded in logic (timers, resize bounds, rendering thresholds).

## 🔍 Implementation Notes
- **New `src/lib/constants.ts`**: context-menu geometry (`CONTEXT_MENU_WIDTH_PX`, `VIEWPORT_EDGE_PADDING_PX`, `PLAYER_DOCK_CLEARANCE_PX`) shared by `AlbumContextMenu`, `PlaylistContextMenu`, `SongContextMenu`, `SmartPlaylistBuilderModal`; sidebar/right-panel sizing (`SIDEBAR_MIN/MAX_WIDTH_PX`, `RIGHT_PANEL_MIN/MAX_WIDTH_PX`, `PANEL_RESIZE_STEP_PX`) shared by `+layout.svelte` and `Sidebar.svelte`; cover-stack transform math (`COVER_STACK_OFFSET_X/Y_PX`, `COVER_STACK_ROTATION_DEG`, `COVER_STACK_SCALE_STEP`, `COVER_STACK_OPACITY_STEP`) shared by `CoverStack.svelte` and `PlaylistView.svelte`'s independently-implemented copy of the same math; search caps (`MAX_SEARCH_SUGGESTIONS_PER_CATEGORY`, `MAX_RECENT_SEARCHES`); `LIGHTNESS_STEP` shared by the "nudge lightness until readable/accessible" loops in `colorUtils.ts` and `theme.svelte.ts`.
- **File-local constants**: debounce/timeout delays (`OrganizeFiles.svelte`, `FoldersView.svelte`, `PlaylistView.svelte`, `updater.svelte.ts`), column-resize bounds (`OrganizeFiles.svelte`), miniplayer resize bounds (`Miniplayer.svelte`), waveform/moodbar rendering thresholds (`WaveformSeekBar.svelte`), scroll-row buffer/step (`HorizontalScrollRow.svelte`), max-iteration bounds for contrast-adjustment loops (`colorUtils.ts`).
- A number of these had duplicate explanatory comments copy-pasted alongside the literal in 2-3 files (e.g. the PlayerBar dock-clearance `96px` note) — that was the clearest signal they belonged in one shared, named place instead.
- No behavior changes — pure renames of existing literals to `const`s with the same values.
- This PR is one of three from the same audit (magic numbers / i18n gaps / component extraction) being submitted as separate PRs; it and the others may touch a few of the same files (e.g. the context menus), so a rebase may be needed depending on merge order.

## 🧪 Test Plan
- [x] `bun run check` (svelte-check) — 0 errors, 0 warnings
- [x] `bun run test -- --run` (frontend) — 260 tests passed
- [ ] `cargo test` (src-tauri, if Rust changed) — no Rust changes
- [x] Manually reviewed the full diff to confirm every substitution is a literal-for-constant swap with no logic changes

## 📸 Screenshots
Not applicable — no visual/behavioral changes.

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed — not applicable, no user-facing behavior changed

---
_Generated by [Claude Code](https://claude.ai/code/session_01WMNEwTxuuiBQBbAKumAcPe)_