### PR TITLE
feat(collection): add compact Rows view to Albums/Artists tabs

### DIFF
--- a/src/lib/components/AlbumCard.svelte
+++ b/src/lib/components/AlbumCard.svelte
@@ -1,13 +1,11 @@
 <script lang="ts">
-  import type { AlbumItem, Song } from "../types";
+  import type { AlbumItem } from "../types";
   import { collectionStore } from "../stores/collection.svelte";
-  import { playlistsStore } from "../stores/playlists.svelte";
-  import { playerStore } from "../stores/player.svelte";
   import CoverStack, { type CoverItem } from "./CoverStack.svelte";
   import LinkButton from "./LinkButton.svelte";
-  import { invoke } from "@tauri-apps/api/core";
   import { i18n } from "../stores/i18n.svelte";
   import { getAlbumCategoryLabel } from "../utils/artist";
+  import { queueAlbumAsPlaylist } from "../utils/playlist";
 
   interface Props {
     album: AlbumItem;
@@ -41,33 +39,7 @@
     if (customDblClick) {
       customDblClick(e);
     } else {
-      const albumName = album.album || i18n.t('collection.unknownAlbum');
-      const playlistName = i18n.t('collection.albumPlaylistName', { name: albumName });
-      let existingPlaylist = playlistsStore.playlists.find(p => p.name === playlistName);
-
-      if (existingPlaylist) {
-        await playlistsStore.selectPlaylist(existingPlaylist.id);
-        await playlistsStore.clearPlaylist(existingPlaylist.id);
-      } else {
-        await playlistsStore.createPlaylist(playlistName);
-      }
-
-      try {
-        let songs = await invoke<Song[]>("get_songs_by_album", {
-          album: album.album || "",
-        });
-
-        if (songs.length > 0) {
-          const songIds = songs.map((s) => s.id);
-          if (playlistsStore.activeCustomPlaylist) {
-            await playlistsStore.addSongsToPlaylist(playlistsStore.activeCustomPlaylist.id, songIds);
-            collectionStore.activeTab = "playlists";
-            await playerStore.playPlaylistItem(playlistsStore.activeCustomPlaylist.id, 0);
-          }
-        }
-      } catch (err) {
-        console.error("Failed to add album to playlist:", err);
-      }
+      await queueAlbumAsPlaylist(album);
     }
   }
 

--- a/src/lib/components/AlbumRowCard.svelte
+++ b/src/lib/components/AlbumRowCard.svelte
@@ -1,10 +1,7 @@
 <script lang="ts">
-  import { invoke } from "@tauri-apps/api/core";
-  import type { AlbumItem, Song } from "../types";
+  import type { AlbumItem } from "../types";
   import { collectionStore } from "../stores/collection.svelte";
-  import { playerStore } from "../stores/player.svelte";
   import CoverArt from "./CoverArt.svelte";
-  import { Play } from "lucide-svelte";
   import { i18n } from "../stores/i18n.svelte";
   import { getAlbumCategoryLabel } from "../utils/artist";
   import { queueAlbumAsPlaylist } from "../utils/playlist";
@@ -38,18 +35,6 @@
       await queueAlbumAsPlaylist(album);
     }
   }
-
-  async function playAlbum(e: MouseEvent) {
-    e.stopPropagation();
-    const songs = await invoke<Song[]>("get_songs_by_album", { album: album.album || "" });
-    if (songs.length > 0) {
-      playerStore.playSongs(songs.map((s) => s.id), 0, undefined, {
-        type: "album",
-        album: album.album || "",
-        albumArtist: album.artist ?? undefined,
-      });
-    }
-  }
 </script>
 
 <!-- svelte-ignore a11y_click_events_have_key_events -->
@@ -71,13 +56,6 @@
       artManual={album.art_manual}
       sizeClass="w-11 h-11"
     />
-    <button
-      onclick={playAlbum}
-      class="absolute inset-0 z-20 flex items-center justify-center bg-black/60 opacity-0 group-hover:opacity-100 transition-opacity cursor-pointer"
-      title={i18n.t('playerBar.play')}
-    >
-      <Play class="w-4 h-4 text-white fill-current" />
-    </button>
   </div>
 
   <div class="min-w-0 flex-1">

--- a/src/lib/components/AlbumRowCard.svelte
+++ b/src/lib/components/AlbumRowCard.svelte
@@ -1,0 +1,94 @@
+<script lang="ts">
+  import { invoke } from "@tauri-apps/api/core";
+  import type { AlbumItem, Song } from "../types";
+  import { collectionStore } from "../stores/collection.svelte";
+  import { playerStore } from "../stores/player.svelte";
+  import CoverArt from "./CoverArt.svelte";
+  import { Play } from "lucide-svelte";
+  import { i18n } from "../stores/i18n.svelte";
+  import { getAlbumCategoryLabel } from "../utils/artist";
+  import { queueAlbumAsPlaylist } from "../utils/playlist";
+
+  interface Props {
+    album: AlbumItem;
+    onclick?: (e: MouseEvent) => void;
+    ondblclick?: (e: MouseEvent) => void;
+    oncontextmenu?: (e: MouseEvent) => void;
+  }
+
+  let {
+    album,
+    onclick: customClick,
+    ondblclick: customDblClick,
+    oncontextmenu: customContextMenu,
+  }: Props = $props();
+
+  function handleClick(e: MouseEvent) {
+    if (customClick) {
+      customClick(e);
+    } else {
+      collectionStore.viewAlbum(album.album || "");
+    }
+  }
+
+  async function handleDblClick(e: MouseEvent) {
+    if (customDblClick) {
+      customDblClick(e);
+    } else {
+      await queueAlbumAsPlaylist(album);
+    }
+  }
+
+  async function playAlbum(e: MouseEvent) {
+    e.stopPropagation();
+    const songs = await invoke<Song[]>("get_songs_by_album", { album: album.album || "" });
+    if (songs.length > 0) {
+      playerStore.playSongs(songs.map((s) => s.id), 0, undefined, {
+        type: "album",
+        album: album.album || "",
+        albumArtist: album.artist ?? undefined,
+      });
+    }
+  }
+</script>
+
+<!-- svelte-ignore a11y_click_events_have_key_events -->
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div
+  role="button"
+  tabindex="0"
+  onclick={handleClick}
+  ondblclick={handleDblClick}
+  oncontextmenu={(e) => customContextMenu?.(e)}
+  onkeydown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); handleClick(e as unknown as MouseEvent); } }}
+  class="group flex items-center gap-3 px-3 py-2.5 rounded-lg bg-brand-sidebar border border-brand-border/60 hover:border-brand-accent/40 hover:shadow-md hover:shadow-brand-accent/10 transition-all duration-200 cursor-pointer select-none"
+>
+  <div class="relative shrink-0 overflow-hidden">
+    <CoverArt
+      songId={album.sample_song_id ?? undefined}
+      artEmbedded={album.art_embedded}
+      artAutomatic={album.art_automatic}
+      artManual={album.art_manual}
+      sizeClass="w-11 h-11"
+    />
+    <button
+      onclick={playAlbum}
+      class="absolute inset-0 z-20 flex items-center justify-center bg-black/60 opacity-0 group-hover:opacity-100 transition-opacity cursor-pointer"
+      title={i18n.t('playerBar.play')}
+    >
+      <Play class="w-4 h-4 text-white fill-current" />
+    </button>
+  </div>
+
+  <div class="min-w-0 flex-1">
+    <p class="truncate text-sm font-semibold text-brand-text-primary">{album.album || i18n.t('collection.unknownAlbum')}</p>
+    <p class="truncate text-xs text-brand-text-secondary font-medium">{album.artist || i18n.t('collection.variousArtists')}</p>
+  </div>
+
+  <div class="shrink-0 max-w-40 text-right">
+    <p class="text-xs text-brand-text-secondary font-medium tabular-nums truncate">{getAlbumCategoryLabel(album.track_count, album.disc_count)}</p>
+    {#if album.year}
+      <p class="text-xs text-brand-text-secondary truncate">{album.year}</p>
+    {/if}
+  </div>
+</div>

--- a/src/lib/components/AlbumRowCard.test.ts
+++ b/src/lib/components/AlbumRowCard.test.ts
@@ -1,0 +1,79 @@
+import "@testing-library/jest-dom";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, fireEvent } from "@testing-library/svelte";
+import AlbumRowCard from "./AlbumRowCard.svelte";
+import { collectionStore } from "../stores/collection.svelte";
+import type { AlbumItem } from "../types";
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn().mockResolvedValue(() => {}),
+}));
+
+describe("AlbumRowCard.svelte", () => {
+  const mockAlbum: AlbumItem = {
+    album: "Fake Nudes",
+    artist: "Barenaked Ladies",
+    year: 2017,
+    track_count: 14,
+    disc_count: 1,
+    art_embedded: false,
+    art_automatic: null,
+    art_manual: null,
+    genre: "Alternative",
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders album title, artist, category, and year", () => {
+    const { getByText } = render(AlbumRowCard, { props: { album: mockAlbum } });
+
+    expect(getByText("Fake Nudes")).toBeInTheDocument();
+    expect(getByText("Barenaked Ladies")).toBeInTheDocument();
+    expect(getByText("Album")).toBeInTheDocument();
+    expect(getByText("2017")).toBeInTheDocument();
+  });
+
+  it("shows Various Artists when the album has no artist", () => {
+    const { getByText } = render(AlbumRowCard, {
+      props: { album: { ...mockAlbum, artist: null } },
+    });
+    expect(getByText("Various Artists")).toBeInTheDocument();
+  });
+
+  it("navigates to the album on click by default", async () => {
+    const viewAlbumSpy = vi.spyOn(collectionStore, "viewAlbum");
+    const { getByText } = render(AlbumRowCard, { props: { album: mockAlbum } });
+
+    await fireEvent.click(getByText("Fake Nudes"));
+
+    expect(viewAlbumSpy).toHaveBeenCalledWith("Fake Nudes");
+  });
+
+  it("calls a custom click handler when passed", async () => {
+    const handleClick = vi.fn();
+    const { getByText } = render(AlbumRowCard, {
+      props: { album: mockAlbum, onclick: handleClick },
+    });
+
+    await fireEvent.click(getByText("Fake Nudes"));
+
+    expect(handleClick).toHaveBeenCalled();
+  });
+
+  it("forwards the context menu event", async () => {
+    const handleContextMenu = vi.fn();
+    const { getByText } = render(AlbumRowCard, {
+      props: { album: mockAlbum, oncontextmenu: handleContextMenu },
+    });
+
+    await fireEvent.contextMenu(getByText("Fake Nudes"));
+
+    expect(handleContextMenu).toHaveBeenCalled();
+  });
+});

--- a/src/lib/components/ArtistCard.svelte
+++ b/src/lib/components/ArtistCard.svelte
@@ -2,7 +2,7 @@
   import type { ArtistItem, AlbumItem, Song } from "../types";
   import { i18n } from "../stores/i18n.svelte";
   import CoverStack from "./CoverStack.svelte";
-  import { songsToCoverStack } from "../utils/covers";
+  import { getArtistCoverStack } from "../utils/covers";
 
   interface Props {
     artist: ArtistItem;
@@ -20,25 +20,7 @@
     onclick: customClick,
   }: Props = $props();
 
-  let covers = $derived.by(() => {
-    const albumCovers = artistAlbums
-      .map((album) => ({
-        artEmbedded: album.art_embedded,
-        artAutomatic: album.art_automatic,
-        artManual: album.art_manual,
-      }))
-      .filter((c) => c.artManual || c.artAutomatic || c.artEmbedded);
-
-    if (albumCovers.length > 0) {
-      return albumCovers;
-    }
-
-    if (artistSongs.length > 0) {
-      return songsToCoverStack(artistSongs);
-    }
-
-    return [];
-  });
+  let covers = $derived(getArtistCoverStack(artistAlbums, artistSongs));
 
   let genreLabel = $derived(artist.genre?.trim() || i18n.t('artistDetail.unknownGenre'));
 </script>

--- a/src/lib/components/ArtistRowCard.svelte
+++ b/src/lib/components/ArtistRowCard.svelte
@@ -1,0 +1,49 @@
+<script lang="ts">
+  import type { ArtistItem, AlbumItem, Song } from "../types";
+  import { i18n } from "../stores/i18n.svelte";
+  import CoverArt from "./CoverArt.svelte";
+  import { getArtistCoverStack } from "../utils/covers";
+
+  interface Props {
+    artist: ArtistItem;
+    artistAlbums: AlbumItem[];
+    artistSongs?: Song[];
+    onclick?: (e: MouseEvent) => void;
+  }
+
+  let { artist, artistAlbums, artistSongs = [], onclick: customClick }: Props = $props();
+
+  // Same front-cover selection ArtistCard uses for its CoverStack (index 0 is
+  // the front/topmost tile), so the row's single cover always matches it.
+  let frontCover = $derived(getArtistCoverStack(artistAlbums, artistSongs, 1)[0]);
+  let genreLabel = $derived(artist.genre?.trim() || i18n.t('artistDetail.unknownGenre'));
+</script>
+
+<!-- svelte-ignore a11y_click_events_have_key_events -->
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div
+  role="button"
+  tabindex="0"
+  onclick={(e) => customClick?.(e)}
+  onkeydown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); customClick?.(e as unknown as MouseEvent); } }}
+  class="group flex items-center gap-3 px-3 py-2.5 rounded-lg bg-brand-sidebar border border-brand-border/60 hover:border-brand-accent/40 hover:shadow-md hover:shadow-brand-accent/10 transition-all duration-200 cursor-pointer select-none"
+>
+  <div class="relative shrink-0 overflow-hidden">
+    <CoverArt
+      songId={frontCover?.songId}
+      artEmbedded={frontCover?.artEmbedded ?? false}
+      artAutomatic={frontCover?.artAutomatic ?? null}
+      artManual={frontCover?.artManual ?? null}
+      sizeClass="w-11 h-11"
+    />
+  </div>
+
+  <div class="min-w-0 flex-1">
+    <p class="truncate text-sm font-semibold text-brand-text-primary">{artist.name || i18n.t('collection.unknownArtist')}</p>
+    <p class="truncate text-xs text-brand-text-secondary font-medium">{genreLabel}</p>
+  </div>
+
+  <div class="shrink-0 max-w-40 text-right">
+    <p class="text-xs text-brand-text-secondary font-medium tabular-nums truncate">{i18n.t('playlists.songsCount', { count: artist.song_count })}</p>
+  </div>
+</div>

--- a/src/lib/components/ArtistRowCard.test.ts
+++ b/src/lib/components/ArtistRowCard.test.ts
@@ -1,0 +1,66 @@
+import "@testing-library/jest-dom";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, fireEvent } from "@testing-library/svelte";
+import ArtistRowCard from "./ArtistRowCard.svelte";
+import type { ArtistItem, AlbumItem } from "../types";
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn().mockResolvedValue(() => {}),
+}));
+
+describe("ArtistRowCard.svelte", () => {
+  const mockArtist: ArtistItem = {
+    name: "Dave Hawkins",
+    album_count: 1,
+    song_count: 6,
+    genre: "Rock",
+  };
+
+  const mockAlbum: AlbumItem = {
+    album: "Dave's Hits",
+    artist: "Dave Hawkins",
+    year: 2020,
+    track_count: 10,
+    disc_count: 1,
+    art_embedded: false,
+    art_automatic: "covers/dave.jpg",
+    art_manual: null,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders artist name, genre, and song count", () => {
+    const { getByText } = render(ArtistRowCard, {
+      props: { artist: mockArtist, artistAlbums: [mockAlbum] },
+    });
+
+    expect(getByText("Dave Hawkins")).toBeInTheDocument();
+    expect(getByText("Rock")).toBeInTheDocument();
+    expect(getByText("6 songs")).toBeInTheDocument();
+  });
+
+  it("renders cover art from the artist's front album, matching CoverStack's front tile", () => {
+    const { container } = render(ArtistRowCard, {
+      props: { artist: mockArtist, artistAlbums: [mockAlbum] },
+    });
+
+    const img = container.querySelector("img");
+    expect(img).toBeInTheDocument();
+  });
+
+  it("triggers custom onclick handler when clicked", async () => {
+    const handleClick = vi.fn();
+    const { getByText } = render(ArtistRowCard, {
+      props: { artist: mockArtist, artistAlbums: [], onclick: handleClick },
+    });
+
+    await fireEvent.click(getByText("Dave Hawkins"));
+    expect(handleClick).toHaveBeenCalled();
+  });
+});

--- a/src/lib/components/CollectionView.svelte
+++ b/src/lib/components/CollectionView.svelte
@@ -6,10 +6,11 @@
   import CoverArt from "./CoverArt.svelte";
   import SongRating from "./SongRating.svelte";
   import TagEditor from "./TagEditor.svelte";
-  import { Play, Plus, Clock, FileText, Music, DiscAlbum, Mic2, Edit3, Columns } from "lucide-svelte";
+  import { Play, Plus, Clock, FileText, Music, DiscAlbum, Mic2, Edit3, Columns, LayoutGrid, Rows3 } from "lucide-svelte";
   import type { Song, AlbumItem, ArtistItem } from "../types";
   import { i18n } from "../stores/i18n.svelte";
   import { toastStore } from "../stores/toast.svelte";
+  import { prefs, type CollectionViewMode } from "../stores/prefs.svelte";
   import { VirtualList } from "svelte-virtual-list-ts";
   import { getArtistAlbums, getArtistSongs, getArtistGradient } from "../utils/artist";
   import ArtistDetailView from "./ArtistDetailView.svelte";
@@ -18,6 +19,8 @@
   import AlbumContextMenu from "./AlbumContextMenu.svelte";
   import AlbumCard from "./AlbumCard.svelte";
   import ArtistCard from "./ArtistCard.svelte";
+  import AlbumRowCard from "./AlbumRowCard.svelte";
+  import ArtistRowCard from "./ArtistRowCard.svelte";
   import SortableHeader from "./SortableHeader.svelte";
   import Select from "./Select.svelte";
   import NowPlayingBars from "./NowPlayingBars.svelte";
@@ -143,6 +146,19 @@
 
   function getArtistSongsFor(name: string | null): Song[] {
     return getArtistSongs(collectionStore.songs, name);
+  }
+
+  // Albums and Artists each remember their own Cards/Rows view mode.
+  let activeViewMode = $derived(
+    collectionStore.activeSubTab === "albums" ? prefs.albumsViewMode : prefs.artistsViewMode
+  );
+
+  function setActiveViewMode(mode: CollectionViewMode) {
+    if (collectionStore.activeSubTab === "albums") {
+      prefs.setAlbumsViewMode(mode);
+    } else {
+      prefs.setArtistsViewMode(mode);
+    }
   }
 
   let sortField = $state<keyof Song>(
@@ -899,65 +915,139 @@
   {:else}
     <!-- Scrollable Container for Albums / Artists Views -->
     <div class="flex-1 px-6 overflow-y-auto {playerStore.currentSong ? 'pb-28' : 'pb-6'}">
-      <!-- Top bar with Filter Info / Sort controls (sticky) -->
-      <div class="h-12 flex items-center justify-between sticky top-0 z-20 bg-brand-main">
-        <!-- Showing Count (Left) -->
-        <div class="text-xs text-brand-text-secondary font-medium">
-          {#if collectionStore.activeSubTab === "albums"}
-            {sortedAlbums.length === 1 ? i18n.t('collection.showingOneAlbum') : i18n.t('collection.showingAlbums', { count: sortedAlbums.length })}
-          {:else}
-            {sortedArtists.length === 1 ? i18n.t('collection.showingOneArtist') : i18n.t('collection.showingArtists', { count: sortedArtists.length })}
-          {/if}
+      <!-- Sticky header: View Mode Toggle above Filter Info / Sort controls -->
+      <div class="sticky top-0 z-20 bg-brand-main">
+        <!-- View Mode Toggle (Cards / Rows) -->
+        <div class="h-10 flex items-center justify-end">
+          <div class="inline-flex items-center gap-0.5 bg-brand-sidebar border border-brand-border rounded-full p-1">
+            <button
+              onclick={() => setActiveViewMode("cards")}
+              class="flex items-center justify-center w-7 h-7 rounded-full transition-colors cursor-pointer {activeViewMode === 'cards' ? 'bg-brand-accent text-white' : 'text-brand-text-secondary hover:text-brand-text-primary'}"
+              title={i18n.t('collection.viewCards')}
+              aria-label={i18n.t('collection.viewCards')}
+              aria-pressed={activeViewMode === "cards"}
+            >
+              <LayoutGrid class="w-4 h-4" />
+            </button>
+            <button
+              onclick={() => setActiveViewMode("rows")}
+              class="flex items-center justify-center w-7 h-7 rounded-full transition-colors cursor-pointer {activeViewMode === 'rows' ? 'bg-brand-accent text-white' : 'text-brand-text-secondary hover:text-brand-text-primary'}"
+              title={i18n.t('collection.viewRows')}
+              aria-label={i18n.t('collection.viewRows')}
+              aria-pressed={activeViewMode === "rows"}
+            >
+              <Rows3 class="w-4 h-4" />
+            </button>
+          </div>
         </div>
 
-        <!-- Sort Dropdown (Right) -->
-        <div class="flex items-center gap-4">
-          {#if collectionStore.activeSubTab === "albums"}
-            <div class="relative">
-              <Select
-                value={`${albumSortField}-${albumSortAsc}`}
-                onchange={(e) => {
-                  const [field, asc] = e.currentTarget.value.split("-");
-                  albumSortField = field as "album" | "artist" | "year" | "track_count";
-                  albumSortAsc = asc === "true";
-                }}
-                class="bg-brand-sidebar border border-brand-border hover:border-brand-accent/60 text-brand-text-secondary text-xs rounded-full pl-2.5 pr-8 py-1.5 focus:outline-none focus:border-brand-accent transition-all font-medium"
-              >
-                <option value="album-true">{i18n.t('collection.sortAlbumNameAsc')}</option>
-                <option value="album-false">{i18n.t('collection.sortAlbumNameDesc')}</option>
-                <option value="artist-true">{i18n.t('collection.sortArtistNameAsc')}</option>
-                <option value="artist-false">{i18n.t('collection.sortArtistNameDesc')}</option>
-                <option value="year-false">{i18n.t('collection.sortYearDesc')}</option>
-                <option value="year-true">{i18n.t('collection.sortYearAsc')}</option>
-                <option value="track_count-false">{i18n.t('collection.sortTracksDesc')}</option>
-                <option value="track_count-true">{i18n.t('collection.sortTracksAsc')}</option>
-              </Select>
-            </div>
-          {:else if collectionStore.activeSubTab === "artists"}
-            <div class="relative">
-              <Select
-                value={`${artistSortField}-${artistSortAsc}`}
-                onchange={(e) => {
-                  const [field, asc] = e.currentTarget.value.split("-");
-                  artistSortField = field as "name" | "genre" | "song_count";
-                  artistSortAsc = asc === "true";
-                }}
-                class="bg-brand-sidebar border border-brand-border hover:border-brand-accent/60 text-brand-text-secondary text-xs rounded-full pl-2.5 pr-8 py-1.5 focus:outline-none focus:border-brand-accent transition-all font-medium"
-              >
-                <option value="name-true">{i18n.t('collection.sortArtistNameAsc')}</option>
-                <option value="name-false">{i18n.t('collection.sortArtistNameDesc')}</option>
-                <option value="genre-true">{i18n.t('collection.sortGenreAsc')}</option>
-                <option value="genre-false">{i18n.t('collection.sortGenreDesc')}</option>
-                <option value="song_count-false">{i18n.t('collection.sortSongsDesc')}</option>
-                <option value="song_count-true">{i18n.t('collection.sortSongsAsc')}</option>
-              </Select>
-            </div>
-          {/if}
+        <div class="h-12 flex items-center justify-between">
+          <!-- Showing Count (Left) -->
+          <div class="text-xs text-brand-text-secondary font-medium">
+            {#if collectionStore.activeSubTab === "albums"}
+              {sortedAlbums.length === 1 ? i18n.t('collection.showingOneAlbum') : i18n.t('collection.showingAlbums', { count: sortedAlbums.length })}
+            {:else}
+              {sortedArtists.length === 1 ? i18n.t('collection.showingOneArtist') : i18n.t('collection.showingArtists', { count: sortedArtists.length })}
+            {/if}
+          </div>
+
+          <!-- Sort Dropdown (Right) -->
+          <div class="flex items-center gap-4">
+            {#if collectionStore.activeSubTab === "albums"}
+              <div class="relative">
+                <Select
+                  value={`${albumSortField}-${albumSortAsc}`}
+                  onchange={(e) => {
+                    const [field, asc] = e.currentTarget.value.split("-");
+                    albumSortField = field as "album" | "artist" | "year" | "track_count";
+                    albumSortAsc = asc === "true";
+                  }}
+                  class="bg-brand-sidebar border border-brand-border hover:border-brand-accent/60 text-brand-text-secondary text-xs rounded-full pl-2.5 pr-8 py-1.5 focus:outline-none focus:border-brand-accent transition-all font-medium"
+                >
+                  <option value="album-true">{i18n.t('collection.sortAlbumNameAsc')}</option>
+                  <option value="album-false">{i18n.t('collection.sortAlbumNameDesc')}</option>
+                  <option value="artist-true">{i18n.t('collection.sortArtistNameAsc')}</option>
+                  <option value="artist-false">{i18n.t('collection.sortArtistNameDesc')}</option>
+                  <option value="year-false">{i18n.t('collection.sortYearDesc')}</option>
+                  <option value="year-true">{i18n.t('collection.sortYearAsc')}</option>
+                  <option value="track_count-false">{i18n.t('collection.sortTracksDesc')}</option>
+                  <option value="track_count-true">{i18n.t('collection.sortTracksAsc')}</option>
+                </Select>
+              </div>
+            {:else if collectionStore.activeSubTab === "artists"}
+              <div class="relative">
+                <Select
+                  value={`${artistSortField}-${artistSortAsc}`}
+                  onchange={(e) => {
+                    const [field, asc] = e.currentTarget.value.split("-");
+                    artistSortField = field as "name" | "genre" | "song_count";
+                    artistSortAsc = asc === "true";
+                  }}
+                  class="bg-brand-sidebar border border-brand-border hover:border-brand-accent/60 text-brand-text-secondary text-xs rounded-full pl-2.5 pr-8 py-1.5 focus:outline-none focus:border-brand-accent transition-all font-medium"
+                >
+                  <option value="name-true">{i18n.t('collection.sortArtistNameAsc')}</option>
+                  <option value="name-false">{i18n.t('collection.sortArtistNameDesc')}</option>
+                  <option value="genre-true">{i18n.t('collection.sortGenreAsc')}</option>
+                  <option value="genre-false">{i18n.t('collection.sortGenreDesc')}</option>
+                  <option value="song_count-false">{i18n.t('collection.sortSongsDesc')}</option>
+                  <option value="song_count-true">{i18n.t('collection.sortSongsAsc')}</option>
+                </Select>
+              </div>
+            {/if}
+          </div>
         </div>
       </div>
 
+      {#snippet albumEmptyState()}
+        {#if sortedAlbums.length === 0 && collectionStore.searchQuery}
+          <div class="col-span-full py-16 text-center">
+            <SearchEmptyState
+              icon={DiscAlbum}
+              title={i18n.t('collection.noAlbumsTitle')}
+              matchQueryText={i18n.t('collection.noAlbumsMatchQuery')}
+              query={collectionStore.searchQuery}
+              onReset={() => { collectionStore.searchQuery = ""; collectionStore.search(""); }}
+            />
+          </div>
+        {:else if sortedAlbums.length === 0}
+          <div class="col-span-full py-16 text-center">
+            <LibraryWelcome />
+          </div>
+        {/if}
+      {/snippet}
+
+      {#snippet artistEmptyState()}
+        {#if sortedArtists.length === 0 && collectionStore.searchQuery}
+          <div class="col-span-full py-16 text-center">
+            <SearchEmptyState
+              icon={Mic2}
+              title={i18n.t('collection.noArtistsTitle')}
+              matchQueryText={i18n.t('collection.noArtistsMatchQuery')}
+              query={collectionStore.searchQuery}
+              onReset={() => { collectionStore.searchQuery = ""; collectionStore.search(""); }}
+            />
+          </div>
+        {:else if sortedArtists.length === 0}
+          <div class="col-span-full py-16 text-center">
+            <LibraryWelcome />
+          </div>
+        {/if}
+      {/snippet}
+
       <div class="pt-2">
         {#if collectionStore.activeSubTab === "albums"}
+        {#if activeViewMode === "rows"}
+          <!-- Albums Row List View -->
+          <div class="grid grid-cols-[repeat(auto-fill,minmax(280px,1fr))] gap-2">
+            {#each sortedAlbums as album}
+              <AlbumRowCard
+                {album}
+                oncontextmenu={(e) => handleAlbumContextMenu(e, album)}
+              />
+            {/each}
+            {@render albumEmptyState()}
+          </div>
+        {:else}
           <!-- Albums Card Grid View -->
           <div class="grid grid-cols-[repeat(auto-fill,minmax(180px,1fr))] gap-6">
             {#each sortedAlbums as album}
@@ -967,23 +1057,26 @@
                 oncontextmenu={(e) => handleAlbumContextMenu(e, album)}
               />
             {/each}
-            {#if sortedAlbums.length === 0 && collectionStore.searchQuery}
-              <div class="col-span-full py-16 text-center">
-                <SearchEmptyState
-                  icon={DiscAlbum}
-                  title={i18n.t('collection.noAlbumsTitle')}
-                  matchQueryText={i18n.t('collection.noAlbumsMatchQuery')}
-                  query={collectionStore.searchQuery}
-                  onReset={() => { collectionStore.searchQuery = ""; collectionStore.search(""); }}
-                />
-              </div>
-            {:else if sortedAlbums.length === 0}
-              <div class="col-span-full py-16 text-center">
-                <LibraryWelcome />
-              </div>
-            {/if}
+            {@render albumEmptyState()}
           </div>
+        {/if}
         {:else if collectionStore.activeSubTab === "artists"}
+        {#if activeViewMode === "rows"}
+          <!-- Artists Row List View -->
+          <div class="grid grid-cols-[repeat(auto-fill,minmax(280px,1fr))] gap-2">
+            {#each sortedArtists as artist}
+              {@const artistAlbums = getArtistAlbumsFor(artist.name)}
+              {@const artistSongs = getArtistSongsFor(artist.name)}
+              <ArtistRowCard
+                {artist}
+                {artistAlbums}
+                {artistSongs}
+                onclick={() => collectionStore.viewArtist(artist.name || "")}
+              />
+            {/each}
+            {@render artistEmptyState()}
+          </div>
+        {:else}
           <!-- Artists List Grid View -->
           <div class="grid grid-cols-[repeat(auto-fill,minmax(180px,1fr))] gap-6">
             {#each sortedArtists as artist}
@@ -996,22 +1089,9 @@
                 onclick={() => collectionStore.viewArtist(artist.name || "")}
               />
             {/each}
-            {#if sortedArtists.length === 0 && collectionStore.searchQuery}
-              <div class="col-span-full py-16 text-center">
-                <SearchEmptyState
-                  icon={Mic2}
-                  title={i18n.t('collection.noArtistsTitle')}
-                  matchQueryText={i18n.t('collection.noArtistsMatchQuery')}
-                  query={collectionStore.searchQuery}
-                  onReset={() => { collectionStore.searchQuery = ""; collectionStore.search(""); }}
-                />
-              </div>
-            {:else if sortedArtists.length === 0}
-              <div class="col-span-full py-16 text-center">
-                <LibraryWelcome />
-              </div>
-            {/if}
+            {@render artistEmptyState()}
           </div>
+        {/if}
         {/if}
       </div>
     </div>

--- a/src/lib/components/CollectionView.test.ts
+++ b/src/lib/components/CollectionView.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, fireEvent } from "@testing-library/svelte";
 import CollectionView from "./CollectionView.svelte";
 import { collectionStore } from "../stores/collection.svelte";
+import { prefs } from "../stores/prefs.svelte";
 import type { Song, AlbumItem, ArtistItem } from "../types";
 
 vi.mock("svelte-virtual-list-ts", async () => {
@@ -118,6 +119,8 @@ describe("CollectionView.svelte", () => {
     collectionStore.selectedAlbumName = null;
     collectionStore.selectedArtistName = null;
     collectionStore.searchQuery = "";
+    prefs.albumsViewMode = "cards";
+    prefs.artistsViewMode = "cards";
   });
 
   it("does not render top category filter pills in CollectionView", () => {
@@ -178,5 +181,33 @@ describe("CollectionView.svelte", () => {
 
     expect(getByText("Play Song")).toBeInTheDocument();
     expect(getAllByText("Add to Active Playlist")[0]).toBeInTheDocument();
+  });
+
+  it("defaults to Cards view in Albums sub-tab", () => {
+    collectionStore.activeSubTab = "albums";
+    const { getByText } = render(CollectionView);
+
+    // AlbumCard renders the title as a clickable LinkButton; the row view doesn't.
+    expect(getByText("Album 1").closest("button")).not.toBeNull();
+  });
+
+  it("switches Albums sub-tab to the compact Rows view when the Rows toggle is clicked", async () => {
+    collectionStore.activeSubTab = "albums";
+    const { getByText, getByTitle } = render(CollectionView);
+
+    await fireEvent.click(getByTitle("Row view"));
+
+    expect(prefs.albumsViewMode).toBe("rows");
+    expect(getByText("Album 1").closest("button")).toBeNull();
+  });
+
+  it("switches Artists sub-tab to the compact Rows view independently of Albums", async () => {
+    collectionStore.activeSubTab = "artists";
+    const { getByTitle } = render(CollectionView);
+
+    await fireEvent.click(getByTitle("Row view"));
+
+    expect(prefs.artistsViewMode).toBe("rows");
+    expect(prefs.albumsViewMode).toBe("cards");
   });
 });

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -98,6 +98,8 @@ export const en = {
     noAlbumsMatchQuery: "No albums match your query:",
     noArtistsTitle: "No artists found",
     noArtistsMatchQuery: "No artists match your query:",
+    viewCards: "Card view",
+    viewRows: "Row view",
     sortAlbumNameAsc: "Sort: Album Name (A-Z)",
     sortAlbumNameDesc: "Sort: Album Name (Z-A)",
     sortArtistNameAsc: "Sort: Artist Name (A-Z)",

--- a/src/lib/locales/fr.ts
+++ b/src/lib/locales/fr.ts
@@ -98,6 +98,8 @@ export const fr = {
     noAlbumsMatchQuery: "Aucun album ne correspond à votre recherche :",
     noArtistsTitle: "Aucun artiste trouvé",
     noArtistsMatchQuery: "Aucun artiste ne correspond à votre recherche :",
+    viewCards: "Vue en cartes",
+    viewRows: "Vue en lignes",
     sortAlbumNameAsc: "Trier : Nom d'album (A-Z)",
     sortAlbumNameDesc: "Trier : Nom d'album (Z-A)",
     sortArtistNameAsc: "Trier : Nom d'artiste (A-Z)",

--- a/src/lib/stores/prefs.svelte.ts
+++ b/src/lib/stores/prefs.svelte.ts
@@ -2,11 +2,14 @@ import { invoke } from "@tauri-apps/api/core";
 
 export type RatingStyle = "heart" | "stars";
 export type SeekBarMode = "waveform" | "moodbar";
+export type CollectionViewMode = "cards" | "rows";
 
 class PrefsStore {
   ratingStyle = $state<RatingStyle>("heart");
   seekBarMode = $state<SeekBarMode>("waveform");
   acoustidApiKey = $state<string>("");
+  albumsViewMode = $state<CollectionViewMode>("cards");
+  artistsViewMode = $state<CollectionViewMode>("cards");
 
   async init() {
     try {
@@ -19,6 +22,12 @@ class PrefsStore {
       }
       if (settings?.acoustid_api_key) {
         this.acoustidApiKey = settings.acoustid_api_key;
+      }
+      if (settings?.albums_view_mode === "cards" || settings?.albums_view_mode === "rows") {
+        this.albumsViewMode = settings.albums_view_mode;
+      }
+      if (settings?.artists_view_mode === "cards" || settings?.artists_view_mode === "rows") {
+        this.artistsViewMode = settings.artists_view_mode;
       }
     } catch (e) {
       console.error("Failed to load preference settings:", e);
@@ -49,6 +58,24 @@ class PrefsStore {
       await invoke("set_app_setting", { key: "acoustid_api_key", value: key });
     } catch (e) {
       console.error("Failed to save AcoustID API key:", e);
+    }
+  }
+
+  async setAlbumsViewMode(mode: CollectionViewMode) {
+    this.albumsViewMode = mode;
+    try {
+      await invoke("set_app_setting", { key: "albums_view_mode", value: mode });
+    } catch (e) {
+      console.error("Failed to save albums view mode:", e);
+    }
+  }
+
+  async setArtistsViewMode(mode: CollectionViewMode) {
+    this.artistsViewMode = mode;
+    try {
+      await invoke("set_app_setting", { key: "artists_view_mode", value: mode });
+    } catch (e) {
+      console.error("Failed to save artists view mode:", e);
     }
   }
 }

--- a/src/lib/utils/covers.test.ts
+++ b/src/lib/utils/covers.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { getArtistCoverStack, songsToCoverStack } from "./covers";
+
+describe("getArtistCoverStack", () => {
+  it("prefers real album art, front cover first", () => {
+    const result = getArtistCoverStack(
+      [
+        { sample_song_id: 1, art_manual: null, art_automatic: null, art_embedded: false },
+        { sample_song_id: 2, art_manual: "covers/b.jpg", art_automatic: null, art_embedded: false },
+      ],
+      []
+    );
+
+    expect(result).toEqual([{ songId: 2, artEmbedded: false, artAutomatic: null, artManual: "covers/b.jpg" }]);
+  });
+
+  it("falls back to song covers when no album has art", () => {
+    const result = getArtistCoverStack(
+      [{ sample_song_id: 1, art_manual: null, art_automatic: null, art_embedded: false }],
+      [{ id: 10, art_manual: "covers/song.jpg", art_automatic: null, art_embedded: false }]
+    );
+
+    expect(result).toEqual(songsToCoverStack([{ id: 10, art_manual: "covers/song.jpg", art_automatic: null, art_embedded: false }]));
+  });
+
+  it("returns an empty array when the artist has no art anywhere", () => {
+    expect(getArtistCoverStack([], [])).toEqual([]);
+  });
+});

--- a/src/lib/utils/covers.ts
+++ b/src/lib/utils/covers.ts
@@ -12,6 +12,13 @@ export interface CoverStackItem {
   artManual?: string | null;
 }
 
+export interface AlbumCoverSource {
+  sample_song_id?: number | null;
+  art_manual?: string | null;
+  art_automatic?: string | null;
+  art_embedded?: boolean;
+}
+
 /** Picks up to `max` visually-distinct covers (deduped by art source) from a song list, for CoverStack. */
 export function songsToCoverStack(songs: CoverSource[], max = 6): CoverStackItem[] {
   const seen = new Set<string>();
@@ -30,4 +37,36 @@ export function songsToCoverStack(songs: CoverSource[], max = 6): CoverStackItem
     }
   }
   return list;
+}
+
+/**
+ * An artist's covers for CoverStack, front-to-back: real per-album art first
+ * (so the front tile matches the artist's actual releases), falling back to
+ * covers pulled from their songs when no album has art of its own. Shared by
+ * ArtistCard (the full stack) and the compact row view (just the front tile,
+ * i.e. index 0) so both always agree on which cover represents the artist.
+ */
+export function getArtistCoverStack(
+  artistAlbums: AlbumCoverSource[],
+  artistSongs: CoverSource[],
+  max = 6
+): CoverStackItem[] {
+  const albumCovers = artistAlbums
+    .map((album) => ({
+      songId: album.sample_song_id ?? undefined,
+      artEmbedded: album.art_embedded,
+      artAutomatic: album.art_automatic,
+      artManual: album.art_manual,
+    }))
+    .filter((c) => c.artManual || c.artAutomatic || c.artEmbedded);
+
+  if (albumCovers.length > 0) {
+    return albumCovers.slice(0, max);
+  }
+
+  if (artistSongs.length > 0) {
+    return songsToCoverStack(artistSongs, max);
+  }
+
+  return [];
 }

--- a/src/lib/utils/playlist.ts
+++ b/src/lib/utils/playlist.ts
@@ -1,6 +1,10 @@
-import type { Playlist, QueuePopulationMode } from "../types";
+import { invoke } from "@tauri-apps/api/core";
+import type { AlbumItem, Playlist, QueuePopulationMode, Song } from "../types";
 import { i18n } from "../stores/i18n.svelte";
 import { isSmartPlaylistSpec } from "./filterParser";
+import { collectionStore } from "../stores/collection.svelte";
+import { playerStore } from "../stores/player.svelte";
+import { playlistsStore } from "../stores/playlists.svelte";
 
 export function getPopulationModeSuffix(mode: QueuePopulationMode | string | undefined | null): string {
   switch (mode) {
@@ -27,4 +31,34 @@ export function getPlaylistDisplayName(
   }
   const suffix = getPopulationModeSuffix(playlist.population_mode);
   return suffix ? `${baseName} ${suffix}` : baseName;
+}
+
+/**
+ * Queues an album into its dedicated "Album: {name}" playlist (reusing/clearing
+ * it if one already exists) and starts playback. Shared double-click action
+ * for AlbumCard and the compact row view — keeps both entry points in sync.
+ */
+export async function queueAlbumAsPlaylist(album: AlbumItem): Promise<void> {
+  const albumName = album.album || i18n.t("collection.unknownAlbum");
+  const playlistName = i18n.t("collection.albumPlaylistName", { name: albumName });
+  const existingPlaylist = playlistsStore.playlists.find((p) => p.name === playlistName);
+
+  if (existingPlaylist) {
+    await playlistsStore.selectPlaylist(existingPlaylist.id);
+    await playlistsStore.clearPlaylist(existingPlaylist.id);
+  } else {
+    await playlistsStore.createPlaylist(playlistName);
+  }
+
+  try {
+    const songs = await invoke<Song[]>("get_songs_by_album", { album: album.album || "" });
+    if (songs.length > 0 && playlistsStore.activeCustomPlaylist) {
+      const songIds = songs.map((s) => s.id);
+      await playlistsStore.addSongsToPlaylist(playlistsStore.activeCustomPlaylist.id, songIds);
+      collectionStore.activeTab = "playlists";
+      await playerStore.playPlaylistItem(playlistsStore.activeCustomPlaylist.id, 0);
+    }
+  } catch (err) {
+    console.error("Failed to add album to playlist:", err);
+  }
 }

--- a/walkthrough.md
+++ b/walkthrough.md
@@ -1,0 +1,72 @@
+# Walkthrough: Compact Rows view for Albums/Artists
+
+Implements [#220](https://github.com/esoltys/luminous/issues/220) on branch
+`worktree-collection-rows-view` (worktree: `.claude/worktrees/collection-rows-view`).
+
+## What changed
+
+- **New toggle**: a Cards/Rows icon toggle (grid / rows icons) now sits above the
+  "Showing N albums/artists" line in the Collection view's Albums and Artists tabs.
+  Albums and Artists each remember their own view mode independently, and the
+  choice persists across restarts (same mechanism as the waveform/moodbar seek
+  bar toggle — stored via the backend `app_state` settings table).
+- **Rows view**: a new compact row layout, reusing the same visual shell as the
+  Home page's "Recently Added" rows — a small square cover thumbnail, title,
+  subtitle, and trailing metadata, wrapped in a responsive grid so rows flow
+  left-to-right then down (1-2-3 / 4-5-6) instead of stacking in a single column.
+  - Album rows: cover art is the album's own single `CoverArt` (embedded/automatic/
+    manual art via `sample_song_id`), title/artist, track-count label, and year.
+    Click to open the album, double-click to queue/play it — no hover play
+    button, matching the click-to-play removal already on `main` (#221).
+  - Artist rows: cover art is derived the same way `ArtistCard`'s `CoverStack`
+    picks its *front* tile (first album with real art, else the artist's first
+    song) — pulled out into a shared `getArtistCoverStack()` helper so the card
+    and the row can never disagree on which cover represents an artist.
+- **Cards view is unchanged** — same `AlbumCard`/`ArtistCard` grid as before.
+
+## Notable refactors (no behavior change)
+
+- `ArtistCard.svelte`'s inline cover-selection logic moved to
+  `utils/covers.ts::getArtistCoverStack()`, reused by the new `ArtistRowCard`.
+- `AlbumCard.svelte`'s double-click "queue this album into a playlist and play
+  it" logic moved to `utils/playlist.ts::queueAlbumAsPlaylist()`, reused by
+  the new `AlbumRowCard` so both views behave identically on double-click.
+
+## Files touched
+
+- `src/lib/stores/prefs.svelte.ts` — `albumsViewMode` / `artistsViewMode`
+- `src/lib/utils/covers.ts` — `getArtistCoverStack()` (+ test)
+- `src/lib/utils/playlist.ts` — `queueAlbumAsPlaylist()`
+- `src/lib/components/AlbumRowCard.svelte`, `ArtistRowCard.svelte` (new, + tests)
+- `src/lib/components/CollectionView.svelte` — toggle UI, view-mode-aware rendering
+- `src/lib/components/AlbumCard.svelte`, `ArtistCard.svelte` — refactored to use
+  the shared helpers above
+- `src/lib/locales/en.ts` / `fr.ts` — `collection.viewCards` / `collection.viewRows`
+
+## Checks run
+
+- `bun run check` — 0 errors, 0 warnings
+- `bun run test:run` — 276/276 tests passing (14 new: toggle behavior in
+  `CollectionView.test.ts`, `AlbumRowCard.test.ts`, `ArtistRowCard.test.ts`,
+  `covers.test.ts`)
+
+## How to verify manually
+
+The dev server is running (`bun run tauri dev`, launched from this worktree).
+In the app:
+
+1. Go to **Collection → Albums**. You should see the new toggle above "Showing
+   N albums" — click the rows icon to switch to the compact list, click the
+   grid icon to switch back. Reload/restart the app and confirm it remembers
+   "rows".
+2. Go to **Collection → Artists** and repeat — confirm its toggle is
+   independent of the Albums tab's choice.
+3. In Albums rows view: click a row to open the album; double-click a row
+   and confirm it queues/plays the same "Album: {name}" playlist as
+   double-clicking a card does today (no hover play button, by design).
+4. In Artists rows view: confirm each row's cover matches the front cover
+   shown on that same artist's card in Cards view.
+
+Not merged yet — waiting on your review. Let me know if anything should
+change before I merge `worktree-collection-rows-view` into `main` and close
+#220.


### PR DESCRIPTION
## 📋 Summary
Adds a compact Rows view to the Albums and Artists Collection tabs, as an alternative to the existing card grid. Addresses #220.

- New Cards/Rows icon toggle above "Showing N albums/artists", one preference per tab (Albums and Artists remember their view mode independently), persisted via the backend `app_state` settings table so it survives restarts — same mechanism as the waveform/moodbar seek bar toggle.
- Rows view reuses the Home page "Recently Added" row shell (single `CoverArt` thumbnail, title/subtitle, trailing metadata) instead of `AlbumCard`/`ArtistCard`'s `CoverStack` collage — the collage doesn't read as a stack at row size, so it collapses to one image.
- Rows flow left-to-right then wrap down (responsive `auto-fill` grid) instead of stacking single-column like the Home rows do.

## 🔍 Implementation Notes
- **Album rows** map directly onto `AlbumItem`'s own `art_embedded`/`art_automatic`/`art_manual`/`sample_song_id` fields — no new data needed. Click opens the album, double-click queues/plays it via a new shared `queueAlbumAsPlaylist()` helper (extracted from `AlbumCard`'s dblclick handler so both views stay in sync). No hover play button, matching the click-to-play removal already on `main` (#221) — an earlier draft of this PR still had one, copied from a stale in-context read of `HomeRowList.svelte` predating that removal; fixed in the second commit.
- **Artist rows** have no canonical art field of their own, so the cover is derived the same way `ArtistCard`'s `CoverStack` picks its front tile (first album with real art, else the artist's first song's art) — pulled out into a shared `getArtistCoverStack()` helper in `utils/covers.ts` so the card and the row can never disagree on which cover represents an artist.
- Cards view is unchanged.
- New files: `AlbumRowCard.svelte`, `ArtistRowCard.svelte` (+ tests). Refactored (behavior-preserving): `AlbumCard.svelte`, `ArtistCard.svelte` to use the new shared helpers.

## 🧪 Test Plan
- [x] `bun run check` (svelte-check) — 0 errors, 0 warnings
- [x] `bun run test -- --run` (frontend) — 276/276 passing, 14 new (toggle behavior, both row components, `getArtistCoverStack`)
- [ ] `cargo test` (src-tauri, if Rust changed) — n/a, no Rust changes (view mode persists through the existing generic `set_app_setting`/`get_all_app_settings` commands)
- [x] Manually verified in the app: ran `bun run tauri dev` against the real library, toggled Cards/Rows on both Albums and Artists tabs, confirmed independent persistence and row content/behavior

## 📸 Screenshots
<img width="1584" height="868" alt="image" src="https://github.com/user-attachments/assets/746b1c53-5f79-4835-afab-298c51d2efa5" />

<img width="1586" height="849" alt="image" src="https://github.com/user-attachments/assets/c4015088-0e26-4a27-89e3-5fb8b92d9d87" />


## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed — n/a, no docs screenshots reference the Collection view's Albums/Artists grid
