### PR TITLE
chore: bump version to 0.98.0, add release notes

### DIFF
--- a/docs/release-notes-v0.98.0.md
+++ b/docs/release-notes-v0.98.0.md
@@ -1,0 +1,79 @@
+# Release Notes - Luminous v0.98.0
+
+Luminous v0.98.0 is a feature-heavy release since v0.97.0, headlined by real in-app
+auto-update support and a batch of features shaped directly by community requests —
+including the first feature request filed by an outside user.
+
+### 📣 Community
+- **A second thank-you to [@Crocodile73](https://github.com/Crocodile73)**: after filing
+  Luminous's first-ever user-reported bug back in v0.96.0, they're back with its first
+  user-requested *feature*: [#219](https://github.com/esoltys/luminous/issues/219), asking
+  for album/playlist cards to stop starting playback on a plain click. Fixed below.
+- **More requests, shipped**: independent album ratings (#242), grouped batch notifications
+  for folder imports (#233), and scroll position preservation across views (#232) all came
+  out of user feedback and GitHub Discussions — thank you to everyone filing issues and
+  requests; keep them coming.
+
+### 🌟 New Features
+- **Real In-App Auto-Update** (#211): Replaces the old "check GitHub, then hand you a link"
+  updater with the actual Tauri Updater plugin — signature-verified in-app download,
+  install, and restart on Windows and Linux AppImage builds, instead of guessing a download
+  asset by file extension. Since this is the first release able to *consume* a signed
+  update, there's nothing to self-update to until v0.99.0 ships — auto-update won't
+  actually activate until the release after this one.
+- **Independent Album Ratings**: Albums can now be rated 0.5–5.0 stars (or favourited),
+  separate from any individual song rating — useful when you love an album as a whole but
+  have different favourite tracks on it. Sortable in the Collection view (#244).
+- **Compact Rows View for Albums & Artists**: A Cards/Rows toggle, remembering its own mode
+  per tab, matching the density option Playlists already had (#225).
+- **Row/Grid Toggle & Redesigned Glow for Playlists**: Auto and Custom playlist grids get
+  the same Cards/Rows toggle as Albums/Artists, plus a translucent tinted-glow redesign
+  (replacing the old opaque color blocks) extended across playlist cards, Queue, and Smart
+  Playlists (#229).
+- **Playlists Refresh-All Button**: A Refresh icon next to the view toggle re-syncs
+  genre/decade auto-playlists and force-regenerates every dynamic playlist, bypassing the
+  normal 24h staleness gate (#243).
+- **Native App Shell**: Right-click no longer falls through to the browser's default
+  context menu, and reload/find/print/zoom shortcuts are disabled — Luminous now reads as a
+  native app instead of a stock webview (#227).
+- **Grouped, Accurate Import Notifications**: Dropping a folder of songs into a watched
+  directory now collapses into a single progress toast instead of one-per-file (or, in some
+  cases, duplicate/miscounted toasts from the same import) (#235).
+- **Scroll Position Preserved Across Views**: Switching tabs, opening/closing a detail view,
+  or using Back/Forward no longer resets your scroll position to the top (#237).
+
+### 🎨 Visual & UX Improvements
+- **Removed UI Sound Cues**: The synthesized toast/favourite tones felt like clutter on top
+  of the music already playing; dropped entirely along with their settings toggle (#215).
+- **Shuffle/Repeat Icon Pairing**: Illegible tiny text badges ("IA", "1x") replaced with
+  full-size paired mode icons and guide tooltips; the non-functional "One by One" repeat
+  mode was removed rather than left as a dead option (#236).
+- **Instructive-Voice Copy Pass**: Settings and tooltip hint text rewritten from
+  descriptive/third-person to imperative voice, matching the rest of the app's copy, in
+  both English and French (#234).
+- **Cards Navigate, Not Play**: Clicking an album/playlist card now only navigates to it —
+  playback no longer starts unexpectedly from a stray click (#221, fixes #219).
+- **Accent-Contrast Text Color Fix**: Switched to a perceived-brightness heuristic for
+  choosing black vs. white text on accent-colored buttons, fixing muddy-looking text on
+  medium-saturation theme accents; pane-layout toggles now use the same active-state accent
+  color as other view toggles (#245).
+- **Clear Messaging on Schema Mismatch**: Opening an older build against a database from a
+  newer one now explains the version mismatch instead of silently showing an empty library
+  (#226).
+
+### 🐛 Stability & Bug Fixes
+- **Auto/Smart Playlists Silently Capped**: Genre/decade auto-playlists and rule-based Smart
+  Playlists only ever populated their first 25–100 matching songs regardless of how many
+  actually matched; now every matching song is included (#241).
+- **Duplicate Songs After Case-Only Renames**: Renaming an album folder's casing only (e.g.
+  "HERO" → "Hero") on a case-insensitive filesystem produced a duplicate track listing
+  instead of updating the existing one; a new Clean Up merge action also remediates
+  libraries that already picked up duplicates from this bug (#238).
+- **Startup Window Flash**: The window now stays hidden until fully created instead of
+  flashing on launch (#239).
+- **File Watcher Race Conditions**: Fixed redundant per-subfolder library scans, duplicate
+  "songs added" toasts racing the watcher's own batch events, inflated song counts from
+  non-audio files, and a watcher/tag-editor write race — all part of the same batch
+  notification overhaul (#235).
+- **Removed Dead `mood` Column**: Cleaned up a database column that was never populated from
+  file tags and had no write path (#218).

--- a/docs/release-notes-v0.98.0.md
+++ b/docs/release-notes-v0.98.0.md
@@ -11,7 +11,7 @@ including the first feature request filed by an outside user.
   for album/playlist cards to stop starting playback on a plain click. Fixed below.
 - **More requests, shipped**: independent album ratings (#242), grouped batch notifications
   for folder imports (#233), and scroll position preservation across views (#232) all came
-  out of user feedback and GitHub Discussions — thank you to everyone filing issues and
+  out of user feedback — thank you to everyone filing issues and
   requests; keep them coming.
 
 ### 🌟 New Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "luminous",
-  "version": "0.97.0",
+  "version": "0.98.0",
   "description": "A high-performance home for the music you already own",
   "author": "Eric James Soltys <ericjamessoltys@outlook.com>",
   "license": "MIT",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3043,7 +3043,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "luminous"
-version = "0.97.0"
+version = "0.98.0"
 dependencies = [
  "anyhow",
  "bs1770",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "luminous"
-version = "0.97.0"
+version = "0.98.0"
 description = "A high-performance home for the music you already own"
 authors = ["Eric James Soltys <ericjamessoltys@outlook.com>"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Luminous",
-  "version": "0.97.0",
+  "version": "0.98.0",
   "identifier": "org.luminous.music",
   "build": {
     "beforeDevCommand": "bun run dev",
@@ -47,154 +47,200 @@
     ],
     "fileAssociations": [
       {
-        "ext": ["mp3"],
+        "ext": [
+          "mp3"
+        ],
         "name": "MP3 Audio",
         "description": "MPEG Layer-3 audio file",
         "mimeType": "audio/mpeg",
         "role": "Viewer"
       },
       {
-        "ext": ["flac"],
+        "ext": [
+          "flac"
+        ],
         "name": "FLAC Audio",
         "description": "Free Lossless Audio Codec file",
         "mimeType": "audio/flac",
         "role": "Viewer"
       },
       {
-        "ext": ["ogg", "opus"],
+        "ext": [
+          "ogg",
+          "opus"
+        ],
         "name": "Ogg Audio",
         "description": "Ogg Vorbis/Opus audio file",
         "mimeType": "audio/ogg",
         "role": "Viewer"
       },
       {
-        "ext": ["m4a"],
+        "ext": [
+          "m4a"
+        ],
         "name": "M4A Audio",
         "description": "AAC audio in an MPEG-4 container",
         "mimeType": "audio/mp4",
         "role": "Viewer"
       },
       {
-        "ext": ["alac"],
+        "ext": [
+          "alac"
+        ],
         "name": "ALAC Audio",
         "description": "Apple Lossless audio in an MPEG-4 container",
         "mimeType": "audio/mp4",
         "role": "Viewer"
       },
       {
-        "ext": ["aac"],
+        "ext": [
+          "aac"
+        ],
         "name": "AAC Audio",
         "description": "Advanced Audio Coding file",
         "mimeType": "audio/aac",
         "role": "Viewer"
       },
       {
-        "ext": ["wav"],
+        "ext": [
+          "wav"
+        ],
         "name": "WAV Audio",
         "description": "Waveform audio file",
         "mimeType": "audio/vnd.wave",
         "role": "Viewer"
       },
       {
-        "ext": ["aiff", "aif"],
+        "ext": [
+          "aiff",
+          "aif"
+        ],
         "name": "AIFF Audio",
         "description": "Audio Interchange File Format",
         "mimeType": "audio/x-aiff",
         "role": "Viewer"
       },
       {
-        "ext": ["wv"],
+        "ext": [
+          "wv"
+        ],
         "name": "WavPack Audio",
         "description": "WavPack compressed audio file",
         "mimeType": "audio/x-wavpack",
         "role": "Viewer"
       },
       {
-        "ext": ["mpc"],
+        "ext": [
+          "mpc"
+        ],
         "name": "Musepack Audio",
         "description": "Musepack compressed audio file",
         "mimeType": "audio/x-musepack",
         "role": "Viewer"
       },
       {
-        "ext": ["ape"],
+        "ext": [
+          "ape"
+        ],
         "name": "Monkey's Audio",
         "description": "Monkey's Audio lossless file",
         "mimeType": "audio/x-ape",
         "role": "Viewer"
       },
       {
-        "ext": ["tta"],
+        "ext": [
+          "tta"
+        ],
         "name": "True Audio",
         "description": "True Audio lossless file",
         "mimeType": "audio/x-tta",
         "role": "Viewer"
       },
       {
-        "ext": ["dsf"],
+        "ext": [
+          "dsf"
+        ],
         "name": "DSD Stream File",
         "description": "DSD audio stream file",
         "mimeType": "audio/x-dsf",
         "role": "Viewer"
       },
       {
-        "ext": ["dff"],
+        "ext": [
+          "dff"
+        ],
         "name": "DSDIFF Audio",
         "description": "Philips DSDIFF audio file",
         "mimeType": "audio/x-dff",
         "role": "Viewer"
       },
       {
-        "ext": ["asf"],
+        "ext": [
+          "asf"
+        ],
         "name": "Advanced Systems Format",
         "description": "Windows Media container file",
         "mimeType": "application/vnd.ms-asf",
         "role": "Viewer"
       },
       {
-        "ext": ["wma"],
+        "ext": [
+          "wma"
+        ],
         "name": "Windows Media Audio",
         "description": "Windows Media Audio file",
         "mimeType": "audio/x-ms-wma",
         "role": "Viewer"
       },
       {
-        "ext": ["m4b"],
+        "ext": [
+          "m4b"
+        ],
         "name": "AAC Audiobook",
         "description": "AAC audiobook file",
         "mimeType": "audio/x-m4b",
         "role": "Viewer"
       },
       {
-        "ext": ["m3u"],
+        "ext": [
+          "m3u"
+        ],
         "name": "M3U Playlist",
         "description": "M3U playlist file",
         "mimeType": "audio/x-mpegurl",
         "role": "Viewer"
       },
       {
-        "ext": ["m3u8"],
+        "ext": [
+          "m3u8"
+        ],
         "name": "M3U8 Playlist",
         "description": "M3U8 playlist file",
         "mimeType": "application/vnd.apple.mpegurl",
         "role": "Viewer"
       },
       {
-        "ext": ["pls"],
+        "ext": [
+          "pls"
+        ],
         "name": "PLS Playlist",
         "description": "PLS playlist file",
         "mimeType": "audio/x-scpls",
         "role": "Viewer"
       },
       {
-        "ext": ["xspf"],
+        "ext": [
+          "xspf"
+        ],
         "name": "XSPF Playlist",
         "description": "XML Shareable Playlist Format file",
         "mimeType": "application/xspf+xml",
         "role": "Viewer"
       }
     ],
-    "resources": ["icons/filetypes/"],
+    "resources": [
+      "icons/filetypes/"
+    ],
     "windows": {
       "nsis": {
         "installerHooks": "windows/installer-hooks.nsh"


### PR DESCRIPTION
## 📋 Summary
Version bump + release notes for the next release, split out from #246 per feedback (release housekeeping shouldn't gate on/be gated by the updater code change).

- Bumps `package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml` (+ `Cargo.lock`) to `0.98.0` via the existing `scripts/bump-version.ts`.
- Adds `docs/release-notes-v0.98.0.md` covering everything merged since `v0.97.0`, including #246 (real Tauri Updater wiring, now on `main`).

## 🔍 Implementation Notes
- Release notes follow the existing format/tone (`docs/release-notes-v0.97.0.md`, etc.): 📣 Community / 🌟 New Features / 🎨 Visual & UX / 🐛 Stability & Bug Fixes.
- Per request, the Community section spotlights user-filed feature requests (label `user request`) instead of a bug report this time — including a callback to @Crocodile73, who filed both Luminous's first user-reported bug (v0.96.0) and now its first user-requested feature (#219).
- Explicitly calls out that in-app auto-update won't actually have anything to self-update *to* until v0.99.0 ships, since v0.98.0 is the first release able to consume a signed `latest.json`.

## 🧪 Test Plan
- [x] `bun run check` (svelte-check) — 0 errors
- [x] `cargo check` (src-tauri) — clean, `Cargo.lock` regenerated with the new package version
- [x] Manually verified in the app — n/a, docs + version metadata only

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs updated (this PR *is* the docs update)