### PR TITLE
Migrate remaining hand-rolled buttons and text inputs onto shared components

### DIFF
--- a/src/lib/components/AlbumTagEditor.svelte
+++ b/src/lib/components/AlbumTagEditor.svelte
@@ -6,6 +6,8 @@
   import { toastStore } from "../stores/toast.svelte";
   import FormField from "./FormField.svelte";
   import Modal from "./Modal.svelte";
+  import Button from "./Button.svelte";
+  import Input from "./Input.svelte";
 
   interface Props {
     songIds: number[];
@@ -98,43 +100,22 @@
         <div class="grid grid-cols-2 gap-4">
           <!-- Album Title -->
           <FormField label={i18n.t('albumTagEditor.albumField')} for="album-tag-album" span2>
-            <input
-              id="album-tag-album"
-              bind:value={album}
-              disabled={isSaving}
-              class="bg-brand-main border border-brand-border rounded-lg px-3 py-2 text-xs text-brand-text-primary outline-none focus:border-brand-accent focus:ring-1 focus:ring-brand-accent disabled:opacity-50"
-            />
+            <Input id="album-tag-album" bind:value={album} disabled={isSaving} size="sm" class="w-full" />
           </FormField>
 
           <!-- Album Artist -->
           <FormField label={i18n.t('albumTagEditor.albumArtistField')} for="album-tag-albumartist" span2>
-            <input
-              id="album-tag-albumartist"
-              bind:value={albumArtist}
-              disabled={isSaving}
-              class="bg-brand-main border border-brand-border rounded-lg px-3 py-2 text-xs text-brand-text-primary outline-none focus:border-brand-accent focus:ring-1 focus:ring-brand-accent disabled:opacity-50"
-            />
+            <Input id="album-tag-albumartist" bind:value={albumArtist} disabled={isSaving} size="sm" class="w-full" />
           </FormField>
 
           <!-- Genre -->
           <FormField label={i18n.t('albumTagEditor.genreField')} for="album-tag-genre">
-            <input
-              id="album-tag-genre"
-              bind:value={genre}
-              disabled={isSaving}
-              class="bg-brand-main border border-brand-border rounded-lg px-3 py-2 text-xs text-brand-text-primary outline-none focus:border-brand-accent focus:ring-1 focus:ring-brand-accent disabled:opacity-50"
-            />
+            <Input id="album-tag-genre" bind:value={genre} disabled={isSaving} size="sm" class="w-full" />
           </FormField>
 
           <!-- Year -->
           <FormField label={i18n.t('albumTagEditor.yearField')} for="album-tag-year">
-            <input
-              id="album-tag-year"
-              type="number"
-              bind:value={year}
-              disabled={isSaving}
-              class="bg-brand-main border border-brand-border rounded-lg px-3 py-2 text-xs text-brand-text-primary outline-none focus:border-brand-accent focus:ring-1 focus:ring-brand-accent disabled:opacity-50"
-            />
+            <Input id="album-tag-year" type="number" bind:value={year} disabled={isSaving} size="sm" class="w-full" />
           </FormField>
         </div>
       </div>
@@ -142,18 +123,10 @@
 
     <!-- Footer -->
     <div class="h-16 flex items-center justify-end px-6 border-t border-brand-border gap-3 bg-brand-main shrink-0">
-      <button
-        onclick={onClose}
-        disabled={isSaving}
-        class="px-4 py-2 text-xs font-semibold text-brand-text-secondary hover:text-brand-text-primary transition-colors disabled:opacity-50"
-      >
+      <Button onclick={onClose} disabled={isSaving} variant="secondary" size="sm">
         {i18n.t('albumTagEditor.cancelBtn')}
-      </button>
-      <button
-        onclick={handleSave}
-        disabled={isSaving}
-        class="flex items-center gap-2 px-5 py-2 rounded-xl bg-brand-accent hover:bg-brand-accent-hover text-white text-xs font-bold transition-all shadow-md shadow-brand-accent/20 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
-      >
+      </Button>
+      <Button onclick={handleSave} disabled={isSaving} variant="primary" size="sm">
         {#if isSaving}
           <LoaderCircle class="w-3.5 h-3.5 animate-spin" />
           <span>{i18n.t('albumTagEditor.saving')}</span>
@@ -161,6 +134,6 @@
           <Save class="w-3.5 h-3.5" />
           <span>{i18n.t('albumTagEditor.saveBtn')}</span>
         {/if}
-      </button>
+      </Button>
     </div>
 </Modal>

--- a/src/lib/components/Button.svelte
+++ b/src/lib/components/Button.svelte
@@ -7,7 +7,8 @@
   import type { Snippet } from "svelte";
 
   interface Props {
-    onclick: (e: MouseEvent) => void;
+    onclick?: (e: MouseEvent) => void;
+    type?: "button" | "submit";
     disabled?: boolean;
     title?: string;
     variant?: ButtonVariant;
@@ -18,6 +19,7 @@
 
   let {
     onclick,
+    type = "button",
     disabled = false,
     title,
     variant = "secondary",
@@ -44,6 +46,7 @@
 
 <button
   {onclick}
+  {type}
   {disabled}
   {title}
   class="flex items-center justify-center rounded-full font-semibold transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed {sizeClasses[size]} {variantClasses[variant]} {className}"

--- a/src/lib/components/CollectionView.svelte
+++ b/src/lib/components/CollectionView.svelte
@@ -23,6 +23,7 @@
   import EmptyState from "./EmptyState.svelte";
   import NowPlayingBars from "./NowPlayingBars.svelte";
   import LinkButton from "./LinkButton.svelte";
+  import Button from "./Button.svelte";
 
   // activeSubTab and activeTab are managed globally via collectionStore
 
@@ -574,13 +575,10 @@
                   {/if}
                 </p>
                 {#if collectionStore.searchQuery}
-                  <button
-                    onclick={() => { collectionStore.searchQuery = ""; collectionStore.search(""); }}
-                    class="px-3.5 py-2 text-xs bg-brand-accent hover:bg-brand-accent-hover text-brand-accent-contrast rounded-xl shadow transition-all font-semibold cursor-pointer flex items-center gap-1.5"
-                  >
+                  <Button onclick={() => { collectionStore.searchQuery = ""; collectionStore.search(""); }} variant="primary" size="sm">
                     <FilterX class="w-3.5 h-3.5" />
                     {i18n.t('collection.resetSearchFilters')}
-                  </button>
+                  </Button>
                 {/if}
               </div>
             </div>

--- a/src/lib/components/FoldersView.svelte
+++ b/src/lib/components/FoldersView.svelte
@@ -14,6 +14,8 @@
   import OrganizeFiles from "./OrganizeFiles.svelte";
   import Toggle from "./Toggle.svelte";
   import Select from "./Select.svelte";
+  import Button from "./Button.svelte";
+  import Input from "./Input.svelte";
 
   const COPY_FEEDBACK_DURATION_MS = 1500;
   const PRUNE_MESSAGE_DURATION_MS = 8000;
@@ -340,14 +342,10 @@
       <div class="bg-brand-sidebar border border-brand-border rounded-xl p-6 space-y-4">
         <div class="flex items-center justify-between">
           <h3 class="text-xs text-brand-text-secondary font-bold tracking-wider uppercase">{i18n.t('settings.appAndUpdatesTitle')}</h3>
-          <button
-            onclick={() => updaterStore.checkForUpdates()}
-            disabled={updaterStore.checkStatus === 'checking'}
-            class="px-3 py-1.5 rounded-lg text-xs font-semibold bg-brand-main border border-brand-border hover:bg-brand-sidebar hover:border-brand-accent/50 text-brand-text-primary transition-all flex items-center gap-1.5 cursor-pointer disabled:opacity-50"
-          >
+          <Button onclick={() => updaterStore.checkForUpdates()} disabled={updaterStore.checkStatus === 'checking'} variant="secondary" size="sm">
             <RefreshCw class="w-3.5 h-3.5 {updaterStore.checkStatus === 'checking' ? 'animate-spin text-brand-accent-text' : ''}" />
             {updaterStore.checkStatus === 'checking' ? i18n.t('settings.updateChecking') : i18n.t('settings.updateCheckNowBtn')}
-          </button>
+          </Button>
         </div>
 
         <!-- Version & Format Info Row -->
@@ -400,13 +398,10 @@
                 </p>
               </div>
             </div>
-            <button
-              onclick={() => openExternalUrl(updaterStore.downloadUrl || updaterStore.releaseUrl)}
-              class="px-4 py-2 rounded-lg bg-brand-accent hover:bg-brand-accent-hover text-brand-accent-contrast font-semibold text-xs flex items-center gap-1.5 transition-colors cursor-pointer shadow-md shrink-0"
-            >
+            <Button onclick={() => openExternalUrl(updaterStore.downloadUrl || updaterStore.releaseUrl)} variant="primary" size="sm" class="shrink-0">
               <Download class="w-4 h-4" />
               {updaterStore.installFormat.supports_self_update ? i18n.t('settings.updateDownloadBtn') : i18n.t('settings.updateDownloadGithubBtn')}
-            </button>
+            </Button>
           </div>
         {:else if updaterStore.checkStatus === 'up-to-date'}
           <div class="text-xs text-brand-text-primary font-medium flex items-center gap-1.5 pt-1">
@@ -453,12 +448,9 @@
       <!-- Watched Folders Section -->
       <div class="flex justify-between items-center">
         <h3 class="text-xs text-brand-text-secondary font-bold tracking-wider uppercase">{i18n.t('settings.tabFolders')}</h3>
-        <button
-          onclick={handleAddDirectory}
-          class="bg-brand-accent hover:bg-brand-accent-hover text-brand-accent-contrast px-3.5 py-1.5 rounded-lg text-xs font-semibold flex items-center gap-1.5 transition-colors shadow-lg shadow-brand-accent/20 cursor-pointer"
-        >
+        <Button onclick={handleAddDirectory} variant="primary" size="sm">
           <Plus class="w-4 h-4" /> {i18n.t('settings.addFolder')}
-        </button>
+        </Button>
       </div>
 
       <!-- Folders List -->
@@ -524,25 +516,27 @@
 
         <!-- Manual Action Buttons -->
         <div class="flex flex-wrap items-center gap-3">
-          <button
+          <Button
             onclick={() => collectionStore.startScan(false)}
             disabled={collectionStore.isScanning}
-            class="bg-brand-accent hover:bg-brand-accent-hover text-brand-accent-contrast px-4 py-2 rounded-lg text-xs font-semibold flex items-center gap-2 transition-all shadow-md shadow-brand-accent/10 cursor-pointer disabled:opacity-50"
+            variant="primary"
+            size="sm"
             title={i18n.t('settings.incrementalRescanHint')}
           >
             <RefreshCw class="w-4 h-4" />
             {i18n.t('settings.incrementalRescanBtn')}
-          </button>
+          </Button>
 
-          <button
+          <Button
             onclick={() => collectionStore.startScan(true)}
             disabled={collectionStore.isScanning}
-            class="bg-brand-main hover:bg-brand-sidebar border border-brand-border hover:border-brand-accent/40 text-brand-text-primary px-4 py-2 rounded-lg text-xs font-semibold flex items-center gap-2 transition-colors cursor-pointer disabled:opacity-50"
+            variant="secondary"
+            size="sm"
             title={i18n.t('settings.forceFullScanHint')}
           >
             <RotateCcw class="w-4 h-4 text-brand-accent-text" />
             {i18n.t('settings.forceFullScanBtn')}
-          </button>
+          </Button>
         </div>
 
         <!-- Configuration Toggles -->
@@ -611,14 +605,10 @@
 
       <div class="bg-brand-sidebar border border-brand-border rounded-xl p-6 space-y-5">
         <div class="flex flex-wrap items-center gap-3">
-          <button
-            onclick={handlePruneMissing}
-            disabled={collectionStore.isScanning}
-            class="bg-brand-main hover:bg-red-950/20 text-brand-text-secondary hover:text-red-400 border border-brand-border hover:border-red-900/30 px-4 py-2 rounded-lg text-xs font-semibold flex items-center gap-2 transition-colors cursor-pointer disabled:opacity-50"
-          >
-            <Eraser class="w-4 h-4 text-brand-accent-text" />
+          <Button onclick={handlePruneMissing} disabled={collectionStore.isScanning} variant="destructive" size="sm">
+            <Eraser class="w-4 h-4" />
             {i18n.t('settings.pruneMissingBtn')}
-          </button>
+          </Button>
           <span class="text-xs text-brand-text-secondary">{i18n.t('settings.pruneMissingHint')}</span>
 
           {#if pruneMsg}
@@ -725,12 +715,9 @@
               </h4>
             </div>
             {#if editingThemeId}
-              <button
-                onclick={() => { editingThemeId = null; }}
-                class="text-xs text-brand-text-secondary hover:text-brand-text-primary px-3 py-1.5 rounded-lg border border-brand-border hover:border-brand-accent/40 transition-colors cursor-pointer"
-              >
+              <Button onclick={() => { editingThemeId = null; }} variant="secondary" size="sm">
                 {i18n.t('settings.cancel')}
-              </button>
+              </Button>
             {/if}
           </div>
 
@@ -738,20 +725,18 @@
               <div class="flex flex-col md:flex-row gap-4 items-end justify-between">
                 <div class="flex flex-col gap-1.5 flex-1 max-w-sm">
                   <label for="theme-name-input" class="text-xs text-brand-text-secondary font-semibold">{i18n.t('settings.themeNameLabel')}</label>
-                  <input
+                  <Input
                     id="theme-name-input"
                     type="text"
                     bind:value={newThemeName}
                     placeholder={i18n.t('settings.themeNamePlaceholder')}
-                    class="bg-brand-main border border-brand-border rounded-lg px-3 py-2 text-xs text-brand-text-primary outline-none focus:border-brand-accent w-full"
+                    size="md"
+                    class="w-full"
                   />
                 </div>
-                <button
-                  onclick={loadActiveThemeColors}
-                  class="bg-brand-main hover:bg-brand-sidebar border border-brand-border hover:border-brand-accent/40 text-brand-text-primary px-4 py-2 rounded-lg text-xs font-semibold flex items-center gap-1.5 transition-colors cursor-pointer shrink-0 h-9"
-                >
+                <Button onclick={loadActiveThemeColors} variant="secondary" size="sm" class="shrink-0 h-9">
                   <RotateCcw class="w-4 h-4 text-brand-accent-text" /> {i18n.t('settings.importColors')}
-                </button>
+                </Button>
               </div>
 
               <div class="grid grid-cols-2 md:grid-cols-3 gap-6 pt-2">
@@ -811,18 +796,12 @@
               </div>
 
               <div class="flex flex-wrap items-center gap-3 pt-3 border-t border-brand-border">
-                <button
-                  onclick={saveCustomTheme}
-                  class="bg-brand-accent hover:bg-brand-accent-hover text-brand-accent-contrast px-4 py-2 rounded-lg text-xs font-semibold transition-all shadow-md shadow-brand-accent/10 cursor-pointer"
-                >
+                <Button onclick={saveCustomTheme} variant="primary" size="sm">
                   {editingThemeId ? i18n.t('settings.saveChanges') : i18n.t('settings.saveCustom')}
-                </button>
-                <button
-                  onclick={applyCustomTheme}
-                  class="bg-brand-main hover:bg-brand-sidebar border border-brand-accent/60 text-brand-accent-text hover:text-brand-text-primary px-4 py-2 rounded-lg text-xs font-semibold transition-all cursor-pointer"
-                >
+                </Button>
+                <Button onclick={applyCustomTheme} variant="accent-soft" size="sm">
                   {i18n.t('settings.applyTheme')}
-                </button>
+                </Button>
               </div>
             </div>
         </div>

--- a/src/lib/components/Input.svelte
+++ b/src/lib/components/Input.svelte
@@ -1,0 +1,71 @@
+<script lang="ts" module>
+  export type InputSize = "md" | "sm";
+  export type InputSurface = "main" | "sidebar";
+</script>
+
+<script lang="ts">
+  interface Props {
+    value?: string | number | null;
+    type?: string;
+    id?: string;
+    name?: string;
+    placeholder?: string;
+    disabled?: boolean;
+    required?: boolean;
+    size?: InputSize;
+    surface?: InputSurface;
+    /** Swaps the border/ring to the accent color, e.g. to flag a field that was just auto-filled. */
+    highlighted?: boolean;
+    class?: string;
+    style?: string;
+    oninput?: (e: Event & { currentTarget: HTMLInputElement }) => void;
+    onchange?: (e: Event & { currentTarget: HTMLInputElement }) => void;
+    onkeydown?: (e: KeyboardEvent & { currentTarget: HTMLInputElement }) => void;
+    onfocus?: (e: FocusEvent & { currentTarget: HTMLInputElement }) => void;
+  }
+
+  let {
+    value = $bindable(""),
+    type = "text",
+    id,
+    name,
+    placeholder,
+    disabled = false,
+    required = false,
+    size = "md",
+    surface = "main",
+    highlighted = false,
+    class: className = "",
+    style,
+    oninput,
+    onchange,
+    onkeydown,
+    onfocus,
+  }: Props = $props();
+
+  const sizeClasses: Record<InputSize, string> = {
+    md: "rounded-xl px-3.5 py-2 text-sm font-medium",
+    sm: "rounded-lg px-2.5 py-1.5 text-xs",
+  };
+
+  const surfaceClasses: Record<InputSurface, string> = {
+    main: "bg-brand-main",
+    sidebar: "bg-brand-sidebar",
+  };
+</script>
+
+<input
+  {id}
+  {name}
+  {type}
+  bind:value
+  {placeholder}
+  {disabled}
+  {required}
+  {oninput}
+  {onchange}
+  {onkeydown}
+  {onfocus}
+  {style}
+  class="border text-brand-text-primary outline-none focus:border-brand-accent disabled:opacity-50 transition-colors {surfaceClasses[surface]} {sizeClasses[size]} {highlighted ? 'border-brand-accent ring-1 ring-brand-accent/40' : 'border-brand-border'} {className}"
+/>

--- a/src/lib/components/LyricsView.svelte
+++ b/src/lib/components/LyricsView.svelte
@@ -3,6 +3,7 @@
   import { playerStore } from "../stores/player.svelte";
   import { FileText, Edit3, Save, X, RefreshCw, Music2 } from "lucide-svelte";
   import LoadingSpinner from "./LoadingSpinner.svelte";
+  import Button from "./Button.svelte";
   import { i18n } from "../stores/i18n.svelte";
   import { toastStore } from "../stores/toast.svelte";
 
@@ -238,39 +239,23 @@
     {#if playerStore.currentSong}
       <div class="flex items-center gap-2">
         {#if playerStore.currentSong.is_instrumental}
-          <button
-            onclick={() => toggleInstrumental(false)}
-            class="flex items-center gap-1.5 bg-brand-main/50 border border-brand-border hover:bg-brand-main/80 text-brand-text-secondary hover:text-brand-text-primary px-3 py-1.5 rounded-lg text-xs font-semibold transition-all duration-150 cursor-pointer"
-          >
+          <Button onclick={() => toggleInstrumental(false)} variant="secondary" size="sm">
             <Music2 class="w-3.5 h-3.5" /> {i18n.t('lyrics.unmarkInstrumental', {}, "Unmark Instrumental")}
-          </button>
+          </Button>
         {:else if !isEditing}
-          <button
-            onclick={() => loadLyrics(playerStore.currentSong?.id, true)}
-            class="flex items-center gap-1.5 bg-brand-main/50 border border-brand-border hover:bg-brand-main/80 text-brand-text-secondary hover:text-brand-text-primary px-3 py-1.5 rounded-lg text-xs font-semibold transition-all duration-150 cursor-pointer"
-            title={i18n.t('lyrics.refetchTooltip', {}, "Refetch lyrics online")}
-          >
+          <Button onclick={() => loadLyrics(playerStore.currentSong?.id, true)} variant="secondary" size="sm" title={i18n.t('lyrics.refetchTooltip', {}, "Refetch lyrics online")}>
             <RefreshCw class="w-3.5 h-3.5" /> {i18n.t('lyrics.refetchBtn', {}, "Refetch")}
-          </button>
-          <button
-            onclick={startEditing}
-            class="flex items-center gap-1.5 bg-brand-accent hover:bg-brand-accent-hover text-brand-accent-contrast px-3 py-1.5 rounded-lg text-xs font-semibold transition-all duration-150 shadow-lg shadow-brand-accent/20 cursor-pointer"
-          >
+          </Button>
+          <Button onclick={startEditing} variant="primary" size="sm">
             <Edit3 class="w-3.5 h-3.5" /> {i18n.t('settings.editThemeShort')}
-          </button>
+          </Button>
         {:else}
-          <button
-            onclick={() => { isEditing = false; }}
-            class="flex items-center gap-1.5 bg-brand-main/50 border border-brand-border hover:bg-brand-main/80 text-brand-text-secondary hover:text-brand-text-primary px-3 py-1.5 rounded-lg text-xs font-semibold transition-all cursor-pointer"
-          >
+          <Button onclick={() => { isEditing = false; }} variant="secondary" size="sm">
             <X class="w-3.5 h-3.5" /> {i18n.t('settings.cancel')}
-          </button>
-          <button
-            onclick={saveManualLyrics}
-            class="flex items-center gap-1.5 bg-brand-accent hover:bg-brand-accent-hover text-brand-accent-contrast px-3 py-1.5 rounded-lg text-xs font-semibold transition-all shadow-md cursor-pointer"
-          >
+          </Button>
+          <Button onclick={saveManualLyrics} variant="primary" size="sm">
             <Save class="w-3.5 h-3.5" /> {i18n.t('tagEditor.saveBtnShort')}
-          </button>
+          </Button>
         {/if}
       </div>
     {/if}
@@ -296,12 +281,9 @@
             {i18n.t('lyrics.instrumentalDesc', {}, "This track is marked as instrumental. Online lyrics search is bypassed.")}
           </p>
         </div>
-        <button
-          onclick={() => toggleInstrumental(false)}
-          class="mt-2 bg-brand-main/60 hover:bg-brand-main border border-brand-border text-brand-text-secondary hover:text-brand-text-primary px-4 py-2 rounded-lg text-xs font-semibold transition-all cursor-pointer shadow-sm"
-        >
+        <Button onclick={() => toggleInstrumental(false)} variant="secondary" size="sm" class="mt-2">
           {i18n.t('lyrics.unmarkInstrumental', {}, "Unmark Instrumental")}
-        </button>
+        </Button>
       </div>
     {:else if isEditing}
       <!-- Editor Mode -->
@@ -350,19 +332,13 @@
         <p class="text-sm font-semibold text-rose-400">{i18n.t('lyrics.lyricsNotFound')}</p>
         <p class="text-xs text-brand-text-secondary/50 max-w-sm">{errorMsg}</p>
         <div class="flex items-center gap-2 mt-2">
-          <button
-            onclick={() => loadLyrics(playerStore.currentSong?.id)}
-            class="bg-brand-main/50 hover:bg-brand-main/80 border border-brand-border text-brand-text-secondary hover:text-brand-text-primary px-4 py-2 rounded-lg text-xs font-semibold transition-all cursor-pointer"
-          >
+          <Button onclick={() => loadLyrics(playerStore.currentSong?.id)} variant="secondary" size="sm">
             {i18n.t('lyrics.retrySearch', {}, "Retry Search")}
-          </button>
+          </Button>
           {#if playerStore.currentSong}
-            <button
-              onclick={() => toggleInstrumental(true)}
-              class="bg-brand-accent/20 hover:bg-brand-accent/30 border border-brand-accent/40 text-brand-accent-text px-4 py-2 rounded-lg text-xs font-semibold transition-all cursor-pointer"
-            >
+            <Button onclick={() => toggleInstrumental(true)} variant="accent-soft" size="sm">
               {i18n.t('lyrics.markInstrumental', {}, "Mark as Instrumental")}
-            </button>
+            </Button>
           {/if}
         </div>
       </div>
@@ -372,12 +348,9 @@
         {#if playerStore.currentSong}
           <p class="text-sm font-semibold text-brand-text-secondary/80">{i18n.t('lyrics.lyricsNotFound')}</p>
           <p class="text-xs text-brand-text-secondary/50 max-w-xs mt-1">{i18n.t('lyrics.lyricsHelpText')}</p>
-          <button
-            onclick={() => toggleInstrumental(true)}
-            class="mt-3 bg-brand-accent/20 hover:bg-brand-accent/30 border border-brand-accent/40 text-brand-accent-text px-4 py-2 rounded-lg text-xs font-semibold transition-all cursor-pointer"
-          >
+          <Button onclick={() => toggleInstrumental(true)} variant="accent-soft" size="sm" class="mt-3">
             {i18n.t('lyrics.markInstrumental', {}, "Mark as Instrumental")}
-          </button>
+          </Button>
         {:else}
           <p class="text-sm font-semibold text-brand-text-secondary/80">{i18n.t('playerBar.notPlaying')}</p>
           <p class="text-xs text-brand-text-secondary/50 mt-1">{i18n.t('lyrics.lyricsHelpText')}</p>

--- a/src/lib/components/PlaylistView.svelte
+++ b/src/lib/components/PlaylistView.svelte
@@ -39,6 +39,7 @@
   import NowPlayingBars from "./NowPlayingBars.svelte";
   import LinkButton from "./LinkButton.svelte";
   import Button from "./Button.svelte";
+  import Input from "./Input.svelte";
   import { portal } from "../utils/portal";
   import {
     COVER_STACK_OFFSET_X_PX,
@@ -725,11 +726,13 @@
         <!-- Search Filter Bar -->
         <div class="relative flex-1 max-w-xs">
           <Search class="w-3.5 h-3.5 absolute left-3 top-1/2 -translate-y-1/2 text-brand-text-secondary/60 pointer-events-none" />
-          <input
+          <Input
             type="text"
             bind:value={filterQuery}
             placeholder={i18n.t("playlists.filterPlaceholder")}
-            class="w-full pl-8 pr-7 py-1 text-xs bg-brand-sidebar/60 border border-brand-border/60 rounded-md text-brand-text-primary placeholder:text-brand-text-secondary/50 focus:outline-none focus:border-brand-accent transition-colors"
+            size="sm"
+            class="w-full"
+            style="padding-left: 2rem; padding-right: 1.75rem;"
           />
           {#if filterQuery}
             <button

--- a/src/lib/components/PlaylistsCollectionView.svelte
+++ b/src/lib/components/PlaylistsCollectionView.svelte
@@ -14,6 +14,8 @@
   import SmartPlaylistBuilderModal from "./SmartPlaylistBuilderModal.svelte";
   import EmptyState from "./EmptyState.svelte";
   import Select from "./Select.svelte";
+  import Button from "./Button.svelte";
+  import Input from "./Input.svelte";
   import { FolderInput, Plus, ListMusic, Sparkles } from "lucide-svelte";
   import { isSmartPlaylistSpec } from "../utils/filterParser";
 
@@ -245,22 +247,14 @@
         <!-- Actions + Sort Dropdown (Right) -->
         <div class="flex items-center gap-2">
           {#if collectionStore.playlistsSubTab === "custom"}
-            <button
-              onclick={() => { showCreateForm = !showCreateForm; }}
-              class="flex items-center gap-1.5 bg-brand-accent hover:bg-brand-accent-hover text-brand-accent-contrast px-2.5 py-1.5 text-xs font-semibold rounded-lg transition-colors cursor-pointer"
-              title={i18n.t('playlists.newPlaylistBtn')}
-            >
+            <Button onclick={() => { showCreateForm = !showCreateForm; }} variant="primary" size="sm" title={i18n.t('playlists.newPlaylistBtn')}>
               <Plus class="w-3.5 h-3.5" />
               <span>{i18n.t('playlists.newPlaylistBtn')}</span>
-            </button>
-            <button
-              onclick={handleImportPlaylist}
-              class="flex items-center gap-1.5 bg-brand-sidebar hover:bg-brand-main border border-brand-border/60 text-brand-text-primary px-2.5 py-1.5 text-xs font-semibold rounded-lg transition-colors cursor-pointer"
-              title={i18n.t('playlists.importPlaylistTooltip')}
-            >
+            </Button>
+            <Button onclick={handleImportPlaylist} variant="secondary" size="sm" title={i18n.t('playlists.importPlaylistTooltip')}>
               <FolderInput class="w-3.5 h-3.5 text-brand-accent-text" />
               <span>{i18n.t('playlists.importPlaylistBtn')}</span>
-            </button>
+            </Button>
           {/if}
 
           <div class="relative">
@@ -305,22 +299,14 @@
 
       {#if collectionStore.playlistsSubTab === "custom" && showCreateForm}
         <form onsubmit={handleCreatePlaylist} class="flex items-center gap-2 mb-4">
-          <input
-            bind:value={newPlaylistName}
-            placeholder={i18n.t('playlists.createPlaylistPlaceholder')}
-            class="bg-brand-sidebar border border-brand-border rounded-lg px-3 py-1.5 text-xs w-64 text-brand-text-primary focus:outline-none focus:border-brand-accent"
-          />
-          <button type="submit" class="bg-brand-accent hover:bg-brand-accent-hover text-brand-accent-contrast rounded-lg px-3 py-1.5 text-xs font-semibold cursor-pointer">
+          <Input bind:value={newPlaylistName} placeholder={i18n.t('playlists.createPlaylistPlaceholder')} size="sm" surface="sidebar" class="w-64" />
+          <Button type="submit" variant="primary" size="sm">
             {i18n.t('sidebar.create')}
-          </button>
-          <button
-            type="button"
-            onclick={() => collectionStore.openSmartBuilder()}
-            class="bg-indigo-600 hover:bg-indigo-700 text-white rounded-lg px-3 py-1.5 text-xs font-semibold cursor-pointer flex items-center gap-1.5 transition-colors"
-          >
+          </Button>
+          <Button type="button" onclick={() => collectionStore.openSmartBuilder()} variant="accent-soft" size="sm">
             <Sparkles class="w-3.5 h-3.5" />
             <span>{i18n.t('playlists.advancedBtn')}</span>
-          </button>
+          </Button>
         </form>
       {/if}
 

--- a/src/lib/components/SmartPlaylistBuilderModal.svelte
+++ b/src/lib/components/SmartPlaylistBuilderModal.svelte
@@ -10,6 +10,8 @@
   import PopulationModeTabs from "./PopulationModeTabs.svelte";
   import Toggle from "./Toggle.svelte";
   import Select from "./Select.svelte";
+  import Button from "./Button.svelte";
+  import Input from "./Input.svelte";
   import { PLAYER_DOCK_CLEARANCE_PX } from "../constants";
 
   interface Props {
@@ -256,13 +258,13 @@
         <label for="smart-playlist-name-input" class="block text-xs font-semibold text-brand-text-secondary uppercase tracking-wider mb-1.5">
           {i18n.t("smartPlaylistBuilder.nameLabel")}
         </label>
-        <input
+        <Input
           id="smart-playlist-name-input"
           type="text"
           bind:value={playlistName}
           oninput={() => { userHasEditedName = true; }}
           placeholder={i18n.t("smartPlaylistBuilder.namePlaceholder")}
-          class="w-full bg-brand-main border border-brand-border rounded-xl px-3.5 py-2 text-sm text-brand-text-primary focus:outline-none focus:border-brand-accent font-medium"
+          class="w-full"
           required
         />
       </div>
@@ -314,11 +316,13 @@
               </Select>
 
               <!-- Value Input -->
-              <input
+              <Input
                 type="text"
                 bind:value={rule.value}
                 placeholder={i18n.t("smartPlaylistBuilder.valuePlaceholder")}
-                class="flex-1 bg-brand-sidebar border border-brand-border text-brand-text-primary text-xs rounded-lg px-2.5 py-1.5 focus:outline-none focus:border-brand-accent min-w-0"
+                size="sm"
+                surface="sidebar"
+                class="flex-1 min-w-0"
               />
 
               <!-- Delete Rule -->
@@ -358,20 +362,13 @@
 
       <!-- Footer Buttons -->
       <div class="flex items-center justify-end gap-3 pt-4 border-t border-brand-border/60">
-        <button
-          type="button"
-          onclick={onClose}
-          class="px-4 py-2 text-xs font-semibold text-brand-text-secondary hover:text-brand-text-primary transition-colors cursor-pointer"
-        >
+        <Button type="button" onclick={onClose} variant="secondary" size="sm">
           {i18n.t("smartPlaylistBuilder.cancel")}
-        </button>
-        <button
-          type="submit"
-          class="px-4 py-2 bg-brand-accent hover:bg-brand-accent-hover text-brand-accent-contrast text-xs font-semibold rounded-xl shadow-lg transition-all cursor-pointer flex items-center gap-1.5"
-        >
+        </Button>
+        <Button type="submit" variant="primary" size="sm">
           <Sparkles class="w-3.5 h-3.5" />
           {editing ? i18n.t("smartPlaylistBuilder.updateBtn") : i18n.t("smartPlaylistBuilder.createBtn")}
-        </button>
+        </Button>
       </div>
     </form>
   </div>

--- a/src/lib/components/TagEditor.svelte
+++ b/src/lib/components/TagEditor.svelte
@@ -10,6 +10,8 @@
   import FormField from "./FormField.svelte";
   import LoadingSpinner from "./LoadingSpinner.svelte";
   import Modal from "./Modal.svelte";
+  import Button from "./Button.svelte";
+  import Input from "./Input.svelte";
 
   interface Props {
     songId: number;
@@ -222,65 +224,56 @@
           <div class="grid grid-cols-2 gap-4">
             <!-- Title -->
             <FormField label={i18n.t('tagEditor.titleField')} for="tag-title" span2>
-              <input
+              <Input
                 id="tag-title"
                 bind:value={title}
                 oninput={() => changedFields.delete("title")}
                 disabled={isSaving}
-                class="bg-brand-main border rounded-lg px-3 py-2 text-xs text-brand-text-primary outline-none focus:border-brand-accent focus:ring-1 focus:ring-brand-accent disabled:opacity-50 transition-colors {changedFields.has('title') ? 'border-brand-accent ring-1 ring-brand-accent/40' : 'border-brand-border'}"
+                size="sm"
+                highlighted={changedFields.has('title')}
+                class="w-full"
               />
             </FormField>
 
             <!-- Artist -->
             <FormField label={i18n.t('tagEditor.artistField')} for="tag-artist">
-              <input
+              <Input
                 id="tag-artist"
                 bind:value={artist}
                 oninput={() => changedFields.delete("artist")}
                 disabled={isSaving}
-                class="bg-brand-main border rounded-lg px-3 py-2 text-xs text-brand-text-primary outline-none focus:border-brand-accent focus:ring-1 focus:ring-brand-accent disabled:opacity-50 transition-colors {changedFields.has('artist') ? 'border-brand-accent ring-1 ring-brand-accent/40' : 'border-brand-border'}"
+                size="sm"
+                highlighted={changedFields.has('artist')}
+                class="w-full"
               />
             </FormField>
 
             <!-- Album -->
             <FormField label={i18n.t('tagEditor.albumField')} for="tag-album">
-              <input
+              <Input
                 id="tag-album"
                 bind:value={album}
                 oninput={() => changedFields.delete("album")}
                 disabled={isSaving}
-                class="bg-brand-main border rounded-lg px-3 py-2 text-xs text-brand-text-primary outline-none focus:border-brand-accent focus:ring-1 focus:ring-brand-accent disabled:opacity-50 transition-colors {changedFields.has('album') ? 'border-brand-accent ring-1 ring-brand-accent/40' : 'border-brand-border'}"
+                size="sm"
+                highlighted={changedFields.has('album')}
+                class="w-full"
               />
             </FormField>
 
             <!-- Album Artist -->
             <FormField label={i18n.t('tagEditor.albumArtistField')} for="tag-albumartist">
-              <input
-                id="tag-albumartist"
-                bind:value={albumArtist}
-                disabled={isSaving}
-                class="bg-brand-main border border-brand-border rounded-lg px-3 py-2 text-xs text-brand-text-primary outline-none focus:border-brand-accent focus:ring-1 focus:ring-brand-accent disabled:opacity-50"
-              />
+              <Input id="tag-albumartist" bind:value={albumArtist} disabled={isSaving} size="sm" class="w-full" />
             </FormField>
 
             <!-- Composer -->
             <FormField label={i18n.t('tagEditor.composerField')} for="tag-composer">
-              <input
-                id="tag-composer"
-                bind:value={composer}
-                disabled={isSaving}
-                class="bg-brand-main border border-brand-border rounded-lg px-3 py-2 text-xs text-brand-text-primary outline-none focus:border-brand-accent focus:ring-1 focus:ring-brand-accent disabled:opacity-50"
-              />
+              <Input id="tag-composer" bind:value={composer} disabled={isSaving} size="sm" class="w-full" />
             </FormField>
 
             <!-- Genre -->
             <FormField label={i18n.t('tagEditor.genreField')} for="tag-genre" span2>
-              <input
-                id="tag-genre"
-                bind:value={genre}
-                disabled={isSaving}
-                class="bg-brand-main border border-brand-border rounded-lg px-3 py-2 text-xs text-brand-text-primary outline-none focus:border-brand-accent focus:ring-1 focus:ring-brand-accent disabled:opacity-50"
-              />
+              <Input id="tag-genre" bind:value={genre} disabled={isSaving} size="sm" class="w-full" />
             </FormField>
 
             <!-- Rating (library-only, saves immediately) -->
@@ -291,47 +284,51 @@
 
             <!-- Year -->
             <FormField label={i18n.t('tagEditor.yearField')} for="tag-year">
-              <input
+              <Input
                 id="tag-year"
                 type="number"
                 value={year ?? ""}
                 disabled={isSaving}
                 oninput={(e) => {
-                  const val = parseInt((e.target as HTMLInputElement).value, 10);
+                  const val = parseInt(e.currentTarget.value, 10);
                   year = isNaN(val) ? null : val;
                   changedFields.delete("year");
                 }}
-                class="bg-brand-main border rounded-lg px-3 py-2 text-xs text-brand-text-primary outline-none focus:border-brand-accent focus:ring-1 focus:ring-brand-accent disabled:opacity-50 transition-colors {changedFields.has('year') ? 'border-brand-accent ring-1 ring-brand-accent/40' : 'border-brand-border'}"
+                size="sm"
+                highlighted={changedFields.has('year')}
+                class="w-full"
               />
             </FormField>
 
             <!-- Track Number -->
             <FormField label={i18n.t('tagEditor.trackField')} for="tag-track">
-              <input
+              <Input
                 id="tag-track"
                 type="number"
                 value={track ?? ""}
                 disabled={isSaving}
                 oninput={(e) => {
-                  const val = parseInt((e.target as HTMLInputElement).value, 10);
+                  const val = parseInt(e.currentTarget.value, 10);
                   track = isNaN(val) ? null : val;
                 }}
-                class="bg-brand-main border border-brand-border rounded-lg px-3 py-2 text-xs text-brand-text-primary outline-none focus:border-brand-accent focus:ring-1 focus:ring-brand-accent disabled:opacity-50"
+                size="sm"
+                class="w-full"
               />
             </FormField>
 
             <!-- Disc Number -->
             <FormField label={i18n.t('tagEditor.discField')} for="tag-disc" span2>
-              <input
+              <Input
                 id="tag-disc"
                 type="number"
                 value={disc ?? ""}
                 disabled={isSaving}
                 oninput={(e) => {
-                  const val = parseInt((e.target as HTMLInputElement).value, 10);
+                  const val = parseInt(e.currentTarget.value, 10);
                   disc = isNaN(val) ? null : val;
                 }}
-                class="bg-brand-main border border-brand-border rounded-lg px-3 py-2 text-xs text-brand-text-primary outline-none focus:border-brand-accent focus:ring-1 focus:ring-brand-accent disabled:opacity-50"
+                size="sm"
+                class="w-full"
               />
             </FormField>
           </div>
@@ -343,11 +340,7 @@
     <div class="h-16 flex items-center justify-between px-6 border-t border-brand-border shrink-0 bg-brand-main">
       {#if !isLoading && !errorMsg}
         <div class="flex items-center gap-3">
-          <button
-            onclick={handleLookup}
-            disabled={isLookingUp || isSaving}
-            class="flex items-center gap-1.5 bg-brand-sidebar border border-brand-border hover:bg-brand-main text-brand-text-secondary hover:text-brand-text-primary px-4 py-2 rounded-lg text-xs font-semibold transition-all disabled:opacity-50"
-          >
+          <Button onclick={handleLookup} disabled={isLookingUp || isSaving} variant="secondary" size="sm">
             {#if isLookingUp}
               <LoaderCircle class="w-3.5 h-3.5 animate-spin text-brand-accent-text" />
               {i18n.t('tagEditor.lookingUp')}
@@ -355,7 +348,7 @@
               <Sparkles class="w-3.5 h-3.5 text-brand-accent-text" />
               {i18n.t('tagEditor.lookupAcoustID')}
             {/if}
-          </button>
+          </Button>
           {#if lookupSucceeded}
             <div in:fade class="flex items-center gap-1.5 text-brand-accent-text text-xs font-semibold">
               <Check class="w-3.5 h-3.5 font-bold {changedFields.size > 0 ? 'animate-bounce' : ''}" />
@@ -368,18 +361,10 @@
       {/if}
 
       <div class="flex items-center gap-2">
-        <button
-          onclick={onClose}
-          disabled={isSaving}
-          class="bg-brand-sidebar border border-brand-border hover:bg-brand-main text-brand-text-secondary hover:text-brand-text-primary px-4 py-2 rounded-lg text-xs font-semibold transition-all"
-        >
+        <Button onclick={onClose} disabled={isSaving} variant="secondary" size="sm">
           {i18n.t('tagEditor.cancelBtn')}
-        </button>
-        <button
-          onclick={handleSave}
-          disabled={isLoading || !!errorMsg || isSaving}
-          class="flex items-center gap-1.5 bg-brand-accent hover:bg-brand-accent-hover text-brand-accent-contrast px-4 py-2 rounded-lg text-xs font-semibold transition-all shadow-lg shadow-brand-accent/20 disabled:opacity-50"
-        >
+        </Button>
+        <Button onclick={handleSave} disabled={isLoading || !!errorMsg || isSaving} variant="primary" size="sm">
           {#if isSaving}
             <LoaderCircle class="w-3.5 h-3.5 animate-spin" />
             {i18n.t('tagEditor.updatingTags')}
@@ -387,7 +372,7 @@
             <Save class="w-3.5 h-3.5" />
             {i18n.t('tagEditor.saveBtn')}
           {/if}
-        </button>
+        </Button>
       </div>
     </div>
 </Modal>


### PR DESCRIPTION
## Summary
- Migrates the remaining hand-rolled action buttons in `TagEditor`, `AlbumTagEditor`, `SmartPlaylistBuilderModal`, `FoldersView`, `LyricsView`, `CollectionView`, and `PlaylistsCollectionView` onto the shared `Button` component introduced in #147, unifying mismatched `rounded-*`/padding/color combinations into one family.
- Adds an optional `type` prop to `Button` (defaulting to `"button"`) so it can be used as a form submit button without becoming `type="submit"` everywhere.
- Introduces a new `Input` component (`size="md"`/`"sm"`, `surface`, `highlighted`) modeled on the Smart Playlist builder's fields, and migrates the remaining hand-rolled text inputs onto it — including the playlist "Filter songs..." bar, which previously looked unstyled next to the rest of the UI.

## Out of scope (left as-is, different families)
- Icon-only buttons (modal close `X`, inline play icons)
- Tab switchers, theme swatch cards, external-link cards
- The global top-bar search (border lives on the wrapping `<form>`, not the `<input>`)
- `OrganizeFiles`'s monospace template/destination fields
- The playlist inline-rename field (large heading-style edit, not a form field)
- Non-text inputs (checkboxes, radios, range sliders, color pickers)

Closes #148.

## Test plan
- [x] `bun run check` (svelte-check) — 0 errors
- [x] `bun run test` — 261/261 tests pass
- [x] Manual pass in a running `bun run tauri dev`: Tag Editor, Album Tag Editor, Smart Playlist builder, Settings (Folders/Tools/Themes tabs), Lyrics view, Collection empty-search state, Playlists tab (New/Import/Create/Advanced buttons + create-playlist input), playlist Filter songs bar