### PR TITLE
feat(playlists): add refresh-all button next to the view toggle

### DIFF
--- a/src-tauri/src/playlist.rs
+++ b/src-tauri/src/playlist.rs
@@ -10,6 +10,16 @@ use rusqlite::{params, OptionalExtension};
 use std::sync::Arc;
 use uuid::Uuid;
 
+/// Minimum number of matching library songs required before a genre/decade
+/// auto-playlist is created. Once created, an auto-playlist is populated
+/// with every matching song (see [`NO_SONG_LIMIT`]), not just this many.
+const MIN_LIBRARY_SONGS_FOR_AUTO_PLAYLIST: i64 = 25;
+
+/// SQLite treats a negative `LIMIT` as "no limit" — used when populating an
+/// auto-playlist so it includes every matching song, however large the
+/// library (e.g. 500+ songs in a single decade).
+const NO_SONG_LIMIT: i64 = -1;
+
 // ---------------------------------------------------------------------------
 // Undo/Redo stack operations
 // ---------------------------------------------------------------------------
@@ -257,10 +267,17 @@ impl PlaylistManager {
                 .unwrap_or_default();
 
             // Check library threshold first. Auto-playlists are created if the library
-            // has at least 25 total songs for this genre (QueuePopulationMode::All).
+            // has at least MIN_LIBRARY_SONGS_FOR_AUTO_PLAYLIST total songs for this genre
+            // (QueuePopulationMode::All).
             // Once created, an auto-playlist is only pruned if all songs for this genre are removed (0 songs).
-            let total_songs = scanner.get_songs_by_genre(genre, 25, QueuePopulationMode::All)?;
-            if existing_row.is_none() && total_songs.len() < 25 {
+            let total_songs = scanner.get_songs_by_genre(
+                genre,
+                MIN_LIBRARY_SONGS_FOR_AUTO_PLAYLIST,
+                QueuePopulationMode::All,
+            )?;
+            if existing_row.is_none()
+                && total_songs.len() < MIN_LIBRARY_SONGS_FOR_AUTO_PLAYLIST as usize
+            {
                 continue;
             }
             if existing_row.is_some() && total_songs.is_empty() {
@@ -274,7 +291,7 @@ impl PlaylistManager {
                 continue;
             }
 
-            let songs = scanner.get_songs_by_genre(genre, 25, mode)?;
+            let songs = scanner.get_songs_by_genre(genre, NO_SONG_LIMIT, mode)?;
 
             let needs_generation = match existing_row {
                 None => true,
@@ -358,10 +375,17 @@ impl PlaylistManager {
                 .unwrap_or_default();
 
             // Check library threshold first. Auto-playlists are created if the library
-            // has at least 25 total songs for this decade (QueuePopulationMode::All).
+            // has at least MIN_LIBRARY_SONGS_FOR_AUTO_PLAYLIST total songs for this decade
+            // (QueuePopulationMode::All).
             // Once created, an auto-playlist is only pruned if all songs for this decade are removed (0 songs).
-            let total_songs = scanner.get_songs_by_decade(decade, 25, QueuePopulationMode::All)?;
-            if existing_row.is_none() && total_songs.len() < 25 {
+            let total_songs = scanner.get_songs_by_decade(
+                decade,
+                MIN_LIBRARY_SONGS_FOR_AUTO_PLAYLIST,
+                QueuePopulationMode::All,
+            )?;
+            if existing_row.is_none()
+                && total_songs.len() < MIN_LIBRARY_SONGS_FOR_AUTO_PLAYLIST as usize
+            {
                 continue;
             }
             if existing_row.is_some() && total_songs.is_empty() {
@@ -375,7 +399,7 @@ impl PlaylistManager {
                 continue;
             }
 
-            let songs = scanner.get_songs_by_decade(decade, 25, mode)?;
+            let songs = scanner.get_songs_by_decade(decade, NO_SONG_LIMIT, mode)?;
 
             let needs_generation = match existing_row {
                 None => true,
@@ -462,14 +486,14 @@ impl PlaylistManager {
 
         let scanner = CollectionScanner::new(self.db.clone());
         let songs = if let Some(decade) = spec.strip_prefix("decade:") {
-            scanner.get_songs_by_decade(decade, 100, mode)?
+            scanner.get_songs_by_decade(decade, NO_SONG_LIMIT, mode)?
         } else if !spec.contains(':') {
             // Bare-name convention: a system genre auto-playlist, not a Smart
             // Playlist rule spec (which always contains a "field:" rule).
-            scanner.get_songs_by_genre(&spec, 100, mode)?
+            scanner.get_songs_by_genre(&spec, NO_SONG_LIMIT, mode)?
         } else {
             let query = spec.replace(';', " ");
-            scanner.search_songs_by_mode(&query, 100, mode)?
+            scanner.search_songs_by_mode(&query, NO_SONG_LIMIT, mode)?
         };
 
         let now = chrono::Utc::now().timestamp();
@@ -1557,6 +1581,45 @@ mod tests {
 
         let tracks = manager.get_playlist_tracks(decade_playlists[0].id).unwrap();
         assert_eq!(tracks.len(), 25);
+
+        let _ = std::fs::remove_dir_all(temp_dir);
+    }
+
+    #[test]
+    fn test_sync_decade_auto_playlists_includes_every_matching_song() {
+        let (db, temp_dir) = setup_test_db();
+        let db_arc = std::sync::Arc::new(db);
+
+        {
+            let conn = db_arc.pool.get().unwrap();
+            // Well above the old hardcoded 25-song population cap.
+            for i in 0..60 {
+                conn.execute(
+                    &format!(
+                        "INSERT INTO songs (title, originalyear, source, unavailable) VALUES ('Track 80s {}', 1985, 1, 0)",
+                        i
+                    ),
+                    [],
+                )
+                .unwrap();
+            }
+        }
+
+        let manager = PlaylistManager::new(db_arc.clone()).unwrap();
+        manager.sync_decade_auto_playlists().unwrap();
+
+        let playlists = manager.get_playlists().unwrap();
+        let decade_playlist = playlists
+            .iter()
+            .find(|p| p.dynamic_enabled && p.dynamic_spec.as_deref() == Some("decade:1980s"))
+            .expect("expected 1980s auto-playlist to be created");
+
+        let tracks = manager.get_playlist_tracks(decade_playlist.id).unwrap();
+        assert_eq!(
+            tracks.len(),
+            60,
+            "auto-playlist should include every matching song, not just the first 25"
+        );
 
         let _ = std::fs::remove_dir_all(temp_dir);
     }

--- a/src/lib/components/PlaylistsCollectionView.svelte
+++ b/src/lib/components/PlaylistsCollectionView.svelte
@@ -19,7 +19,7 @@
   import Select from "./Select.svelte";
   import Button from "./Button.svelte";
   import Input from "./Input.svelte";
-  import { FolderInput, Plus, ListMusic, Sparkles, LayoutGrid, Rows3 } from "lucide-svelte";
+  import { FolderInput, Plus, ListMusic, Sparkles, LayoutGrid, Rows3, RefreshCw } from "lucide-svelte";
   import { isSmartPlaylistSpec } from "../utils/filterParser";
   import { getPlaylistDisplayName } from "../utils/playlist";
   import { rememberScroll } from "../utils/scrollMemory";
@@ -48,6 +48,32 @@
     }
     await playlistsStore.refreshAutoPlaylistCounts();
   });
+
+  let isRefreshingAll = $state(false);
+
+  async function handleRefreshAll() {
+    if (isRefreshingAll) return;
+    isRefreshingAll = true;
+    try {
+      // Pick up genres/decades that just crossed the auto-playlist threshold,
+      // and prune ones that no longer have any matching songs.
+      await invoke("sync_genre_auto_playlists");
+      await invoke("sync_decade_auto_playlists");
+      await playlistsStore.refreshPlaylists();
+
+      // Force-regenerate every dynamic playlist (genre/decade auto-playlists
+      // and user-created Smart Playlists) with the latest matching songs,
+      // bypassing the 24h staleness gate the background sync uses.
+      const dynamicIds = playlistsStore.playlists.filter((p) => p.dynamic_enabled).map((p) => p.id);
+      await Promise.all(dynamicIds.map((id) => invoke("refresh_auto_playlist", { playlistId: id })));
+
+      await playlistsStore.refreshAutoPlaylistCounts();
+    } catch (err) {
+      console.error("Failed to refresh playlists:", err);
+    } finally {
+      isRefreshingAll = false;
+    }
+  }
 
   // System genre auto-playlists are stored with a raw genre name as dynamic_spec (e.g. "Rock", "Jazz").
   // Smart playlists built via the Smart Playlist builder always contain a "field:value" rule (e.g. "genre:jazz rating:>=4").
@@ -278,6 +304,15 @@
 
           <!-- View Mode Toggle + Sort Dropdown (Right) -->
           <div class="flex items-center gap-2">
+            <button
+              onclick={handleRefreshAll}
+              disabled={isRefreshingAll}
+              class="flex items-center justify-center w-9 h-9 rounded-full border border-brand-border bg-brand-sidebar text-brand-text-secondary hover:text-brand-accent-text hover:border-brand-accent/60 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed shadow-xs"
+              title={i18n.t('playlists.refreshAllPlaylistsTooltip')}
+              aria-label={i18n.t('playlists.refreshAllPlaylistsTooltip')}
+            >
+              <RefreshCw class="w-4 h-4 {isRefreshingAll ? 'animate-spin' : ''}" />
+            </button>
             <div class="inline-flex items-center gap-0.5 bg-brand-sidebar border border-brand-border rounded-full p-1">
               <button
                 onclick={() => setActiveViewMode("cards")}

--- a/src/lib/components/PlaylistsCollectionView.test.ts
+++ b/src/lib/components/PlaylistsCollectionView.test.ts
@@ -1,9 +1,10 @@
 import "@testing-library/jest-dom";
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render } from "@testing-library/svelte";
+import { render, fireEvent, waitFor } from "@testing-library/svelte";
 import PlaylistsCollectionView from "./PlaylistsCollectionView.svelte";
 import { collectionStore } from "../stores/collection.svelte";
 import { playlistsStore } from "../stores/playlists.svelte";
+import { invoke } from "@tauri-apps/api/core";
 
 vi.mock("@tauri-apps/api/core", () => ({
   invoke: vi.fn().mockImplementation((cmd: string) => {
@@ -34,6 +35,7 @@ vi.mock("@tauri-apps/api/core", () => ({
     if (cmd === "sync_genre_auto_playlists" || cmd === "sync_decade_auto_playlists") {
       return Promise.resolve(null);
     }
+    if (cmd === "refresh_auto_playlist") return Promise.resolve(null);
     return Promise.resolve([]);
   }),
 }));
@@ -75,5 +77,40 @@ describe("PlaylistsCollectionView.svelte - Decades Auto Playlists", () => {
     const { getByText } = render(PlaylistsCollectionView);
     expect(getByText("1980s")).toBeInTheDocument();
     expect(getByText("Rock")).toBeInTheDocument();
+  });
+
+  it("refreshes auto-playlists and Smart Playlists when the refresh-all button is clicked", async () => {
+    playlistsStore.playlists = [
+      {
+        id: 1,
+        name: "1980s",
+        dynamic_enabled: true,
+        dynamic_spec: "decade:1980s",
+        track_count: 12,
+        created: 1700000000,
+        updated: 1700000000,
+      },
+      {
+        id: 2,
+        name: "Rock",
+        dynamic_enabled: true,
+        dynamic_spec: "Rock",
+        track_count: 8,
+        created: 1700000000,
+        updated: 1700000000,
+      },
+    ];
+
+    const { getByTitle } = render(PlaylistsCollectionView);
+    const refreshButton = getByTitle("Refresh all auto-playlists and Smart Playlists with the latest songs from your library");
+
+    await fireEvent.click(refreshButton);
+
+    await waitFor(() => {
+      expect(invoke).toHaveBeenCalledWith("sync_genre_auto_playlists");
+      expect(invoke).toHaveBeenCalledWith("sync_decade_auto_playlists");
+      expect(invoke).toHaveBeenCalledWith("refresh_auto_playlist", { playlistId: 1 });
+      expect(invoke).toHaveBeenCalledWith("refresh_auto_playlist", { playlistId: 2 });
+    });
   });
 });

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -447,6 +447,7 @@ export const en = {
     makeActiveBtn: "Make Active",
     activeBadgeLabel: "Active",
     refreshAutoPlaylistTooltip: "Refresh auto-playlist with a new selection of songs from your library",
+    refreshAllPlaylistsTooltip: "Refresh all auto-playlists and Smart Playlists with the latest songs from your library",
     allMatchingTracksAdded: "All matching songs from your library have been added to this auto-playlist.",
     playSelected: "Play Selected",
     removeSelected: "Remove Selected",

--- a/src/lib/locales/fr.ts
+++ b/src/lib/locales/fr.ts
@@ -446,6 +446,7 @@ export const fr = {
     makeActiveBtn: "Définir comme active",
     activeBadgeLabel: "Active",
     refreshAutoPlaylistTooltip: "Rafraîchir la playlist automatique avec une nouvelle sélection de titres de votre bibliothèque",
+    refreshAllPlaylistsTooltip: "Rafraîchir toutes les playlists automatiques et intelligentes avec les derniers titres de votre bibliothèque",
     allMatchingTracksAdded: "Tous les titres correspondants de votre bibliothèque ont été ajoutés à cette liste automatique.",
     playSelected: "Lire la sélection",
     removeSelected: "Retirer la sélection",


### PR DESCRIPTION
## 📋 Summary
Adds a Refresh icon to the left of the card/row view toggle on the Playlists collection screen (both the Auto and Custom sub-tabs). Clicking it:
- Re-syncs genre/decade auto-playlists (`sync_genre_auto_playlists` / `sync_decade_auto_playlists`) so newly-thresholded genres/decades get created and emptied ones get pruned.
- Force-regenerates every dynamic playlist — auto-playlists and rule-based Smart Playlists alike — via the existing `refresh_auto_playlist` command, bypassing the 24h staleness gate the background sync normally uses, so it's an immediate full refresh.

No backend changes — reuses existing commands, including the unlimited-song population fix from #241.

## 🔍 Implementation Notes
- `src/lib/components/PlaylistsCollectionView.svelte`: new `handleRefreshAll` handler + button, spins/disables while in flight.
- `src/lib/locales/en.ts` / `fr.ts`: added `playlists.refreshAllPlaylistsTooltip`.

## 🧪 Test Plan
- [x] `bun run check` (svelte-check) — clean
- [x] `bun run test -- --run` (frontend) — all 291 tests pass, including a new test verifying the button triggers sync + per-playlist refresh calls
- [ ] `cargo test` (src-tauri) — no Rust changes
- [x] Manually verified in the app

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed — N/A, small icon addition to an existing toolbar