### PR TITLE
fix(packaging): add missing project metadata and AppStream metainfo for Linux packages

### DIFF
--- a/src-tauri/icons/org.luminous.music.metainfo.xml
+++ b/src-tauri/icons/org.luminous.music.metainfo.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>org.luminous.music</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>MIT</project_license>
+  <name>Luminous</name>
+  <summary>A modern, elegant music player</summary>
+  <description>
+    <p>
+      Luminous is a fast, beautifully designed desktop music player featuring gapless playback, 
+      10-band and 20-band DSP equalizer, synchronized LRCLIB lyrics, automatic cover art extraction, 
+      and advanced music library management.
+    </p>
+  </description>
+  <developer_name>Eric James Soltys</developer_name>
+  <launchable type="desktop-id">org.luminous.music.desktop</launchable>
+  <url type="homepage">https://esoltys.dev/luminous/</url>
+  <url type="vcs-browser">https://github.com/esoltys/luminous</url>
+  <url type="bugtracker">https://github.com/esoltys/luminous/issues</url>
+  <categories>
+    <category>AudioVideo</category>
+    <category>Audio</category>
+    <category>Music</category>
+    <category>Player</category>
+  </categories>
+  <content_rating type="oars-1.1" />
+</component>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -30,6 +30,13 @@
   "bundle": {
     "active": true,
     "targets": "all",
+    "publisher": "Eric James Soltys (https://esoltys.dev/luminous/)",
+    "copyright": "Copyright © 2026 Eric James Soltys",
+    "license": "MIT",
+    "licenseFile": "../LICENSE",
+    "category": "Music",
+    "shortDescription": "Luminous Music Player — A modern, elegant music player",
+    "longDescription": "Luminous is a modern, fast, and feature-rich desktop music player featuring gapless playback, 10-band and 20-band DSP equalizer, synchronized LRCLIB lyrics, automatic cover art extraction, and advanced music library management.",
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",
@@ -195,17 +202,20 @@
     "linux": {
       "deb": {
         "files": {
-          "/usr/share/icons/hicolor": "icons/hicolor"
+          "/usr/share/icons/hicolor": "icons/hicolor",
+          "/usr/share/metainfo/org.luminous.music.metainfo.xml": "icons/org.luminous.music.metainfo.xml"
         }
       },
       "rpm": {
         "files": {
-          "/usr/share/icons/hicolor": "icons/hicolor"
+          "/usr/share/icons/hicolor": "icons/hicolor",
+          "/usr/share/metainfo/org.luminous.music.metainfo.xml": "icons/org.luminous.music.metainfo.xml"
         }
       },
       "appimage": {
         "files": {
-          "/usr/share/icons/hicolor": "icons/hicolor"
+          "/usr/share/icons/hicolor": "icons/hicolor",
+          "/usr/share/metainfo/org.luminous.music.metainfo.xml": "icons/org.luminous.music.metainfo.xml"
         }
       }
     }


### PR DESCRIPTION
## 📋 Summary
Adds missing project metadata (`publisher`, `copyright`, `license`, `licenseFile`, `category`, `shortDescription`, `longDescription`) to `tauri.conf.json` and creates an AppStream metainfo XML file (`org.luminous.music.metainfo.xml`). This ensures Linux package managers (such as GNOME Software and AppCenter) display accurate author, license, description, and website information when installing `.deb`, `.rpm`, or `.appimage` packages.

## 🔍 Implementation Notes
- **`src-tauri/tauri.conf.json`**:
  - Configured `publisher` as `Eric James Soltys (https://esoltys.dev/luminous/)` so the Debian control file sets `Maintainer` properly.
  - Specified `license` as `MIT` and `licenseFile` pointing to `../LICENSE`.
  - Defined `shortDescription`, `longDescription`, `copyright`, and `category`.
  - Mapped `/usr/share/metainfo/org.luminous.music.metainfo.xml` under Linux package output files (`deb`, `rpm`, `appimage`).
- **`src-tauri/icons/org.luminous.music.metainfo.xml`**:
  - Created AppStream specification file with project metadata, launchable ID, content rating, categories, and homepage link (`https://esoltys.dev/luminous/`).

## 🧪 Test Plan
- [x] Verified `src-tauri/tauri.conf.json` syntax and structure.
- [x] Verified `org.luminous.music.metainfo.xml` XML syntax and AppStream compliance.
- [x] Verified build configuration structure parses cleanly.

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed
