### PR TITLE
fix: relocate auto playlist actions to overflow menu (#269)

### DIFF
--- a/src/lib/components/AutoPlaylistDetailView.svelte
+++ b/src/lib/components/AutoPlaylistDetailView.svelte
@@ -532,36 +532,6 @@ import { shuffleArray } from "../utils/shuffle";
             disabled={loading || songs.length === 0}
             class="shrink-0"
           />
-          <IconActionButton
-            onclick={handleAddAllToPlaylist}
-            disabled={loading || songs.length === 0}
-            title={playlistsStore.activeCustomPlaylist
-              ? i18n.t('albumDetail.addAllToPlaylistTooltip', { name: playlistsStore.activeCustomPlaylist.name })
-              : i18n.t('albumDetail.addAllToPlaylistTooltipDefault')}
-            class="shrink-0"
-          >
-            {#snippet icon()}<Plus class="w-4 h-4" />{/snippet}
-          </IconActionButton>
-          <IconActionButton
-            onclick={handleSaveAsCustomPlaylist}
-            disabled={loading || songs.length === 0}
-            title={i18n.t('playlists.saveAsCustomTooltip')}
-            class="shrink-0"
-          >
-            {#snippet icon()}<FolderPlus class="w-4 h-4" />{/snippet}
-          </IconActionButton>
-
-          {#if (kind === "genre" || kind === "decade") && playlistId !== undefined}
-            <!-- Refresh button: force-regenerate playlist with fresh songs from library -->
-            <IconActionButton
-              onclick={handleRefreshAutoPlaylist}
-              disabled={loading || isRefreshing}
-              title={i18n.t('playlists.refreshAutoPlaylistTooltip')}
-              class="shrink-0"
-            >
-              {#snippet icon()}<RefreshCw class="w-4 h-4 {isRefreshing ? 'animate-spin' : ''}" />{/snippet}
-            </IconActionButton>
-          {/if}
           <ColumnSelector align="left" iconOnly />
         </div>
 
@@ -1193,17 +1163,38 @@ import { shuffleArray } from "../utils/shuffle";
     y={overflowMenuPos.y}
     onClose={() => { overflowMenuPos = null; }}
   >
+    <ContextMenuItem
+      icon={Plus}
+      label={playlistsStore.activeCustomPlaylist
+        ? i18n.t('albumDetail.addAllToPlaylistTooltip', { name: playlistsStore.activeCustomPlaylist.name })
+        : i18n.t('albumDetail.addAllToPlaylistTooltipDefault')}
+      onclick={() => { handleAddAllToPlaylist(); overflowMenuPos = null; }}
+      disabled={loading || songs.length === 0}
+    />
+    <ContextMenuItem
+      icon={FolderPlus}
+      label={i18n.t("playlists.saveAsCustomTooltip")}
+      onclick={() => { handleSaveAsCustomPlaylist(); overflowMenuPos = null; }}
+      disabled={loading || songs.length === 0}
+    />
+
+    {#if (kind === "genre" || kind === "decade") && playlistId !== undefined}
+      <ContextMenuItem
+        icon={RefreshCw}
+        label={i18n.t("playlists.refreshPlaylistBtn", {}, "Refresh Playlist")}
+        onclick={() => { handleRefreshAutoPlaylist(); overflowMenuPos = null; }}
+        disabled={loading || isRefreshing}
+      />
+    {/if}
+
     {#if kind === "history"}
+      <ContextMenuDivider />
       <ContextMenuItem
         icon={Eraser}
+        destructive
         label={i18n.t("playlists.clearHistoryBtn", {}, "Clear History")}
         onclick={handleClearHistory}
-      />
-    {:else}
-      <ContextMenuItem
-        icon={FolderPlus}
-        label={i18n.t("playlists.saveAsCustomTooltip")}
-        onclick={() => { handleSaveAsCustomPlaylist(); overflowMenuPos = null; }}
+        disabled={loading || songs.length === 0}
       />
     {/if}
   </ContextMenu>

--- a/src/lib/components/ContextMenuItem.svelte
+++ b/src/lib/components/ContextMenuItem.svelte
@@ -9,22 +9,26 @@
     accent?: boolean;
     /** Highlights the item as a destructive action (e.g. Remove/Delete). */
     destructive?: boolean;
+    disabled?: boolean;
   }
 
-  let { icon: Icon, label, onclick, accent = false, destructive = false }: Props = $props();
+  let { icon: Icon, label, onclick, accent = false, destructive = false, disabled = false }: Props = $props();
 </script>
 
 <button
-  {onclick}
-  class="w-full text-left px-3 py-1.5 flex items-center gap-2.5 transition-colors cursor-pointer {destructive
-    ? 'hover:bg-red-500/10 hover:text-red-400 text-red-400'
-    : accent
-      ? 'hover:bg-brand-accent/15 hover:text-brand-accent-text'
-      : 'hover:bg-brand-main hover:text-brand-text-primary'}"
+  onclick={disabled ? undefined : onclick}
+  {disabled}
+  class="w-full text-left px-3 py-1.5 flex items-center gap-2.5 transition-colors {disabled
+    ? 'opacity-40 cursor-not-allowed text-brand-text-secondary'
+    : destructive
+      ? 'hover:bg-red-500/10 hover:text-red-400 text-red-400 cursor-pointer'
+      : accent
+        ? 'hover:bg-brand-accent/15 hover:text-brand-accent-text cursor-pointer'
+        : 'hover:bg-brand-main hover:text-brand-text-primary cursor-pointer'}"
   role="menuitem"
 >
   <Icon
-    class="w-3.5 h-3.5 shrink-0 {destructive ? 'text-red-400' : accent ? 'text-brand-accent-text' : 'text-brand-text-secondary'}"
+    class="w-3.5 h-3.5 shrink-0 {disabled ? 'text-brand-text-secondary/50' : destructive ? 'text-red-400' : accent ? 'text-brand-accent-text' : 'text-brand-text-secondary'}"
   />
   <span>{label}</span>
 </button>

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -460,6 +460,7 @@ export const en = {
     relativeYearsAgo: "{count} years ago",
     makeActiveBtn: "Make Active",
     activeBadgeLabel: "Active",
+    refreshPlaylistBtn: "Refresh Playlist",
     refreshAutoPlaylistTooltip: "Refresh auto-playlist with a new selection of songs from your library",
     refreshAllPlaylistsTooltip: "Refresh all auto-playlists and Smart Playlists with the latest songs from your library",
     allMatchingTracksAdded: "All matching songs from your library have been added to this auto-playlist.",

--- a/src/lib/locales/fr.ts
+++ b/src/lib/locales/fr.ts
@@ -459,6 +459,7 @@ export const fr = {
     relativeYearsAgo: "Il y a {count} ans",
     makeActiveBtn: "Définir comme active",
     activeBadgeLabel: "Active",
+    refreshPlaylistBtn: "Rafraîchir la playlist",
     refreshAutoPlaylistTooltip: "Rafraîchir la playlist automatique avec une nouvelle sélection de titres de votre bibliothèque",
     refreshAllPlaylistsTooltip: "Rafraîchir toutes les playlists automatiques et intelligentes avec les derniers titres de votre bibliothèque",
     allMatchingTracksAdded: "Tous les titres correspondants de votre bibliothèque ont été ajoutés à cette liste automatique.",


### PR DESCRIPTION
## 📋 Summary

Addresses #269

Relocates the less-frequently-used auto-playlist actions (Add All to Playlist, Save as Custom Playlist, and Refresh) out of the primary header action row and into the `...` overflow context menu in `AutoPlaylistDetailView.svelte`. This simplifies the auto-playlist header layout, keeping only Play, Shuffle Play, and the Column Selector inline, mirroring the pattern already used in `PlaylistView.svelte`.

## 🔍 Implementation Notes

- **ContextMenuItem.svelte**: Added `disabled?: boolean` property support to Svelte props, button DOM bindings, and menu styling (`opacity-40 cursor-not-allowed`) to enable visual feedback and click prevention for disabled menu actions.
- **AutoPlaylistDetailView.svelte**:
  - Removed "Add All", "Save as Custom", and "Refresh" from the primary action button row under the playlist metadata.
  - Placed them into the `...` overflow context menu.
  - Disabled these actions when `loading` is true or the playlist is empty (`songs.length === 0`).
  - Swapped the long, verbose tooltip string for a concise menu label: **"Refresh Playlist"** (and **"Rafraîchir la playlist"** in French).
- **en.ts / fr.ts**: Defined `refreshPlaylistBtn` for the shorter "Refresh Playlist" label.

## 🧪 Test Plan

- [x] `bun run check` (svelte-check) - Verified clean type check with 0 errors and 0 warnings.
- [x] `bun run test -- --run` (frontend) - Verified all 300 frontend tests pass.
- [x] Manually verified in the app - Verified visual alignment of headers and that overflow button triggers the correct menu options with appropriate loading/disabled visual treatments.

## ✅ Checklist

- [x] No unrelated changes bundled in
