### PR TITLE
Detect and explain a database schema newer than the app

### DIFF
--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -43,6 +43,26 @@ pub fn get_commit_hash() -> String {
     option_env!("BUILD_COMMIT_HASH").unwrap_or("").to_string()
 }
 
+#[derive(serde::Serialize)]
+pub struct DbSchemaStatus {
+    pub db_version: i32,
+    pub app_version: i32,
+    pub db_newer_than_app: bool,
+}
+
+/// Lets the frontend distinguish "library is genuinely empty" from "this
+/// database was last opened by a newer build and this one can't read its
+/// current schema" — the latter looks identical to an empty library (queries
+/// naming a since-added/removed column just fail) without this check.
+#[tauri::command]
+pub fn get_db_schema_status(state: State<'_, crate::AppState>) -> DbSchemaStatus {
+    DbSchemaStatus {
+        db_version: state.db.schema_version,
+        app_version: crate::db::CURRENT_SCHEMA_VERSION,
+        db_newer_than_app: state.db.is_newer_than_app(),
+    }
+}
+
 pub fn get_fade_settings_from_db(
     db: &crate::db::Database,
 ) -> Result<crate::models::FadeSettings, String> {

--- a/src-tauri/src/commands/window.rs
+++ b/src-tauri/src/commands/window.rs
@@ -103,7 +103,10 @@ pub async fn enter_miniplayer_mode(
         height: target_h,
     }));
     if let (Some(px), Some(py)) = (x, y) {
-        let _ = window.set_position(tauri::Position::Logical(tauri::LogicalPosition { x: px, y: py }));
+        let _ = window.set_position(tauri::Position::Logical(tauri::LogicalPosition {
+            x: px,
+            y: py,
+        }));
     } else {
         let _ = window.move_window(Position::TopRight);
     }
@@ -135,7 +138,10 @@ pub async fn exit_miniplayer_mode(
         height: target_h,
     }));
     if let (Some(px), Some(py)) = (x, y) {
-        let _ = window.set_position(tauri::Position::Logical(tauri::LogicalPosition { x: px, y: py }));
+        let _ = window.set_position(tauri::Position::Logical(tauri::LogicalPosition {
+            x: px,
+            y: py,
+        }));
     } else {
         let _ = window.move_window(Position::Center);
     }
@@ -146,10 +152,7 @@ pub async fn exit_miniplayer_mode(
 }
 
 #[tauri::command]
-pub async fn move_window_to_preset(
-    window: WebviewWindow,
-    position: String,
-) -> Result<(), String> {
+pub async fn move_window_to_preset(window: WebviewWindow, position: String) -> Result<(), String> {
     let pos = match position.as_str() {
         "TopLeft" => Position::TopLeft,
         "TopRight" => Position::TopRight,
@@ -166,9 +169,7 @@ pub async fn move_window_to_preset(
 }
 
 #[tauri::command]
-pub async fn get_window_geometry(
-    window: WebviewWindow,
-) -> Result<serde_json::Value, String> {
+pub async fn get_window_geometry(window: WebviewWindow) -> Result<serde_json::Value, String> {
     let size = window.inner_size().map_err(|e| e.to_string())?;
     let pos = window.outer_position().ok();
     let scale_factor = window.scale_factor().unwrap_or(1.0);

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -9,14 +9,27 @@ use std::path::PathBuf;
 pub type DbPool = Pool<SqliteConnectionManager>;
 
 /// Current schema version. Increment when adding migrations.
-const CURRENT_SCHEMA_VERSION: i32 = 13;
+pub const CURRENT_SCHEMA_VERSION: i32 = 13;
 
 #[derive(Debug)]
 pub struct Database {
     pub pool: DbPool,
+    /// Schema version found in `schema_version` on open, after any migrations this
+    /// build knows how to run. Normally equal to `CURRENT_SCHEMA_VERSION`, but can be
+    /// higher if this database was last opened by a newer build of the app (older
+    /// builds only ever migrate upward, never down) — see `is_newer_than_app`.
+    pub schema_version: i32,
 }
 
 impl Database {
+    /// True when this database's schema is ahead of what this build knows how to
+    /// read/write — e.g. a newer build ran migrations this older binary has never
+    /// seen. Queries that name columns added/removed by those migrations will fail
+    /// even though the app otherwise starts fine.
+    pub fn is_newer_than_app(&self) -> bool {
+        self.schema_version > CURRENT_SCHEMA_VERSION
+    }
+
     /// Create (or open) the Luminous database in `app_data_dir/luminous.db`.
     pub fn new(app_data_dir: PathBuf) -> Result<Self> {
         std::fs::create_dir_all(&app_data_dir).context("failed to create app data directory")?;
@@ -40,13 +53,24 @@ impl Database {
             .build(manager)
             .context("failed to create connection pool")?;
 
-        let db = Self { pool };
-        db.run_migrations()?;
+        let db = Self {
+            pool,
+            schema_version: 0,
+        };
+        let schema_version = db.run_migrations()?;
 
-        Ok(db)
+        Ok(Self {
+            schema_version,
+            ..db
+        })
     }
 
-    fn run_migrations(&self) -> Result<()> {
+    /// Runs any migrations this build knows about and returns the resulting schema
+    /// version. If the database is already ahead of `CURRENT_SCHEMA_VERSION` (opened
+    /// by a newer build previously), every `version < N` check below is false, so no
+    /// migration runs and the on-disk version is returned unchanged — see
+    /// `is_newer_than_app`.
+    fn run_migrations(&self) -> Result<i32> {
         let conn = self.pool.get().context("failed to get db connection")?;
 
         // Create schema_version table if it doesn't exist
@@ -183,7 +207,17 @@ impl Database {
             )?;
         }
 
-        Ok(())
+        if version > CURRENT_SCHEMA_VERSION {
+            log::warn!(
+                "Database schema version {version} is newer than this app supports (max {CURRENT_SCHEMA_VERSION}) — was this database last opened by a newer version of Luminous? Skipping migrations; some data may not load until you update the app."
+            );
+            // No migration above ran (every `version < N` check was false), so the
+            // on-disk version is unchanged.
+            return Ok(version);
+        }
+
+        // Every migration up to CURRENT_SCHEMA_VERSION ran above.
+        Ok(CURRENT_SCHEMA_VERSION)
     }
 }
 
@@ -516,6 +550,43 @@ mod tests {
             |r| r.get(0)
         ).unwrap();
         assert_eq!(tables_count, 3);
+
+        // Cleanup
+        let _ = std::fs::remove_dir_all(temp_dir);
+    }
+
+    #[test]
+    fn test_schema_newer_than_app_detected_without_running_migrations_backward() {
+        let temp_dir = std::env::temp_dir().join(format!(
+            "luminous_test_{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let db = Database::new(temp_dir.clone()).unwrap();
+        assert_eq!(db.schema_version, CURRENT_SCHEMA_VERSION);
+        assert!(!db.is_newer_than_app());
+        drop(db);
+
+        // Simulate a newer build having stamped a future schema version onto
+        // this database, as if it were opened by that build previously.
+        {
+            let manager = SqliteConnectionManager::file(temp_dir.join("luminous.db"));
+            let pool = r2d2::Pool::builder().max_size(1).build(manager).unwrap();
+            let conn = pool.get().unwrap();
+            conn.execute(
+                "INSERT OR REPLACE INTO schema_version (version) VALUES (?1)",
+                params![CURRENT_SCHEMA_VERSION + 1],
+            )
+            .unwrap();
+        }
+
+        // Reopening with this (older) build must not error and must not try
+        // to run migrations backward — it should just surface the mismatch.
+        let db = Database::new(temp_dir.clone()).unwrap();
+        assert_eq!(db.schema_version, CURRENT_SCHEMA_VERSION + 1);
+        assert!(db.is_newer_than_app());
 
         // Cleanup
         let _ = std::fs::remove_dir_all(temp_dir);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -687,6 +687,7 @@ pub fn run() {
             commands::settings::set_app_setting,
             commands::settings::get_all_app_settings,
             commands::settings::get_commit_hash,
+            commands::settings::get_db_schema_status,
             commands::settings::get_fade_settings,
             commands::settings::set_fade_settings,
             install_format::get_install_format,

--- a/src/lib/components/LibraryWelcome.svelte
+++ b/src/lib/components/LibraryWelcome.svelte
@@ -1,8 +1,14 @@
 <script lang="ts">
-  import { Music, FolderClosed } from "lucide-svelte";
+  import { Music, FolderClosed, RefreshCw } from "lucide-svelte";
   import { i18n } from "../stores/i18n.svelte";
   import { collectionStore } from "../stores/collection.svelte";
   import Button from "./Button.svelte";
+
+  // A database last opened by a newer Luminous build looks identical to a
+  // genuinely empty library (song queries naming a since-changed column just
+  // fail) — this flag, set once at startup from get_db_schema_status, lets us
+  // tell the two apart instead of misleadingly offering to "add a folder".
+  let dbNewer = $derived(collectionStore.dbSchemaStatus?.db_newer_than_app ?? false);
 </script>
 
 <!-- Shown wherever a view would otherwise render an empty grid/list because no
@@ -10,17 +16,34 @@
      matched nothing" empty states, which keep their own dashed-border treatment. -->
 <div class="flex flex-col items-center justify-center max-w-sm mx-auto text-center p-8 bg-brand-sidebar/40 rounded-xl border border-brand-border select-none">
   <div class="w-14 h-14 rounded-full bg-brand-accent/15 border border-brand-accent/30 flex items-center justify-center mb-4">
-    <Music class="w-7 h-7 text-brand-accent-text" />
+    {#if dbNewer}
+      <RefreshCw class="w-7 h-7 text-brand-accent-text" />
+    {:else}
+      <Music class="w-7 h-7 text-brand-accent-text" />
+    {/if}
   </div>
-  <h3 class="text-base font-semibold text-brand-text-primary mb-1.5">{i18n.t('emptyLibrary.title')}</h3>
-  <p class="text-xs text-brand-text-secondary mb-5 leading-relaxed">{i18n.t('emptyLibrary.text')}</p>
-  <div class="flex items-center gap-2">
-    <Button onclick={() => collectionStore.addDirectoryDialog()} variant="primary" size="sm">
-      <FolderClosed class="w-3.5 h-3.5" />
-      {i18n.t('settings.addFolder')}
+  {#if dbNewer}
+    <h3 class="text-base font-semibold text-brand-text-primary mb-1.5">{i18n.t('dbNewerThanApp.title')}</h3>
+    <p class="text-xs text-brand-text-secondary mb-5 leading-relaxed">
+      {i18n.t('dbNewerThanApp.text', {
+        dbVersion: collectionStore.dbSchemaStatus?.db_version,
+        appVersion: collectionStore.dbSchemaStatus?.app_version,
+      })}
+    </p>
+    <Button onclick={() => { collectionStore.activeTab = 'settings'; }} variant="primary" size="sm">
+      {i18n.t('sidebar.settings')}
     </Button>
-    <Button onclick={() => { collectionStore.activeTab = 'help'; }} variant="secondary" size="sm">
-      {i18n.t('sidebar.help')}
-    </Button>
-  </div>
+  {:else}
+    <h3 class="text-base font-semibold text-brand-text-primary mb-1.5">{i18n.t('emptyLibrary.title')}</h3>
+    <p class="text-xs text-brand-text-secondary mb-5 leading-relaxed">{i18n.t('emptyLibrary.text')}</p>
+    <div class="flex items-center gap-2">
+      <Button onclick={() => collectionStore.addDirectoryDialog()} variant="primary" size="sm">
+        <FolderClosed class="w-3.5 h-3.5" />
+        {i18n.t('settings.addFolder')}
+      </Button>
+      <Button onclick={() => { collectionStore.activeTab = 'help'; }} variant="secondary" size="sm">
+        {i18n.t('sidebar.help')}
+      </Button>
+    </div>
+  {/if}
 </div>

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -61,6 +61,10 @@ export const en = {
     title: "Welcome to Luminous",
     text: "Your music library is currently empty. Check out Help in the sidebar to get started, or add a folder to begin scanning your music."
   },
+  dbNewerThanApp: {
+    title: "Database From a Newer Version",
+    text: "This library was last opened by a newer version of Luminous (database v{dbVersion}, this app supports v{appVersion}). Your folders and songs are still there — update Luminous to see them again."
+  },
   collection: {
     artists: "Artists ({count})",
     albums: "Albums ({count})",

--- a/src/lib/locales/fr.ts
+++ b/src/lib/locales/fr.ts
@@ -61,6 +61,10 @@ export const fr = {
     title: "Bienvenue dans Luminous",
     text: "Votre bibliothèque musicale est actuellement vide. Consultez l'Aide dans la barre latérale pour commencer, ou ajoutez un dossier pour analyser votre musique."
   },
+  dbNewerThanApp: {
+    title: "Base de données d'une version plus récente",
+    text: "Cette bibliothèque a été ouverte pour la dernière fois par une version plus récente de Luminous (base de données v{dbVersion}, cette application prend en charge la v{appVersion}). Vos dossiers et vos morceaux sont toujours là — mettez à jour Luminous pour les retrouver."
+  },
   collection: {
     artists: "Artistes ({count})",
     albums: "Albums ({count})",

--- a/src/lib/stores/collection.svelte.ts
+++ b/src/lib/stores/collection.svelte.ts
@@ -7,6 +7,7 @@ import type {
   Song,
   MusicDirectory,
   LibraryStats,
+  DbSchemaStatus,
   ScanProgress,
   AlbumItem,
   ArtistItem,
@@ -96,6 +97,11 @@ class CollectionStore {
    *  treating "not loaded yet" as "confirmed empty" (e.g. flashing the sidebar/tab
    *  to an empty-library state on every launch before real stats arrive). */
   statsLoaded = $state<boolean>(false);
+  /** Set once at startup. When `db_newer_than_app` is true, the library looking
+   *  empty isn't real emptiness — this build can't read data written by whatever
+   *  newer build last touched the database. LibraryWelcome swaps its message
+   *  based on this instead of the normal "add a folder" copy. */
+  dbSchemaStatus = $state<DbSchemaStatus | null>(null);
   isScanning = $state<boolean>(false);
   scanProgress = $state<ScanProgress | null>(null);
 
@@ -482,6 +488,7 @@ class CollectionStore {
       this.recordHistory();
 
       await this.refreshDirectories();
+      await this.refreshDbSchemaStatus();
       await this.refreshStats();
       await this.refreshLibrary();
 
@@ -653,6 +660,14 @@ class CollectionStore {
   async refreshStats() {
     this.stats = await invoke("get_library_stats");
     this.statsLoaded = true;
+  }
+
+  async refreshDbSchemaStatus() {
+    try {
+      this.dbSchemaStatus = await invoke<DbSchemaStatus>("get_db_schema_status");
+    } catch (err) {
+      console.error("Failed to load db schema status:", err);
+    }
   }
 
   async refreshLibrary() {

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -212,6 +212,16 @@ export interface LibraryStats {
   total_filesize_bytes: number;
 }
 
+/** Whether the on-disk database's schema is ahead of what this build understands —
+ *  e.g. a newer build of Luminous opened it previously. When true, song queries that
+ *  name a since-added/removed column fail, making the library look empty even though
+ *  it isn't; see LibraryWelcome.svelte. */
+export interface DbSchemaStatus {
+  db_version: number;
+  app_version: number;
+  db_newer_than_app: boolean;
+}
+
 export interface AlbumItem {
   artist: string | null;
   album: string | null;


### PR DESCRIPTION
## 📋 Summary
An older Luminous build opened against a database that was already migrated by a newer build (e.g. after `ALTER TABLE songs DROP COLUMN mood` in #218) silently fails every song query naming a since-changed column — the library looks empty even though the data is intact and the watched folders still show. This adds a proper detection + message for that mismatch instead of letting it masquerade as an empty library.

## 🔍 Implementation Notes
- `Database` now records the on-disk `schema_version` found on open and exposes `is_newer_than_app()`. Migrations already no-op when the DB is ahead of `CURRENT_SCHEMA_VERSION` (every `version < N` check is false), so this only adds *detection*, not new migration behavior — no risk of running migrations backward.
- New `get_db_schema_status` command exposes `{db_version, app_version, db_newer_than_app}` to the frontend.
- `collectionStore` fetches this once at startup alongside directories/stats.
- `LibraryWelcome.svelte` — the one shared empty-state component behind Home and every Collection tab — branches on `db_newer_than_app`: swaps the "add a folder" copy for an explanation of the version mismatch (with live db/app version numbers interpolated) and a button to Settings instead of Add Folder. Added in both EN and FR locales.
- `cargo fmt` (via pre-commit hook) also reformatted `src-tauri/src/commands/window.rs` — pure whitespace, unrelated to this change, left as-is.

## 🧪 Test Plan
- [x] `bun run check` (svelte-check) — 0 errors
- [x] `bun run vitest run src/lib/stores/collection.test.ts` — 18 passed
- [x] `cargo test` (db:: tests) — 2 passed, including a new test that stamps a future schema version and confirms it's detected without attempting backward migration
- [ ] Manually verified in the app — not run against a real newer-schema DB; logic verified via unit test + a static mockup of the new message

## 📸 Screenshots
Mocked side-by-side comparison of the old vs. new empty-state message (before/after) was shown for review during implementation; not attached here since it's a rendered mockup, not the real app.
<img width="1156" height="731" alt="image" src="https://github.com/user-attachments/assets/08b61865-7801-4b1e-b60c-83400f3254ef" />


## ✅ Checklist
- [x] No unrelated changes bundled in (aside from the incidental `window.rs` formatting noted above)
- [ ] Docs/screenshots updated if user-facing behavior changed — this is an edge-case error state, not a documented feature; not added to the docs screenshot harness