### PR TITLE
fix: handle watched-folder disconnects gracefully during playback

### DIFF
--- a/src-tauri/src/collection.rs
+++ b/src-tauri/src/collection.rs
@@ -125,11 +125,7 @@ impl CollectionScanner {
             .map(|d| PathBuf::from(d.path))
             .collect();
 
-        let unreachable_roots: Vec<PathBuf> = all_roots
-            .iter()
-            .filter(|root| std::fs::read_dir(root).is_err())
-            .cloned()
-            .collect();
+        let unreachable_roots = unreachable_watched_roots(conn);
 
         for root in &unreachable_roots {
             log::warn!(
@@ -2021,6 +2017,50 @@ pub fn delete_path_and_subpaths(db: &Database, path_str: &str) -> Result<usize> 
     Ok(deleted)
 }
 
+/// Soft-delete counterpart to `delete_path_and_subpaths`, used when `path_str`
+/// falls under a watched root that's currently unreachable (see
+/// `unreachable_watched_roots`) — flags matching songs `unavailable` instead
+/// of removing them, so a disconnected drive observed by the realtime watcher
+/// can't be mistaken for a bulk deletion the way a plain hard-delete would.
+fn mark_path_and_subpaths_unavailable(db: &Database, path_str: &str) -> Result<usize> {
+    let conn = db.pool.get()?;
+    let path_fw = path_str.replace('\\', "/");
+    let path_bw = path_str.replace('/', "\\");
+
+    let marked = conn.execute(
+        "UPDATE songs SET unavailable = 1
+         WHERE unavailable = 0 AND (
+            path = ?1 OR path = ?2
+            OR path LIKE ?1 || '/%'
+            OR path LIKE ?1 || '\\%'
+            OR path LIKE ?2 || '/%'
+            OR path LIKE ?2 || '\\%'
+         )",
+        params![path_fw, path_bw],
+    )?;
+    Ok(marked)
+}
+
+/// Watched directory roots that can't currently be read (disconnected drive,
+/// sleeping network share, etc). Shared by the scanner's missing-file check
+/// (`CollectionScanner::find_missing_song_ids`) and the realtime watcher below
+/// so a temporary disconnect is never treated as a bulk deletion by either
+/// path.
+fn unreachable_watched_roots(conn: &rusqlite::Connection) -> Vec<PathBuf> {
+    let mut roots = Vec::new();
+    if let Ok(mut stmt) = conn.prepare("SELECT path FROM directories") {
+        if let Ok(rows) = stmt.query_map([], |row| row.get::<_, String>(0)) {
+            for path in rows.flatten() {
+                let p = PathBuf::from(&path);
+                if std::fs::read_dir(&p).is_err() {
+                    roots.push(p);
+                }
+            }
+        }
+    }
+    roots
+}
+
 /// Message delivered from the notify callback to the watcher thread. A plain
 /// `notify::Event` channel would silently lose whatever changes happened
 /// during an `Err` (e.g. the OS's change-journal buffer overflowing during a
@@ -2196,8 +2236,41 @@ pub fn start_watcher(app: AppHandle, state: &crate::AppState) {
                         let _ = app_clone.emit("library-changed", ());
                     }
 
+                    // A disconnected drive makes `notify` report every path under it as
+                    // "removed" the same as an actual deletion would. Songs under a root
+                    // that's currently unreachable get soft-flagged instead of
+                    // hard-deleted here, mirroring the scan-time protection in
+                    // `find_missing_song_ids` — otherwise unplugging a watched USB drive
+                    // mid-session would permanently wipe every song on it from the library.
+                    let unreachable_roots = unreachable_watched_roots(&conn);
+
                     for path in &still_removed {
                         let path_str = path.to_string_lossy().to_string();
+
+                        if unreachable_roots.iter().any(|root| path.starts_with(root)) {
+                            log::warn!(
+                                "Watcher saw '{}' disappear, but its watched root is currently \
+                                 unreachable (disconnected drive or network share?) — marking \
+                                 unavailable instead of deleting",
+                                path_str
+                            );
+                            match mark_path_and_subpaths_unavailable(&db_for_thread, &path_str) {
+                                Ok(marked) => {
+                                    if marked > 0 {
+                                        log::info!(
+                                            "Marked {} song(s) unavailable under unreachable root",
+                                            marked
+                                        );
+                                        let _ = app_clone.emit("library-changed", ());
+                                    }
+                                }
+                                Err(e) => {
+                                    log::error!("Failed to mark path unavailable in db: {e}");
+                                }
+                            }
+                            continue;
+                        }
+
                         log::info!("Watcher detected deletion: {}", path_str);
                         match delete_path_and_subpaths(&db_for_thread, &path_str) {
                             Ok(deleted) => {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -323,6 +323,7 @@ pub fn run() {
                             let mut p = player.lock().await;
                             match event {
                                 crate::audio::AudioEvent::Playing { .. } => {
+                                    p.reset_playback_errors();
                                     let _ = app.emit(
                                         "track-changed",
                                         serde_json::json!({
@@ -373,7 +374,32 @@ pub fn run() {
                                         "[Luminous Backend] ERROR from audio engine: {}",
                                         message
                                     );
-                                    let _ = p.next_track().await;
+                                    let outcome = p.note_playback_error();
+
+                                    if let Some(song) = &outcome.failed_song {
+                                        let _ = app.emit(
+                                            "playback-error",
+                                            serde_json::json!({
+                                                "songId": song.id,
+                                                "title": song.title,
+                                                "path": song.path,
+                                            }),
+                                        );
+                                    }
+                                    if outcome.flagged_unavailable {
+                                        let _ = app.emit("library-changed", ());
+                                    }
+
+                                    if outcome.should_stop {
+                                        log::error!(
+                                            "Stopping playback after {} consecutive audio errors \
+                                             — likely a disconnected drive or dead playlist",
+                                            crate::player::MAX_CONSECUTIVE_PLAYBACK_ERRORS
+                                        );
+                                        let _ = p.stop().await;
+                                    } else {
+                                        let _ = p.next_track().await;
+                                    }
                                     let state = p.get_state().await;
                                     let _ = app.emit("playback-state", state);
                                 }

--- a/src-tauri/src/player.rs
+++ b/src-tauri/src/player.rs
@@ -16,6 +16,30 @@ use rand::seq::SliceRandom;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
+/// After this many consecutive playback failures with no successful
+/// `Playing` event in between, the player gives up and stops instead of
+/// continuing to advance. Every song under a watched root that's currently
+/// unreachable (disconnected drive, sleeping network share) still reads as
+/// "available" to the DB — see `find_missing_song_ids` — so without this
+/// ceiling, advancing past a failed track (`next_track`) can keep failing
+/// forever, and under `RepeatMode::Playlist` specifically has no other
+/// terminating condition at all.
+pub(crate) const MAX_CONSECUTIVE_PLAYBACK_ERRORS: u32 = 5;
+
+/// Outcome of a single playback failure, returned by `Player::note_playback_error`.
+pub struct PlaybackErrorOutcome {
+    /// The song that failed to play, for a user-facing toast.
+    pub failed_song: Option<Song>,
+    /// True once `MAX_CONSECUTIVE_PLAYBACK_ERRORS` consecutive failures have
+    /// happened with no successful play in between — the caller should stop
+    /// instead of advancing further.
+    pub should_stop: bool,
+    /// True if the failed song was flagged `unavailable` in the DB as a
+    /// result (its file was confirmed gone at the moment of failure) — the
+    /// caller should let the frontend know its cached library data is stale.
+    pub flagged_unavailable: bool,
+}
+
 /// A candidate for the gapless "next track" — resolved by peeking at the
 /// playback context without mutating it.
 struct GaplessTarget {
@@ -74,6 +98,10 @@ pub struct Player {
     /// Position at which we trigger the scrobble (50% of track length).
     scrobble_point_nanosec: Option<u64>,
     scrobbled: bool,
+
+    /// Consecutive playback failures since the last successful `Playing`
+    /// event — see `MAX_CONSECUTIVE_PLAYBACK_ERRORS`.
+    consecutive_playback_errors: u32,
 }
 
 impl Player {
@@ -284,6 +312,7 @@ impl Player {
             queue: std::collections::VecDeque::new(),
             scrobble_point_nanosec,
             scrobbled: false,
+            consecutive_playback_errors: 0,
         };
 
         player.rebuild_shuffle_order();
@@ -642,6 +671,49 @@ impl Player {
         } else {
             self.audio.lock().await.resume()
         }
+    }
+
+    /// Called by the audio-event loop when the engine reports it couldn't
+    /// open/decode the current track. Flags the failed song `unavailable` if
+    /// its file is confirmed gone right now (a live single-file check, not
+    /// the directory-unreachable heuristic `find_missing_song_ids` uses —
+    /// so it's safe even when the drive as a whole is still being treated as
+    /// "can't currently verify" rather than "confirmed missing").
+    pub fn note_playback_error(&mut self) -> PlaybackErrorOutcome {
+        self.consecutive_playback_errors += 1;
+        let should_stop = self.consecutive_playback_errors >= MAX_CONSECUTIVE_PLAYBACK_ERRORS;
+
+        let mut flagged_unavailable = false;
+        if let Some(song) = &self.current_song {
+            let missing_on_disk = song
+                .path
+                .as_deref()
+                .map(|p| !std::path::Path::new(p).exists())
+                .unwrap_or(false);
+            if missing_on_disk {
+                if let Ok(conn) = self._db.pool.get() {
+                    flagged_unavailable = conn
+                        .execute(
+                            "UPDATE songs SET unavailable = 1 WHERE id = ?1 AND unavailable = 0",
+                            rusqlite::params![song.id],
+                        )
+                        .map(|n| n > 0)
+                        .unwrap_or(false);
+                }
+            }
+        }
+
+        PlaybackErrorOutcome {
+            failed_song: self.current_song.clone(),
+            should_stop,
+            flagged_unavailable,
+        }
+    }
+
+    /// Clears the consecutive-failure counter — called whenever the engine
+    /// confirms a track actually started playing.
+    pub fn reset_playback_errors(&mut self) {
+        self.consecutive_playback_errors = 0;
     }
 
     pub async fn stop(&mut self) -> Result<()> {

--- a/src/lib/components/AlbumDetailView.svelte
+++ b/src/lib/components/AlbumDetailView.svelte
@@ -724,16 +724,19 @@
           </div>
         {:else}
           {#each sortedSongs as song, index (song.id)}
+            {@const disconnected = !song.unavailable && collectionStore.isPathOnDisconnectedDrive(song.path)}
+            {@const disabled = song.unavailable || disconnected}
             <!-- svelte-ignore a11y_no_static_element_interactions -->
             <!-- svelte-ignore a11y_click_events_have_key_events -->
             <div
               data-song-row="true"
-              onclick={(e) => !song.unavailable && handleSongClick(e, song)}
-              ondblclick={() => !song.unavailable && handlePlaySong(song)}
-              oncontextmenu={(e) => !song.unavailable && handleContextMenu(e, song)}
+              onclick={(e) => !disabled && handleSongClick(e, song)}
+              ondblclick={() => !disabled && handlePlaySong(song)}
+              oncontextmenu={(e) => !disabled && handleContextMenu(e, song)}
               style={gridColsStyle}
+              title={disconnected ? i18n.t('collection.driveDisconnectedTooltip') : undefined}
               class="grid items-center hover:bg-brand-sidebar/40 group transition-colors py-2 px-4 text-sm
-                {song.unavailable ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}
+                {disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}
                 {selectedSongIds.has(song.id) ? 'bg-brand-accent/20 border-l-2 border-brand-accent text-brand-accent-text-hover' : (playerStore.currentSong && playerStore.currentSong.id === song.id ? 'bg-brand-accent/10 text-brand-accent-text-hover' : '')}"
             >
               <div class="text-center flex justify-center relative w-9 h-6 items-center">
@@ -743,9 +746,10 @@
                   </div>
                 {/if}
                 <button
-                  onclick={(e) => { e.stopPropagation(); handlePlaySong(song); }}
-                  class="absolute flex items-center justify-center opacity-0 group-hover:opacity-100 text-brand-accent-text hover:text-brand-accent-text-hover transition-all duration-150 cursor-pointer"
-                  title={i18n.t('collection.playSong')}
+                  onclick={(e) => { e.stopPropagation(); if (!disabled) handlePlaySong(song); }}
+                  class="absolute flex items-center justify-center opacity-0 group-hover:opacity-100 text-brand-accent-text hover:text-brand-accent-text-hover transition-all duration-150 cursor-pointer disabled:opacity-0 disabled:cursor-not-allowed"
+                  disabled={disabled}
+                  title={disconnected ? i18n.t('collection.driveDisconnectedTooltip') : i18n.t('collection.playSong')}
                 >
                   <Play class="w-3.5 h-3.5 fill-current" />
                 </button>

--- a/src/lib/components/AutoPlaylistDetailView.svelte
+++ b/src/lib/components/AutoPlaylistDetailView.svelte
@@ -786,18 +786,21 @@
           </div>
         {:else}
           {#each sortedSongs as song, index (song.id)}
+            {@const disconnected = !song.unavailable && collectionStore.isPathOnDisconnectedDrive(song.path)}
+            {@const disabled = song.unavailable || disconnected}
             <div
               role="row"
               tabindex="0"
               onkeydown={(e) => {
-                if (e.key === 'Enter' && !song.unavailable) handlePlaySong(song);
+                if (e.key === 'Enter' && !disabled) handlePlaySong(song);
               }}
               data-song-row="true"
-              onclick={(e) => !song.unavailable && handleSongClick(e, song)}
-              ondblclick={() => !song.unavailable && handlePlaySong(song)}
+              onclick={(e) => !disabled && handleSongClick(e, song)}
+              ondblclick={() => !disabled && handlePlaySong(song)}
               oncontextmenu={(e) => handleContextMenu(e, song)}
+              title={disconnected ? i18n.t('collection.driveDisconnectedTooltip') : undefined}
               class="grid items-center py-2.5 px-4 group transition-all duration-150 select-none text-sm border-b border-brand-border/40
-                {song.unavailable ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}
+                {disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}
                 {selectedSongIds.has(song.id) ? 'bg-brand-accent/20 text-brand-accent-text-hover' : (playerStore.currentSong && playerStore.currentSong.id === song.id ? 'bg-brand-accent/10 text-brand-accent-text-hover' : 'hover:bg-brand-sidebar/40')}"
               style={gridColsStyle}
             >
@@ -813,9 +816,10 @@
                     </span>
                   {/if}
                   <button
-                    onclick={(e) => { e.stopPropagation(); handlePlaySong(song); }}
-                    class="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 text-brand-accent-text hover:text-brand-accent-text-hover transition-opacity cursor-pointer"
-                    title={i18n.t('collection.playSong')}
+                    onclick={(e) => { e.stopPropagation(); if (!disabled) handlePlaySong(song); }}
+                    class="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 text-brand-accent-text hover:text-brand-accent-text-hover transition-opacity cursor-pointer disabled:opacity-0 disabled:cursor-not-allowed"
+                    disabled={disabled}
+                    title={disconnected ? i18n.t('collection.driveDisconnectedTooltip') : i18n.t('collection.playSong')}
                   >
                     <Play class="w-4 h-4 fill-current" />
                   </button>

--- a/src/lib/components/CollectionView.svelte
+++ b/src/lib/components/CollectionView.svelte
@@ -679,16 +679,19 @@
           {:else}
             {#key gridColsStyle}
             <VirtualList items={filteredSongs} let:item={song}>
+              {@const disconnected = !song.unavailable && collectionStore.isPathOnDisconnectedDrive(song.path)}
+              {@const disabled = song.unavailable || disconnected}
               <!-- svelte-ignore a11y_no_static_element_interactions -->
               <!-- svelte-ignore a11y_click_events_have_key_events -->
               <div
                 data-song-row="true"
-                onclick={(e) => !song.unavailable && handleSongClick(e, song)}
-                ondblclick={() => !song.unavailable && handlePlaySong(song)}
-                oncontextmenu={(e) => !song.unavailable && handleContextMenu(e, song)}
+                onclick={(e) => !disabled && handleSongClick(e, song)}
+                ondblclick={() => !disabled && handlePlaySong(song)}
+                oncontextmenu={(e) => !disabled && handleContextMenu(e, song)}
                 style={gridColsStyle}
+                title={disconnected ? i18n.t('collection.driveDisconnectedTooltip') : undefined}
                 class="grid items-center border-b border-brand-border/40 hover:bg-brand-sidebar/40 group transition-colors py-2.5 px-4 text-sm
-                  {song.unavailable ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}
+                  {disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}
                   {selectedSongIds.has(song.id) ? 'bg-brand-accent/20 border-l-2 border-brand-accent text-brand-accent-text-hover' : (playerStore.currentSong && playerStore.currentSong.id === song.id ? 'bg-brand-accent/10 text-brand-accent-text-hover' : '')}"
               >
                 <div class="text-center flex justify-center relative w-9 h-6 items-center">
@@ -698,9 +701,10 @@
                     </div>
                   {/if}
                   <button
-                    onclick={() => handlePlaySong(song)}
-                    class="absolute flex items-center justify-center opacity-0 group-hover:opacity-100 text-brand-accent-text hover:text-brand-accent-text-hover transition-all duration-150 cursor-pointer"
-                    title={i18n.t('collection.playSong')}
+                    onclick={() => !disabled && handlePlaySong(song)}
+                    class="absolute flex items-center justify-center opacity-0 group-hover:opacity-100 text-brand-accent-text hover:text-brand-accent-text-hover transition-all duration-150 cursor-pointer disabled:opacity-0 disabled:cursor-not-allowed"
+                    disabled={disabled}
+                    title={disconnected ? i18n.t('collection.driveDisconnectedTooltip') : i18n.t('collection.playSong')}
                   >
                     <Play class="w-4 h-4 fill-current" />
                   </button>

--- a/src/lib/components/PlaylistView.svelte
+++ b/src/lib/components/PlaylistView.svelte
@@ -1095,7 +1095,9 @@
       <!-- Rows -->
       <div class="divide-y divide-brand-border/40">
         {#each filteredTracks as item, index}
-          {@const unavailable = isItemUnavailable(item)}
+          {@const trueUnavailable = isItemUnavailable(item)}
+          {@const disconnected = !trueUnavailable && collectionStore.isPathOnDisconnectedDrive(item.song?.path)}
+          {@const unavailable = trueUnavailable || disconnected}
           {@const isDuplicate = duplicateUuids.includes(item.uuid)}
           {@const isSelected = selectedUuids.has(item.uuid)}
           {@const actualIndex = playlistsStore.activePlaylistTracks.findIndex(t => t.uuid === item.uuid)}
@@ -1154,11 +1156,18 @@
             {#if collectionStore.visibleColumns.title}
               <div class="font-medium truncate pr-4 min-w-0 {isSelected || (!unavailable && playerStore.playlistItemUuid === item.uuid) ? 'text-brand-accent-text-hover' : unavailable ? 'text-brand-text-secondary' : 'text-brand-text-primary'}">
                 <div class="flex items-center gap-2 max-w-full">
-                  {#if unavailable}
+                  {#if trueUnavailable}
                     <span title={i18n.t("playlists.fileNotFoundTooltip")}>
                       <AlertTriangle class="w-3.5 h-3.5 shrink-0 text-amber-400/80" />
                     </span>
                     <span class="truncate line-through decoration-brand-text-secondary/40">
+                      {item.song?.title ?? i18n.t("collection.unknownSong")}
+                    </span>
+                  {:else if disconnected}
+                    <span title={i18n.t("collection.driveDisconnectedTooltip")}>
+                      <AlertTriangle class="w-3.5 h-3.5 shrink-0 text-amber-400/80" />
+                    </span>
+                    <span class="truncate">
                       {item.song?.title ?? i18n.t("collection.unknownSong")}
                     </span>
                   {:else if item.song?.title}
@@ -1185,8 +1194,10 @@
 
             {#if collectionStore.visibleColumns.artist}
               <div class="text-brand-text-secondary truncate pr-4 min-w-0">
-                {#if unavailable}
+                {#if trueUnavailable}
                   <span class="text-brand-text-secondary italic text-xs">{i18n.t("playlists.fileNotFoundText")}</span>
+                {:else if disconnected}
+                  <span class="text-brand-text-secondary italic text-xs">{i18n.t("collection.driveDisconnectedText")}</span>
                 {:else if item.song?.artist}
                   <LinkButton
                     onclick={(e) => { e.stopPropagation(); collectionStore.viewArtist(item.song?.album_artist?.trim() || item.song?.artist || ""); }}

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -92,6 +92,8 @@ export const en = {
     unknownSong: "Unknown Song",
     unknownArtist: "Unknown Artist",
     unknownAlbum: "Unknown Album",
+    driveDisconnectedTooltip: "Drive disconnected — reconnect to play",
+    driveDisconnectedText: "Drive disconnected",
     noAlbumsTitle: "No albums found",
     noAlbumsMatchQuery: "No albums match your query:",
     noArtistsTitle: "No artists found",
@@ -559,7 +561,9 @@ export const en = {
     lyricsStatusLabel: "Lyrics",
     lyricsSynced: "Synced (LRC)",
     lyricsPlain: "Plain text",
-    lyricsNone: "Not downloaded"
+    lyricsNone: "Not downloaded",
+    trackSkippedToast: 'Couldn\'t play "{title}" — file not found. Skipped.',
+    tracksSkippedToast: "Skipped {count} unavailable tracks."
   },
   miniplayer: {
     title: "Miniplayer",

--- a/src/lib/locales/fr.ts
+++ b/src/lib/locales/fr.ts
@@ -92,6 +92,8 @@ export const fr = {
     unknownSong: "Chanson inconnue",
     unknownArtist: "Artiste inconnu",
     unknownAlbum: "Album inconnu",
+    driveDisconnectedTooltip: "Lecteur déconnecté — reconnectez-le pour lire",
+    driveDisconnectedText: "Lecteur déconnecté",
     noAlbumsTitle: "Aucun album trouvé",
     noAlbumsMatchQuery: "Aucun album ne correspond à votre recherche :",
     noArtistsTitle: "Aucun artiste trouvé",
@@ -528,7 +530,9 @@ export const fr = {
     lyricsStatusLabel: "Paroles",
     lyricsSynced: "Synchronisées (LRC)",
     lyricsPlain: "Texte brut",
-    lyricsNone: "Non téléchargées"
+    lyricsNone: "Non téléchargées",
+    trackSkippedToast: 'Impossible de lire « {title} » — fichier introuvable. Morceau ignoré.',
+    tracksSkippedToast: "{count} morceaux indisponibles ignorés."
   },
   miniplayer: {
     title: "Mini-lecteur",

--- a/src/lib/stores/collection.svelte.ts
+++ b/src/lib/stores/collection.svelte.ts
@@ -498,6 +498,7 @@ class CollectionStore {
           invoke("set_app_setting", { key: "last_scan_time", value: nowStr }).catch((err) => {
             console.error("Failed to save last_scan_time:", err);
           });
+          this.refreshDirectories();
           const songCountBeforeRefresh = this.stats.total_songs;
           this.refreshStats().then(() => {
             const added = this.stats.total_songs - songCountBeforeRefresh;
@@ -547,10 +548,12 @@ class CollectionStore {
         }
       });
 
-      // Listen to library changed events (e.g. from background directory watcher)
+      // Listen to library changed events (e.g. from background directory watcher,
+      // or a song getting flagged unavailable after a failed play)
       await listen("library-changed", () => {
         this.refreshStats();
         this.refreshLibrary();
+        this.refreshDirectories();
         invoke("refresh_playback_queue").catch((err) => {
           console.error("Failed to refresh playback queue after library change:", err);
         });
@@ -589,6 +592,21 @@ class CollectionStore {
 
   async refreshDirectories() {
     this.directories = await invoke("get_directories");
+  }
+
+  /**
+   * True when `path` lives under a watched directory that's currently
+   * unreachable (disconnected USB drive, sleeping network share, etc).
+   * Distinct from `song.unavailable`, which only flips once the backend has
+   * confirmed the file is actually gone — a song on a merely-disconnected
+   * drive still reads as "available" there (see collection.rs's
+   * find_missing_song_ids doc comment) until a play is attempted or the
+   * user un-watches the folder. This lets the UI show a "disconnected"
+   * state proactively instead of waiting for a failed play.
+   */
+  isPathOnDisconnectedDrive(path: string | null | undefined): boolean {
+    if (!path) return false;
+    return this.directories.some((d) => d.is_available === false && path.startsWith(d.path));
   }
 
   async refreshStats() {

--- a/src/lib/stores/player.svelte.ts
+++ b/src/lib/stores/player.svelte.ts
@@ -37,6 +37,12 @@ export class PlayerStore {
   /** Previous playback state for detecting playing→stopped transitions. */
   private _previousState: PlayState = "stopped";
 
+  /** Titles pending a "couldn't play" toast — batched so a run of consecutive
+   *  unavailable tracks (e.g. a whole disconnected drive) shows one summary
+   *  toast instead of a notification per failed track. */
+  private _playbackErrorBatch: string[] = [];
+  private _playbackErrorTimer: ReturnType<typeof setTimeout> | null = null;
+
   isAutoPlayExhausted(playlistId: number): boolean {
     return this.exhaustedPlaylistIds.includes(playlistId);
   }
@@ -102,6 +108,22 @@ export class PlayerStore {
         themeStore.updateArtworkColors(this.currentSong);
       });
 
+      // A song couldn't be opened/decoded (e.g. its file just vanished —
+      // watched drive disconnected). The backend already skips past it; this
+      // just tells the user why playback jumped. Batched (see
+      // _playbackErrorBatch) because a disconnected drive mid-playlist can
+      // fail several consecutive tracks in a row before the backend's
+      // circuit breaker stops it — one toast per failure would be a
+      // notification avalanche.
+      await listen<{ songId: number; title: string | null; path: string | null }>(
+        "playback-error",
+        (event) => {
+          this._playbackErrorBatch.push(event.payload.title || i18n.t("collection.unknownSong"));
+          if (this._playbackErrorTimer) clearTimeout(this._playbackErrorTimer);
+          this._playbackErrorTimer = setTimeout(() => this.flushPlaybackErrorToast(), 400);
+        }
+      );
+
       // Keep the current song's stats in sync when they change elsewhere
       // (rating edits in list views, scrobble-point playcount bumps).
       await listen<SongStatsPayload>("song-stats-changed", (event) => {
@@ -117,6 +139,25 @@ export class PlayerStore {
       }
     } catch (err) {
       console.error("Failed to initialize PlayerStore:", err);
+    }
+  }
+
+  private flushPlaybackErrorToast() {
+    const titles = this._playbackErrorBatch;
+    this._playbackErrorBatch = [];
+    this._playbackErrorTimer = null;
+    if (titles.length === 0) return;
+
+    if (titles.length === 1) {
+      toastStore.show(
+        i18n.t("playerBar.trackSkippedToast", { title: titles[0] }, `Couldn't play "${titles[0]}" — file not found. Skipped.`),
+        "error"
+      );
+    } else {
+      toastStore.show(
+        i18n.t("playerBar.tracksSkippedToast", { count: titles.length }, `Skipped ${titles.length} unavailable tracks.`),
+        "error"
+      );
     }
   }
 


### PR DESCRIPTION
## 📋 Summary

Fixes how Luminous handles a watched folder's underlying drive disconnecting mid-session (e.g. a USB thumb drive), both during playback and in the realtime library watcher.

Songs under a watched drive that's currently unreachable are deliberately kept flagged "available" in the DB — this is intentional, so a sleeping/disconnected drive doesn't read as a mass deletion during a scan (`find_missing_song_ids`). That protection had gaps on two other paths, one of which was a real data-loss bug:

- **Realtime watcher hard-delete (data loss):** the file watcher hard-deleted songs the instant `notify` reported their path as "removed," with none of the scan-time guard against disconnected drives. Unplugging a watched drive mid-session could permanently wipe every song on it from the library. Now soft-flags `unavailable` instead when the path's watched root is unreachable, mirroring the existing scan-time protection.
- **Playback cascade/loop:** a failed track open unconditionally called `next_track()`, which had no terminating condition under `RepeatMode::Playlist` — an entire disconnected-drive playlist could spin forever. Now stops after 5 consecutive failures.
- **Silent failure → auto-flag + toast:** a failed play now flags that song `unavailable` immediately (a live existence check, not the directory-unreachable heuristic) instead of waiting for a manual "stop watching" or rescan, and surfaces a toast instead of failing silently. A run of consecutive failures batches into one summary toast ("Skipped N unavailable tracks") instead of one per track.
- **Proactive UI state:** songs on a currently-disconnected drive show a distinct "Drive disconnected" state in Collection/Album/AutoPlaylist/Playlist views before a play is even attempted, instead of looking fully normal until it fails.

## 🔍 Implementation Notes

- `src-tauri/src/collection.rs`: new `unreachable_watched_roots()` helper (shared with the scanner's existing `find_missing_song_ids`) and `mark_path_and_subpaths_unavailable()`, used by the realtime watcher's `still_removed` handling before falling back to `delete_path_and_subpaths`.
- `src-tauri/src/player.rs`: `MAX_CONSECUTIVE_PLAYBACK_ERRORS` circuit breaker, `note_playback_error()` / `reset_playback_errors()` on `Player`.
- `src-tauri/src/lib.rs`: `AudioEvent::Error` handler now uses the above instead of unconditionally advancing; emits `playback-error` and `library-changed` as appropriate.
- `src/lib/stores/player.svelte.ts`: listens for `playback-error`, batches into one toast per 400ms window (same debounce window the backend's own watcher already uses).
- `src/lib/stores/collection.svelte.ts`: `isPathOnDisconnectedDrive()` helper; wires `refreshDirectories()` into the scan-done and `library-changed` handlers so `is_available` stays fresh.
- CollectionView/AlbumDetailView/AutoPlaylistDetailView/PlaylistView: fold "disconnected" into the existing per-row disabled/opacity state, with a distinct tooltip.
- One pre-existing, unrelated test failure (`test_prune_missing_songs_hard_deletes`) reproduces identically on `main` without this branch's changes — not touched here.

## 🧪 Test Plan

- [x] `bun run check` (svelte-check) — 0 errors, 0 warnings
- [ ] `bun run test -- --run` (frontend)
- [x] `cargo test` (src-tauri) — 78/79 pass; the 1 failure is pre-existing on `main`, unrelated
- [x] Manually verified in the app: added a thumb drive as a watched folder, removed it mid-playback — got a toast, the watched-folder list updated, affected songs showed disabled, and playback skipped past the unavailable tracks. Follow-up round fixed a "notification avalanche" (one toast per skipped track) into a single batched toast.

## ✅ Checklist

- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed — n/a, no new screenshot-worthy view added