### PR TITLE
Add independent album ratings, separate from song ratings

### DIFF
--- a/scripts/mock-library.ts
+++ b/scripts/mock-library.ts
@@ -190,6 +190,7 @@ export function deriveAlbums(songs: Song[]): AlbumItem[] {
         art_automatic: song.art_automatic ?? null,
         art_manual: song.art_manual ?? null,
         genre: song.genre ?? null,
+        rating: -1,
       });
     }
   }

--- a/src-tauri/src/collection.rs
+++ b/src-tauri/src/collection.rs
@@ -1003,7 +1003,11 @@ impl CollectionScanner {
                     GROUP BY genre
                     ORDER BY COUNT(*) DESC, genre ASC
                     LIMIT 1
-                ) AS genre
+                ) AS genre,
+                COALESCE(
+                    (SELECT rating FROM album_ratings ar WHERE ar.album_key = songs.album),
+                    -1
+                ) AS rating
              FROM songs
              WHERE source IN (1, 2) AND album IS NOT NULL AND unavailable = 0
              GROUP BY album
@@ -1021,6 +1025,7 @@ impl CollectionScanner {
                     "art_automatic": row.get::<_, Option<String>>(6)?,
                     "art_manual": row.get::<_, Option<String>>(7)?,
                     "genre": row.get::<_, Option<String>>(8)?,
+                    "rating": row.get::<_, f32>(9)?,
                 }))
             })?
             .filter_map(|r| r.ok())
@@ -1253,7 +1258,7 @@ impl CollectionScanner {
         let song_ids: Vec<i64> = agg_rows.iter().map(|r| r.representative_song_id).collect();
         let songs_by_id = get_songs_by_ids(&conn, &song_ids)?;
 
-        let items = agg_rows
+        let mut items: Vec<HomeItem> = agg_rows
             .into_iter()
             .filter_map(|row| {
                 let (song, album_track_count, album_disc_count) =
@@ -1268,6 +1273,7 @@ impl CollectionScanner {
                 ))
             })
             .collect();
+        attach_album_ratings(&conn, &mut items)?;
         Ok(items)
     }
 
@@ -1291,10 +1297,9 @@ impl CollectionScanner {
             })?
             .filter_map(|r| r.ok())
             .collect();
-        Ok(group_songs_into_home_items(
-            songs_with_counts,
-            limit as usize,
-        ))
+        let mut items = group_songs_into_home_items(songs_with_counts, limit as usize);
+        attach_album_ratings(&conn, &mut items)?;
+        Ok(items)
     }
 }
 
@@ -1334,6 +1339,7 @@ fn group_songs_into_home_items(
                             art_manual: song.art_manual.clone(),
                             genre: song.genre.clone(),
                             sample_song_id: Some(song.id),
+                            rating: crate::stats::RATING_UNRATED,
                         },
                     });
                 }
@@ -1347,6 +1353,21 @@ fn group_songs_into_home_items(
     }
 
     items
+}
+
+/// Fill in the real rating for every `HomeItem::Album` in `items`, looked up
+/// from `album_ratings`. `group_songs_into_home_items`/`home_item_for_context`
+/// build `AlbumItem`s without a DB connection in scope, so they default to
+/// unrated — this backfills the actual value once a connection is available.
+fn attach_album_ratings(conn: &rusqlite::Connection, items: &mut [HomeItem]) -> Result<()> {
+    for item in items.iter_mut() {
+        if let HomeItem::Album { album } = item {
+            if let Some(ref name) = album.album {
+                album.rating = crate::stats::get_album_rating(conn, name)?;
+            }
+        }
+    }
+    Ok(())
 }
 
 /// Dedup key for context-aware Recently Played — one entry per album,
@@ -1436,6 +1457,7 @@ fn home_item_for_context(
                     art_manual: song.art_manual.clone(),
                     genre: song.genre.clone(),
                     sample_song_id: Some(song.id),
+                    rating: crate::stats::RATING_UNRATED,
                 },
             }
         }
@@ -3270,6 +3292,52 @@ mod tests {
                 assert_eq!(
                     album.track_count, 10,
                     "should count all 10 tracks, not split by artist"
+                );
+            }
+            other => panic!("expected Album item, got {other:?}"),
+        }
+
+        let _ = std::fs::remove_dir_all(temp_dir);
+    }
+
+    #[test]
+    fn test_recently_added_surfaces_existing_album_rating() {
+        let temp_dir = std::env::temp_dir().join(format!(
+            "luminous_rec_added_rating_test_{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let db = Arc::new(Database::new(temp_dir.clone()).unwrap());
+        let scanner = CollectionScanner::new(db.clone());
+        let conn = db.pool.get().unwrap();
+
+        // Needs 2+ tracks — a single-track "album" renders as a Song item, not
+        // an Album item (see group_songs_into_home_items's album_track_count > 1 check).
+        for i in 1..=2 {
+            let song = Song {
+                source: SongSource::LocalFile,
+                path: Some(format!("path/rated_{i}.mp3")),
+                title: Some(format!("Rated Track {i}")),
+                artist: Some("Artist A".to_string()),
+                album: Some("Rated Album".to_string()),
+                album_artist: None,
+                added: Some(1000),
+                ..Default::default()
+            };
+            upsert_song(&conn, &song).unwrap();
+        }
+
+        crate::stats::set_album_rating(&conn, "Rated Album", 4.5).unwrap();
+
+        let items = scanner.get_recently_added(10).unwrap();
+        match &items[0] {
+            HomeItem::Album { album } => {
+                assert_eq!(album.album.as_deref(), Some("Rated Album"));
+                assert_eq!(
+                    album.rating, 4.5,
+                    "should surface the rating set via set_album_rating, not default to unrated"
                 );
             }
             other => panic!("expected Album item, got {other:?}"),

--- a/src-tauri/src/commands/stats.rs
+++ b/src-tauri/src/commands/stats.rs
@@ -30,3 +30,23 @@ pub async fn set_song_rating(
 
     Ok(normalized)
 }
+
+#[tauri::command]
+pub async fn set_album_rating(
+    album: String,
+    rating: f32,
+    app: AppHandle,
+    state: State<'_, AppState>,
+) -> Result<f32, String> {
+    let normalized = {
+        let conn = state.db.pool.get().map_err(|e| e.to_string())?;
+        crate::stats::set_album_rating(&conn, &album, rating).map_err(|e| e.to_string())?
+    };
+
+    let _ = app.emit(
+        "album-stats-changed",
+        serde_json::json!({ "album": album, "rating": normalized }),
+    );
+
+    Ok(normalized)
+}

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 pub type DbPool = Pool<SqliteConnectionManager>;
 
 /// Current schema version. Increment when adding migrations.
-pub const CURRENT_SCHEMA_VERSION: i32 = 13;
+pub const CURRENT_SCHEMA_VERSION: i32 = 14;
 
 #[derive(Debug)]
 pub struct Database {
@@ -204,6 +204,17 @@ impl Database {
             conn.execute(
                 "INSERT OR REPLACE INTO schema_version (version) VALUES (?1)",
                 params![13],
+            )?;
+        }
+
+        if version < 14 {
+            log::info!(
+                "Running migration 14: album_ratings table for independent album ratings (#242)"
+            );
+            conn.execute_batch(MIGRATION_14)?;
+            conn.execute(
+                "INSERT OR REPLACE INTO schema_version (version) VALUES (?1)",
+                params![14],
             )?;
         }
 
@@ -525,6 +536,19 @@ ALTER TABLE playlists ADD COLUMN population_mode TEXT NOT NULL DEFAULT 'all';
 
 const MIGRATION_13: &str = "
 ALTER TABLE songs DROP COLUMN mood;
+";
+
+// ---------------------------------------------------------------------------
+// Migration 14: album_ratings — independent album-level ratings, separate
+// from song ratings. Keyed by album title, matching how CollectionScanner::
+// get_albums already groups albums (by title alone, not artist) (#242).
+// ---------------------------------------------------------------------------
+
+const MIGRATION_14: &str = "
+CREATE TABLE IF NOT EXISTS album_ratings (
+    album_key TEXT PRIMARY KEY,
+    rating REAL NOT NULL DEFAULT -1
+);
 ";
 
 #[cfg(test)]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -735,6 +735,7 @@ pub fn run() {
             install_format::get_install_format,
             // Stats commands
             commands::stats::set_song_rating,
+            commands::stats::set_album_rating,
             // Organizer commands
             commands::organizer::preview_organize,
             commands::organizer::apply_organize,

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -666,6 +666,10 @@ pub struct AlbumItem {
     pub art_manual: Option<String>,
     pub genre: Option<String>,
     pub sample_song_id: Option<i64>,
+    /// Independent album rating (-1 = unrated, else 0.5–5.0). Populated by callers
+    /// that have a DB connection handy (see `attach_album_ratings`); defaults to
+    /// unrated at construction time.
+    pub rating: f32,
 }
 
 /// Represents a dynamic item in the Home curation carousels (a Song, an Album, or a Playlist).

--- a/src-tauri/src/stats.rs
+++ b/src-tauri/src/stats.rs
@@ -93,6 +93,31 @@ pub fn normalize_rating(rating: f32) -> f32 {
     snapped.clamp(0.5, 5.0)
 }
 
+/// Persist a rating for an album, keyed by album title (matching how
+/// `CollectionScanner::get_albums` groups albums), returning the normalized
+/// value actually stored. Independent of any song rating on that album.
+pub fn set_album_rating(conn: &Connection, album: &str, rating: f32) -> Result<f32> {
+    let normalized = normalize_rating(rating);
+    conn.execute(
+        "INSERT INTO album_ratings (album_key, rating) VALUES (?1, ?2)
+         ON CONFLICT(album_key) DO UPDATE SET rating = excluded.rating",
+        params![album, normalized],
+    )?;
+    Ok(normalized)
+}
+
+/// Look up an album's rating, defaulting to unrated when no row exists yet.
+pub fn get_album_rating(conn: &Connection, album: &str) -> Result<f32> {
+    let rating = conn
+        .query_row(
+            "SELECT rating FROM album_ratings WHERE album_key = ?1",
+            params![album],
+            |r| r.get::<_, f32>(0),
+        )
+        .unwrap_or(RATING_UNRATED);
+    Ok(rating)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -221,6 +246,41 @@ mod tests {
         assert_eq!(cleared, RATING_UNRATED);
         let (_, _, _, rating) = stats_row(&conn, id);
         assert_eq!(rating, RATING_UNRATED);
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn test_set_album_rating_persists_normalized_value_independent_of_songs() {
+        let (db, dir) = test_db();
+        let conn = db.pool.get().unwrap();
+        let id = insert_song(&conn, "/tmp/album_song.flac");
+        set_rating(&conn, id, 2.0).unwrap();
+
+        let stored = set_album_rating(&conn, "Test Album", 4.3).unwrap();
+        assert_eq!(stored, 4.5);
+        assert_eq!(get_album_rating(&conn, "Test Album").unwrap(), 4.5);
+
+        // Song rating on an unrelated song is untouched by the album rating.
+        let (_, _, _, song_rating) = stats_row(&conn, id);
+        assert_eq!(song_rating, 2.0);
+
+        let updated = set_album_rating(&conn, "Test Album", 1.0).unwrap();
+        assert_eq!(updated, 1.0);
+        assert_eq!(get_album_rating(&conn, "Test Album").unwrap(), 1.0);
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn test_get_album_rating_defaults_to_unrated() {
+        let (db, dir) = test_db();
+        let conn = db.pool.get().unwrap();
+
+        assert_eq!(
+            get_album_rating(&conn, "Never Rated").unwrap(),
+            RATING_UNRATED
+        );
 
         let _ = std::fs::remove_dir_all(dir);
     }

--- a/src/lib/components/AlbumCard.svelte
+++ b/src/lib/components/AlbumCard.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
+  import { invoke } from "@tauri-apps/api/core";
   import type { AlbumItem } from "../types";
   import { collectionStore } from "../stores/collection.svelte";
   import CoverStack, { type CoverItem } from "./CoverStack.svelte";
   import LinkButton from "./LinkButton.svelte";
+  import SongRating from "./SongRating.svelte";
   import { i18n } from "../stores/i18n.svelte";
-  import { getAlbumCategoryLabel } from "../utils/artist";
   import { queueAlbumAsPlaylist } from "../utils/playlist";
 
   interface Props {
@@ -41,6 +42,11 @@
     } else {
       await queueAlbumAsPlaylist(album);
     }
+  }
+
+  async function rateAlbum(rating: number) {
+    if (!album.album) return;
+    album.rating = await invoke<number>("set_album_rating", { album: album.album, rating });
   }
 
 </script>
@@ -89,7 +95,7 @@
     </div>
     <div class="flex items-center justify-between mt-0.5 text-xs text-brand-text-secondary font-medium gap-2">
       <span class="truncate min-w-0">{album.genre || ""}</span>
-      <span class="shrink-0">{getAlbumCategoryLabel(album.track_count, album.disc_count)}</span>
+      <span class="shrink-0"><SongRating rating={album.rating} onRate={rateAlbum} size="sm" /></span>
     </div>
   </div>
 </div>

--- a/src/lib/components/AlbumCard.test.ts
+++ b/src/lib/components/AlbumCard.test.ts
@@ -3,11 +3,9 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, fireEvent } from "@testing-library/svelte";
 import AlbumCard from "./AlbumCard.svelte";
 import { collectionStore } from "../stores/collection.svelte";
+import { prefs } from "../stores/prefs.svelte";
+import { invoke } from "@tauri-apps/api/core";
 import type { AlbumItem } from "../types";
-
-vi.mock("@tauri-apps/api/core", () => ({
-  invoke: vi.fn().mockResolvedValue([]),
-}));
 
 vi.mock("@tauri-apps/api/event", () => ({
   listen: vi.fn().mockResolvedValue(() => {}),
@@ -24,42 +22,32 @@ describe("AlbumCard.svelte", () => {
     art_automatic: null,
     art_manual: null,
     genre: "Alternative",
+    rating: -1,
   };
 
   beforeEach(() => {
     vi.clearAllMocks();
+    prefs.ratingStyle = "stars";
   });
 
-  it("renders album title, artist, year, genre, and category", () => {
+  it("renders album title, artist, year, and genre", () => {
     const { getByText } = render(AlbumCard, { props: { album: mockAlbum } });
 
     expect(getByText("Fake Nudes")).toBeInTheDocument();
     expect(getByText("Barenaked Ladies")).toBeInTheDocument();
     expect(getByText("2017")).toBeInTheDocument();
     expect(getByText("Alternative")).toBeInTheDocument();
-    expect(getByText("Album")).toBeInTheDocument();
   });
 
-  it("shows Single for a one-track release", () => {
-    const { getByText } = render(AlbumCard, {
-      props: { album: { ...mockAlbum, track_count: 1 } },
-    });
-    expect(getByText("Single")).toBeInTheDocument();
-  });
+  it("rates the album via the rating widget without navigating to it", async () => {
+    vi.mocked(invoke).mockResolvedValueOnce(4);
+    const viewAlbumSpy = vi.spyOn(collectionStore, "viewAlbum");
+    const { getByLabelText } = render(AlbumCard, { props: { album: mockAlbum } });
 
-  it("shows EP for a 2-6 track release", () => {
-    const { getByText } = render(AlbumCard, {
-      props: { album: { ...mockAlbum, track_count: 5 } },
-    });
-    expect(getByText("EP")).toBeInTheDocument();
-  });
+    await fireEvent.click(getByLabelText("Rate 4 of 5"));
 
-  it("shows an N-Disc Set label instead of Album when multi-disc, never both", () => {
-    const { getByText, queryByText } = render(AlbumCard, {
-      props: { album: { ...mockAlbum, track_count: 20, disc_count: 2 } },
-    });
-    expect(getByText("2-Disc Set")).toBeInTheDocument();
-    expect(queryByText("Album")).not.toBeInTheDocument();
+    expect(invoke).toHaveBeenCalledWith("set_album_rating", { album: "Fake Nudes", rating: 4 });
+    expect(viewAlbumSpy).not.toHaveBeenCalled();
   });
 
   it("navigates to album when album title is clicked", async () => {

--- a/src/lib/components/AlbumDetailView.svelte
+++ b/src/lib/components/AlbumDetailView.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { invoke } from "@tauri-apps/api/core";
   import { listen } from "@tauri-apps/api/event";
-  import { applySongStats, type SongStatsPayload } from "../utils/stats";
+  import { applySongStats, type SongStatsPayload, applyAlbumStats, type AlbumStatsPayload } from "../utils/stats";
   import { collectionStore } from "../stores/collection.svelte";
   import { playerStore } from "../stores/player.svelte";
   import { playlistsStore } from "../stores/playlists.svelte";
@@ -357,6 +357,12 @@
     song.rating = await invoke<number>("set_song_rating", { songId: song.id, rating });
   }
 
+  async function rateAlbum(rating: number) {
+    if (!albumItem?.album) return;
+    const normalized = await invoke<number>("set_album_rating", { album: albumItem.album, rating });
+    albumItem.rating = normalized;
+  }
+
   // Sync rating/playcount changes from other views and scrobble bumps into
   // this view's locally fetched song list.
   $effect(() => {
@@ -365,6 +371,22 @@
     listen<SongStatsPayload>("song-stats-changed", (event) => {
       const song = songs.find((s) => s.id === event.payload.song_id);
       if (song) applySongStats(song, event.payload);
+    }).then((fn) => {
+      if (disposed) fn();
+      else unlisten = fn;
+    });
+    return () => {
+      disposed = true;
+      unlisten?.();
+    };
+  });
+
+  // Sync album rating changes made from other views (e.g. the Collection grid).
+  $effect(() => {
+    let unlisten: (() => void) | undefined;
+    let disposed = false;
+    listen<AlbumStatsPayload>("album-stats-changed", (event) => {
+      if (albumItem && albumItem.album === event.payload.album) applyAlbumStats(albumItem, event.payload);
     }).then((fn) => {
       if (disposed) fn();
       else unlisten = fn;
@@ -419,6 +441,10 @@
           <span>{songs.length === 1 ? i18n.t('playlists.oneSong') : i18n.t('playlists.songsCount', { count: songs.length })}</span>
           <span>•</span>
           <span>{totalDurationLabel}</span>
+          {#if albumItem}
+            <span>•</span>
+            <SongRating rating={albumItem.rating} onRate={rateAlbum} size="sm" />
+          {/if}
         </div>
 
         <!-- Control Buttons -->

--- a/src/lib/components/AlbumRowCard.svelte
+++ b/src/lib/components/AlbumRowCard.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
+  import { invoke } from "@tauri-apps/api/core";
   import type { AlbumItem } from "../types";
   import { collectionStore } from "../stores/collection.svelte";
   import CoverArt from "./CoverArt.svelte";
+  import SongRating from "./SongRating.svelte";
   import { i18n } from "../stores/i18n.svelte";
-  import { getAlbumCategoryLabel } from "../utils/artist";
   import { queueAlbumAsPlaylist } from "../utils/playlist";
 
   interface Props {
@@ -35,6 +36,11 @@
       await queueAlbumAsPlaylist(album);
     }
   }
+
+  async function rateAlbum(rating: number) {
+    if (!album.album) return;
+    album.rating = await invoke<number>("set_album_rating", { album: album.album, rating });
+  }
 </script>
 
 <!-- svelte-ignore a11y_click_events_have_key_events -->
@@ -58,15 +64,14 @@
     />
   </div>
 
-  <div class="min-w-0 flex-1">
-    <p class="truncate text-sm font-semibold text-brand-text-primary">{album.album || i18n.t('collection.unknownAlbum')}</p>
-    <p class="truncate text-xs text-brand-text-secondary font-medium">{album.artist || i18n.t('collection.variousArtists')}</p>
-  </div>
-
-  <div class="shrink-0 max-w-40 text-right">
-    <p class="text-xs text-brand-text-secondary font-medium tabular-nums truncate">{getAlbumCategoryLabel(album.track_count, album.disc_count)}</p>
-    {#if album.year}
-      <p class="text-xs text-brand-text-secondary truncate">{album.year}</p>
-    {/if}
+  <div class="min-w-0 flex-1 flex flex-col gap-0.5">
+    <div class="flex items-center justify-between gap-2">
+      <p class="truncate text-sm font-semibold text-brand-text-primary min-w-0">{album.album || i18n.t('collection.unknownAlbum')}</p>
+      <span class="text-xs text-brand-text-secondary font-medium tabular-nums shrink-0">{album.year || ""}</span>
+    </div>
+    <div class="flex items-center justify-between gap-2">
+      <p class="truncate text-xs text-brand-text-secondary font-medium min-w-0">{album.artist || i18n.t('collection.variousArtists')}</p>
+      <span class="shrink-0"><SongRating rating={album.rating} onRate={rateAlbum} size="sm" /></span>
+    </div>
   </div>
 </div>

--- a/src/lib/components/AlbumRowCard.test.ts
+++ b/src/lib/components/AlbumRowCard.test.ts
@@ -3,11 +3,9 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, fireEvent } from "@testing-library/svelte";
 import AlbumRowCard from "./AlbumRowCard.svelte";
 import { collectionStore } from "../stores/collection.svelte";
+import { prefs } from "../stores/prefs.svelte";
+import { invoke } from "@tauri-apps/api/core";
 import type { AlbumItem } from "../types";
-
-vi.mock("@tauri-apps/api/core", () => ({
-  invoke: vi.fn().mockResolvedValue([]),
-}));
 
 vi.mock("@tauri-apps/api/event", () => ({
   listen: vi.fn().mockResolvedValue(() => {}),
@@ -24,19 +22,31 @@ describe("AlbumRowCard.svelte", () => {
     art_automatic: null,
     art_manual: null,
     genre: "Alternative",
+    rating: -1,
   };
 
   beforeEach(() => {
     vi.clearAllMocks();
+    prefs.ratingStyle = "stars";
   });
 
-  it("renders album title, artist, category, and year", () => {
+  it("renders album title/year on top and artist/rating on bottom", () => {
     const { getByText } = render(AlbumRowCard, { props: { album: mockAlbum } });
 
     expect(getByText("Fake Nudes")).toBeInTheDocument();
-    expect(getByText("Barenaked Ladies")).toBeInTheDocument();
-    expect(getByText("Album")).toBeInTheDocument();
     expect(getByText("2017")).toBeInTheDocument();
+    expect(getByText("Barenaked Ladies")).toBeInTheDocument();
+  });
+
+  it("rates the album via the rating widget without navigating to it", async () => {
+    vi.mocked(invoke).mockResolvedValueOnce(4);
+    const viewAlbumSpy = vi.spyOn(collectionStore, "viewAlbum");
+    const { getByLabelText } = render(AlbumRowCard, { props: { album: mockAlbum } });
+
+    await fireEvent.click(getByLabelText("Rate 4 of 5"));
+
+    expect(invoke).toHaveBeenCalledWith("set_album_rating", { album: "Fake Nudes", rating: 4 });
+    expect(viewAlbumSpy).not.toHaveBeenCalled();
   });
 
   it("shows Various Artists when the album has no artist", () => {

--- a/src/lib/components/ArtistCard.test.ts
+++ b/src/lib/components/ArtistCard.test.ts
@@ -29,6 +29,7 @@ describe("ArtistCard.svelte", () => {
     art_embedded: true,
     art_automatic: "covers/dave.jpg",
     art_manual: null,
+    rating: -1,
   };
 
   const mockSongWithArt: Song = {

--- a/src/lib/components/ArtistDetailView.svelte
+++ b/src/lib/components/ArtistDetailView.svelte
@@ -281,7 +281,7 @@
         {#each discographyItems as album (album.album)}
           <AlbumCard
             {album}
-            widthClass="w-40 shrink-0"
+            widthClass="w-48 shrink-0"
             showArtist={false}
             onclick={() => openAlbum(album)}
             oncontextmenu={(e) => handleAlbumContextMenu(e, album)}
@@ -304,7 +304,7 @@
     <div class="px-6 pt-10 {playerStore.currentSong ? 'pb-28' : 'pb-6'}">
       <HorizontalScrollRow title={i18n.t('artistDetail.playlistsFeaturing', { artist: artistName })}>
         {#each playlists as playlist (playlist.id)}
-          <PlaylistCard {playlist} widthClass="w-44 shrink-0" onClick={() => openPlaylist(playlist)} />
+          <PlaylistCard {playlist} widthClass="w-48 shrink-0" onClick={() => openPlaylist(playlist)} />
         {/each}
       </HorizontalScrollRow>
     </div>

--- a/src/lib/components/ArtistRowCard.test.ts
+++ b/src/lib/components/ArtistRowCard.test.ts
@@ -29,6 +29,7 @@ describe("ArtistRowCard.svelte", () => {
     art_embedded: false,
     art_automatic: "covers/dave.jpg",
     art_manual: null,
+    rating: -1,
   };
 
   beforeEach(() => {

--- a/src/lib/components/CollectionView.svelte
+++ b/src/lib/components/CollectionView.svelte
@@ -215,10 +215,13 @@
     });
   });
 
-  let albumSortField = $state<"album" | "artist" | "year" | "track_count">(
-    (typeof window !== "undefined" &&
-      (localStorage.getItem("sort_album_field") as "album" | "artist" | "year" | "track_count")) ||
-      "album"
+  let albumSortField = $state<"album" | "artist" | "year" | "rating">(
+    (() => {
+      if (typeof window === "undefined") return "album";
+      const saved = localStorage.getItem("sort_album_field");
+      if (saved === "track_count") return "album";
+      return (saved as "album" | "artist" | "year" | "rating") || "album";
+    })()
   );
   let albumSortAsc = $state(
     typeof window !== "undefined" ? localStorage.getItem("sort_album_asc") !== "false" : true
@@ -963,7 +966,7 @@
                   value={`${albumSortField}-${albumSortAsc}`}
                   onchange={(e) => {
                     const [field, asc] = e.currentTarget.value.split("-");
-                    albumSortField = field as "album" | "artist" | "year" | "track_count";
+                    albumSortField = field as "album" | "artist" | "year" | "rating";
                     albumSortAsc = asc === "true";
                   }}
                   class="bg-brand-sidebar border border-brand-border hover:border-brand-accent/60 text-brand-text-secondary text-xs rounded-full pl-2.5 pr-8 py-1.5 focus:outline-none focus:border-brand-accent transition-all font-medium"
@@ -974,8 +977,8 @@
                   <option value="artist-false">{i18n.t('collection.sortArtistNameDesc')}</option>
                   <option value="year-false">{i18n.t('collection.sortYearDesc')}</option>
                   <option value="year-true">{i18n.t('collection.sortYearAsc')}</option>
-                  <option value="track_count-false">{i18n.t('collection.sortTracksDesc')}</option>
-                  <option value="track_count-true">{i18n.t('collection.sortTracksAsc')}</option>
+                  <option value="rating-false">{i18n.t('collection.sortRatingDesc')}</option>
+                  <option value="rating-true">{i18n.t('collection.sortRatingAsc')}</option>
                 </Select>
               </div>
             {:else if collectionStore.activeSubTab === "artists"}

--- a/src/lib/components/CollectionView.test.ts
+++ b/src/lib/components/CollectionView.test.ts
@@ -85,6 +85,7 @@ describe("CollectionView.svelte", () => {
       art_embedded: false,
       art_automatic: null,
       art_manual: null,
+      rating: -1,
     },
   ];
 

--- a/src/lib/components/HomeRowList.svelte
+++ b/src/lib/components/HomeRowList.svelte
@@ -1,12 +1,11 @@
 <script lang="ts">
-  import type { HomeItem, Song, Playlist } from "../types";
+  import type { HomeItem, Song, Playlist, AlbumItem } from "../types";
   import { playerStore } from "../stores/player.svelte";
   import { collectionStore } from "../stores/collection.svelte";
   import { playlistsStore } from "../stores/playlists.svelte";
   import { invoke } from "@tauri-apps/api/core";
   import { isSmartPlaylistSpec } from "../utils/filterParser";
   import { formatRelativeDate } from "../utils/date";
-  import { getAlbumCategoryLabel } from "../utils/artist";
   import CoverArt from "./CoverArt.svelte";
   import PlaylistCoverThumb from "./PlaylistCoverThumb.svelte";
   import SongRating from "./SongRating.svelte";
@@ -52,22 +51,23 @@
     return playlistCategoryFor(item.playlist);
   }
 
+  // Album items render their own title/year + artist/rating layout instead
+  // of this trailing block (see the template), so these only need to cover
+  // song and playlist.
   function trailingLabel(item: HomeItem): string {
-    if (item.type === "song") {
-      return i18n.t("playerBar.songLabel");
-    }
-    if (item.type === "album") {
-      return getAlbumCategoryLabel(item.album.track_count, item.album.disc_count);
-    }
-    return i18n.t("playlists.playlistTypeLabel");
+    if (item.type === "song") return i18n.t("playerBar.songLabel");
+    if (item.type === "playlist") return i18n.t("playlists.playlistTypeLabel");
+    return "";
   }
 
   function genreFor(item: HomeItem): string {
     if (item.type === "song") return item.song.genre || "";
-    if (item.type === "album") return item.album.genre || "";
-    return item.playlist.track_count === 1
-      ? i18n.t("playlists.oneSong")
-      : i18n.t("playlists.songsCount", { count: item.playlist.track_count });
+    if (item.type === "playlist") {
+      return item.playlist.track_count === 1
+        ? i18n.t("playlists.oneSong")
+        : i18n.t("playlists.songsCount", { count: item.playlist.track_count });
+    }
+    return "";
   }
 
   function addedDateFor(item: HomeItem): string {
@@ -110,6 +110,11 @@
 
   async function rateSong(song: Song, rating: number) {
     song.rating = await invoke<number>("set_song_rating", { songId: song.id, rating });
+  }
+
+  async function rateAlbum(album: AlbumItem, rating: number) {
+    if (!album.album) return;
+    album.rating = await invoke<number>("set_album_rating", { album: album.album, rating });
   }
 </script>
 
@@ -158,27 +163,40 @@
           {/if}
         </div>
 
-        <div class="min-w-0 flex-1">
-          <div class="flex items-center gap-2">
-            <p class="truncate text-sm font-semibold text-brand-text-primary">{titleFor(item)}</p>
-            {#if item.type === "song"}
-              <span class="shrink-0">
-                <SongRating rating={item.song.rating} onRate={(r) => rateSong(item.song, r)} />
-              </span>
+        {#if item.type === "album"}
+          <div class="min-w-0 flex-1 flex flex-col gap-0.5">
+            <div class="flex items-center justify-between gap-2">
+              <p class="truncate text-sm font-semibold text-brand-text-primary min-w-0">{titleFor(item)}</p>
+              <span class="text-xs text-brand-text-secondary font-medium tabular-nums shrink-0">{item.album.year || ""}</span>
+            </div>
+            <div class="flex items-center justify-between gap-2">
+              <p class="truncate text-xs text-brand-text-secondary font-medium min-w-0">{subtitleFor(item)}</p>
+              <span class="shrink-0"><SongRating rating={item.album.rating} onRate={(r) => rateAlbum(item.album, r)} size="sm" /></span>
+            </div>
+          </div>
+        {:else}
+          <div class="min-w-0 flex-1">
+            <div class="flex items-center gap-2">
+              <p class="truncate text-sm font-semibold text-brand-text-primary">{titleFor(item)}</p>
+              {#if item.type === "song"}
+                <span class="shrink-0">
+                  <SongRating rating={item.song.rating} onRate={(r) => rateSong(item.song, r)} />
+                </span>
+              {/if}
+            </div>
+            <p class="truncate text-xs text-brand-text-secondary font-medium">{subtitleFor(item)}</p>
+          </div>
+
+          <div class="shrink-0 max-w-40 text-right">
+            <p class="text-xs text-brand-text-secondary font-medium tabular-nums truncate">{trailingLabel(item)}</p>
+            {#if genreFor(item)}
+              <p class="text-xs text-brand-text-secondary truncate">{genreFor(item)}</p>
+            {/if}
+            {#if addedDateFor(item)}
+              <p class="text-xs text-brand-text-secondary/70 truncate">{addedDateFor(item)}</p>
             {/if}
           </div>
-          <p class="truncate text-xs text-brand-text-secondary font-medium">{subtitleFor(item)}</p>
-        </div>
-
-        <div class="shrink-0 max-w-40 text-right">
-          <p class="text-xs text-brand-text-secondary font-medium tabular-nums truncate">{trailingLabel(item)}</p>
-          {#if genreFor(item)}
-            <p class="text-xs text-brand-text-secondary truncate">{genreFor(item)}</p>
-          {/if}
-          {#if addedDateFor(item)}
-            <p class="text-xs text-brand-text-secondary/70 truncate">{addedDateFor(item)}</p>
-          {/if}
-        </div>
+        {/if}
       </div>
     {/each}
 

--- a/src/lib/components/HomeRowList.test.ts
+++ b/src/lib/components/HomeRowList.test.ts
@@ -37,6 +37,7 @@ function makeAlbum(overrides: Partial<AlbumItem> = {}): AlbumItem {
     art_automatic: null,
     art_manual: null,
     genre: "Rock",
+    rating: -1,
     ...overrides,
   };
 }
@@ -71,27 +72,23 @@ describe("HomeRowList.svelte", () => {
     expect(queryByText("01")).not.toBeInTheDocument();
   });
 
-  it("renders album rows using the album title, artist, and a category label, without a per-song rating", () => {
+  it("renders album rows with title/year on top and artist/rating on bottom, matching the Albums grid row layout", () => {
     const items: HomeItem[] = [{ type: "album", album: makeAlbum() }];
     const { getByText, container } = render(HomeRowList, { props: { items, variant: "rank" } });
 
     expect(getByText("Full Moon Fever")).toBeInTheDocument();
+    expect(getByText("1989")).toBeInTheDocument();
     expect(getByText("Tom Petty")).toBeInTheDocument();
-    // 12 tracks, 1 disc -> "Album" category label fills the trailing slot,
-    // with the album's genre shown below it.
-    expect(getByText("Album")).toBeInTheDocument();
-    expect(getByText("Rock")).toBeInTheDocument();
-    // No song rating control (heart/star) for album-grouped rows.
-    expect(container.querySelector('[aria-pressed]')).not.toBeInTheDocument();
-    expect(container.querySelector('[aria-label="Rating"]')).not.toBeInTheDocument();
+    // Rating widget (heart/star, driven by prefs.ratingStyle) now renders for album rows too.
+    expect(container.querySelector('[aria-pressed]')).toBeInTheDocument();
   });
 
-  it("omits the genre line for albums with no genre", () => {
-    const items: HomeItem[] = [{ type: "album", album: makeAlbum({ genre: null }) }];
+  it("omits the year when the album has none", () => {
+    const items: HomeItem[] = [{ type: "album", album: makeAlbum({ year: null }) }];
     const { getByText, queryByText } = render(HomeRowList, { props: { items, variant: "rank" } });
 
-    expect(getByText("Album")).toBeInTheDocument();
-    expect(queryByText("Rock")).not.toBeInTheDocument();
+    expect(getByText("Full Moon Fever")).toBeInTheDocument();
+    expect(queryByText("1989")).not.toBeInTheDocument();
   });
 
   it("renders playlist rows with a 'Playlist' label, category, and track count", () => {

--- a/src/lib/components/SongRating.test.ts
+++ b/src/lib/components/SongRating.test.ts
@@ -28,17 +28,17 @@ describe("SongRating", () => {
     expect(onRate).toHaveBeenCalledWith(-1);
   });
 
-  it("renders five stars in stars mode", () => {
+  it("renders five stars plus a clear button in stars mode", () => {
     prefs.ratingStyle = "stars";
     const { getAllByRole } = render(SongRating, { rating: 3, onRate: vi.fn() });
-    expect(getAllByRole("button")).toHaveLength(5);
+    expect(getAllByRole("button")).toHaveLength(6);
   });
 
   it("star clicks pass through the star value", async () => {
     prefs.ratingStyle = "stars";
     const onRate = vi.fn();
-    const { getAllByRole } = render(SongRating, { rating: -1, onRate });
-    await fireEvent.click(getAllByRole("button")[2]);
+    const { getByLabelText } = render(SongRating, { rating: -1, onRate });
+    await fireEvent.click(getByLabelText("Rate 3 of 5"));
     expect(onRate).toHaveBeenCalledWith(3);
   });
 });

--- a/src/lib/components/StarRating.svelte
+++ b/src/lib/components/StarRating.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Star } from "lucide-svelte";
+  import { Star, CircleSlash } from "lucide-svelte";
   import { i18n } from "../stores/i18n.svelte";
 
   interface Props {
@@ -15,6 +15,7 @@
   let hoverValue = $state<number | null>(null);
 
   const starClass = $derived(size === "md" ? "w-4 h-4" : "w-3.5 h-3.5");
+  const clearClass = $derived(size === "md" ? "w-3.5 h-3.5" : "w-3 h-3");
   const shown = $derived(hoverValue ?? (rating > 0 ? rating : 0));
 
   // Left half of a star = half-star value, right half = full-star value.
@@ -32,6 +33,11 @@
     onRate(value === rating ? -1 : value);
   }
 
+  function handleClear(e: MouseEvent) {
+    e.stopPropagation();
+    onRate?.(-1);
+  }
+
   function fillFraction(star: number): number {
     return Math.max(0, Math.min(1, shown - (star - 1)));
   }
@@ -43,6 +49,18 @@
   aria-label={i18n.t('rating.label')}
   onmouseleave={() => (hoverValue = null)}
 >
+  {#if onRate}
+    <button
+      type="button"
+      disabled={rating <= 0}
+      onclick={handleClear}
+      class="block text-brand-text-secondary/50 hover:text-brand-text-secondary transition-colors cursor-pointer disabled:cursor-default disabled:pointer-events-none"
+      title={i18n.t('rating.clearTooltip')}
+      aria-label={i18n.t('rating.clearTooltip')}
+    >
+      <CircleSlash class={clearClass} />
+    </button>
+  {/if}
   {#each [1, 2, 3, 4, 5] as star}
     <button
       type="button"

--- a/src/lib/components/StarRating.test.ts
+++ b/src/lib/components/StarRating.test.ts
@@ -6,23 +6,40 @@ import StarRating from "./StarRating.svelte";
 // to the full-star value (the left-half/half-star branch requires real layout).
 
 describe("StarRating", () => {
-  it("renders five stars", () => {
+  it("renders five stars when read-only (no clear button without onRate)", () => {
     const { getAllByRole } = render(StarRating, { rating: 3 });
     expect(getAllByRole("button")).toHaveLength(5);
   });
 
+  it("renders five stars plus a clear button when interactive", () => {
+    const { getAllByRole } = render(StarRating, { rating: 3, onRate: vi.fn() });
+    expect(getAllByRole("button")).toHaveLength(6);
+  });
+
   it("calls onRate with the clicked star value", async () => {
     const onRate = vi.fn();
-    const { getAllByRole } = render(StarRating, { rating: -1, onRate });
-    await fireEvent.click(getAllByRole("button")[3]);
+    const { getByLabelText } = render(StarRating, { rating: -1, onRate });
+    await fireEvent.click(getByLabelText("Rate 4 of 5"));
     expect(onRate).toHaveBeenCalledWith(4);
   });
 
   it("clears the rating when the current value is clicked again", async () => {
     const onRate = vi.fn();
-    const { getAllByRole } = render(StarRating, { rating: 2, onRate });
-    await fireEvent.click(getAllByRole("button")[1]);
+    const { getByLabelText } = render(StarRating, { rating: 2, onRate });
+    await fireEvent.click(getByLabelText("Rate 2 of 5"));
     expect(onRate).toHaveBeenCalledWith(-1);
+  });
+
+  it("clears the rating via the clear button", async () => {
+    const onRate = vi.fn();
+    const { getByLabelText } = render(StarRating, { rating: 2, onRate });
+    await fireEvent.click(getByLabelText("Clear rating"));
+    expect(onRate).toHaveBeenCalledWith(-1);
+  });
+
+  it("disables the clear button when already unrated", () => {
+    const { getByLabelText } = render(StarRating, { rating: -1, onRate: vi.fn() });
+    expect(getByLabelText("Clear rating")).toBeDisabled();
   });
 
   it("is inert without an onRate handler", async () => {

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -110,8 +110,8 @@ export const en = {
     sortArtistNameDesc: "Sort: Artist Name (Z-A)",
     sortYearDesc: "Sort: Year (Newest)",
     sortYearAsc: "Sort: Year (Oldest)",
-    sortTracksDesc: "Sort: Songs (Most)",
-    sortTracksAsc: "Sort: Songs (Least)",
+    sortRatingDesc: "Sort: Rating (Highest)",
+    sortRatingAsc: "Sort: Rating (Lowest)",
     sortSongsDesc: "Sort: Songs (Most)",
     sortSongsAsc: "Sort: Songs (Least)",
     sortAlbumsDesc: "Sort: Albums (Most)",
@@ -731,7 +731,8 @@ export const en = {
     label: "Rating",
     setTooltip: "Rate {value} of 5",
     favoriteTooltip: "Add to favourites",
-    unfavoriteTooltip: "Remove from favourites"
+    unfavoriteTooltip: "Remove from favourites",
+    clearTooltip: "Clear rating"
   },
   common: {
     scrollLeft: "Scroll left",

--- a/src/lib/locales/fr.ts
+++ b/src/lib/locales/fr.ts
@@ -110,8 +110,8 @@ export const fr = {
     sortArtistNameDesc: "Trier : Nom d'artiste (Z-A)",
     sortYearDesc: "Trier : Année (Plus récente)",
     sortYearAsc: "Trier : Année (Plus ancienne)",
-    sortTracksDesc: "Trier : Chansons (Plus grand nombre)",
-    sortTracksAsc: "Trier : Chansons (Moins grand nombre)",
+    sortRatingDesc: "Trier : Note (Plus élevée)",
+    sortRatingAsc: "Trier : Note (Plus basse)",
     sortSongsDesc: "Trier : Chansons (Plus grand nombre)",
     sortSongsAsc: "Trier : Chansons (Moins grand nombre)",
     sortAlbumsDesc: "Trier : Albums (Plus grand nombre)",
@@ -728,7 +728,8 @@ export const fr = {
     label: "Note",
     setTooltip: "Noter {value} sur 5",
     favoriteTooltip: "Ajouter aux favoris",
-    unfavoriteTooltip: "Retirer des favoris"
+    unfavoriteTooltip: "Retirer des favoris",
+    clearTooltip: "Effacer la note"
   },
   common: {
     scrollLeft: "Défiler vers la gauche",

--- a/src/lib/stores/collection.svelte.ts
+++ b/src/lib/stores/collection.svelte.ts
@@ -15,7 +15,7 @@ import type {
   RecentSearchItem,
   QueuePopulationMode,
 } from "../types";
-import { applySongStats, type SongStatsPayload } from "../utils/stats";
+import { applySongStats, type SongStatsPayload, applyAlbumStats, type AlbumStatsPayload } from "../utils/stats";
 import { playlistsStore } from "./playlists.svelte";
 import { toastStore } from "./toast.svelte";
 import { MAX_RECENT_SEARCHES } from "../constants";
@@ -661,6 +661,13 @@ class CollectionStore {
           const song = list.find((s) => s.id === event.payload.song_id);
           if (song) applySongStats(song, event.payload);
         }
+      });
+
+      // Keep cached album rows in sync with ratings set from other views
+      // (Album Detail view, other Collection grid instances).
+      await listen<AlbumStatsPayload>("album-stats-changed", (event) => {
+        const album = this.albums.find((a) => a.album === event.payload.album);
+        if (album) applyAlbumStats(album, event.payload);
       });
 
       if (this.scanOnStartup) {

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -243,6 +243,8 @@ export interface AlbumItem {
   art_manual: string | null;
   genre?: string | null;
   sample_song_id?: number | null;
+  /** Independent album rating (-1 = unrated, else 0.5–5.0), separate from any song's rating. */
+  rating: number;
 }
 
 export interface ArtistItem {

--- a/src/lib/utils/stats.ts
+++ b/src/lib/utils/stats.ts
@@ -1,4 +1,4 @@
-import type { Song } from "../types";
+import type { AlbumItem, Song } from "../types";
 
 /** Payload of the backend's `song-stats-changed` event. */
 export interface SongStatsPayload {
@@ -15,4 +15,15 @@ export function applySongStats(song: Song, payload: SongStatsPayload) {
   if (typeof payload.playcount === "number") song.playcount = payload.playcount;
   if (typeof payload.skipcount === "number") song.skipcount = payload.skipcount;
   if (payload.lastplayed !== undefined) song.lastplayed = payload.lastplayed ?? undefined;
+}
+
+/** Payload of the backend's `album-stats-changed` event. */
+export interface AlbumStatsPayload {
+  album: string;
+  rating?: number;
+}
+
+/** Apply an album rating event to an album item held in any view or store. */
+export function applyAlbumStats(album: AlbumItem, payload: AlbumStatsPayload) {
+  if (typeof payload.rating === "number") album.rating = payload.rating;
 }


### PR DESCRIPTION
## 📋 Summary
Adds a first-class, independent album rating — separate from any song's rating — addressing #242. Sites like Album of the Year rate the album as a whole, and a listener may love an album overall while still having different favourite tracks on it; previously there was no way to express that in Luminous.

## 🔍 Implementation Notes

**Backend** — there was no `albums` table (albums are derived from `songs` at query time), so this adds a dedicated `album_ratings` table (migration 14) keyed by album title, matching how `CollectionScanner::get_albums` already groups albums. `set_album_rating`/`get_album_rating` reuse the existing `normalize_rating`/`RATING_UNRATED` conventions from song ratings (0.5–5.0 half-steps, `-1` sentinel). `get_albums` now LEFT JOINs the rating in.

One gap found along the way: Home-carousel `AlbumItem`s (Recently Added, Most Played) are built via a separate code path (`group_songs_into_home_items`/`home_item_for_context`) with no DB connection in scope, so they always defaulted to unrated regardless of the album's actual rating. Added `attach_album_ratings()` to backfill the real value once a connection is available in `get_recently_added`/`get_most_frequently_played`, and a regression test (`test_recently_added_surfaces_existing_album_rating`) covering it.

**Frontend** — reused the existing `SongRating`/`StarRating` widgets as-is (they were already generic, not song-specific) rather than forking a new component:
- Rating widget appended to the Album Detail view's stats line.
- Albums grid card, row card, and "Recently Added"/"Most Played" home rows all show the rating bottom-right, with row layouts changed to title/year on top, artist/rating on bottom (dropped the old track-count/category label from these to make room, per layout feedback during review).
- Added an explicit clear-rating button (circle-slash icon) next to the stars — the only prior way to clear a rating was re-clicking the current star value, which wasn't discoverable.
- Albums can now be sorted by rating in the Collection view, replacing the less useful sort-by-song-count.
- Artist page album/playlist carousels were widened (`w-40`/`w-44` → `w-48`) to match the Collection grid and Home carousel card sizing.

Not in scope: this doesn't touch the `AlbumItem` Rust struct's construction for the Home *carousel* card grid (`CarouselCard.svelte`) beyond the rating backfill above — no layout changes were requested there.

## 🧪 Test Plan
- [x] `bun run check` (svelte-check) — 0 errors
- [x] `bun run test -- --run` (frontend) — 291 passed
- [x] `cargo test` (src-tauri) — 85 passed, including new album-rating unit/integration tests
- [x] `cargo clippy` — no new warnings (15 pre-existing warnings, all in untouched files)
- [ ] Manually verified in the app — not done by me; this environment can't drive the Tauri app (no IPC bridge in a plain browser preview), so this needs a human pass in `bun run tauri dev`. Worth checking: rating a song vs. album stay independent, the clear button, sort-by-rating ordering, and the new row layouts in Collection/Recently Added/Artist page.

## ✅ Checklist
- [x] No unrelated changes bundled in
- [ ] Docs/screenshots updated — not done; several album card/row screenshots in `docs/screenshots/` are now stale (rating widget, layout changes). Flagging for a follow-up regen via `bun run take-screenshots` rather than doing it blind in this session.