### PR TITLE
Disable browser-default shortcuts and context menu via tauri-plugin-prevent-default

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2671,6 +2671,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3066,6 +3075,7 @@ dependencies = [
  "tauri-plugin-notification",
  "tauri-plugin-opener",
  "tauri-plugin-positioner",
+ "tauri-plugin-prevent-default",
  "tauri-plugin-shell",
  "tauri-plugin-single-instance",
  "tauri-plugin-updater",
@@ -5251,6 +5261,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5858,6 +5889,22 @@ dependencies = [
  "tauri",
  "tauri-plugin",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "tauri-plugin-prevent-default"
+version = "5.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "674bac5c9831f4ca7ae42840768ac968b76353dcbe30bb0aad149c56f0be1389"
+dependencies = [
+ "bitflags 2.13.0",
+ "itertools 0.15.0",
+ "serde",
+ "strum",
+ "tauri",
+ "thiserror 2.0.18",
+ "webview2-com",
+ "windows 0.61.3",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -31,6 +31,12 @@ tauri-plugin-updater = "2"
 # on Wayland).
 tauri-plugin-window-state = "2"
 tauri-plugin-positioner = "2"
+# Suppress stock webview browser chrome (reload, find, print, zoom, native
+# context menu, devtools in release builds) so the app reads as native
+# rather than a browser tab (#212). `platform-windows` unlocks WebView2-only
+# settings (accelerator keys, pinch/ctrl-wheel zoom) not covered by the
+# cross-platform JS-injection flags, so it's only pulled in on Windows.
+tauri-plugin-prevent-default = "5"
 
 
 # --- Serialization ---
@@ -96,6 +102,12 @@ chrono = { version = "0.4", features = ["serde"] }
 parking_lot = "0.12"
 rand = "0.8"
 percent-encoding = "2"
+
+# WebView2-only settings for tauri-plugin-prevent-default (zoom control,
+# browser accelerator keys) — the feature links webview2-com/windows, so it's
+# gated to the Windows target only.
+[target.'cfg(windows)'.dependencies]
+tauri-plugin-prevent-default = { version = "5", features = ["platform-windows"] }
 
 [dev-dependencies]
 cucumber = { version = "0.20", features = ["macros"] }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -59,6 +59,42 @@ pub struct AppState {
     pub media_session: Option<media_session::MediaSessionHandle>,
 }
 
+/// Suppresses stock webview browser chrome — reload/find/print keybindings and
+/// the native right-click menu — so Luminous reads as a native app rather than
+/// a webview (#212). The only carve-out is `DEV_TOOLS` in debug builds, so
+/// `Ctrl+Shift+I` still opens devtools under `cargo tauri dev`; everything
+/// else (including the context menu and reload) is suppressed in both debug
+/// and release builds.
+///
+/// Zoom (`Ctrl+Plus/Minus`, `Ctrl+MouseWheel`, pinch-to-zoom) isn't covered by
+/// the plugin's cross-platform JS flags, so on Windows it's additionally
+/// killed at the WebView2 settings level via the `platform-windows` feature.
+/// `browser_accelerator_keys` is WebView2's blanket switch for the same
+/// shortcuts `Flags` targets (plus zoom, plus devtools) — only flipped off in
+/// release so it doesn't fight the devtools carve-out above.
+fn build_prevent_default_plugin<R: tauri::Runtime>() -> tauri::plugin::TauriPlugin<R> {
+    use tauri_plugin_prevent_default::Flags;
+
+    let flags = if cfg!(debug_assertions) {
+        Flags::all().difference(Flags::DEV_TOOLS)
+    } else {
+        Flags::all()
+    };
+    let builder = tauri_plugin_prevent_default::Builder::new().with_flags(flags);
+
+    #[cfg(target_os = "windows")]
+    let builder = {
+        use tauri_plugin_prevent_default::PlatformOptions;
+        let mut platform = PlatformOptions::new().pinch_zoom(false).zoom_control(false);
+        if !cfg!(debug_assertions) {
+            platform = platform.browser_accelerator_keys(false);
+        }
+        builder.platform(platform)
+    };
+
+    builder.build()
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     #[cfg(target_os = "linux")]
@@ -143,6 +179,7 @@ pub fn run() {
         .plugin(tauri_plugin_window_state::Builder::default().build())
         .plugin(tauri_plugin_positioner::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
+        .plugin(build_prevent_default_plugin())
         .plugin(tauri_plugin_single_instance::init(|app, args, _cwd| {
             if let Some(window) = app.get_webview_window("main") {
                 let _ = window.show();


### PR DESCRIPTION
## 📋 Summary
Addresses #212. Adopts `tauri-plugin-prevent-default` so Luminous reads as a native app instead of a stock webview: right-click no longer falls through to the native "Back/Reload/Inspect" menu, and `F5`/`Ctrl+R` reload, `Ctrl+F` find, `Ctrl+P` print, and zoom (`Ctrl+Plus/Minus`, `Ctrl+MouseWheel`, pinch) no longer fire.

## 🔍 Implementation Notes
- [`src-tauri/Cargo.toml`](src-tauri/Cargo.toml): added `tauri-plugin-prevent-default = "5"`, with the `platform-windows` feature enabled only under `[target.'cfg(windows)'.dependencies]` (it links `webview2-com`/`windows`, which don't build on other targets).
- [`src-tauri/src/lib.rs`](src-tauri/src/lib.rs): added `build_prevent_default_plugin()` and registered it alongside the other `.plugin(...)` calls.
  - Flags disable context menu, reload, find, print, downloads, etc. in **both** debug and release builds. The only carve-out is `DEV_TOOLS` in debug builds, so `Ctrl+Shift+I` still opens devtools under `cargo tauri dev`.
  - Zoom isn't covered by the plugin's cross-platform JS flags, so on Windows it's additionally killed at the WebView2 settings level (`pinch_zoom`, `zoom_control`) via the `platform-windows` feature — applied in both debug and release since it doesn't interact with devtools.
  - `browser_accelerator_keys` (WebView2's blanket switch covering the same shortcuts plus devtools) is only flipped off in release, so it doesn't fight the devtools carve-out in dev.
- OS-level global media-key shortcuts (registered via `tauri-plugin-global-shortcut`) are unaffected — they're a separate mechanism from this plugin's webview-scoped JS key interception.
- Audited existing `oncontextmenu` handlers in `CollectionView.svelte` and `AlbumCard.svelte` — all of them open custom context menus rather than purely suppressing the native one, so nothing was redundant to remove there.
- No Tauri capability/ACL changes needed — the plugin injects a script and touches WebView2 settings directly; it exposes no `#[tauri::command]`s to the frontend.

## 🧪 Test Plan
- [x] `cargo check` (src-tauri) — clean, no new warnings
- [x] `cargo test --no-run` (src-tauri) — test binaries compile
- [ ] `bun run check` (svelte-check) — no frontend changes in this PR
- [ ] `bun run test -- --run` (frontend) — no frontend changes in this PR
- [x] Manually verified in the app:
  - Dev build (`cargo tauri dev`): confirmed right-click and `F5`/`Ctrl+R` reload are suppressed; `Ctrl+Shift+I` still opens devtools.
  - Release build: confirmed everything (context menu, reload, zoom, devtools) is disabled.
  - Not yet verified on macOS/Linux (WKWebView/WebKitGTK) — this session's environment is Windows only.

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] No user-facing UI change, so no screenshot harness updates needed