### PR TITLE
fix(ui): prevent sidebar resizer width expansion on hover

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -232,7 +232,7 @@
                   aria-valuemax={SIDEBAR_MAX_WIDTH_PX}
                   aria-label={i18n.t('topNav.resizeSidebar')}
                   tabindex="0"
-                  class="relative w-1 hover:w-1.5 active:w-1.5 bg-brand-border hover:bg-brand-accent/50 active:bg-brand-accent cursor-col-resize transition-all self-stretch flex-shrink-0 z-30 touch-none focus:outline-none focus:bg-brand-accent focus:w-1.5"
+                  class="relative w-1 bg-brand-border hover:bg-brand-accent/50 active:bg-brand-accent cursor-col-resize transition-colors self-stretch flex-shrink-0 z-30 touch-none focus:outline-none focus:bg-brand-accent"
                   onpointerdown={startResizeSidebar}
                   onkeydown={handleSidebarKeyDown}
                 >
@@ -260,7 +260,7 @@
                   aria-valuemax={RIGHT_PANEL_MAX_WIDTH_PX}
                   aria-label={i18n.t('topNav.resizeRightPanel')}
                   tabindex="0"
-                  class="relative w-1 hover:w-1.5 active:w-1.5 bg-brand-border hover:bg-brand-accent/50 active:bg-brand-accent cursor-col-resize transition-all self-stretch flex-shrink-0 z-30 touch-none focus:outline-none focus:bg-brand-accent focus:w-1.5"
+                  class="relative w-1 bg-brand-border hover:bg-brand-accent/50 active:bg-brand-accent cursor-col-resize transition-colors self-stretch flex-shrink-0 z-30 touch-none focus:outline-none focus:bg-brand-accent"
                   onpointerdown={startResizeRightPanel}
                   onkeydown={handleRightPanelKeyDown}
                 >


### PR DESCRIPTION
## 📋 Summary
Prevent sidebar resizer element from increasing width on hover/active/focus states (`hover:w-1.5`, `active:w-1.5`, `focus:w-1.5`), which previously altered flex layout dimensions and caused unnecessary redraws of the middle main content pane.

## 🔍 Implementation Notes
- Updated left and right sidebar resizers in `src/routes/+layout.svelte`.
- Kept constant element width `w-1` (4px).
- Maintained hover, active, and focus color transitions (`hover:bg-brand-accent/50 active:bg-brand-accent focus:bg-brand-accent`) and `cursor-col-resize` on the expanded touch/hover overlay.

## 🧪 Test Plan
- [x] `bun run check` (svelte-check: 0 errors, 0 warnings)
- [x] `bun run test:run` (frontend test suite)
- [x] Manually verified sidebar edge hover behavior: resizer changes color highlight and cursor without changing width or triggering middle pane redraws.

## ✅ Checklist
- [x] No unrelated changes bundled in
