### PR TITLE
fix(organize): declare missing refreshKey prop on OrganizeFiles

### DIFF
--- a/src/lib/components/OrganizeFiles.svelte
+++ b/src/lib/components/OrganizeFiles.svelte
@@ -29,6 +29,7 @@
     embedded = false,
     songIds = [],
     initialScope = "selection",
+    refreshKey = 0,
     onClose,
     onSuccess,
   }: {
@@ -37,6 +38,8 @@
     embedded?: boolean;
     songIds?: number[];
     initialScope?: "selection" | "library";
+    /** Bump this to force the preview to refetch (e.g. after an external prune). */
+    refreshKey?: number;
     onClose?: () => void;
     onSuccess?: () => void;
   } = $props();
@@ -274,6 +277,7 @@
     const _s = scope;
     const _ids = activeSongIds;
     const _open = effectiveOpen;
+    const _refresh = refreshKey;
 
     if (_open) {
       if (debounceTimer) clearTimeout(debounceTimer);


### PR DESCRIPTION
## Summary
- `FoldersView.svelte` (added in #175, the bug-173 fix) passes `refreshKey={organizeRefreshKey}` to `<OrganizeFiles>` to force a preview refetch after `handlePruneMissing()` completes, but `OrganizeFiles.svelte` never declared a `refreshKey` prop.
- This broke `bun run check` (`Object literal may only specify known properties, and '"refreshKey"' does not exist in type '$$ComponentProps'`) and silently left the post-prune refresh non-functional since the prop was dropped.
- Added `refreshKey` to `OrganizeFiles.svelte`'s props (defaulting to `0`) and included it in the existing debounced preview `$effect`'s tracked dependencies, so bumping it now triggers a refetch as originally intended.

## Test plan
- [x] `bun run check` — 0 errors (was 1 type error before the fix)
- [ ] Manually verify in the running app: open Folders view, trigger "Clean Up Missing Files", confirm the organize preview list refreshes afterward