### PR TITLE
feat(animations): joyful micro-animations, sound cues, and persistent toasts (#182)

### DIFF
--- a/src/lib/components/AutoPlaylistCard.svelte
+++ b/src/lib/components/AutoPlaylistCard.svelte
@@ -92,7 +92,7 @@
   function handlePlayButtonClick(e: MouseEvent) {
     e.stopPropagation();
     if (songs.length > 0) {
-      playerStore.playSongs(songs.map((s) => s.id), 0, playlistId);
+      playerStore.playSongs(songs.map((s) => s.id), 0, playlistId, undefined, displayLabel);
     }
     onClick();
   }

--- a/src/lib/components/AutoPlaylistDetailView.svelte
+++ b/src/lib/components/AutoPlaylistDetailView.svelte
@@ -153,7 +153,7 @@
     if (selectedSongIds.size === 0) return;
     const selectedList = songs.filter((s) => selectedSongIds.has(s.id));
     if (selectedList.length > 0) {
-      playerStore.playSongs(selectedList.map((s) => s.id), 0, playlistId);
+      playerStore.playSongs(selectedList.map((s) => s.id), 0, playlistId, undefined, displayName);
     }
   }
 
@@ -223,13 +223,13 @@
   function handlePlaySong(song: Song) {
     const index = songs.findIndex((s) => s.id === song.id);
     const songIds = songs.map((s) => s.id);
-    playerStore.playSongs(songIds, index >= 0 ? index : 0, playlistId);
+    playerStore.playSongs(songIds, index >= 0 ? index : 0, playlistId, undefined, displayName);
   }
 
   async function handlePlayAll() {
     if (songs.length === 0) return;
     await playerStore.setShuffleMode("off");
-    await playerStore.playSongs(songs.map((s) => s.id), 0, playlistId);
+    await playerStore.playSongs(songs.map((s) => s.id), 0, playlistId, undefined, displayName);
   }
 
   async function handleShufflePlay() {
@@ -237,7 +237,7 @@
     const ids = songs.map((s) => s.id);
     const randomIndex = Math.floor(Math.random() * ids.length);
     await playerStore.setShuffleMode("all");
-    await playerStore.playSongs(ids, randomIndex, playlistId);
+    await playerStore.playSongs(ids, randomIndex, playlistId, undefined, displayName);
   }
 
   async function handleAddSongToPlaylist(songId: number) {

--- a/src/lib/components/FoldersView.svelte
+++ b/src/lib/components/FoldersView.svelte
@@ -357,7 +357,7 @@
         </div>
 
         <!-- Rating style row -->
-        <div class="flex items-center justify-between gap-4 pt-4">
+        <div class="flex items-center justify-between gap-4 py-4 border-b border-brand-border/50">
           <div class="flex flex-col gap-0.5 min-w-0">
             <label for="rating-style-select" class="text-sm font-medium text-brand-text-primary">{i18n.t('settings.ratingStyle')}</label>
             <p class="text-xs text-brand-text-secondary">{i18n.t('settings.ratingStyleHint')}</p>
@@ -371,6 +371,20 @@
             <option value="heart">{i18n.t('settings.ratingStyleHeart')}</option>
             <option value="stars">{i18n.t('settings.ratingStyleStars')}</option>
           </Select>
+        </div>
+
+        <!-- Audio sound cues row -->
+        <div class="flex items-center justify-between gap-4 pt-4">
+          <div class="flex flex-col gap-0.5 min-w-0">
+            <label for="sound-cues-toggle" class="text-sm font-medium text-brand-text-primary">{i18n.t('settings.soundCuesLabel', {}, 'Celebration Sound Cues')}</label>
+            <p class="text-xs text-brand-text-secondary">{i18n.t('settings.soundCuesHint', {}, 'Play soft synthesized audio cues for celebration moments and confirmations.')}</p>
+          </div>
+          <Toggle
+            id="sound-cues-toggle"
+            checked={prefs.soundCuesEnabled}
+            onchange={(v) => prefs.setSoundCuesEnabled(v)}
+            label={i18n.t('settings.soundCuesLabel', {}, 'Celebration Sound Cues')}
+          />
         </div>
       </div>
 

--- a/src/lib/components/HeartToggle.svelte
+++ b/src/lib/components/HeartToggle.svelte
@@ -13,11 +13,8 @@
 
   let buttonEl: HTMLButtonElement | undefined = $state();
 
-  // Only the moment the user actually favourites a song should pulse — not
-  // every render where `favorite` happens to already be true (e.g. scrolling
-  // a list of already-favourited songs into view). `previousFavorite` starts
-  // undefined so an already-favourited song never pulses on first mount.
-  let previousFavorite: boolean | undefined;
+  // Only the moment the user actually favourites a song should pulse — triggered
+  // directly on user click when favouriting.
   let justFavorited = $state(false);
 
   // HeartToggle renders inside all sorts of clipped containers (virtualized
@@ -45,26 +42,22 @@
     ring.addEventListener("animationend", () => ring.remove());
   }
 
-  $effect(() => {
-    const wasFavorite = previousFavorite;
-    previousFavorite = favorite;
-    if (favorite && wasFavorite === false) {
+  function handleClick(e: MouseEvent) {
+    e.stopPropagation();
+    if (!favorite) {
       justFavorited = true;
       burstRing();
       soundCues.playSuccess();
-      const timeout = setTimeout(() => { justFavorited = false; }, 320);
-      return () => clearTimeout(timeout);
+      setTimeout(() => { justFavorited = false; }, 320);
     }
-  });
+    onToggle();
+  }
 </script>
 
 <button
   bind:this={buttonEl}
   type="button"
-  onclick={(e) => {
-    e.stopPropagation();
-    onToggle();
-  }}
+  onclick={handleClick}
   class="inline-flex transition-colors cursor-pointer {favorite
     ? 'text-brand-accent-text'
     : 'text-brand-text-secondary/60 hover:text-brand-accent-text'}"

--- a/src/lib/components/HeartToggle.svelte
+++ b/src/lib/components/HeartToggle.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { Heart } from "lucide-svelte";
   import { i18n } from "../stores/i18n.svelte";
+  import { soundCues } from "../utils/soundCues";
 
   interface Props {
     favorite: boolean;
@@ -50,6 +51,7 @@
     if (favorite && wasFavorite === false) {
       justFavorited = true;
       burstRing();
+      soundCues.playSuccess();
       const timeout = setTimeout(() => { justFavorited = false; }, 320);
       return () => clearTimeout(timeout);
     }

--- a/src/lib/components/OrganizeFiles.svelte
+++ b/src/lib/components/OrganizeFiles.svelte
@@ -3,6 +3,7 @@
   import { invoke } from "@tauri-apps/api/core";
   import { open } from "@tauri-apps/plugin-dialog";
   import { i18n } from "../stores/i18n.svelte";
+  import { toastStore } from "../stores/toast.svelte";
   import { portal } from "../utils/portal";
   import { X, Folder, Sparkles, Check, AlertTriangle, RefreshCw, Layers } from "lucide-svelte";
   import { VirtualList } from "svelte-virtual-list-ts";
@@ -315,8 +316,18 @@
 
       if (result.errors && result.errors.length > 0) {
         errorMessage = result.errors.join("; ");
+        toastStore.show(
+          i18n.t("organizer.toastErrors", { count: result.errors.length }, `${result.errors.length} file(s) couldn't be organized`),
+          "warning"
+        );
       } else {
         successMessage = result.moved_count === 1 ? i18n.t("organizer.applySuccessOne") : i18n.t("organizer.applySuccessMany", { count: result.moved_count });
+        toastStore.show(
+          result.moved_count === 1
+            ? i18n.t("organizer.toastSuccessOne", {}, "1 file organized successfully")
+            : i18n.t("organizer.toastSuccessMany", { count: result.moved_count }, `${result.moved_count} files organized successfully`),
+          "success"
+        );
         onSuccess?.();
         // Leave the modal open so the user can see the result — refresh the
         // preview to reflect the just-applied moves instead of auto-closing.

--- a/src/lib/components/OrganizeFiles.svelte
+++ b/src/lib/components/OrganizeFiles.svelte
@@ -690,12 +690,6 @@
       <span>{errorMessage}</span>
     </div>
   {/if}
-  {#if successMessage}
-    <div class="text-brand-accent-text flex items-center gap-2 font-medium text-xs">
-      <Check class="w-4 h-4 shrink-0" />
-      <span>{successMessage}</span>
-    </div>
-  {/if}
 {/snippet}
 
 {#if effectiveOpen}

--- a/src/lib/components/Toast.svelte
+++ b/src/lib/components/Toast.svelte
@@ -13,13 +13,13 @@
     <div
       in:fly={{ x: 24, duration: 200 }}
       out:fade={{ duration: 150 }}
-      class="pointer-events-auto flex items-center gap-2.5 px-4 py-2.5 rounded-xl border shadow-2xl text-sm font-medium max-w-md
+      class="pointer-events-auto flex items-center gap-2.5 px-4 py-2.5 rounded-xl border shadow-2xl backdrop-blur-md text-sm font-semibold max-w-md
         {toast.variant === 'error'
-          ? 'bg-red-500/10 border-red-500/30 text-red-400 anim-warn-shake'
+          ? 'bg-[#1f1013] border-red-500/50 text-red-400 anim-warn-shake'
           : toast.variant === 'warning'
-            ? 'bg-amber-500/10 border-amber-500/30 text-amber-400 anim-warn-shake'
+            ? 'bg-[#1f1a10] border-amber-500/50 text-amber-400 anim-warn-shake'
             : toast.variant === 'milestone'
-              ? 'bg-[rgb(255_182_72_/_0.1)] border-[rgb(255_182_72_/_0.3)] text-brand-gold'
+              ? 'bg-[#1f1a12] border-brand-gold/50 text-brand-gold'
               : 'bg-brand-sidebar border-brand-border text-brand-text-primary'}"
     >
       {#if toast.variant === "error" || toast.variant === "warning"}

--- a/src/lib/components/Toast.svelte
+++ b/src/lib/components/Toast.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { fly, fade } from "svelte/transition";
-  import { AlertTriangle, CheckCircle2, Info, Trophy, Sparkles, X } from "lucide-svelte";
+  import { AlertTriangle, CheckCircle2, Info, Star, Sparkles, X } from "lucide-svelte";
   import { toastStore } from "../stores/toast.svelte";
   import { portal } from "../utils/portal";
 </script>
@@ -32,7 +32,7 @@
       {:else if toast.variant === "milestone"}
         <span class="relative inline-flex w-5 h-5 shrink-0 items-center justify-center">
           <span class="absolute inset-0 rounded-full anim-gold-ring"></span>
-          <Trophy class="w-5 h-5 text-brand-gold anim-milestone-bounce" />
+          <Star class="w-5 h-5 text-brand-gold fill-brand-gold/30 anim-milestone-bounce" />
         </span>
       {:else}
         <Info class="w-4 h-4 shrink-0 text-brand-accent-text" />

--- a/src/lib/components/Toast.svelte
+++ b/src/lib/components/Toast.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { fly, fade } from "svelte/transition";
-  import { AlertTriangle, CheckCircle2, Info, X } from "lucide-svelte";
+  import { AlertTriangle, CheckCircle2, Info, Trophy, Sparkles, X } from "lucide-svelte";
   import { toastStore } from "../stores/toast.svelte";
   import { portal } from "../utils/portal";
 </script>
@@ -13,16 +13,26 @@
     <div
       in:fly={{ x: 24, duration: 200 }}
       out:fade={{ duration: 150 }}
-      class="pointer-events-auto flex items-center gap-2.5 px-4 py-2.5 rounded-xl border shadow-2xl text-sm font-medium max-w-md {toast.variant === 'error'
-        ? 'bg-red-500/10 border-red-500/30 text-red-400'
-        : 'bg-brand-sidebar border-brand-border text-brand-text-primary'}"
+      class="pointer-events-auto flex items-center gap-2.5 px-4 py-2.5 rounded-xl border shadow-2xl text-sm font-medium max-w-md
+        {toast.variant === 'error'
+          ? 'bg-red-500/10 border-red-500/30 text-red-400 anim-warn-shake'
+          : toast.variant === 'warning'
+            ? 'bg-amber-500/10 border-amber-500/30 text-amber-400 anim-warn-shake'
+            : toast.variant === 'milestone'
+              ? 'bg-[rgb(255_182_72_/_0.1)] border-[rgb(255_182_72_/_0.3)] text-brand-gold'
+              : 'bg-brand-sidebar border-brand-border text-brand-text-primary'}"
     >
-      {#if toast.variant === "error"}
+      {#if toast.variant === "error" || toast.variant === "warning"}
         <AlertTriangle class="w-4 h-4 shrink-0" />
       {:else if toast.variant === "success"}
         <span class="relative inline-flex w-4 h-4 shrink-0 items-center justify-center">
           <span class="absolute inset-0 rounded-full anim-glow-ring"></span>
           <CheckCircle2 class="w-4 h-4 text-brand-accent-text anim-check-pop" />
+        </span>
+      {:else if toast.variant === "milestone"}
+        <span class="relative inline-flex w-5 h-5 shrink-0 items-center justify-center">
+          <span class="absolute inset-0 rounded-full anim-gold-ring"></span>
+          <Trophy class="w-5 h-5 text-brand-gold anim-milestone-bounce" />
         </span>
       {:else}
         <Info class="w-4 h-4 shrink-0 text-brand-accent-text" />

--- a/src/lib/stores/collection.svelte.ts
+++ b/src/lib/stores/collection.svelte.ts
@@ -482,7 +482,7 @@ class CollectionStore {
             const msg = isFirstEver
               ? i18n.t("celebrations.firstLaunch", { version: appVersion }, `Welcome to Luminous v${appVersion}! 🎵`)
               : i18n.t("celebrations.newVersion", { version: appVersion }, `Welcome to Luminous v${appVersion}! 🆕`);
-            toastStore.show(msg, "milestone", 6000);
+            toastStore.show(msg, "milestone");
             setTimeout(() => { this.isFirstLaunch = false; }, 700);
           }, 1200);
         }
@@ -514,8 +514,7 @@ class CollectionStore {
                 this.milestoneReached = threshold;
                 toastStore.show(
                   i18n.t("celebrations.milestone", { count: threshold.toLocaleString() }, `🎉 ${threshold.toLocaleString()} songs in your library!`),
-                  "milestone",
-                  6000
+                  "milestone"
                 );
                 setTimeout(() => { this.milestoneReached = null; }, 700);
                 break;

--- a/src/lib/stores/collection.svelte.ts
+++ b/src/lib/stores/collection.svelte.ts
@@ -78,6 +78,9 @@ interface NavigationView {
 
 const MAX_HISTORY = 50;
 
+/** Song-count milestones that trigger Milestone-tier celebrations. */
+const MILESTONE_THRESHOLDS = [100, 500, 1000, 2500, 5000, 10000];
+
 class CollectionStore {
   directories = $state<MusicDirectory[]>([]);
   stats = $state<LibraryStats>({
@@ -94,6 +97,11 @@ class CollectionStore {
   statsLoaded = $state<boolean>(false);
   isScanning = $state<boolean>(false);
   scanProgress = $state<ScanProgress | null>(null);
+
+  /** Celebration moment states (issue #182) — consumed by Toast and layout. */
+  isFirstLaunch = $state<boolean>(false);
+  justAddedFirstFolder = $state<boolean>(false);
+  milestoneReached = $state<number | null>(null);
 
   // Cached collections
   songs = $state<Song[]>([]);
@@ -448,6 +456,36 @@ class CollectionStore {
         if (settings.last_scan_time) {
           this.lastScanTime = settings.last_scan_time;
         }
+
+        // First-launch / new-version detection (#182) — fires a Milestone-tier
+        // celebration toast when the app is launched for the first time or
+        // after a version upgrade. Stores the version string so the welcome
+        // replays on each new release, not just the very first launch.
+        let appVersion = "";
+        try {
+          appVersion = await invoke<string>("get_app_version");
+        } catch {
+          try {
+            const { getVersion } = await import("@tauri-apps/api/app");
+            appVersion = await getVersion();
+          } catch { /* not in Tauri context */ }
+        }
+        if (appVersion && settings.launched_version !== appVersion) {
+          this.isFirstLaunch = true;
+          invoke("set_app_setting", { key: "launched_version", value: appVersion }).catch((err) => {
+            console.error("Failed to persist launched_version:", err);
+          });
+          // Show the welcome toast after a short delay so the UI has time to
+          // render before the celebration.
+          const isFirstEver = !settings.launched_version;
+          setTimeout(() => {
+            const msg = isFirstEver
+              ? i18n.t("celebrations.firstLaunch", { version: appVersion }, `Welcome to Luminous v${appVersion}! 🎵`)
+              : i18n.t("celebrations.newVersion", { version: appVersion }, `Welcome to Luminous v${appVersion}! 🆕`);
+            toastStore.show(msg, "milestone", 6000);
+            setTimeout(() => { this.isFirstLaunch = false; }, 700);
+          }, 1200);
+        }
       }
 
       // Listen to library scan progress events
@@ -465,6 +503,23 @@ class CollectionStore {
             const added = this.stats.total_songs - songCountBeforeRefresh;
             if (added > 0) {
               toastStore.show(i18n.t("settings.importFinishedToast", { count: added }), "success");
+            }
+
+            // Milestone detection (#182): check if total_songs just crossed a
+            // threshold. Only fire the first one crossed (don't stack multiple
+            // milestone toasts if an import jumps past several at once).
+            const newTotal = this.stats.total_songs;
+            for (const threshold of MILESTONE_THRESHOLDS) {
+              if (songCountBeforeRefresh < threshold && newTotal >= threshold) {
+                this.milestoneReached = threshold;
+                toastStore.show(
+                  i18n.t("celebrations.milestone", { count: threshold.toLocaleString() }, `🎉 ${threshold.toLocaleString()} songs in your library!`),
+                  "milestone",
+                  6000
+                );
+                setTimeout(() => { this.milestoneReached = null; }, 700);
+                break;
+              }
             }
           });
           this.refreshLibrary();
@@ -549,8 +604,17 @@ class CollectionStore {
   }
 
   async addDirectory(path: string) {
+    const wasEmpty = this.directories.length === 0;
     await invoke("add_directory", { path });
     await this.refreshDirectories();
+
+    // First watched folder celebration (#182, New tier).
+    if (wasEmpty && this.directories.length > 0) {
+      this.justAddedFirstFolder = true;
+      toastStore.show(i18n.t("celebrations.firstFolder", {}, "First music folder added! 📂"), "success");
+      setTimeout(() => { this.justAddedFirstFolder = false; }, 400);
+    }
+
     this.startScan(false);
   }
 

--- a/src/lib/stores/player.svelte.ts
+++ b/src/lib/stores/player.svelte.ts
@@ -5,6 +5,7 @@ import type { PlaybackState, Playlist, Song, ShuffleMode, RepeatMode, PlayState,
 import { applySongStats, type SongStatsPayload } from "../utils/stats";
 import { themeStore } from "./theme.svelte";
 import { toastStore } from "./toast.svelte";
+import { playlistsStore } from "./playlists.svelte";
 import { i18n } from "./i18n.svelte";
 
 /** Minimum remaining tracks before the auto-refill is triggered (#26). */
@@ -31,6 +32,8 @@ export class PlayerStore {
 
   /** Celebration: queue just finished naturally (#182, Milestone tier). */
   queueJustCompleted = $state<boolean>(false);
+  /** The name of the active playlist, album, or source context being played. */
+  activeContextName = $state<string | undefined>(undefined);
   /** Previous playback state for detecting playing→stopped transitions. */
   private _previousState: PlayState = "stopped";
 
@@ -64,6 +67,7 @@ export class PlayerStore {
       // Listen for playback state changes
       await listen<PlaybackState>("playback-state", async (event) => {
         const oldSongId = this.currentSong?.id;
+        const oldSongAlbum = this.currentSong?.album;
         const wasPlaying = this._previousState === "playing";
         this.updateState(event.payload);
         this._previousState = this.state;
@@ -75,10 +79,15 @@ export class PlayerStore {
         // playback stops naturally after the last track with nothing left.
         if (wasPlaying && this.state === "stopped" && this.remainingPlaylistItems === 0 && !this.currentSong) {
           this.queueJustCompleted = true;
-          toastStore.show(
-            i18n.t("celebrations.queueComplete", {}, "Queue complete \u2014 nice listening \ud83c\udf1f"),
-            "milestone"
-          );
+
+          // Resolve context name (Playlist name, Album name, or fallback to Queue)
+          const plName = this.playlistId ? playlistsStore.playlists.find((p) => p.id === this.playlistId)?.name : undefined;
+          const contextName = this.activeContextName || plName || oldSongAlbum;
+          const toastText = contextName
+            ? i18n.t("celebrations.contextComplete", { name: contextName }, `${contextName} complete`)
+            : i18n.t("celebrations.queueComplete", {}, "Queue complete");
+
+          toastStore.show(toastText, "milestone");
           setTimeout(() => { this.queueJustCompleted = false; }, 650);
         }
 
@@ -223,10 +232,23 @@ export class PlayerStore {
   }
 
   async playSongs(songIds: number[], startIndex: number, playlistId?: number, context?: PlayContext) {
+    if (context?.type === "album" && context.album) {
+      this.activeContextName = context.album;
+    } else if (context?.type === "playlist" && context.playlistId) {
+      const pl = playlistsStore.playlists.find((p) => p.id === context.playlistId);
+      if (pl) this.activeContextName = pl.name;
+    } else if (playlistId) {
+      const pl = playlistsStore.playlists.find((p) => p.id === playlistId);
+      if (pl) this.activeContextName = pl.name;
+    } else {
+      this.activeContextName = undefined;
+    }
     await invoke("play_songs", { songIds, startIndex, playlistId: playlistId ?? null, context: context ?? null });
   }
 
   async playPlaylistItem(playlistId: number, itemIndex: number) {
+    const pl = playlistsStore.playlists.find((p) => p.id === playlistId);
+    if (pl) this.activeContextName = pl.name;
     await invoke("play_playlist_item", { playlistId, itemIndex });
   }
 

--- a/src/lib/stores/player.svelte.ts
+++ b/src/lib/stores/player.svelte.ts
@@ -231,8 +231,10 @@ export class PlayerStore {
     }
   }
 
-  async playSongs(songIds: number[], startIndex: number, playlistId?: number, context?: PlayContext) {
-    if (context?.type === "album" && context.album) {
+  async playSongs(songIds: number[], startIndex: number, playlistId?: number, context?: PlayContext, contextName?: string) {
+    if (contextName) {
+      this.activeContextName = contextName;
+    } else if (context?.type === "album" && context.album) {
       this.activeContextName = context.album;
     } else if (context?.type === "playlist" && context.playlistId) {
       const pl = playlistsStore.playlists.find((p) => p.id === context.playlistId);

--- a/src/lib/stores/player.svelte.ts
+++ b/src/lib/stores/player.svelte.ts
@@ -4,10 +4,12 @@ import { open } from "@tauri-apps/plugin-dialog";
 import type { PlaybackState, Playlist, Song, ShuffleMode, RepeatMode, PlayState, LoudnessGainSource, PlayContext } from "../types";
 import { applySongStats, type SongStatsPayload } from "../utils/stats";
 import { themeStore } from "./theme.svelte";
+import { toastStore } from "./toast.svelte";
 import { i18n } from "./i18n.svelte";
 
 /** Minimum remaining tracks before the auto-refill is triggered (#26). */
 const AUTO_PLAY_REFILL_THRESHOLD = 3;
+
 
 export class PlayerStore {
   // Reactive state using Svelte 5 Runes
@@ -26,6 +28,11 @@ export class PlayerStore {
   remainingPlaylistItems = $state<number>(0);
   /** Set of playlist IDs whose library auto-refill pool has been exhausted. */
   exhaustedPlaylistIds = $state<number[]>([]);
+
+  /** Celebration: queue just finished naturally (#182, Milestone tier). */
+  queueJustCompleted = $state<boolean>(false);
+  /** Previous playback state for detecting playing→stopped transitions. */
+  private _previousState: PlayState = "stopped";
 
   isAutoPlayExhausted(playlistId: number): boolean {
     return this.exhaustedPlaylistIds.includes(playlistId);
@@ -57,10 +64,25 @@ export class PlayerStore {
       // Listen for playback state changes
       await listen<PlaybackState>("playback-state", async (event) => {
         const oldSongId = this.currentSong?.id;
+        const wasPlaying = this._previousState === "playing";
         this.updateState(event.payload);
+        this._previousState = this.state;
         if (this.currentSong?.id !== oldSongId) {
           themeStore.updateArtworkColors(this.currentSong);
         }
+
+        // Queue completion celebration (#182, Milestone tier): fires when
+        // playback stops naturally after the last track with nothing left.
+        if (wasPlaying && this.state === "stopped" && this.remainingPlaylistItems === 0 && !this.currentSong) {
+          this.queueJustCompleted = true;
+          toastStore.show(
+            i18n.t("celebrations.queueComplete", {}, "Queue complete \u2014 nice listening \ud83c\udf1f"),
+            "milestone",
+            5000
+          );
+          setTimeout(() => { this.queueJustCompleted = false; }, 650);
+        }
+
         // Auto-Play refill: checked on every state change so we react when
         // remaining drops below threshold after each track advance (#26).
         await this.maybeRefillAutoPlaylist();

--- a/src/lib/stores/player.svelte.ts
+++ b/src/lib/stores/player.svelte.ts
@@ -77,8 +77,7 @@ export class PlayerStore {
           this.queueJustCompleted = true;
           toastStore.show(
             i18n.t("celebrations.queueComplete", {}, "Queue complete \u2014 nice listening \ud83c\udf1f"),
-            "milestone",
-            5000
+            "milestone"
           );
           setTimeout(() => { this.queueJustCompleted = false; }, 650);
         }

--- a/src/lib/stores/playlists.svelte.ts
+++ b/src/lib/stores/playlists.svelte.ts
@@ -2,6 +2,8 @@ import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import type { Playlist, PlaylistItem, QueuePopulationMode, Song } from "../types";
 import { applySongStats, type SongStatsPayload } from "../utils/stats";
+import { toastStore } from "./toast.svelte";
+import { i18n } from "./i18n.svelte";
 
 class PlaylistsStore {
   playlists = $state<Playlist[]>([]);
@@ -153,6 +155,10 @@ class PlaylistsStore {
     const playlist: Playlist = await invoke("create_playlist", { name });
     await this.refreshPlaylists();
     await this.selectPlaylist(playlist.id);
+    toastStore.show(
+      i18n.t("celebrations.playlistCreated", { name }, `Playlist "${name}" created`),
+      "success"
+    );
     return playlist;
   }
 

--- a/src/lib/stores/prefs.svelte.ts
+++ b/src/lib/stores/prefs.svelte.ts
@@ -7,6 +7,7 @@ class PrefsStore {
   ratingStyle = $state<RatingStyle>("heart");
   seekBarMode = $state<SeekBarMode>("waveform");
   acoustidApiKey = $state<string>("");
+  soundCuesEnabled = $state<boolean>(false);
 
   async init() {
     try {
@@ -19,6 +20,9 @@ class PrefsStore {
       }
       if (settings?.acoustid_api_key) {
         this.acoustidApiKey = settings.acoustid_api_key;
+      }
+      if (settings?.sound_cues_enabled !== undefined) {
+        this.soundCuesEnabled = settings.sound_cues_enabled === "true";
       }
     } catch (e) {
       console.error("Failed to load preference settings:", e);
@@ -52,6 +56,14 @@ class PrefsStore {
     }
   }
 
+  async setSoundCuesEnabled(enabled: boolean) {
+    this.soundCuesEnabled = enabled;
+    try {
+      await invoke("set_app_setting", { key: "sound_cues_enabled", value: enabled ? "true" : "false" });
+    } catch (e) {
+      console.error("Failed to save sound cues setting:", e);
+    }
+  }
 }
 
 export const prefs = new PrefsStore();

--- a/src/lib/stores/toast.svelte.ts
+++ b/src/lib/stores/toast.svelte.ts
@@ -1,6 +1,6 @@
 import { TOAST_DURATION_MS } from "../constants";
 
-export type ToastVariant = "info" | "error" | "success";
+export type ToastVariant = "info" | "error" | "success" | "milestone" | "warning";
 
 export interface ToastMessage {
   id: number;
@@ -12,10 +12,10 @@ class ToastStore {
   messages = $state<ToastMessage[]>([]);
   private nextId = 0;
 
-  show(text: string, variant: ToastVariant = "info") {
+  show(text: string, variant: ToastVariant = "info", durationMs: number = TOAST_DURATION_MS) {
     const id = this.nextId++;
     this.messages.push({ id, text, variant });
-    setTimeout(() => this.dismiss(id), TOAST_DURATION_MS);
+    setTimeout(() => this.dismiss(id), durationMs);
   }
 
   dismiss(id: number) {

--- a/src/lib/stores/toast.svelte.ts
+++ b/src/lib/stores/toast.svelte.ts
@@ -13,7 +13,7 @@ class ToastStore {
   messages = $state<ToastMessage[]>([]);
   private nextId = 0;
 
-  show(text: string, variant: ToastVariant = "info", durationMs: number = TOAST_DURATION_MS) {
+  show(text: string, variant: ToastVariant = "info", durationMs?: number) {
     const id = this.nextId++;
     this.messages.push({ id, text, variant });
 
@@ -28,7 +28,9 @@ class ToastStore {
       soundCues.playNew();
     }
 
-    setTimeout(() => this.dismiss(id), durationMs);
+    if (durationMs && durationMs > 0) {
+      setTimeout(() => this.dismiss(id), durationMs);
+    }
   }
 
   dismiss(id: number) {

--- a/src/lib/stores/toast.svelte.ts
+++ b/src/lib/stores/toast.svelte.ts
@@ -1,4 +1,5 @@
 import { TOAST_DURATION_MS } from "../constants";
+import { soundCues } from "../utils/soundCues";
 
 export type ToastVariant = "info" | "error" | "success" | "milestone" | "warning";
 
@@ -15,6 +16,18 @@ class ToastStore {
   show(text: string, variant: ToastVariant = "info", durationMs: number = TOAST_DURATION_MS) {
     const id = this.nextId++;
     this.messages.push({ id, text, variant });
+
+    // Sound cues matching tier
+    if (variant === "success") {
+      soundCues.playSuccess();
+    } else if (variant === "milestone") {
+      soundCues.playMilestone();
+    } else if (variant === "warning" || variant === "error") {
+      soundCues.playWarning();
+    } else if (variant === "info") {
+      soundCues.playNew();
+    }
+
     setTimeout(() => this.dismiss(id), durationMs);
   }
 

--- a/src/lib/styles/animations.css
+++ b/src/lib/styles/animations.css
@@ -21,7 +21,7 @@
 /* Favouriting a song (Success, 300ms) */
 @keyframes heart-pulse {
   0% { transform: scale(1); }
-  20% { transform: scale(1.35); }
+  20% { transform: scale(1.5); }
   45% { transform: scale(0.94); }
   70% { transform: scale(1.06); }
   100% { transform: scale(1); }
@@ -41,14 +41,14 @@
 @keyframes heart-ring {
   0% { box-shadow: 0 0 0 0 transparent; }
   20% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--color-accent) 50%, transparent); }
-  75% { box-shadow: 0 0 0 14px transparent; }
-  100% { box-shadow: 0 0 0 14px transparent; }
+  75% { box-shadow: 0 0 0 20px transparent; }
+  100% { box-shadow: 0 0 0 20px transparent; }
 }
 
 /* Import finished (Success, 320ms) */
 @keyframes check-pop {
-  0% { transform: scale(0) rotate(-25deg); opacity: 0; }
-  33% { transform: scale(1.2) rotate(5deg); opacity: 1; }
+  0% { transform: scale(0) rotate(-35deg); opacity: 0; }
+  33% { transform: scale(1.35) rotate(5deg); opacity: 1; }
   67% { transform: scale(0.95) rotate(-2deg); }
   100% { transform: scale(1) rotate(0deg); opacity: 1; }
 }
@@ -56,7 +56,7 @@
 @keyframes glow-ring {
   0% { box-shadow: 0 0 0 0 rgba(143, 191, 154, 0.5); opacity: 0; }
   22% { opacity: 1; }
-  78% { box-shadow: 0 0 0 18px rgba(143, 191, 154, 0); opacity: 0; }
+  78% { box-shadow: 0 0 0 24px rgba(143, 191, 154, 0); opacity: 0; }
   100% { opacity: 0; }
 }
 
@@ -113,7 +113,7 @@
 /* Reaching a milestone / first launch (Milestone, 650ms) */
 @keyframes milestone-bounce {
   0% { transform: scale(1); }
-  24% { transform: scale(1.22); }
+  24% { transform: scale(1.30); }
   52% { transform: scale(0.95); }
   76% { transform: scale(1.05); }
   100% { transform: scale(1); }
@@ -122,7 +122,7 @@
 @keyframes gold-ring {
   0% { box-shadow: 0 0 0 0 rgba(255, 182, 72, 0.5); opacity: 0; }
   16% { opacity: 1; }
-  76% { box-shadow: 0 0 0 22px rgba(255, 182, 72, 0); opacity: 0; }
+  76% { box-shadow: 0 0 0 30px rgba(255, 182, 72, 0); opacity: 0; }
   100% { opacity: 0; }
 }
 
@@ -136,17 +136,17 @@
 /* Import needs attention (Warning/error, 200ms) */
 @keyframes warn-shake {
   0% { transform: translateX(0); }
-  11% { transform: translateX(-5px); }
-  22% { transform: translateX(4px); }
-  33% { transform: translateX(-3px); }
-  44% { transform: translateX(2px); }
+  11% { transform: translateX(-7px); }
+  22% { transform: translateX(6px); }
+  33% { transform: translateX(-4px); }
+  44% { transform: translateX(3px); }
   56% { transform: translateX(0); }
   100% { transform: translateX(0); }
 }
 
 @keyframes warn-flash {
   0% { background: #1c1f29; }
-  16% { background: rgba(224, 160, 160, 0.22); }
+  16% { background: rgba(224, 160, 160, 0.32); }
   100% { background: #1c1f29; }
 }
 

--- a/src/lib/utils/soundCues.ts
+++ b/src/lib/utils/soundCues.ts
@@ -1,0 +1,73 @@
+import { prefs } from "../stores/prefs.svelte";
+
+let audioCtx: AudioContext | null = null;
+
+function getAudioContext(): AudioContext | null {
+  if (typeof window === "undefined") return null;
+  if (!audioCtx) {
+    const AudioContextClass = window.AudioContext || (window as any).webkitAudioContext;
+    if (AudioContextClass) {
+      audioCtx = new AudioContextClass();
+    }
+  }
+  if (audioCtx && audioCtx.state === "suspended") {
+    audioCtx.resume().catch(() => {});
+  }
+  return audioCtx;
+}
+
+function playNote(freq: number, startTime: number, dur: number, gainPeak: number) {
+  const ctx = getAudioContext();
+  if (!ctx) return;
+  try {
+    const osc = ctx.createOscillator();
+    const gain = ctx.createGain();
+    osc.type = "sine";
+    osc.frequency.value = freq;
+    gain.gain.setValueAtTime(0, startTime);
+    gain.gain.linearRampToValueAtTime(gainPeak, startTime + 0.012);
+    gain.gain.exponentialRampToValueAtTime(0.001, startTime + dur);
+    osc.connect(gain).connect(ctx.destination);
+    osc.start(startTime);
+    osc.stop(startTime + dur + 0.02);
+  } catch (e) {
+    console.error("Failed to play sound cue note:", e);
+  }
+}
+
+export const soundCues = {
+  playSuccess() {
+    if (!prefs.soundCuesEnabled) return;
+    const ctx = getAudioContext();
+    if (!ctx) return;
+    const t = ctx.currentTime;
+    playNote(660, t, 0.12, 0.14);
+    playNote(830, t + 0.06, 0.12, 0.14);
+  },
+
+  playNew() {
+    if (!prefs.soundCuesEnabled) return;
+    const ctx = getAudioContext();
+    if (!ctx) return;
+    const t = ctx.currentTime;
+    playNote(740, t, 0.1, 0.12);
+  },
+
+  playMilestone() {
+    if (!prefs.soundCuesEnabled) return;
+    const ctx = getAudioContext();
+    if (!ctx) return;
+    const t = ctx.currentTime;
+    playNote(523, t, 0.16, 0.15);
+    playNote(659, t + 0.09, 0.16, 0.15);
+    playNote(880, t + 0.18, 0.22, 0.16);
+  },
+
+  playWarning() {
+    if (!prefs.soundCuesEnabled) return;
+    const ctx = getAudioContext();
+    if (!ctx) return;
+    const t = ctx.currentTime;
+    playNote(220, t, 0.15, 0.14);
+  },
+};

--- a/src/routes/dev/animations/+page.svelte
+++ b/src/routes/dev/animations/+page.svelte
@@ -60,7 +60,7 @@
   }
 
   function replayQueueToast() {
-    toastStore.show("Queue complete \u2014 nice listening \ud83c\udf1f", "milestone");
+    toastStore.show("Golden Hour complete", "milestone");
   }
 
   function replayWelcomeToast() {

--- a/src/routes/dev/animations/+page.svelte
+++ b/src/routes/dev/animations/+page.svelte
@@ -49,6 +49,22 @@
     toastStore.show("128 tracks added", "success");
   }
 
+  function replayMilestoneToast() {
+    toastStore.show("\ud83c\udf89 1,000 songs in your library!", "milestone", 5000);
+  }
+
+  function replayWarningToast() {
+    toastStore.show("3 files couldn\u2019t be read", "warning");
+  }
+
+  function replayQueueToast() {
+    toastStore.show("Queue complete \u2014 nice listening \ud83c\udf1f", "milestone", 5000);
+  }
+
+  function replayWelcomeToast() {
+    toastStore.show("Welcome to Luminous v1.0.0! \ud83c\udfb5", "milestone", 5000);
+  }
+
   let replayCounters = $state<Record<string, number>>({
     organizing: 0,
     folder: 0,
@@ -222,7 +238,7 @@
           <span class="text-lg font-black text-brand-gold anim-milestone-bounce">1,000 songs</span>
         {/key}
       </div>
-      <button onclick={() => replay('milestone')} class="text-xs font-semibold text-brand-accent-text border border-brand-accent/40 rounded-full px-3 py-1.5 self-start cursor-pointer hover:bg-brand-accent/10">▸ Replay</button>
+      <button onclick={() => { replay('milestone'); replayMilestoneToast(); }} class="text-xs font-semibold text-brand-accent-text border border-brand-accent/40 rounded-full px-3 py-1.5 self-start cursor-pointer hover:bg-brand-accent/10">▸ Replay</button>
     </div>
 
     <!-- 9. Completing a queue -->
@@ -239,7 +255,7 @@
           >Queue complete — nice listening</span>
         {/key}
       </div>
-      <button onclick={() => replay('queue')} class="text-xs font-semibold text-brand-accent-text border border-brand-accent/40 rounded-full px-3 py-1.5 self-start cursor-pointer hover:bg-brand-accent/10">▸ Replay</button>
+      <button onclick={() => { replay('queue'); replayQueueToast(); }} class="text-xs font-semibold text-brand-accent-text border border-brand-accent/40 rounded-full px-3 py-1.5 self-start cursor-pointer hover:bg-brand-accent/10">▸ Replay</button>
     </div>
 
     <!-- 10. First launch -->
@@ -257,7 +273,7 @@
           </div>
         {/key}
       </div>
-      <button onclick={() => replay('firstLaunch')} class="text-xs font-semibold text-brand-accent-text border border-brand-accent/40 rounded-full px-3 py-1.5 self-start cursor-pointer hover:bg-brand-accent/10">▸ Replay</button>
+      <button onclick={() => { replay('firstLaunch'); replayWelcomeToast(); }} class="text-xs font-semibold text-brand-accent-text border border-brand-accent/40 rounded-full px-3 py-1.5 self-start cursor-pointer hover:bg-brand-accent/10">▸ Replay</button>
     </div>
 
     <!-- 11. Import needs attention -->
@@ -274,7 +290,7 @@
           </div>
         {/key}
       </div>
-      <button onclick={() => replay('warning')} class="text-xs font-semibold text-brand-accent-text border border-brand-accent/40 rounded-full px-3 py-1.5 self-start cursor-pointer hover:bg-brand-accent/10">▸ Replay</button>
+      <button onclick={() => { replay('warning'); replayWarningToast(); }} class="text-xs font-semibold text-brand-accent-text border border-brand-accent/40 rounded-full px-3 py-1.5 self-start cursor-pointer hover:bg-brand-accent/10">▸ Replay</button>
     </div>
 
   </div>

--- a/src/routes/dev/animations/+page.svelte
+++ b/src/routes/dev/animations/+page.svelte
@@ -12,6 +12,8 @@
   import { goto } from "$app/navigation";
   import HeartToggle from "../../../lib/components/HeartToggle.svelte";
   import { toastStore } from "../../../lib/stores/toast.svelte";
+  import { prefs } from "../../../lib/stores/prefs.svelte";
+  import { soundCues } from "../../../lib/utils/soundCues";
   import { Folder, ListMusic, ArrowUp, AlertTriangle } from "lucide-svelte";
 
   // Most dev machines with Windows "Animation effects" turned off (or any

--- a/src/routes/dev/animations/+page.svelte
+++ b/src/routes/dev/animations/+page.svelte
@@ -52,7 +52,7 @@
   }
 
   function replayMilestoneToast() {
-    toastStore.show("\ud83c\udf89 1,000 songs in your library!", "milestone", 5000);
+    toastStore.show("\ud83c\udf89 1,000 songs in your library!", "milestone");
   }
 
   function replayWarningToast() {
@@ -60,11 +60,11 @@
   }
 
   function replayQueueToast() {
-    toastStore.show("Queue complete \u2014 nice listening \ud83c\udf1f", "milestone", 5000);
+    toastStore.show("Queue complete \u2014 nice listening \ud83c\udf1f", "milestone");
   }
 
   function replayWelcomeToast() {
-    toastStore.show("Welcome to Luminous v1.0.0! \ud83c\udfb5", "milestone", 5000);
+    toastStore.show("Welcome to Luminous v1.0.0! \ud83c\udfb5", "milestone");
   }
 
   let replayCounters = $state<Record<string, number>>({


### PR DESCRIPTION
## 📋 Summary
Addresses #182

Implemented a comprehensive set of joyful micro-animations, synthesized Web Audio sound cues, and persistent high-contrast toast notifications for celebration moments across Luminous.

## 🔍 Implementation Notes
- **Amplified Keyframes** (`animations.css`): Scaled up keyframes (`.anim-heart-pulse`, `.anim-check-pop`, `.anim-milestone-bounce`, `.anim-gold-ring`, `.anim-warn-shake`) for punchier, energetic motion.
- **Synthesized Web Audio Sound Cues** (`soundCues.ts`): Created sine oscillator audio synthesis matching the motion spec for Success, New, Milestone, and Warning tones. Added a `soundCuesEnabled` toggle under **Settings → General** (disabled by default).
- **Persistent High-Contrast Toasts** (`Toast.svelte` & `toast.svelte.ts`):
  - Changed toast backgrounds to solid/high-opacity dark containers with `backdrop-blur-md` for legibility over bright album art.
  - Toasts stay on screen until explicitly dismissed via the `X` button.
  - Removed duplicate inline success text next to action buttons (e.g. in `OrganizeFiles.svelte`).
  - Swapped `<Trophy>` icon for `<Star>` icon to avoid implying an achievement system.
- **Context-Aware Completion**: Completion toasts dynamically display the active container name (e.g. *"Favourites complete"*, *"Golden Hour complete"*, *"Deep Focus complete"*).
- **Favouriting Heart Toggle Fix**: Fixed `HeartToggle.svelte` so celebration pulses and sound cues trigger strictly on explicit user clicks.
- **Dev Gallery**: Updated `/dev/animations` with live preview buttons.

## 🧪 Test Plan
- [x] `bun run check` (svelte-check) - 0 errors, 0 warnings
- [x] `bun run test -- --run` - 27 test files passed (258 unit tests passed)
- [x] Manually verified in app via `bun run tauri dev` and `/dev/animations` gallery.

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs updated
