### PR TITLE
Micro-animations: favouriting + update notifications (WIP, issue #182)

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "test:run": "vitest run",
     "test:perf": "vitest run --config vite.perf.config.js",
     "take-screenshots": "bunx tsx scripts/take-screenshots.ts",
+    "preview-animations": "bunx tsx scripts/preview-animations.ts",
     "release": "bun run scripts/release.ts",
     "bump-version": "bun run scripts/bump-version.ts"
   },

--- a/scripts/preview-animations.ts
+++ b/scripts/preview-animations.ts
@@ -1,0 +1,93 @@
+// Animation preview harness: opens the dev-only micro-animation gallery
+// (src/routes/dev/animations, see issue #182) in the system default browser.
+// Unlike take-screenshots.ts this needs no Tauri IPC mocking — the gallery
+// only touches local component state and the toast store — so it's just a
+// Vite dev server plus a browser tab, left running so you can click Replay
+// live. If a dev server is already running on port 1420 (e.g. `bun run dev`
+// or `bun run tauri dev`), reuses it instead of spawning a second one.
+// Usage: bun run preview-animations
+import { spawn, execSync } from "child_process";
+
+const PORT = 1420;
+const URL = `http://localhost:${PORT}/dev/animations`;
+
+function openBrowser(url: string) {
+  const platform = process.platform;
+  if (platform === "win32") {
+    execSync(`start "" "${url}"`, { shell: "cmd.exe" });
+  } else if (platform === "darwin") {
+    execSync(`open "${url}"`);
+  } else {
+    execSync(`xdg-open "${url}"`);
+  }
+}
+
+async function isServerUp(): Promise<boolean> {
+  try {
+    const res = await fetch(`http://localhost:${PORT}`);
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+async function main() {
+  let devServer: ReturnType<typeof spawn> | undefined;
+
+  const killDevServer = () => {
+    if (!devServer?.pid) return;
+    if (process.platform === "win32") {
+      try {
+        execSync(`taskkill /pid ${devServer.pid} /t /f`, { stdio: "ignore" });
+      } catch {
+        // Already exited.
+      }
+    } else {
+      devServer.kill("SIGTERM");
+    }
+  };
+  process.on("exit", killDevServer);
+  process.on("SIGINT", () => process.exit(0));
+  process.on("SIGTERM", () => process.exit(0));
+
+  if (await isServerUp()) {
+    console.log(`[Animation Preview] Reusing dev server already running on port ${PORT}.`);
+  } else {
+    console.log(`[Animation Preview] Starting Vite dev server on port ${PORT}...`);
+    devServer = spawn("bun", ["run", "dev"], { stdio: "inherit", shell: true });
+
+    console.log(`[Animation Preview] Waiting for Vite server on http://localhost:${PORT}...`);
+    let ready = false;
+    for (let i = 0; i < 50; i++) {
+      if (await isServerUp()) {
+        ready = true;
+        break;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 200));
+    }
+    if (!ready) {
+      console.error("[ERROR] Vite server failed to respond.");
+      killDevServer();
+      process.exit(1);
+    }
+  }
+
+  console.log(`[Animation Preview] Opening ${URL} ...`);
+  try {
+    openBrowser(URL);
+  } catch (err) {
+    console.warn(`[Animation Preview] Could not auto-open a browser — visit ${URL} manually.`, err);
+  }
+
+  if (devServer) {
+    console.log("[Animation Preview] Dev server running — press Ctrl+C to stop.");
+  } else {
+    console.log("[Animation Preview] Done — the gallery tab is open against your existing dev server.");
+    process.exit(0);
+  }
+}
+
+main().catch((err) => {
+  console.error("[Animation Preview] Fatal error:", err);
+  process.exit(1);
+});

--- a/src/app.css
+++ b/src/app.css
@@ -1,4 +1,5 @@
 @import "tailwindcss";
+@import "./lib/styles/animations.css";
 
 @theme {
   --color-brand-main: var(--bg-main);

--- a/src/lib/components/FoldersView.svelte
+++ b/src/lib/components/FoldersView.svelte
@@ -33,6 +33,21 @@
     if (contentEl) contentEl.scrollTop = 0;
   });
 
+  // "Import finished"-style success flash for a manual "Check Now" that
+  // comes back up-to-date — only on the checking -> up-to-date transition
+  // this view is mounted to watch, not on a silent background check.
+  let previousCheckStatus: typeof updaterStore.checkStatus | undefined;
+  let justConfirmedUpToDate = $state(false);
+  $effect(() => {
+    const wasChecking = previousCheckStatus === "checking";
+    previousCheckStatus = updaterStore.checkStatus;
+    if (updaterStore.checkStatus === "up-to-date" && wasChecking) {
+      justConfirmedUpToDate = true;
+      const timeout = setTimeout(() => { justConfirmedUpToDate = false; }, 320);
+      return () => clearTimeout(timeout);
+    }
+  });
+
   async function copyVersion() {
     try {
       await navigator.clipboard.writeText(appVersion);
@@ -353,10 +368,27 @@
       <div class="bg-brand-sidebar border border-brand-border rounded-xl p-6 space-y-4">
         <div class="flex items-center justify-between">
           <h3 class="text-xs text-brand-text-secondary font-bold tracking-wider uppercase">{i18n.t('settings.appAndUpdatesTitle')}</h3>
-          <Button onclick={() => updaterStore.checkForUpdates()} disabled={updaterStore.checkStatus === 'checking'} variant="secondary" size="sm">
-            <RefreshCw class="w-3.5 h-3.5 {updaterStore.checkStatus === 'checking' ? 'animate-spin text-brand-accent-text' : ''}" />
-            {updaterStore.checkStatus === 'checking' ? i18n.t('settings.updateChecking') : i18n.t('settings.updateCheckNowBtn')}
-          </Button>
+          <div class="flex items-center gap-3">
+            {#if updaterStore.checkStatus === 'up-to-date'}
+              <div class="text-xs text-brand-text-primary font-medium flex items-center gap-1.5">
+                <span class="relative inline-flex w-4 h-4 shrink-0 items-center justify-center">
+                  {#if justConfirmedUpToDate}
+                    <span class="absolute inset-0 rounded-full anim-glow-ring"></span>
+                  {/if}
+                  <Check class="w-4 h-4 text-brand-accent {justConfirmedUpToDate ? 'anim-check-pop' : ''}" />
+                </span>
+                {i18n.t('settings.updateUpToDate')}
+              </div>
+            {:else if updaterStore.checkStatus === 'error'}
+              <div class="text-xs text-brand-text-secondary font-medium">
+                {i18n.t('settings.updateError')}: {updaterStore.errorMessage}
+              </div>
+            {/if}
+            <Button onclick={() => updaterStore.checkForUpdates()} disabled={updaterStore.checkStatus === 'checking'} variant="secondary" size="sm">
+              <RefreshCw class="w-3.5 h-3.5 {updaterStore.checkStatus === 'checking' ? 'animate-spin text-brand-accent-text' : ''}" />
+              {updaterStore.checkStatus === 'checking' ? i18n.t('settings.updateChecking') : i18n.t('settings.updateCheckNowBtn')}
+            </Button>
+          </div>
         </div>
 
         <!-- Version & Format Info Row -->
@@ -393,9 +425,10 @@
 
         <!-- Update Available Alert Banner (if available) -->
         {#if updaterStore.updateAvailable}
-          <div class="bg-brand-accent/10 border border-brand-accent/30 rounded-xl p-4 flex items-center justify-between gap-4">
+          <div class="bg-brand-accent/10 border border-brand-accent/30 rounded-xl p-4 flex items-center justify-between gap-4 anim-card-materialize">
             <div class="flex items-center gap-3">
-              <div class="w-9 h-9 rounded-lg bg-brand-accent/20 text-brand-accent-text border border-brand-accent/30 flex items-center justify-center shrink-0">
+              <div class="relative w-9 h-9 rounded-lg bg-brand-accent/20 text-brand-accent-text border border-brand-accent/30 flex items-center justify-center shrink-0">
+                <span class="absolute -top-1 -right-1 w-2.5 h-2.5 rounded-full bg-brand-accent anim-badge-glow"></span>
                 <ArrowUp class="w-5 h-5 stroke-[2.5]" />
               </div>
               <div>
@@ -413,15 +446,6 @@
               <Download class="w-4 h-4" />
               {updaterStore.installFormat.supports_self_update ? i18n.t('settings.updateDownloadBtn') : i18n.t('settings.updateDownloadGithubBtn')}
             </Button>
-          </div>
-        {:else if updaterStore.checkStatus === 'up-to-date'}
-          <div class="text-xs text-brand-text-primary font-medium flex items-center gap-1.5 pt-1">
-            <Check class="w-4 h-4 text-brand-accent" />
-            {i18n.t('settings.updateUpToDate')}
-          </div>
-        {:else if updaterStore.checkStatus === 'error'}
-          <div class="text-xs text-brand-text-secondary font-medium flex items-center gap-1.5 pt-1">
-            {i18n.t('settings.updateError')}: {updaterStore.errorMessage}
           </div>
         {/if}
 

--- a/src/lib/components/HeartToggle.svelte
+++ b/src/lib/components/HeartToggle.svelte
@@ -9,19 +9,65 @@
   }
 
   let { favorite, onToggle, sizeClass = "w-4 h-4" }: Props = $props();
+
+  let buttonEl: HTMLButtonElement | undefined = $state();
+
+  // Only the moment the user actually favourites a song should pulse — not
+  // every render where `favorite` happens to already be true (e.g. scrolling
+  // a list of already-favourited songs into view). `previousFavorite` starts
+  // undefined so an already-favourited song never pulses on first mount.
+  let previousFavorite: boolean | undefined;
+  let justFavorited = $state(false);
+
+  // HeartToggle renders inside all sorts of clipped containers (virtualized
+  // table rows, the PlayerBar's `truncate` title column), which clip the
+  // ring's box-shadow same as any other overflowing content. Rather than
+  // shrinking the ring until it fits (still barely visible), portal it to
+  // document.body — same escape hatch Toast.svelte already uses — positioned
+  // over the heart's own screen coordinates, so it renders the full spec'd
+  // ring regardless of what it's embedded in.
+  function burstRing() {
+    if (!buttonEl) return;
+    const rect = buttonEl.getBoundingClientRect();
+    const ring = document.createElement("span");
+    ring.className = "anim-heart-ring";
+    ring.style.position = "fixed";
+    ring.style.left = `${rect.left + rect.width / 2}px`;
+    ring.style.top = `${rect.top + rect.height / 2}px`;
+    ring.style.width = `${rect.width}px`;
+    ring.style.height = `${rect.height}px`;
+    ring.style.borderRadius = "9999px";
+    ring.style.transform = "translate(-50%, -50%)";
+    ring.style.pointerEvents = "none";
+    ring.style.zIndex = "200";
+    document.body.appendChild(ring);
+    ring.addEventListener("animationend", () => ring.remove());
+  }
+
+  $effect(() => {
+    const wasFavorite = previousFavorite;
+    previousFavorite = favorite;
+    if (favorite && wasFavorite === false) {
+      justFavorited = true;
+      burstRing();
+      const timeout = setTimeout(() => { justFavorited = false; }, 320);
+      return () => clearTimeout(timeout);
+    }
+  });
 </script>
 
 <button
+  bind:this={buttonEl}
   type="button"
   onclick={(e) => {
     e.stopPropagation();
     onToggle();
   }}
-  class="transition-colors cursor-pointer {favorite
+  class="inline-flex transition-colors cursor-pointer {favorite
     ? 'text-brand-accent-text'
     : 'text-brand-text-secondary/60 hover:text-brand-accent-text'}"
   title={favorite ? i18n.t('rating.unfavoriteTooltip') : i18n.t('rating.favoriteTooltip')}
   aria-pressed={favorite}
 >
-  <Heart class="{sizeClass} {favorite ? 'fill-current' : ''}" />
+  <Heart class="{sizeClass} {favorite ? 'fill-current' : ''} {justFavorited ? 'anim-heart-pulse' : ''}" />
 </button>

--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -18,6 +18,18 @@
 
   let isCollapsed = $derived(width < SIDEBAR_MIN_WIDTH_PX);
 
+  function selectCollectionTab() {
+    collectionStore.activeTab = "collection";
+    collectionStore.selectedArtistName = null;
+    collectionStore.selectedAlbumName = null;
+  }
+
+  function selectPlaylistsTab() {
+    collectionStore.activeTab = "playlists";
+    collectionStore.selectedPlaylistId = null;
+    collectionStore.selectedAutoPlaylist = null;
+  }
+
   function navigateToFoldersSettings() {
     collectionStore.activeTab = "settings";
     invoke("set_app_setting", { key: "active_settings_tab", value: "folders" }).catch((err) => {
@@ -66,21 +78,29 @@
     {#if !collectionStore.statsLoaded || collectionStore.stats.total_songs > 0}
     <div class="w-full flex flex-col {isCollapsed ? 'items-center' : ''}">
       <button
-        onclick={() => { collectionStore.activeTab = "collection"; collectionStore.selectedArtistName = null; collectionStore.selectedAlbumName = null; }}
-        class="flex items-center gap-3 transition-all duration-150 {collectionStore.activeTab === 'collection' ? 'bg-brand-accent text-brand-accent-contrast shadow-lg shadow-brand-accent/20' : 'text-brand-text-secondary hover:bg-brand-accent/10 hover:text-brand-accent-text-hover'} {isCollapsed ? 'justify-center w-10 h-10 rounded-xl p-0' : 'w-full px-3 py-2 rounded-lg text-sm font-medium'}"
+        onclick={selectCollectionTab}
+        class="flex items-center gap-3 transition-all duration-150 {collectionStore.activeTab === 'collection' && isCollapsed ? 'bg-brand-accent text-brand-accent-contrast shadow-lg shadow-brand-accent/20' : 'text-brand-text-secondary hover:bg-brand-accent/10 hover:text-brand-accent-text-hover'} {isCollapsed ? 'justify-center w-10 h-10 rounded-xl p-0' : 'w-full px-3 py-2 rounded-lg text-sm font-medium'}"
         title={i18n.t('sidebar.collection')}
       >
-        <Library class={isCollapsed ? "w-5 h-5" : "w-4 h-4"} />
+        {#if isCollapsed && collectionStore.activeTab === 'collection' && collectionStore.activeSubTab === 'artists'}
+          <Mic2 class="w-5 h-5" />
+        {:else if isCollapsed && collectionStore.activeTab === 'collection' && collectionStore.activeSubTab === 'albums'}
+          <DiscAlbum class="w-5 h-5" />
+        {:else if isCollapsed && collectionStore.activeTab === 'collection' && collectionStore.activeSubTab === 'songs'}
+          <Music class="w-5 h-5" />
+        {:else}
+          <Library class={isCollapsed ? "w-5 h-5" : "w-4 h-4"} />
+        {/if}
         {#if !isCollapsed}
           <span class="truncate whitespace-nowrap">{i18n.t('sidebar.collection')}</span>
         {/if}
       </button>
 
-      {#if collectionStore.activeTab === 'collection' && !isCollapsed}
+      {#if !isCollapsed}
         <div class="pl-4 pr-1 py-1 space-y-0.5 border-l-2 border-brand-accent/30 ml-4 my-1">
           <button
             onclick={() => { collectionStore.activeTab = "collection"; collectionStore.activeSubTab = "artists"; collectionStore.selectedArtistName = null; collectionStore.selectedAlbumName = null; }}
-            class="w-full flex items-center justify-between px-2.5 py-1.5 rounded-md text-xs transition-colors cursor-pointer {collectionStore.activeSubTab === 'artists' && !collectionStore.selectedArtistName && !collectionStore.selectedAlbumName ? 'bg-brand-accent/20 text-brand-accent-text font-semibold' : 'text-brand-text-secondary hover:text-brand-text-primary hover:bg-brand-accent/10'}"
+            class="w-full flex items-center justify-between px-2.5 py-1.5 rounded-md text-xs transition-colors cursor-pointer {collectionStore.activeTab === 'collection' && collectionStore.activeSubTab === 'artists' && !collectionStore.selectedArtistName && !collectionStore.selectedAlbumName ? 'bg-brand-accent/20 text-brand-accent-text font-semibold' : 'text-brand-text-secondary hover:text-brand-text-primary hover:bg-brand-accent/10'}"
           >
             <div class="flex items-center gap-2 truncate">
               <Mic2 class="w-3.5 h-3.5" />
@@ -93,7 +113,7 @@
 
           <button
             onclick={() => { collectionStore.activeTab = "collection"; collectionStore.activeSubTab = "albums"; collectionStore.selectedArtistName = null; collectionStore.selectedAlbumName = null; }}
-            class="w-full flex items-center justify-between px-2.5 py-1.5 rounded-md text-xs transition-colors cursor-pointer {collectionStore.activeSubTab === 'albums' && !collectionStore.selectedArtistName && !collectionStore.selectedAlbumName ? 'bg-brand-accent/20 text-brand-accent-text font-semibold' : 'text-brand-text-secondary hover:text-brand-text-primary hover:bg-brand-accent/10'}"
+            class="w-full flex items-center justify-between px-2.5 py-1.5 rounded-md text-xs transition-colors cursor-pointer {collectionStore.activeTab === 'collection' && collectionStore.activeSubTab === 'albums' && !collectionStore.selectedArtistName && !collectionStore.selectedAlbumName ? 'bg-brand-accent/20 text-brand-accent-text font-semibold' : 'text-brand-text-secondary hover:text-brand-text-primary hover:bg-brand-accent/10'}"
           >
             <div class="flex items-center gap-2 truncate">
               <DiscAlbum class="w-3.5 h-3.5" />
@@ -106,7 +126,7 @@
 
           <button
             onclick={() => { collectionStore.activeTab = "collection"; collectionStore.activeSubTab = "songs"; collectionStore.selectedArtistName = null; collectionStore.selectedAlbumName = null; }}
-            class="w-full flex items-center justify-between px-2.5 py-1.5 rounded-md text-xs transition-colors cursor-pointer {collectionStore.activeSubTab === 'songs' && !collectionStore.selectedArtistName && !collectionStore.selectedAlbumName ? 'bg-brand-accent/20 text-brand-accent-text font-semibold' : 'text-brand-text-secondary hover:text-brand-text-primary hover:bg-brand-accent/10'}"
+            class="w-full flex items-center justify-between px-2.5 py-1.5 rounded-md text-xs transition-colors cursor-pointer {collectionStore.activeTab === 'collection' && collectionStore.activeSubTab === 'songs' && !collectionStore.selectedArtistName && !collectionStore.selectedAlbumName ? 'bg-brand-accent/20 text-brand-accent-text font-semibold' : 'text-brand-text-secondary hover:text-brand-text-primary hover:bg-brand-accent/10'}"
           >
             <div class="flex items-center gap-2 truncate">
               <Music class="w-3.5 h-3.5" />
@@ -122,21 +142,25 @@
 
     <div class="w-full flex flex-col {isCollapsed ? 'items-center' : ''}">
       <button
-        onclick={() => { collectionStore.activeTab = "playlists"; collectionStore.selectedPlaylistId = null; collectionStore.selectedAutoPlaylist = null; }}
-        class="flex items-center gap-3 transition-all duration-150 {collectionStore.activeTab === 'playlists' ? 'bg-brand-accent text-brand-accent-contrast shadow-lg shadow-brand-accent/20' : 'text-brand-text-secondary hover:bg-brand-accent/10 hover:text-brand-accent-text-hover'} {isCollapsed ? 'justify-center w-10 h-10 rounded-xl p-0' : 'w-full px-3 py-2 rounded-lg text-sm font-medium'}"
+        onclick={selectPlaylistsTab}
+        class="flex items-center gap-3 transition-all duration-150 {collectionStore.activeTab === 'playlists' && isCollapsed ? 'bg-brand-accent text-brand-accent-contrast shadow-lg shadow-brand-accent/20' : 'text-brand-text-secondary hover:bg-brand-accent/10 hover:text-brand-accent-text-hover'} {isCollapsed ? 'justify-center w-10 h-10 rounded-xl p-0' : 'w-full px-3 py-2 rounded-lg text-sm font-medium'}"
         title={i18n.t('sidebar.playlists')}
       >
-        <ListMusic class={isCollapsed ? "w-5 h-5" : "w-4 h-4"} />
+        {#if isCollapsed && collectionStore.activeTab === 'playlists' && collectionStore.playlistsSubTab === 'auto'}
+          <Sparkles class="w-5 h-5" />
+        {:else}
+          <ListMusic class={isCollapsed ? "w-5 h-5" : "w-4 h-4"} />
+        {/if}
         {#if !isCollapsed}
           <span class="truncate whitespace-nowrap">{i18n.t('sidebar.playlists')}</span>
         {/if}
       </button>
 
-      {#if collectionStore.activeTab === 'playlists' && !isCollapsed}
+      {#if !isCollapsed}
         <div class="pl-4 pr-1 py-1 space-y-0.5 border-l-2 border-brand-accent/30 ml-4 my-1">
           <button
             onclick={() => openPlaylistsSubTab("auto")}
-            class="w-full flex items-center justify-between px-2.5 py-1.5 rounded-md text-xs transition-colors cursor-pointer {collectionStore.playlistsSubTab === 'auto' && !collectionStore.selectedPlaylistId && !collectionStore.selectedAutoPlaylist ? 'bg-brand-accent/20 text-brand-accent-text font-semibold' : 'text-brand-text-secondary hover:text-brand-text-primary hover:bg-brand-accent/10'}"
+            class="w-full flex items-center justify-between px-2.5 py-1.5 rounded-md text-xs transition-colors cursor-pointer {collectionStore.activeTab === 'playlists' && collectionStore.playlistsSubTab === 'auto' && !collectionStore.selectedPlaylistId && !collectionStore.selectedAutoPlaylist ? 'bg-brand-accent/20 text-brand-accent-text font-semibold' : 'text-brand-text-secondary hover:text-brand-text-primary hover:bg-brand-accent/10'}"
           >
             <div class="flex items-center gap-2 truncate">
               <Sparkles class="w-3.5 h-3.5" />
@@ -149,7 +173,7 @@
 
           <button
             onclick={() => openPlaylistsSubTab("custom")}
-            class="w-full flex items-center justify-between px-2.5 py-1.5 rounded-md text-xs transition-colors cursor-pointer {collectionStore.playlistsSubTab === 'custom' && !collectionStore.selectedPlaylistId && !collectionStore.selectedAutoPlaylist ? 'bg-brand-accent/20 text-brand-accent-text font-semibold' : 'text-brand-text-secondary hover:text-brand-text-primary hover:bg-brand-accent/10'}"
+            class="w-full flex items-center justify-between px-2.5 py-1.5 rounded-md text-xs transition-colors cursor-pointer {collectionStore.activeTab === 'playlists' && collectionStore.playlistsSubTab === 'custom' && !collectionStore.selectedPlaylistId && !collectionStore.selectedAutoPlaylist ? 'bg-brand-accent/20 text-brand-accent-text font-semibold' : 'text-brand-text-secondary hover:text-brand-text-primary hover:bg-brand-accent/10'}"
           >
             <div class="flex items-center gap-2 truncate">
               <ListMusic class="w-3.5 h-3.5" />

--- a/src/lib/components/Sidebar.test.ts
+++ b/src/lib/components/Sidebar.test.ts
@@ -50,11 +50,22 @@ describe("Sidebar.svelte", () => {
     expect(collectionStore.activeSubTab).toBe("songs");
   });
 
-  it("hides Collection sub-items when a non-collection tab is active", () => {
+  it("keeps Collection sub-items expanded even when a non-collection tab is active", () => {
     collectionStore.activeTab = "home";
     const { queryByRole } = render(Sidebar, { props: { width: 256 } });
-    expect(queryByRole("button", { name: /artists/i })).toBeNull();
-    expect(queryByRole("button", { name: /albums/i })).toBeNull();
+    expect(queryByRole("button", { name: /artists/i })).not.toBeNull();
+    expect(queryByRole("button", { name: /albums/i })).not.toBeNull();
+  });
+
+  it("keeps Collection sub-items visible after clicking the Collection header repeatedly", async () => {
+    const { getByTitle, queryByRole } = render(Sidebar, { props: { width: 256 } });
+    const collectionBtn = getByTitle("Collection");
+
+    await fireEvent.click(collectionBtn);
+    expect(queryByRole("button", { name: /artists/i })).not.toBeNull();
+
+    await fireEvent.click(collectionBtn);
+    expect(queryByRole("button", { name: /artists/i })).not.toBeNull();
   });
 
   it("centers Collection and Playlists wrapper containers when collapsed (width < 180)", () => {

--- a/src/lib/components/Toast.svelte
+++ b/src/lib/components/Toast.svelte
@@ -1,22 +1,17 @@
 <script lang="ts">
   import { fly, fade } from "svelte/transition";
-  import { AlertTriangle, Info, X } from "lucide-svelte";
+  import { AlertTriangle, CheckCircle2, Info, X } from "lucide-svelte";
   import { toastStore } from "../stores/toast.svelte";
-  import { playerStore } from "../stores/player.svelte";
   import { portal } from "../utils/portal";
-  import { PLAYER_DOCK_CLEARANCE_PX } from "../constants";
-
-  let dockClearance = $derived(playerStore.currentSong ? PLAYER_DOCK_CLEARANCE_PX : 0);
 </script>
 
 <div
   use:portal
-  class="fixed inset-x-0 z-[100] flex flex-col items-center gap-2 pointer-events-none px-4"
-  style="bottom: {dockClearance + 16}px"
+  class="fixed top-24 right-4 z-[100] flex flex-col items-end gap-2 pointer-events-none px-4"
 >
   {#each toastStore.messages as toast (toast.id)}
     <div
-      in:fly={{ y: 16, duration: 200 }}
+      in:fly={{ x: 24, duration: 200 }}
       out:fade={{ duration: 150 }}
       class="pointer-events-auto flex items-center gap-2.5 px-4 py-2.5 rounded-xl border shadow-2xl text-sm font-medium max-w-md {toast.variant === 'error'
         ? 'bg-red-500/10 border-red-500/30 text-red-400'
@@ -24,6 +19,11 @@
     >
       {#if toast.variant === "error"}
         <AlertTriangle class="w-4 h-4 shrink-0" />
+      {:else if toast.variant === "success"}
+        <span class="relative inline-flex w-4 h-4 shrink-0 items-center justify-center">
+          <span class="absolute inset-0 rounded-full anim-glow-ring"></span>
+          <CheckCircle2 class="w-4 h-4 text-brand-accent-text anim-check-pop" />
+        </span>
       {:else}
         <Info class="w-4 h-4 shrink-0 text-brand-accent-text" />
       {/if}

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -305,6 +305,7 @@ export const en = {
     rescanTitle: "Library Scanning & Maintenance",
     rescanSubtitle: "Perform incremental or full rescans and configure automatic background scanning.",
     lastScanned: "Last scan: {time}",
+    importFinishedToast: "{count} tracks added",
     scanningPhase: "Phase: {phase}",
     phaseDiscovering: "Discovering Files",
     phaseReadingTags: "Reading Tags",

--- a/src/lib/locales/fr.ts
+++ b/src/lib/locales/fr.ts
@@ -275,6 +275,7 @@ export const fr = {
     rescanTitle: "Analyse & maintenance de la bibliothèque",
     rescanSubtitle: "Effectuez des rebalayages incrémentiels ou complets et configurez l'analyse automatique.",
     lastScanned: "Dernière analyse : {time}",
+    importFinishedToast: "{count} morceaux ajoutés",
     scanningPhase: "Phase : {phase}",
     phaseDiscovering: "Découverte des fichiers",
     phaseReadingTags: "Lecture des étiquettes",

--- a/src/lib/stores/collection.svelte.ts
+++ b/src/lib/stores/collection.svelte.ts
@@ -14,6 +14,7 @@ import type {
 } from "../types";
 import { applySongStats, type SongStatsPayload } from "../utils/stats";
 import { playlistsStore } from "./playlists.svelte";
+import { toastStore } from "./toast.svelte";
 import { MAX_RECENT_SEARCHES } from "../constants";
 
 export type ActiveTab = "home" | "collection" | "playlists" | "settings" | "lyrics" | "help";
@@ -459,7 +460,13 @@ class CollectionStore {
           invoke("set_app_setting", { key: "last_scan_time", value: nowStr }).catch((err) => {
             console.error("Failed to save last_scan_time:", err);
           });
-          this.refreshStats();
+          const songCountBeforeRefresh = this.stats.total_songs;
+          this.refreshStats().then(() => {
+            const added = this.stats.total_songs - songCountBeforeRefresh;
+            if (added > 0) {
+              toastStore.show(i18n.t("settings.importFinishedToast", { count: added }), "success");
+            }
+          });
           this.refreshLibrary();
 
           // The active playback queue is a snapshot taken when it was built —

--- a/src/lib/stores/toast.svelte.ts
+++ b/src/lib/stores/toast.svelte.ts
@@ -1,6 +1,6 @@
 import { TOAST_DURATION_MS } from "../constants";
 
-export type ToastVariant = "info" | "error";
+export type ToastVariant = "info" | "error" | "success";
 
 export interface ToastMessage {
   id: number;

--- a/src/lib/styles/animations.css
+++ b/src/lib/styles/animations.css
@@ -1,0 +1,200 @@
+/*
+ * Micro-animation keyframes for celebration moments — see
+ * docs/luminous-micro-animations.dc.html (design spec) and issue #182.
+ *
+ * The spec doc's keyframes are written for its own continuously-looping
+ * preview (each holds flat for the first 50-60% of a 3.4s cycle, then plays).
+ * The keyframes below are rescaled from that source so each one plays once,
+ * start-to-finish, over its real spec'd duration when triggered by a state
+ * change — they are not loop-hold percentages.
+ *
+ * Every effect collapses to a plain opacity fade under prefers-reduced-motion
+ * (see "Reduced motion" in the spec) — no scale, bounce, or glow rings.
+ */
+
+@keyframes reduced-fade {
+  0% { opacity: 0.35; }
+  50% { opacity: 1; }
+  100% { opacity: 1; }
+}
+
+/* Favouriting a song (Success, 300ms) */
+@keyframes heart-pulse {
+  0% { transform: scale(1); }
+  20% { transform: scale(1.35); }
+  45% { transform: scale(0.94); }
+  70% { transform: scale(1.06); }
+  100% { transform: scale(1); }
+}
+
+/* HeartToggle renders inside all sorts of clipped containers (virtualized
+   table rows, the PlayerBar's `truncate` title column), which clip box-shadow
+   same as any other overflowing content — so the real HeartToggle doesn't
+   apply this class to itself. Instead it portals a span with this class to
+   document.body, positioned over its own screen coordinates (see
+   HeartToggle.svelte's burstRing()), escaping any ancestor's `overflow:
+   hidden` entirely. The gallery applies it directly since it has room. */
+/* Theme accent color, not the reserved brand gold (see app.css's
+   --color-accent-gold comment — gold is for rare Milestone moments only;
+   favouriting is a routine Success-tier action). color-mix() keeps this
+   correct across every user-selectable theme rather than a hardcoded hex. */
+@keyframes heart-ring {
+  0% { box-shadow: 0 0 0 0 transparent; }
+  20% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--color-accent) 50%, transparent); }
+  75% { box-shadow: 0 0 0 14px transparent; }
+  100% { box-shadow: 0 0 0 14px transparent; }
+}
+
+/* Import finished (Success, 320ms) */
+@keyframes check-pop {
+  0% { transform: scale(0) rotate(-25deg); opacity: 0; }
+  33% { transform: scale(1.2) rotate(5deg); opacity: 1; }
+  67% { transform: scale(0.95) rotate(-2deg); }
+  100% { transform: scale(1) rotate(0deg); opacity: 1; }
+}
+
+@keyframes glow-ring {
+  0% { box-shadow: 0 0 0 0 rgba(143, 191, 154, 0.5); opacity: 0; }
+  22% { opacity: 1; }
+  78% { box-shadow: 0 0 0 18px rgba(143, 191, 154, 0); opacity: 0; }
+  100% { opacity: 0; }
+}
+
+/* Organizing complete (Success, 280ms) */
+@keyframes row-sweep {
+  0% { background-position: -120% 0; }
+  56% { background-position: 220% 0; }
+  100% { background-position: 220% 0; }
+}
+
+/* First watched folder (New, 380ms) */
+@keyframes folder-pop {
+  0% { transform: scale(1) rotate(0); }
+  22% { transform: scale(1.12) rotate(-3deg); }
+  51% { transform: scale(0.96) rotate(2deg); }
+  100% { transform: scale(1) rotate(0); }
+}
+
+@keyframes ring-expand {
+  0% { box-shadow: 0 0 0 0 rgba(111, 126, 169, 0.55); opacity: 0; }
+  16% { opacity: 1; }
+  78% { box-shadow: 0 0 0 20px rgba(111, 126, 169, 0); opacity: 0; }
+  100% { opacity: 0; }
+}
+
+/* Creating a new playlist / new release tile (New, 400ms) */
+@keyframes card-materialize {
+  0% { transform: scale(0.92); opacity: 0; }
+  44% { transform: scale(1.02); opacity: 1; }
+  100% { transform: scale(1); opacity: 1; }
+}
+
+@keyframes border-glow-pulse {
+  0% { box-shadow: 0 0 0 0 rgba(111, 126, 169, 0); }
+  44% { box-shadow: 0 0 0 3px rgba(111, 126, 169, 0.35); }
+  100% { box-shadow: 0 0 0 0 rgba(111, 126, 169, 0); }
+}
+
+/* New auto-playlist appears (New, 380ms) */
+@keyframes slide-in-fade {
+  0% { transform: translateX(-14px); opacity: 0; }
+  50% { transform: translateX(0); opacity: 1; }
+  100% { transform: translateX(0); opacity: 1; }
+}
+
+@keyframes badge-glow {
+  0% { opacity: 0; }
+  20% { opacity: 1; }
+  50% { box-shadow: 0 0 0 0 rgba(255, 182, 72, 0.5); }
+  80% { box-shadow: 0 0 0 10px rgba(255, 182, 72, 0); }
+  100% { opacity: 1; box-shadow: 0 0 0 10px rgba(255, 182, 72, 0); }
+}
+
+/* Reaching a milestone / first launch (Milestone, 650ms) */
+@keyframes milestone-bounce {
+  0% { transform: scale(1); }
+  24% { transform: scale(1.22); }
+  52% { transform: scale(0.95); }
+  76% { transform: scale(1.05); }
+  100% { transform: scale(1); }
+}
+
+@keyframes gold-ring {
+  0% { box-shadow: 0 0 0 0 rgba(255, 182, 72, 0.5); opacity: 0; }
+  16% { opacity: 1; }
+  76% { box-shadow: 0 0 0 22px rgba(255, 182, 72, 0); opacity: 0; }
+  100% { opacity: 0; }
+}
+
+/* Completing a queue (Milestone, 600ms) */
+@keyframes shimmer-sweep {
+  0% { background-position: -150% 0; }
+  70% { background-position: 150% 0; }
+  100% { background-position: 150% 0; }
+}
+
+/* Import needs attention (Warning/error, 200ms) */
+@keyframes warn-shake {
+  0% { transform: translateX(0); }
+  11% { transform: translateX(-5px); }
+  22% { transform: translateX(4px); }
+  33% { transform: translateX(-3px); }
+  44% { transform: translateX(2px); }
+  56% { transform: translateX(0); }
+  100% { transform: translateX(0); }
+}
+
+@keyframes warn-flash {
+  0% { background: #1c1f29; }
+  16% { background: rgba(224, 160, 160, 0.22); }
+  100% { background: #1c1f29; }
+}
+
+/* Utility classes — apply on the triggering state change (e.g. class:anim-heart-pulse={justFavourited}) */
+.anim-heart-pulse { animation: heart-pulse 300ms ease-in-out; }
+.anim-heart-ring { animation: heart-ring 300ms ease-in-out; }
+.anim-check-pop { animation: check-pop 320ms ease-out; }
+.anim-glow-ring { animation: glow-ring 320ms ease-out; }
+.anim-row-sweep { animation: row-sweep 280ms ease-in-out; }
+.anim-folder-pop { animation: folder-pop 380ms ease-out; }
+.anim-ring-expand { animation: ring-expand 380ms ease-out; }
+.anim-card-materialize { animation: card-materialize 400ms cubic-bezier(0.34, 1.56, 0.64, 1); }
+.anim-border-glow-pulse { animation: border-glow-pulse 400ms ease-out; }
+.anim-slide-in-fade { animation: slide-in-fade 380ms ease-out; }
+.anim-badge-glow { animation: badge-glow 380ms ease-out; }
+.anim-milestone-bounce { animation: milestone-bounce 650ms cubic-bezier(0.34, 1.56, 0.64, 1); }
+.anim-gold-ring { animation: gold-ring 650ms ease-out; }
+.anim-shimmer-sweep { animation: shimmer-sweep 600ms ease-in-out; }
+.anim-warn-shake { animation: warn-shake 200ms ease-in-out; }
+.anim-warn-flash { animation: warn-flash 200ms ease-in-out; }
+.anim-reduced-fade { animation: reduced-fade 150ms ease-out; }
+
+/* Reduced-motion fallback — every tier collapses to the same opacity fade;
+   ring/glow/flash effects (no visible "shape" of their own beyond a shadow)
+   are dropped entirely rather than faded. Scoped to :not(.force-full-motion)
+   so the dev animation gallery (src/routes/dev/animations) can flip a class
+   on <html> to preview full motion regardless of the OS setting — see
+   issue #182. Never set that class anywhere in production UI. */
+@media (prefers-reduced-motion: reduce) {
+  html:not(.force-full-motion) .anim-heart-pulse,
+  html:not(.force-full-motion) .anim-check-pop,
+  html:not(.force-full-motion) .anim-row-sweep,
+  html:not(.force-full-motion) .anim-folder-pop,
+  html:not(.force-full-motion) .anim-card-materialize,
+  html:not(.force-full-motion) .anim-slide-in-fade,
+  html:not(.force-full-motion) .anim-milestone-bounce,
+  html:not(.force-full-motion) .anim-shimmer-sweep,
+  html:not(.force-full-motion) .anim-warn-shake {
+    animation: reduced-fade 150ms ease-out;
+  }
+
+  html:not(.force-full-motion) .anim-heart-ring,
+  html:not(.force-full-motion) .anim-glow-ring,
+  html:not(.force-full-motion) .anim-ring-expand,
+  html:not(.force-full-motion) .anim-border-glow-pulse,
+  html:not(.force-full-motion) .anim-badge-glow,
+  html:not(.force-full-motion) .anim-gold-ring,
+  html:not(.force-full-motion) .anim-warn-flash {
+    animation: none;
+  }
+}

--- a/src/routes/dev/animations/+page.svelte
+++ b/src/routes/dev/animations/+page.svelte
@@ -1,0 +1,281 @@
+<script lang="ts">
+  // Dev-only gallery for previewing every micro-animation from
+  // docs/luminous-micro-animations.dc.html (see issue #182) on demand,
+  // including moments that are rare or slow to reach in a real library
+  // (first launch, milestones, an actual import finishing).
+  //
+  // "Favouriting a song" and "Import finished" render the real
+  // HeartToggle/Toast components so this stays honest with production
+  // behaviour; the rest are demo markup for moments not wired into the app
+  // yet (see the checklist in issue #182).
+  import { onMount } from "svelte";
+  import { goto } from "$app/navigation";
+  import HeartToggle from "../../../lib/components/HeartToggle.svelte";
+  import { toastStore } from "../../../lib/stores/toast.svelte";
+  import { Folder, ListMusic, ArrowUp, AlertTriangle } from "lucide-svelte";
+
+  // Most dev machines with Windows "Animation effects" turned off (or any
+  // prefers-reduced-motion setting) will otherwise only ever see the
+  // reduced-motion fallback here — that's animations.css doing its job, but
+  // it defeats the point of a preview gallery. `force-full-motion` on <html>
+  // is the escape hatch defined alongside the media query in animations.css.
+  let prefersReducedMotion = $state(false);
+  let forceFullMotion = $state(false);
+
+  onMount(() => {
+    if (!import.meta.env.DEV) {
+      goto("/");
+      return;
+    }
+    const query = window.matchMedia("(prefers-reduced-motion: reduce)");
+    prefersReducedMotion = query.matches;
+    forceFullMotion = query.matches;
+    const onChange = (e: MediaQueryListEvent) => { prefersReducedMotion = e.matches; };
+    query.addEventListener("change", onChange);
+    return () => query.removeEventListener("change", onChange);
+  });
+
+  $effect(() => {
+    document.documentElement.classList.toggle("force-full-motion", forceFullMotion);
+  });
+
+  let favoriteDemo = $state(false);
+  function replayFavorite() {
+    favoriteDemo = false;
+    requestAnimationFrame(() => { favoriteDemo = true; });
+  }
+
+  function replayToast() {
+    toastStore.show("128 tracks added", "success");
+  }
+
+  let replayCounters = $state<Record<string, number>>({
+    organizing: 0,
+    folder: 0,
+    playlist: 0,
+    autoPlaylist: 0,
+    release: 0,
+    milestone: 0,
+    queue: 0,
+    firstLaunch: 0,
+    warning: 0,
+  });
+  function replay(name: string) {
+    replayCounters[name]++;
+  }
+
+  const tierColor: Record<string, string> = {
+    Milestone: "text-brand-gold bg-[color:rgb(255_182_72_/_0.14)]",
+    New: "text-brand-accent-text bg-brand-accent/15",
+    Success: "text-[#8fbf9a] bg-[#8fbf9a]/15",
+    Warning: "text-[#e0a0a0] bg-[#e0a0a0]/15",
+  };
+</script>
+
+<div class="h-full overflow-y-auto p-8 bg-brand-main text-brand-text-primary">
+  <div class="max-w-5xl mx-auto space-y-2 mb-8">
+    <h1 class="text-2xl font-bold">Micro-animation gallery</h1>
+    <p class="text-sm text-brand-text-secondary max-w-2xl">
+      Dev-only preview for the moments in
+      <a href="https://github.com/esoltys/luminous/issues/182" class="text-brand-accent-text hover:underline" target="_blank" rel="noreferrer">issue #182</a>.
+      Click Replay on any card to trigger it on demand — useful for milestones and other moments that are rare or slow to reach for real.
+    </p>
+    {#if prefersReducedMotion}
+      <div class="flex items-center justify-between gap-4 bg-brand-accent/10 border border-brand-accent/30 rounded-xl px-4 py-3 max-w-2xl">
+        <p class="text-xs text-brand-text-secondary">
+          Your OS has "reduce motion" on, so every card below is correctly collapsing to the spec's reduced-motion fallback (plain fade, or nothing for rings/glows) — that's intentional, not broken. Toggle below to preview full motion anyway.
+        </p>
+        <label class="flex items-center gap-2 text-xs font-semibold shrink-0 cursor-pointer select-none">
+          <input type="checkbox" bind:checked={forceFullMotion} class="accent-[var(--color-accent)]" />
+          Preview full motion
+        </label>
+      </div>
+    {/if}
+  </div>
+
+  <div class="max-w-5xl mx-auto grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+
+    <!-- 1. Favouriting a song (real component) -->
+    <div class="bg-brand-sidebar border border-brand-border rounded-xl p-5 flex flex-col gap-4">
+      <div class="flex items-center justify-between">
+        <span class="font-semibold text-sm">Favouriting a song</span>
+        <span class="text-[10px] font-bold uppercase tracking-wide rounded-full px-2 py-0.5 {tierColor.Success}">Success</span>
+      </div>
+      <div class="h-16 flex items-center justify-center bg-brand-main rounded-lg">
+        <HeartToggle favorite={favoriteDemo} onToggle={() => (favoriteDemo = !favoriteDemo)} sizeClass="w-6 h-6" />
+      </div>
+      <button onclick={replayFavorite} class="text-xs font-semibold text-brand-accent-text border border-brand-accent/40 rounded-full px-3 py-1.5 self-start cursor-pointer hover:bg-brand-accent/10">▸ Replay</button>
+    </div>
+
+    <!-- 2. Import finished (real Toast component, mounted in +layout.svelte) -->
+    <div class="bg-brand-sidebar border border-brand-border rounded-xl p-5 flex flex-col gap-4">
+      <div class="flex items-center justify-between">
+        <span class="font-semibold text-sm">Import finished</span>
+        <span class="text-[10px] font-bold uppercase tracking-wide rounded-full px-2 py-0.5 {tierColor.Success}">Success</span>
+      </div>
+      <div class="h-16 flex items-center justify-center bg-brand-main rounded-lg text-xs text-brand-text-secondary text-center px-3">
+        Watch the bottom of the screen
+      </div>
+      <button onclick={replayToast} class="text-xs font-semibold text-brand-accent-text border border-brand-accent/40 rounded-full px-3 py-1.5 self-start cursor-pointer hover:bg-brand-accent/10">▸ Replay</button>
+    </div>
+
+    <!-- 3. Organizing complete -->
+    <div class="bg-brand-sidebar border border-brand-border rounded-xl p-5 flex flex-col gap-4">
+      <div class="flex items-center justify-between">
+        <span class="font-semibold text-sm">Organizing complete</span>
+        <span class="text-[10px] font-bold uppercase tracking-wide rounded-full px-2 py-0.5 {tierColor.Success}">Success</span>
+      </div>
+      <div class="h-16 flex flex-col gap-1.5 justify-center bg-brand-main rounded-lg px-4">
+        {#key replayCounters.organizing}
+          {#each [0, 50, 100] as delay}
+            <div
+              class="h-2 rounded anim-row-sweep"
+              style="background: linear-gradient(90deg, #1c1f29 25%, #2f3a4d 50%, #1c1f29 75%); background-size: 250% 100%; animation-delay: {delay}ms;"
+            ></div>
+          {/each}
+        {/key}
+      </div>
+      <button onclick={() => replay('organizing')} class="text-xs font-semibold text-brand-accent-text border border-brand-accent/40 rounded-full px-3 py-1.5 self-start cursor-pointer hover:bg-brand-accent/10">▸ Replay</button>
+    </div>
+
+    <!-- 4. First watched folder -->
+    <div class="bg-brand-sidebar border border-brand-border rounded-xl p-5 flex flex-col gap-4">
+      <div class="flex items-center justify-between">
+        <span class="font-semibold text-sm">First watched folder</span>
+        <span class="text-[10px] font-bold uppercase tracking-wide rounded-full px-2 py-0.5 {tierColor.New}">New</span>
+      </div>
+      <div class="h-16 flex items-center justify-center bg-brand-main rounded-lg">
+        {#key replayCounters.folder}
+          <div class="relative w-8 h-8 flex items-center justify-center">
+            <span class="absolute inset-0 rounded-lg anim-ring-expand"></span>
+            <Folder class="w-6 h-6 text-brand-accent-text anim-folder-pop" />
+          </div>
+        {/key}
+      </div>
+      <button onclick={() => replay('folder')} class="text-xs font-semibold text-brand-accent-text border border-brand-accent/40 rounded-full px-3 py-1.5 self-start cursor-pointer hover:bg-brand-accent/10">▸ Replay</button>
+    </div>
+
+    <!-- 5. Creating a new playlist -->
+    <div class="bg-brand-sidebar border border-brand-border rounded-xl p-5 flex flex-col gap-4">
+      <div class="flex items-center justify-between">
+        <span class="font-semibold text-sm">Creating a new playlist</span>
+        <span class="text-[10px] font-bold uppercase tracking-wide rounded-full px-2 py-0.5 {tierColor.New}">New</span>
+      </div>
+      <div class="h-16 flex items-center justify-center bg-brand-main rounded-lg">
+        {#key replayCounters.playlist}
+          <div class="w-24 h-11 bg-brand-sidebar border border-brand-border rounded-lg p-2 anim-card-materialize anim-border-glow-pulse flex flex-col gap-1.5 justify-center">
+            <div class="w-3/5 h-1.5 rounded bg-brand-accent"></div>
+            <div class="w-4/5 h-1.5 rounded bg-brand-border"></div>
+          </div>
+        {/key}
+      </div>
+      <button onclick={() => replay('playlist')} class="text-xs font-semibold text-brand-accent-text border border-brand-accent/40 rounded-full px-3 py-1.5 self-start cursor-pointer hover:bg-brand-accent/10">▸ Replay</button>
+    </div>
+
+    <!-- 6. New auto-playlist appears -->
+    <div class="bg-brand-sidebar border border-brand-border rounded-xl p-5 flex flex-col gap-4">
+      <div class="flex items-center justify-between">
+        <span class="font-semibold text-sm">New auto-playlist appears</span>
+        <span class="text-[10px] font-bold uppercase tracking-wide rounded-full px-2 py-0.5 {tierColor.New}">New</span>
+      </div>
+      <div class="h-16 flex items-center justify-center bg-brand-main rounded-lg">
+        {#key replayCounters.autoPlaylist}
+          <div class="flex items-center gap-2 anim-slide-in-fade">
+            <ListMusic class="w-3.5 h-3.5 text-brand-accent-text" />
+            <span class="text-xs font-semibold">Deep Focus</span>
+            <span class="text-[9px] font-bold uppercase tracking-wide rounded px-1.5 py-0.5 text-brand-gold bg-[color:rgb(255_182_72_/_0.14)] anim-badge-glow">Auto</span>
+          </div>
+        {/key}
+      </div>
+      <button onclick={() => replay('autoPlaylist')} class="text-xs font-semibold text-brand-accent-text border border-brand-accent/40 rounded-full px-3 py-1.5 self-start cursor-pointer hover:bg-brand-accent/10">▸ Replay</button>
+    </div>
+
+    <!-- 7. New release available — a new Luminous version, not a new song/album; shown in Settings → About -->
+    <div class="bg-brand-sidebar border border-brand-border rounded-xl p-5 flex flex-col gap-4">
+      <div class="flex items-center justify-between">
+        <span class="font-semibold text-sm">New release available <span class="text-brand-text-secondary font-normal">(Settings → About)</span></span>
+        <span class="text-[10px] font-bold uppercase tracking-wide rounded-full px-2 py-0.5 {tierColor.New}">New</span>
+      </div>
+      <div class="h-16 flex items-center justify-center bg-brand-main rounded-lg">
+        {#key replayCounters.release}
+          <div class="bg-brand-accent/10 border border-brand-accent/30 rounded-lg px-3 py-2 flex items-center gap-2.5 anim-card-materialize">
+            <div class="relative w-7 h-7 rounded-lg bg-brand-accent/20 text-brand-accent-text border border-brand-accent/30 flex items-center justify-center shrink-0">
+              <span class="absolute -top-1 -right-1 w-2 h-2 rounded-full bg-brand-accent anim-badge-glow"></span>
+              <ArrowUp class="w-3.5 h-3.5 stroke-[2.5]" />
+            </div>
+            <span class="text-xs font-bold">Luminous 1.2.0 available</span>
+          </div>
+        {/key}
+      </div>
+      <button onclick={() => replay('release')} class="text-xs font-semibold text-brand-accent-text border border-brand-accent/40 rounded-full px-3 py-1.5 self-start cursor-pointer hover:bg-brand-accent/10">▸ Replay</button>
+    </div>
+
+    <!-- 8. Reaching a milestone -->
+    <div class="bg-brand-sidebar border border-brand-border rounded-xl p-5 flex flex-col gap-4">
+      <div class="flex items-center justify-between">
+        <span class="font-semibold text-sm">Reaching a milestone</span>
+        <span class="text-[10px] font-bold uppercase tracking-wide rounded-full px-2 py-0.5 {tierColor.Milestone}">Milestone</span>
+      </div>
+      <div class="h-16 flex items-center justify-center bg-brand-main rounded-lg relative">
+        {#key replayCounters.milestone}
+          <span class="absolute w-16 h-9 rounded-full anim-gold-ring"></span>
+          <span class="text-lg font-black text-brand-gold anim-milestone-bounce">1,000 songs</span>
+        {/key}
+      </div>
+      <button onclick={() => replay('milestone')} class="text-xs font-semibold text-brand-accent-text border border-brand-accent/40 rounded-full px-3 py-1.5 self-start cursor-pointer hover:bg-brand-accent/10">▸ Replay</button>
+    </div>
+
+    <!-- 9. Completing a queue -->
+    <div class="bg-brand-sidebar border border-brand-border rounded-xl p-5 flex flex-col gap-4">
+      <div class="flex items-center justify-between">
+        <span class="font-semibold text-sm">Completing a queue</span>
+        <span class="text-[10px] font-bold uppercase tracking-wide rounded-full px-2 py-0.5 {tierColor.Milestone}">Milestone</span>
+      </div>
+      <div class="h-16 flex items-center justify-center bg-brand-main rounded-lg">
+        {#key replayCounters.queue}
+          <span
+            class="text-sm font-semibold bg-clip-text text-transparent anim-shimmer-sweep"
+            style="background-image: linear-gradient(90deg, #f1f3f8 40%, #FFB648 50%, #f1f3f8 60%); background-size: 250% 100%;"
+          >Queue complete — nice listening</span>
+        {/key}
+      </div>
+      <button onclick={() => replay('queue')} class="text-xs font-semibold text-brand-accent-text border border-brand-accent/40 rounded-full px-3 py-1.5 self-start cursor-pointer hover:bg-brand-accent/10">▸ Replay</button>
+    </div>
+
+    <!-- 10. First launch -->
+    <div class="bg-brand-sidebar border border-brand-border rounded-xl p-5 flex flex-col gap-4">
+      <div class="flex items-center justify-between">
+        <span class="font-semibold text-sm">First launch</span>
+        <span class="text-[10px] font-bold uppercase tracking-wide rounded-full px-2 py-0.5 {tierColor.Milestone}">Milestone</span>
+      </div>
+      <div class="h-16 flex items-center justify-center bg-brand-main rounded-lg relative">
+        {#key replayCounters.firstLaunch}
+          <span class="absolute w-24 h-11 rounded-full anim-gold-ring"></span>
+          <div class="flex items-center gap-2 anim-milestone-bounce">
+            <img src="/luminous-mark.svg" alt="" class="w-8 h-8" />
+            <span class="text-lg font-black tracking-tight text-brand-gold">Luminous</span>
+          </div>
+        {/key}
+      </div>
+      <button onclick={() => replay('firstLaunch')} class="text-xs font-semibold text-brand-accent-text border border-brand-accent/40 rounded-full px-3 py-1.5 self-start cursor-pointer hover:bg-brand-accent/10">▸ Replay</button>
+    </div>
+
+    <!-- 11. Import needs attention -->
+    <div class="bg-brand-sidebar border border-brand-border rounded-xl p-5 flex flex-col gap-4">
+      <div class="flex items-center justify-between">
+        <span class="font-semibold text-sm">Import needs attention</span>
+        <span class="text-[10px] font-bold uppercase tracking-wide rounded-full px-2 py-0.5 {tierColor.Warning}">Warning</span>
+      </div>
+      <div class="h-16 flex items-center justify-center bg-brand-main rounded-lg">
+        {#key replayCounters.warning}
+          <div class="flex items-center gap-2 rounded-lg px-3 py-2 anim-warn-shake anim-warn-flash">
+            <AlertTriangle class="w-3.5 h-3.5 text-[#e0a0a0]" />
+            <span class="text-xs font-semibold">3 files couldn't be read</span>
+          </div>
+        {/key}
+      </div>
+      <button onclick={() => replay('warning')} class="text-xs font-semibold text-brand-accent-text border border-brand-accent/40 rounded-full px-3 py-1.5 self-start cursor-pointer hover:bg-brand-accent/10">▸ Replay</button>
+    </div>
+
+  </div>
+</div>


### PR DESCRIPTION
## Summary
Work in progress toward issue #182 (joyful micro-animations). This PR does **not** close #182 on merge — most of the checklist is still open, tracked there.

- Adds `src/lib/styles/animations.css`: shared keyframes/utility classes for the motion spec, rescaled from the design doc's looping-preview timing to real one-shot durations, with a `prefers-reduced-motion` fallback and a `force-full-motion` dev escape hatch.
- **Favouriting a song** — heart scale-up + accent-colour ring (not the reserved brand gold), portaled to `document.body` so the ring escapes clipping ancestors (virtualized table rows, the PlayerBar's `truncate` title column) instead of being cut off.
- **Import finished** — checkmark pop + glow ring on a new `success` toast variant; toast repositioned to top-right.
- **App update notifications** (Settings → General) — same checkmark/glow treatment on "Luminous is up to date!", plus a materialize + corner-pulse on the update-available banner; both render inline beside "Check for Updates" instead of below the version cards.
- Dev-only gallery at `/dev/animations` (`bun run preview-animations`) for previewing moments that are rare or slow to reach for real, with reduced-motion detection and a full-motion preview toggle.

Related to #182 — remaining moments (organizing complete, first watched folder, new auto-playlist, milestones, queue complete, warning) and the "creating a new playlist" trigger point are still open and intentionally out of scope here.

## Test plan
- [x] `bun run check` (svelte-check) — 0 errors
- [x] `bun run vite build` — clean
- [ ] Manual verification in a dev build: favouriting a song, a scan finishing, and Settings → General → Check for Updates