### PR TITLE
Cap Cucumber scenario concurrency in BDD suites

### DIFF
--- a/src-tauri/tests/cover_art_bdd.rs
+++ b/src-tauri/tests/cover_art_bdd.rs
@@ -183,5 +183,8 @@ fn update_db_art_automatic(w: &mut CoverArtWorld) {
 
 #[tokio::main]
 async fn main() {
-    CoverArtWorld::run("../features/cover_art.feature").await;
+    CoverArtWorld::cucumber()
+        .max_concurrent_scenarios(4)
+        .run_and_exit("../features/cover_art.feature")
+        .await;
 }

--- a/src-tauri/tests/design_tools_bdd.rs
+++ b/src-tauri/tests/design_tools_bdd.rs
@@ -195,5 +195,8 @@ fn switched_to_default_theme(w: &mut DesignToolsWorld) {
 
 #[tokio::main]
 async fn main() {
-    DesignToolsWorld::run("../features/design_tools.feature").await;
+    DesignToolsWorld::cucumber()
+        .max_concurrent_scenarios(4)
+        .run_and_exit("../features/design_tools.feature")
+        .await;
 }

--- a/src-tauri/tests/equalizer_bdd.rs
+++ b/src-tauri/tests/equalizer_bdd.rs
@@ -157,5 +157,8 @@ fn all_coefficients_recalculate(w: &mut EqualizerWorld) {
 
 #[tokio::main]
 async fn main() {
-    EqualizerWorld::run("../features/equalizer.feature").await;
+    EqualizerWorld::cucumber()
+        .max_concurrent_scenarios(4)
+        .run_and_exit("../features/equalizer.feature")
+        .await;
 }

--- a/src-tauri/tests/library_scan_bdd.rs
+++ b/src-tauri/tests/library_scan_bdd.rs
@@ -190,5 +190,8 @@ fn skip_reparsing(w: &mut LibraryScanWorld, path: String) {
 
 #[tokio::main]
 async fn main() {
-    LibraryScanWorld::run("../features/library_scan.feature").await;
+    LibraryScanWorld::cucumber()
+        .max_concurrent_scenarios(4)
+        .run_and_exit("../features/library_scan.feature")
+        .await;
 }

--- a/src-tauri/tests/lyrics_bdd.rs
+++ b/src-tauri/tests/lyrics_bdd.rs
@@ -210,5 +210,8 @@ fn panel_scrolled(w: &mut LyricsWorld) {
 
 #[tokio::main]
 async fn main() {
-    LyricsWorld::run("../features/lyrics.feature").await;
+    LyricsWorld::cucumber()
+        .max_concurrent_scenarios(4)
+        .run_and_exit("../features/lyrics.feature")
+        .await;
 }

--- a/src-tauri/tests/playback_controls_bdd.rs
+++ b/src-tauri/tests/playback_controls_bdd.rs
@@ -130,5 +130,8 @@ fn check_gain_scale(w: &mut PlaybackControlsWorld, expected_gain: f32) {
 
 #[tokio::main]
 async fn main() {
-    PlaybackControlsWorld::run("../features/playback_controls.feature").await;
+    PlaybackControlsWorld::cucumber()
+        .max_concurrent_scenarios(4)
+        .run_and_exit("../features/playback_controls.feature")
+        .await;
 }

--- a/src-tauri/tests/playlists_bdd.rs
+++ b/src-tauri/tests/playlists_bdd.rs
@@ -161,5 +161,8 @@ fn track_order_reapplies(w: &mut PlaylistsWorld, step: &Step) {
 
 #[tokio::main]
 async fn main() {
-    PlaylistsWorld::run("../features/playlists.feature").await;
+    PlaylistsWorld::cucumber()
+        .max_concurrent_scenarios(4)
+        .run_and_exit("../features/playlists.feature")
+        .await;
 }

--- a/src-tauri/tests/tag_editor_bdd.rs
+++ b/src-tauri/tests/tag_editor_bdd.rs
@@ -156,5 +156,8 @@ fn form_fields_populated(w: &mut TagEditorWorld) {
 
 #[tokio::main]
 async fn main() {
-    TagEditorWorld::run("../features/tag_editor.feature").await;
+    TagEditorWorld::cucumber()
+        .max_concurrent_scenarios(4)
+        .run_and_exit("../features/tag_editor.feature")
+        .await;
 }


### PR DESCRIPTION
## 📋 Summary
`cargo test` memory usage was spiking on the dev machine. Investigation found the 8 Cucumber BDD suites in `src-tauri/tests/` (`equalizer_bdd`, `library_scan_bdd`, `playlists_bdd`, `playback_controls_bdd`, `lyrics_bdd`, `cover_art_bdd`, `tag_editor_bdd`, `design_tools_bdd`) all called the bare `SomeWorld::run(...)`, which uses cucumber's default of 64 concurrent scenarios. Several `World`s spin up real state per scenario (e.g. `library_scan_bdd` creates an actual `TempDir` and scans it), so a suite could burst dozens of these in parallel with no cap.

## 🔍 Implementation Notes
- Switched each suite's `main()` from `SomeWorld::run(path)` to `SomeWorld::cucumber().max_concurrent_scenarios(4).run_and_exit(path)`, capping concurrent scenarios from cucumber's default of 64 down to 4.
- 4 is a conservative default chosen to bound peak memory without a meaningful speed cost for these small feature files; easy to tune up/down later.
- Also recreated a local (gitignored) `src-tauri/.cargo/config.toml` with `[build] jobs = 6` to cap parallel rustc processes during compile — this doesn't show up in the diff since `.cargo/` is intentionally untracked, but is worth noting for future sessions since it explains why a "config we'd put in place" wasn't found in a fresh worktree.

## 🧪 Test Plan
- [x] `cargo test` (src-tauri) — `cargo check --tests` passes; full BDD suites compile and run under the new concurrency cap.
- [ ] `bun run check` (svelte-check) — no frontend changes in this PR
- [ ] `bun run test -- --run` (frontend) — no frontend changes in this PR
- [ ] Manually verified in the app — not applicable, test-only change

## 📸 Screenshots
Not applicable — no UI changes.

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed — not applicable, no user-facing behavior changed