### PR TITLE
fix(window): hide window on creation to prevent startup flash

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -13,6 +13,7 @@
     "windows": [
       {
         "title": "Luminous",
+        "visible": false,
         "width": 1280,
         "height": 800,
         "minWidth": 900,


### PR DESCRIPTION
## 📋 Summary
Follows the official [`tauri-plugin-window-state`](https://v2.tauri.app/plugin/window-state/) tip by setting `"visible": false` on the main application window in `tauri.conf.json`.

Because `tauri-plugin-window-state` restores saved window position and size asynchronously after window creation, creating the window with default visibility (`visible: true`) causes a brief visual flicker/position jump on startup. Setting `"visible": false` allows the plugin to automatically reveal the window once state restoration completes seamlessly.

## 🔍 Implementation Notes
- Updated `src-tauri/tauri.conf.json` under `app.windows[0]` to add `"visible": false`.
- `tauri-plugin-window-state` automatically calls `.show()` when state restoration is finished.

## 🧪 Test Plan
- [x] `bun run check` (svelte-check) - 0 errors, 0 warnings
- [x] `cargo check` - 0 errors
- [x] `cargo test --lib` - 82 passed, 0 failed
- [x] Manually verified in `bun run tauri dev` - confirmed no startup window flash when restoring position/size

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed
