### PR TITLE
Set Space Grotesk (700) for detail-view and home headings

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -140,9 +140,9 @@ Theming is **not static**: users can switch between several built-in themes (Lum
 
 ## Typography
 
-Single typeface throughout: **Inter** (`src/app.css:51`), falling back to system UI sans. There is no secondary display face — hierarchy comes from size and weight.
+**Inter** (`src/app.css:58`) throughout, falling back to system UI sans. The only secondary face is **Space Grotesk** (700, `font-heading` utility), reserved for the Display tier — hierarchy elsewhere comes from size and weight, not typeface.
 
-- **Display (36px / 700):** Reserved for album/artist hero titles at the top of detail views.
+- **Display (36px / 700, Space Grotesk):** Album/artist/playlist hero titles and the home page time-of-day greeting.
 - **Headline (24px–20px / 700–600):** Section headers and dialog titles.
 - **Title (18px / 600):** Card and list-group headers.
 - **Body (14px / 12px, 400):** The workhorse sizes — the large majority of UI text in Luminous is `body-sm` (12px) for metadata-dense lists (folders, tags, playlists) and `body-md` (14px) for primary row labels and buttons.
@@ -264,7 +264,7 @@ These are the logo's own identity colors for marketing/social/app-icon-at-rest u
 
 ### Wordmark
 
-"Luminous" is set in **Space Grotesk** (600–700 weight) — a geometric sans whose circular counters echo the mark. It is the only place a second typeface appears; the tagline "Music Player" and all other UI text stay in Inter. Approved lockups: icon alone, icon + wordmark (horizontal), icon + wordmark (stacked), icon + wordmark + "Music Player" tagline (larger/marketing use only). Don't rearrange these relative to each other.
+"Luminous" is set in **Space Grotesk** (600–700 weight) — a geometric sans whose circular counters echo the mark. In-app, the same face (700) carries over to the Display typography tier (detail-view hero titles, home greeting); the tagline "Music Player" and all other UI text stay in Inter. Approved lockups: icon alone, icon + wordmark (horizontal), icon + wordmark (stacked), icon + wordmark + "Music Player" tagline (larger/marketing use only). Don't rearrange these relative to each other.
 
 ### Two artifacts
 

--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "luminous",
       "dependencies": {
+        "@fontsource/space-grotesk": "^5.3.0",
         "@tailwindcss/vite": "^4.3.2",
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2.7.1",
@@ -123,6 +124,8 @@
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
 
     "@exodus/bytes": ["@exodus/bytes@1.15.1", "", { "peerDependencies": { "@noble/hashes": "^1.8.0 || ^2.0.0" }, "optionalPeers": ["@noble/hashes"] }, "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q=="],
+
+    "@fontsource/space-grotesk": ["@fontsource/space-grotesk@5.3.0", "", {}, "sha512-ksnGizDPXIDuvqcTYTSrmZ+evx9sDlS8rp7+42BQ7wU+spt3twEoXfbJz672C+5CLg6VeUQwRy5RXshWb67LcQ=="],
 
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "bump-version": "bun run scripts/bump-version.ts"
   },
   "dependencies": {
+    "@fontsource/space-grotesk": "^5.3.0",
     "@tailwindcss/vite": "^4.3.2",
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-dialog": "^2.7.1",

--- a/src/app.css
+++ b/src/app.css
@@ -1,7 +1,9 @@
 @import "tailwindcss";
 @import "./lib/styles/animations.css";
+@import "@fontsource/space-grotesk/700.css";
 
 @theme {
+  --font-heading: 'Space Grotesk', 'Inter', system-ui, -apple-system, sans-serif;
   --color-brand-main: var(--bg-main);
   --color-brand-sidebar: var(--bg-sidebar);
   --color-brand-playerbar: var(--bg-playerbar);

--- a/src/lib/components/AlbumDetailView.svelte
+++ b/src/lib/components/AlbumDetailView.svelte
@@ -378,7 +378,7 @@
     <div class="flex items-start justify-between gap-6 relative z-10">
       <!-- Left Title & Summary Metadata -->
       <div class="flex flex-col justify-end gap-2 min-w-0 max-w-xl">
-        <h1 class="text-3xl sm:text-4xl font-extrabold text-brand-text-primary leading-snug truncate py-0.5" title={albumName}>
+        <h1 class="text-3xl sm:text-4xl font-heading font-bold text-brand-text-primary leading-snug truncate py-0.5" title={albumName}>
           {albumName}
         </h1>
 

--- a/src/lib/components/ArtistDetailView.svelte
+++ b/src/lib/components/ArtistDetailView.svelte
@@ -198,7 +198,7 @@
     <div class="flex items-start justify-between gap-6 relative z-10">
       <!-- Left Title & Summary Metadata -->
       <div class="flex flex-col justify-end gap-2 max-w-xl">
-        <h1 class="text-3xl sm:text-4xl font-extrabold text-brand-text-primary leading-snug truncate py-0.5">{artistName}</h1>
+        <h1 class="text-3xl sm:text-4xl font-heading font-bold text-brand-text-primary leading-snug truncate py-0.5">{artistName}</h1>
 
         <!-- Summary Metadata Line -->
         <div class="flex items-center gap-3 text-xs text-brand-text-secondary font-medium mt-1">

--- a/src/lib/components/AutoPlaylistDetailView.svelte
+++ b/src/lib/components/AutoPlaylistDetailView.svelte
@@ -427,7 +427,7 @@
     <div class="flex items-start justify-between gap-6 relative z-10">
       <!-- Left Title & Summary Metadata -->
       <div class="flex flex-col justify-end gap-2 min-w-0 max-w-xl">
-        <h1 class="text-3xl sm:text-4xl font-extrabold text-brand-text-primary leading-snug truncate py-0.5" title={displayName}>
+        <h1 class="text-3xl sm:text-4xl font-heading font-bold text-brand-text-primary leading-snug truncate py-0.5" title={displayName}>
           {displayName}
         </h1>
 

--- a/src/lib/components/HomeView.svelte
+++ b/src/lib/components/HomeView.svelte
@@ -52,7 +52,7 @@
   <div class="flex-1 overflow-y-auto {playerStore.currentSong ? 'pb-28' : 'pb-6'}">
     <!-- Header -->
     <div class="px-6 pt-8">
-      <h1 class="text-3xl font-bold text-brand-text-primary">
+      <h1 class="text-3xl font-heading font-bold text-brand-text-primary">
         {getTimeOfDayGreeting()}
       </h1>
       <p class="text-sm text-brand-text-secondary mt-1">

--- a/src/lib/components/PlaylistView.svelte
+++ b/src/lib/components/PlaylistView.svelte
@@ -683,7 +683,7 @@
             <div class="flex items-center gap-3 group/title">
               <h1
                 ondblclick={startRename}
-                class="text-3xl sm:text-4xl font-extrabold text-brand-text-primary cursor-pointer hover:text-brand-accent-text transition-colors truncate py-0.5 leading-snug"
+                class="text-3xl sm:text-4xl font-heading font-bold text-brand-text-primary cursor-pointer hover:text-brand-accent-text transition-colors truncate py-0.5 leading-snug"
                 title={i18n.t("playlists.renamePlaylistTooltip")}
               >
                 {activePlaylist.name}


### PR DESCRIPTION
## Summary
- Adds Space Grotesk (700 weight, self-hosted via `@fontsource/space-grotesk` — no Google Fonts CDN, so it still works offline) as a `font-heading` Tailwind utility.
- Applies it to the album, artist, and playlist detail-view hero titles and the home page time-of-day greeting; everything else stays on Inter.
- Detail-view titles were bumped from `font-extrabold` (800) to `font-bold` (700) to match the single weight file that's loaded.
- Updates the Typography section of `DESIGN.md` to document the new two-typeface system.

## Test plan
- [x] `bun run check` passes with 0 errors
- [ ] Visually confirm in dev server: album/artist/playlist headers and home greeting render in Space Grotesk; rest of UI unchanged