### PR TITLE
Link the update-celebration toast to GitHub releases

### DIFF
--- a/src/lib/components/Toast.svelte
+++ b/src/lib/components/Toast.svelte
@@ -3,6 +3,15 @@
   import { AlertTriangle, CheckCircle2, Info, Star, Sparkles, X } from "lucide-svelte";
   import { toastStore } from "../stores/toast.svelte";
   import { portal } from "../utils/portal";
+
+  async function openExternalUrl(url: string) {
+    try {
+      const { openUrl } = await import("@tauri-apps/plugin-opener");
+      await openUrl(url);
+    } catch {
+      window.open(url, "_blank");
+    }
+  }
 </script>
 
 <div
@@ -37,7 +46,17 @@
       {:else}
         <Info class="w-4 h-4 shrink-0 text-brand-accent-text" />
       {/if}
-      <span class="flex-1">{toast.text}</span>
+      {#if toast.url}
+        <button
+          type="button"
+          onclick={() => openExternalUrl(toast.url!)}
+          class="flex-1 text-left underline decoration-dotted underline-offset-2 hover:decoration-solid cursor-pointer"
+        >
+          {toast.text}
+        </button>
+      {:else}
+        <span class="flex-1">{toast.text}</span>
+      {/if}
       <button
         onclick={() => toastStore.dismiss(toast.id)}
         class="shrink-0 opacity-60 hover:opacity-100 transition-opacity cursor-pointer"

--- a/src/lib/stores/collection.svelte.ts
+++ b/src/lib/stores/collection.svelte.ts
@@ -536,7 +536,10 @@ class CollectionStore {
             const msg = isFirstEver
               ? i18n.t("celebrations.firstLaunch", { version: appVersion }, `Welcome to Luminous v${appVersion}!`)
               : i18n.t("celebrations.newVersion", { version: appVersion }, `Updated to Luminous v${appVersion}`);
-            toastStore.show(msg, "milestone");
+            const releaseUrl = isFirstEver
+              ? undefined
+              : "https://github.com/esoltys/luminous/releases";
+            toastStore.show(msg, "milestone", undefined, releaseUrl);
             setTimeout(() => { this.isFirstLaunch = false; }, 700);
           }, 1200);
         }

--- a/src/lib/stores/toast.svelte.ts
+++ b/src/lib/stores/toast.svelte.ts
@@ -6,6 +6,7 @@ export interface ToastMessage {
   id: number;
   text: string;
   variant: ToastVariant;
+  url?: string;
 }
 
 class ToastStore {
@@ -13,9 +14,9 @@ class ToastStore {
   private nextId = 0;
   private timers = new Map<number, ReturnType<typeof setTimeout>>();
 
-  show(text: string, variant: ToastVariant = "info", durationMs?: number) {
+  show(text: string, variant: ToastVariant = "info", durationMs?: number, url?: string) {
     const id = this.nextId++;
-    this.messages.push({ id, text, variant });
+    this.messages.push({ id, text, variant, url });
     this.scheduleDismiss(id, durationMs);
     return id;
   }


### PR DESCRIPTION
## Summary
- Toast messages can now carry an optional `url`; when set, the toast text renders as a clickable link (dotted underline, solid on hover) instead of plain text.
- The "Updated to Luminous vX.Y.Z" milestone toast shown after an app update now links to https://github.com/esoltys/luminous/releases, opened via `@tauri-apps/plugin-opener` (falling back to `window.open`).
- The first-launch "Welcome to Luminous" toast is left unlinked — no relevant release page for it.

## Test plan
- [x] `bun run check` (svelte-check) passes with no errors
- [x] `vitest run src/lib/stores/toast.test.ts` passes
- [x] Manual verification in the dev app: bump/clear `launched_version` app setting, relaunch, confirm the update toast shows an underlined link and clicking it opens the releases page in the default browser