### PR TITLE
chore: bump version to 0.97.0, add release notes

### DIFF
--- a/docs/release-notes-v0.97.0.md
+++ b/docs/release-notes-v0.97.0.md
@@ -1,0 +1,70 @@
+# Release Notes - Luminous v0.97.0
+
+Luminous v0.97.0 is a large polish-and-stability release since v0.96.0, closing out both the
+Windows (#164) and Linux (#128) 1.0 QA pre-release checklists alongside several new features.
+
+### 🌟 New Features
+- **Toggleable Song-Table Columns**: Every song column is now toggleable and consistent across
+  Collection, Queue, Custom Playlists, Auto-Playlists, and Album views, grouped into Visible /
+  Metatags / Luminous sections (#178, #197).
+- **Joyful Micro-Animations & Sound Cues**: Celebration moments — favouriting a song, finishing
+  an import, hitting a milestone, app updates — now get a motion pass (heart pulse, check pop,
+  gold ring) plus optional synthesized sound cues (off by default, toggle under Settings →
+  General), and toasts stay on screen until dismissed (#182, #191, #195).
+- **Your Own AcoustID API Key**: A field under Settings now accepts a personal AcoustID API key
+  instead of relying solely on the environment variable or the app's built-in fallback (#163).
+- **OS File Associations**: Luminous now registers itself as an "Open With" handler for every
+  audio format it decodes (MP3, FLAC, OGG, Opus, M4A, AAC, ALAC, WAV, AIFF, WV, MPC, APE, TTA,
+  DSF, DFF, ASF, WMA, M4B) and every playlist format it parses (M3U, M3U8, PLS, XSPF), including
+  while the app is already running (#206).
+- **Editable BPM, Grouping & Initial Key**: These previously dead, never-populated columns are
+  now fully working — read at scan time, stored, written back to the file, and editable from the
+  Song Tag Editor (#205).
+
+### 🎨 Visual & UX Improvements
+- **New Display Font — Expose**: Replaced Space Grotesk with Expose across the app UI, in-app
+  Help guides, and design reference docs; self-hosted so it still works offline (#198, #208).
+- **Playlist & Album Toolbar Redesign**: Low-frequency actions (import/export/duplicate-cleanup/
+  clear/delete) moved into a single overflow menu, Undo/Redo/Columns became icon-only controls,
+  and the header layout was unified across Custom Playlists, Auto-Playlists, and Albums (#196,
+  #199, #202); Songs/Playlists toolbars were further realigned for consistent spacing (#205).
+- **Linux Polish**: Opaque playbar with accent glow (blur is a compositor no-op on
+  Linux/WebKitGTK), working miniplayer edge/corner resize handles, and Home page cover art fixes
+  (#204).
+- **Miniplayer Fixes**: Fixed the miniplayer/full-player window size drifting larger with every
+  toggle (#209), and improved hover-overlay opacity, mouse-exit detection, and cover art scaling
+  so art fills the window instead of being capped at 240px (#210).
+- **Sidebar Resizer**: Stopped the resizer from changing width on hover, which was triggering
+  unnecessary redraws of the middle content pane (#203).
+- **Smaller Fixes**: Right-click now selects a song before opening its context menu, sticky Auto/
+  Smart playlist badges no longer render above the header while scrolling, the Sort dropdown is
+  now data-driven from visible columns, and ~20 missing French translations were filled in
+  (#205).
+
+### 🐛 Stability & Bug Fixes
+- **Auto-Playlist Refill Freeze**: Clicking a song in a dynamic auto-play playlist could freeze
+  the app entirely after a runaway loop appended batches of 25 songs to the queue indefinitely;
+  playback state now updates correctly and song lookups are batched instead of queried one at a
+  time (#194).
+- **Watched-Folder Disconnects**: The realtime file watcher hard-deleted every song under a
+  watched drive the instant it disconnected mid-session — a real data-loss bug. It now soft-
+  flags those songs unavailable instead, matching the existing scan-time protection; a failed
+  track no longer loops forever trying `next_track()` under Repeat Playlist (#200).
+- **Album View Playback Deadlock**: Play All and per-track play appeared broken because of a
+  deadlock in the audio engine's error handler that permanently wedged the player mutex app-wide
+  — not just on the album page (#197).
+- **Recently Added Grouping**: A multi-track release with varying per-track artists and no
+  `album_artist` no longer splits into two separate cards; Clean Up also now detects and removes
+  duplicate song entries (#173).
+- **Auto-Playlists Disappearing**: Genre/decade auto-playlists no longer vanish when a filtered
+  population mode (Favourites, Essentials, Discover, Deep Cuts) matches fewer than 25 tracks, and
+  now show a localized fill-mode suffix (e.g. "1980s Rock Deep Cuts") (#168).
+- **Date Added Column**: Fixed the column always rendering blank and sorting as a no-op — the
+  `added` timestamp existed in the database but was never sent to the frontend.
+- **Organize Fixes**: Resolved fake-duplicate cycling, routed physical duplicates and external
+  path collisions into a `Duplicates` folder instead of overwriting files, and fixed a database
+  UNIQUE constraint failure (#164). Empty-folder cleanup no longer silently fails on Windows/
+  OneDrive drives with read-only leftover files (e.g. `desktop.ini`).
+- **Linux Packaging**: Added missing project metadata and an AppStream metainfo file so Linux
+  package managers show accurate author, license, and description info for `.deb`/`.rpm`/
+  `.appimage` builds (#207).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "luminous",
-  "version": "0.96.0",
+  "version": "0.97.0",
   "description": "A high-performance home for the music you already own",
   "author": "Eric James Soltys <ericjamessoltys@outlook.com>",
   "license": "MIT",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3034,7 +3034,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "luminous"
-version = "0.96.0"
+version = "0.97.0"
 dependencies = [
  "anyhow",
  "bs1770",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "luminous"
-version = "0.96.0"
+version = "0.97.0"
 description = "A high-performance home for the music you already own"
 authors = ["Eric James Soltys <ericjamessoltys@outlook.com>"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Luminous",
-  "version": "0.96.0",
+  "version": "0.97.0",
   "identifier": "org.luminous.music",
   "build": {
     "beforeDevCommand": "bun run dev",


### PR DESCRIPTION
## 📋 Summary
Prepares the v0.97.0 release: bumps the app version and adds release notes covering everything shipped since v0.96.0.

- Bumped version to `0.97.0` in `package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`, and `src-tauri/Cargo.lock`.
- Added `docs/release-notes-v0.97.0.md`, summarizing all 40 commits / PRs #175–#210 since v0.96.0 (New Features, Visual & UX Improvements, Stability & Bug Fixes), matching the format of prior release notes.

Notably, both the Windows (#164) and Linux (#128) "1.0 QA pre-release" checklists are closed as of this range — considered bumping straight to 1.0.0, but decided to stay on the existing 0.NN.0 cadence and save the 1.0 label for a later, more deliberate milestone announcement.

## 🔍 Implementation Notes
- Used `bun run scripts/bump-version.ts 0.97.0` for `package.json`/`Cargo.toml`, but hand-edited `tauri.conf.json`'s version field directly instead of letting the script rewrite it — `JSON.stringify` in the script re-formats every array in the file onto multiple lines, which would have produced ~90 lines of unrelated formatting churn against the `fileAssociations` block added in #206.
- `Cargo.lock`'s `luminous` package version was updated by hand to match (not auto-updated by the bump script; a build/`cargo check` would also refresh it).

## 🧪 Test Plan
- [x] `bun run check` (svelte-check)
- [x] `bun run test -- --run` (frontend)
- [x] `cargo test` (src-tauri, if Rust changed)
- [x] Manually verified: diffed each bumped file to confirm only the version fields changed (no incidental formatting churn), and read back the generated release notes markdown for accuracy against the PR range.

## 📸 Screenshots
<img width="1280" height="800" alt="home-EN" src="https://github.com/user-attachments/assets/ebbc14e3-315e-466b-b9af-1ea44f96f042" />

<img width="1280" height="1500" alt="equalizer-EN" src="https://github.com/user-attachments/assets/a2ae2ba2-c6fb-4900-b8a1-51bc5bb05c9b" />

<img width="1280" height="800" alt="song-tag-editor-EN" src="https://github.com/user-attachments/assets/fb78bd7d-6db7-423b-9835-ef124d9a6fcd" />

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed (release notes added; no app UI changed)