### PR TITLE
Remove card-click-to-play on album/playlist cards

### DIFF
--- a/src/lib/components/AlbumCard.svelte
+++ b/src/lib/components/AlbumCard.svelte
@@ -4,7 +4,6 @@
   import { playlistsStore } from "../stores/playlists.svelte";
   import { playerStore } from "../stores/player.svelte";
   import CoverStack, { type CoverItem } from "./CoverStack.svelte";
-  import PlayOverlayButton from "./PlayOverlayButton.svelte";
   import LinkButton from "./LinkButton.svelte";
   import { invoke } from "@tauri-apps/api/core";
   import { i18n } from "../stores/i18n.svelte";
@@ -18,7 +17,6 @@
     onclick?: (e: MouseEvent) => void;
     ondblclick?: (e: MouseEvent) => void;
     oncontextmenu?: (e: MouseEvent) => void;
-    onPlay?: (e: MouseEvent) => void;
   }
 
   let {
@@ -29,34 +27,13 @@
     onclick: customClick,
     ondblclick: customDblClick,
     oncontextmenu: customContextMenu,
-    onPlay: customPlay,
   }: Props = $props();
 
-  async function defaultPlayAlbum(e?: MouseEvent) {
-    if (e) e.stopPropagation();
-    collectionStore.viewAlbum(album.album || "");
-    try {
-      let songs = await invoke<Song[]>("get_songs_by_album", {
-        album: album.album || "",
-      });
-      if (songs.length > 0) {
-        const songIds = songs.map((s) => s.id);
-        playerStore.playSongs(songIds, 0, undefined, {
-          type: "album",
-          album: album.album || "",
-          albumArtist: album.artist ?? undefined,
-        });
-      }
-    } catch (err) {
-      console.error("Failed to play album:", err);
-    }
-  }
-
-  async function handleCardClick(e: MouseEvent) {
+  function handleCardClick(e: MouseEvent) {
     if (customClick) {
       customClick(e);
     } else {
-      await defaultPlayAlbum(e);
+      collectionStore.viewAlbum(album.album || "");
     }
   }
 
@@ -94,13 +71,6 @@
     }
   }
 
-  async function handlePlayButtonClick(e: MouseEvent) {
-    if (customPlay) {
-      customPlay(e);
-    } else {
-      await defaultPlayAlbum(e);
-    }
-  }
 </script>
 
 <!-- svelte-ignore a11y_no_static_element_interactions -->
@@ -118,7 +88,6 @@
       covers={covers && covers.length > 0 ? covers : [{ artEmbedded: album.art_embedded, artAutomatic: album.art_automatic, artManual: album.art_manual }]}
       sizeClass={covers && covers.length > 1 ? "w-24 h-24" : "w-full h-full"}
     />
-    <PlayOverlayButton onPlay={handlePlayButtonClick} />
   </div>
   <div class="p-3.5 flex flex-col flex-1">
     <LinkButton

--- a/src/lib/components/AutoPlaylistCard.svelte
+++ b/src/lib/components/AutoPlaylistCard.svelte
@@ -1,11 +1,9 @@
 <script lang="ts">
   import { invoke } from "@tauri-apps/api/core";
   import { ListMusic, Heart, Clock, Calendar, Music, RefreshCw } from "lucide-svelte";
-  import PlayOverlayButton from "./PlayOverlayButton.svelte";
   import CardBadge from "./CardBadge.svelte";
   import type { PlaylistItem, Song } from "../types";
   import { songsToCoverStack } from "../utils/covers";
-  import { playerStore } from "../stores/player.svelte";
   import { i18n } from "../stores/i18n.svelte";
   import { formatRelativeDate } from "../utils/date";
   import CoverStack from "./CoverStack.svelte";
@@ -88,14 +86,6 @@
     if ((kind !== "genre" && kind !== "decade") || updated === undefined) return null;
     return formatRelativeDate(updated);
   });
-
-  function handlePlayButtonClick(e: MouseEvent) {
-    e.stopPropagation();
-    if (songs.length > 0) {
-      playerStore.playSongs(songs.map((s) => s.id), 0, playlistId, undefined, displayLabel);
-    }
-    onClick();
-  }
 </script>
 
 <!-- svelte-ignore a11y_no_static_element_interactions -->
@@ -130,7 +120,6 @@
         <ListMusic class="w-10 h-10 text-white/90" />
       </div>
     {/if}
-    <PlayOverlayButton onPlay={handlePlayButtonClick} />
 
     {#if autoPlay}
       <CardBadge icon={RefreshCw} label={i18n.t('playlists.autoPlayBadgeLabel')} title={i18n.t('playlists.autoPlayBadgeTooltip')} spin />

--- a/src/lib/components/HomeRowList.svelte
+++ b/src/lib/components/HomeRowList.svelte
@@ -11,7 +11,6 @@
   import PlaylistCoverThumb from "./PlaylistCoverThumb.svelte";
   import SongRating from "./SongRating.svelte";
   import SongContextMenu from "./SongContextMenu.svelte";
-  import { Play } from "lucide-svelte";
   import { i18n } from "../stores/i18n.svelte";
   import { getPlaylistDisplayName } from "../utils/playlist";
 
@@ -103,25 +102,6 @@
     }
   }
 
-  async function playItem(item: HomeItem) {
-    if (item.type === "song") {
-      await playerStore.playSong(item.song.id);
-      return;
-    }
-    if (item.type === "album") {
-      const songs = await invoke<Song[]>("get_songs_by_album", { album: item.album.album || "" });
-      if (songs.length > 0) {
-        playerStore.playSongs(songs.map((s) => s.id), 0, undefined, {
-          type: "album",
-          album: item.album.album || "",
-          albumArtist: item.album.artist ?? undefined,
-        });
-      }
-      return;
-    }
-    await playerStore.playPlaylistItem(item.playlist.id, 0);
-  }
-
   function handleContextMenu(e: MouseEvent, item: HomeItem) {
     if (item.type !== "song") return;
     e.preventDefault();
@@ -176,13 +156,6 @@
           {:else}
             <PlaylistCoverThumb playlist={item.playlist} sizeClass="w-11 h-11" />
           {/if}
-          <button
-            onclick={(e) => { e.stopPropagation(); playItem(item); }}
-            class="absolute inset-0 z-20 flex items-center justify-center bg-black/60 opacity-0 group-hover:opacity-100 transition-opacity cursor-pointer"
-            title={i18n.t('playerBar.play')}
-          >
-            <Play class="w-4 h-4 text-white fill-current" />
-          </button>
         </div>
 
         <div class="min-w-0 flex-1">

--- a/src/lib/components/PlaylistCard.svelte
+++ b/src/lib/components/PlaylistCard.svelte
@@ -1,11 +1,9 @@
 <script lang="ts">
   import { invoke } from "@tauri-apps/api/core";
   import { ListMusic, Calendar, Music, Radio, Layers, Sparkles } from "lucide-svelte";
-  import PlayOverlayButton from "./PlayOverlayButton.svelte";
   import CardBadge from "./CardBadge.svelte";
   import type { Playlist, PlaylistItem } from "../types";
   import { songsToCoverStack } from "../utils/covers";
-  import { playerStore } from "../stores/player.svelte";
   import { playlistsStore } from "../stores/playlists.svelte";
   import { i18n } from "../stores/i18n.svelte";
   import { formatRelativeDate } from "../utils/date";
@@ -58,15 +56,6 @@
   let isActive = $derived(playlistsStore.effectivePinnedPlaylistId === playlist.id);
 
   let updatedLabel = $derived(formatRelativeDate(playlist.updated));
-
-  function handlePlayButtonClick(e: MouseEvent) {
-    e.stopPropagation();
-    const songIds = tracks.filter((t) => t.song && !t.song.unavailable).map((t) => t.song!.id);
-    if (songIds.length > 0) {
-      playerStore.playSongs(songIds, 0, playlist.id);
-    }
-    onClick();
-  }
 </script>
 
 <!-- svelte-ignore a11y_no_static_element_interactions -->
@@ -108,8 +97,6 @@
     {:else if autoKind === "smart"}
       <CardBadge icon={Sparkles} label={i18n.t("playlists.smartBadgeLabel")} title={i18n.t("playlists.smartRuleBasedTooltip")} />
     {/if}
-
-    <PlayOverlayButton onPlay={handlePlayButtonClick} />
   </div>
 
   <button


### PR DESCRIPTION
## Summary
- Removes the implicit "click anywhere on an album/playlist card starts playback" behavior — cards now only navigate on click, matching the existing title/artist link behavior.
- Applies consistently across `AlbumCard.svelte`, `PlaylistCard.svelte`, and `AutoPlaylistCard.svelte` (their `PlayOverlayButton` hover-play affordance is removed along with the fallback play-on-click handlers). `CarouselCard.svelte`'s album/playlist branches reuse these components and inherit the fix automatically.
- Playback remains one click away via the explicit Play button on each destination detail view (`AlbumDetailView`, `PlaylistView`, `AutoPlaylistDetailView`, `ArtistDetailView` all already have their own `PlayShuffleButtons`), so no functionality is lost — just the surprise auto-play on navigation.
- No settings/backend changes — this is a default-behavior fix per maintainer discussion on #219, not a new preference.

Note: `CarouselCard.svelte`'s standalone "song" item branch (individual tracks in Home carousels) keeps its own `PlayOverlayButton`, since a song has no detail page to navigate to and press Play from — removing it would remove the only way to play that track from the carousel. Flagged for discussion in case that should go too.

Fixes #219

## Test plan
- [x] `bun run check` — 0 errors
- [x] `bun run test:run` — 262/262 passing (full suite)
- [ ] Manual check in `bun run tauri dev`: clicking a cover/card in the Albums grid, Playlists grid, Auto-playlists, and Home carousels navigates without starting playback; the destination view's Play button still starts playback normally.