### PR TITLE
Center waveform seek bar and timers in the player bar

### DIFF
--- a/src/lib/components/PlayerBar.svelte
+++ b/src/lib/components/PlayerBar.svelte
@@ -308,10 +308,14 @@
 
     <!-- Scrubber -->
     <div class="flex items-center gap-2.5 w-full text-[10px] text-brand-text-secondary/60">
+      <!-- Invisible spacer matching the mode-toggle button's footprint, so the
+           waveform + timers stay centered instead of skewing left toward it. -->
+      <div class="w-4 h-4 flex-shrink-0" aria-hidden="true"></div>
       <span>{formatTime(playerStore.positionNanosec)}</span>
       <div class="flex-1 flex flex-col gap-1">
         <WaveformSeekBar />
       </div>
+      <span>{formatTime(playerStore.currentSong?.length_nanosec)}</span>
       <button
         onclick={() => prefs.toggleSeekBarMode()}
         class="text-brand-text-secondary/50 hover:text-brand-text-primary transition-colors p-0.5 flex-shrink-0"
@@ -325,7 +329,6 @@
           <Palette class="w-3 h-3" />
         {/if}
       </button>
-      <span>{formatTime(playerStore.currentSong?.length_nanosec)}</span>
     </div>
   </div>
 


### PR DESCRIPTION
## Summary
- The seek-bar-mode toggle button previously sat between the waveform and the trailing timer, making the flex-1 waveform's fixed-width neighbors asymmetric (nothing on the left vs. timer+button on the right), which visually skewed the waveform/timers group left of center under the transport controls.
- Moved the toggle button to after the trailing timer and added a matching invisible spacer before the leading timer, so both sides of the waveform have equal fixed-width content and the group renders centered.

## Test plan
- [ ] Run the app's dev server and visually confirm the waveform + timers are centered under the play controls in the player bar (not verifiable via the sandboxed browser pane here — no Tauri IPC bridge).