### PR TITLE
Blurred album-art backdrop on album detail view

### DIFF
--- a/src/lib/components/AlbumDetailView.svelte
+++ b/src/lib/components/AlbumDetailView.svelte
@@ -21,6 +21,7 @@
   import ColumnSelector from "./ColumnSelector.svelte";
   import { Play, Plus, Edit3, Clock, Music } from "lucide-svelte";
   import type { Song, AlbumItem, PlayContext } from "../types";
+  import { getCoverArtUrl } from "../types";
   import { i18n } from "../stores/i18n.svelte";
   import { toastStore } from "../stores/toast.svelte";
   import { formatTrackNumber } from "../utils/artist";
@@ -134,6 +135,48 @@
     if (albumItem?.artist) return albumItem.artist;
     if (songs.length > 0) return songs[0].album_artist || songs[0].artist || "";
     return "";
+  });
+
+  // Resolves the same art_manual/art_automatic/art_embedded precedence as
+  // CoverArt.svelte and themeStore.updateArtworkColors, but at album level —
+  // embedded art has no album-wide URI, so it falls back to a representative song.
+  let backdropUrl = $state<string | null>(null);
+
+  $effect(() => {
+    const item = albumItem;
+    const fallbackSongId = item?.sample_song_id ?? songs[0]?.id;
+    let cancelled = false;
+
+    async function resolve() {
+      let url: string | null = null;
+      if (item?.art_manual) {
+        url =
+          item.art_manual.startsWith("http://") || item.art_manual.startsWith("https://") || item.art_manual.startsWith("/")
+            ? item.art_manual
+            : getCoverArtUrl(`luminous-art://${item.art_manual}`);
+      } else if (item?.art_automatic) {
+        if (item.art_automatic.startsWith("http://") || item.art_automatic.startsWith("https://") || item.art_automatic.startsWith("/")) {
+          url = item.art_automatic;
+        } else if (item.art_automatic.startsWith("album-")) {
+          url = getCoverArtUrl(`luminous-art://${item.art_automatic}`);
+        } else {
+          url = getCoverArtUrl(`luminous-art://local/${item.art_automatic}`);
+        }
+      } else if (item?.art_embedded && fallbackSongId !== undefined) {
+        try {
+          const uri = await invoke<string | null>("get_cover_art_uri", { songId: fallbackSongId });
+          if (uri) url = getCoverArtUrl(uri);
+        } catch (e) {
+          console.error("Failed to load album backdrop art:", e);
+        }
+      }
+      if (!cancelled) backdropUrl = url;
+    }
+
+    resolve();
+    return () => {
+      cancelled = true;
+    };
   });
 
   // Whether *any* track carries a disc > 1 decides whether every row
@@ -413,7 +456,17 @@
   });
 </script>
 
-<div class="flex-1 flex flex-col overflow-y-auto bg-brand-main text-brand-text-secondary h-full carousel-scroll" use:rememberScroll={`album-detail:${albumName}`}>
+<div
+  class="relative flex-1 flex flex-col overflow-y-auto text-brand-text-secondary h-full carousel-scroll {backdropUrl ? '' : 'bg-brand-main'}"
+  use:rememberScroll={`album-detail:${albumName}`}
+>
+  {#if backdropUrl}
+    <div class="absolute inset-0 z-0 overflow-hidden pointer-events-none" aria-hidden="true">
+      <img src={backdropUrl} alt="" class="w-full h-full object-cover scale-110 blur-2xl" />
+      <div class="absolute inset-0 bg-gradient-to-b from-transparent via-transparent to-brand-main"></div>
+    </div>
+  {/if}
+
   <!-- Album Hero & Summary Banner Header -->
   <div class="relative z-30 w-full border-b border-brand-border/60 bg-brand-main/60 backdrop-blur-md px-6 pt-6 pb-6">
     <div class="flex items-start justify-between gap-6 relative z-10">
@@ -505,10 +558,10 @@
   </div>
 
   <!-- Songs Table Section -->
-  <div class="px-6 py-6" class:pb-28={!!playerStore.currentSong}>
-    <div class="border border-brand-border rounded-lg bg-brand-sidebar/30">
+  <div class="relative z-10 px-6 py-6" class:pb-28={!!playerStore.currentSong}>
+    <div class="border border-brand-border rounded-lg bg-brand-sidebar/50 backdrop-blur-xl shadow-2xl overflow-hidden">
       <!-- Table Header -->
-      <div class="sticky top-0 z-10 flex flex-col rounded-t-lg bg-brand-sidebar border-b border-brand-border text-[10px] text-brand-text-secondary uppercase tracking-wider font-semibold select-none">
+      <div class="sticky top-0 z-10 flex flex-col rounded-t-lg bg-brand-sidebar/80 backdrop-blur-md border-b border-brand-border text-[10px] text-brand-text-secondary uppercase tracking-wider font-semibold select-none">
         <div class="grid items-center py-2.5 px-4" style={gridColsStyle}>
           <div class="text-center w-9"></div>
           {#if collectionStore.visibleColumns.track}

--- a/src/lib/components/AlbumDetailView.svelte
+++ b/src/lib/components/AlbumDetailView.svelte
@@ -561,7 +561,7 @@
   <div class="relative z-10 px-6 py-6" class:pb-28={!!playerStore.currentSong}>
     <div class="border border-brand-border rounded-lg bg-brand-sidebar/50 backdrop-blur-xl shadow-2xl overflow-hidden">
       <!-- Table Header -->
-      <div class="sticky top-0 z-10 flex flex-col rounded-t-lg bg-brand-sidebar/80 backdrop-blur-md border-b border-brand-border text-[10px] text-brand-text-secondary uppercase tracking-wider font-semibold select-none">
+      <div class="sticky top-0 z-10 flex flex-col rounded-t-lg bg-brand-sidebar/80 backdrop-blur-md border-b border-brand-border text-[10px] text-brand-text-primary uppercase tracking-wider font-semibold select-none">
         <div class="grid items-center py-2.5 px-4" style={gridColsStyle}>
           <div class="text-center w-9"></div>
           {#if collectionStore.visibleColumns.track}
@@ -814,7 +814,7 @@
       <div class="divide-y divide-brand-border/40 rounded-b-lg overflow-hidden">
         {#if loading}
           <div class="flex items-center justify-center py-16">
-            <div class="text-brand-text-secondary text-sm">{i18n.t('home.loading')}</div>
+            <div class="text-brand-text-primary text-sm">{i18n.t('home.loading')}</div>
           </div>
         {:else if sortedSongs.length === 0}
           <div class="py-16 text-center select-none">
@@ -854,7 +854,7 @@
               </div>
 
               {#if collectionStore.visibleColumns.track}
-                <div class="text-brand-text-secondary truncate pr-4 min-w-0 font-medium">
+                <div class="text-brand-text-primary truncate pr-4 min-w-0 font-medium">
                   {formatTrackNumber(song.track, song.disc, discCount, index)}
                 </div>
               {/if}
@@ -868,89 +868,89 @@
               {/if}
 
               {#if collectionStore.visibleColumns.artist}
-                <div class="text-brand-text-secondary truncate pr-4 flex items-center min-w-0">
+                <div class="text-brand-text-primary truncate pr-4 flex items-center min-w-0">
                   {#if song.artist}
                     <LinkButton
                       onclick={(e) => { e.stopPropagation(); collectionStore.viewArtist(song.album_artist?.trim() || song.artist || ""); }}
-                      class="text-brand-text-secondary truncate min-w-0"
+                      class="text-brand-text-primary truncate min-w-0"
                       title={i18n.t('collection.filterByArtist', { artist: song.artist })}
                     >
                       {song.artist}
                     </LinkButton>
                   {:else}
-                    <span class="text-brand-text-secondary truncate min-w-0">{i18n.t('collection.unknownArtist')}</span>
+                    <span class="text-brand-text-primary truncate min-w-0">{i18n.t('collection.unknownArtist')}</span>
                   {/if}
                 </div>
               {/if}
 
               {#if collectionStore.visibleColumns.album}
-                <div class="text-brand-text-secondary truncate pr-4 min-w-0 text-xs font-medium">
+                <div class="text-brand-text-primary truncate pr-4 min-w-0 text-xs font-medium">
                   {song.album || i18n.t('collection.unknownAlbum')}
                 </div>
               {/if}
 
               {#if collectionStore.visibleColumns.composer}
-                <div class="text-brand-text-secondary truncate pr-2 min-w-0 text-xs font-medium" title={song.composer}>
+                <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium" title={song.composer}>
                   {song.composer || "—"}
                 </div>
               {/if}
               {#if collectionStore.visibleColumns.album_artist}
-                <div class="text-brand-text-secondary truncate pr-2 min-w-0 text-xs font-medium" title={song.album_artist}>
+                <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium" title={song.album_artist}>
                   {song.album_artist || "—"}
                 </div>
               {/if}
               {#if collectionStore.visibleColumns.format}
-                <div class="text-brand-text-secondary truncate pr-2 min-w-0 text-xs font-semibold uppercase">
+                <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-semibold uppercase">
                   {song.filetype ? song.filetype.toUpperCase() : "—"}
                 </div>
               {/if}
               {#if collectionStore.visibleColumns.year}
-                <div class="text-brand-text-secondary truncate pr-2 min-w-0 text-xs font-medium">
+                <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium">
                   {song.year || "—"}
                 </div>
               {/if}
               {#if collectionStore.visibleColumns.genre}
-                <div class="text-brand-text-secondary truncate pr-2 min-w-0 text-xs font-medium" title={song.genre}>
+                <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium" title={song.genre}>
                   {song.genre || "—"}
                 </div>
               {/if}
               {#if collectionStore.visibleColumns.grouping}
-                <div class="text-brand-text-secondary truncate pr-2 min-w-0 text-xs font-medium" title={song.grouping}>
+                <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium" title={song.grouping}>
                   {song.grouping || "—"}
                 </div>
               {/if}
               {#if collectionStore.visibleColumns.bpm}
-                <div class="text-brand-text-secondary truncate pr-2 min-w-0 text-xs font-mono">
+                <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-mono">
                   {song.bpm || "—"}
                 </div>
               {/if}
               {#if collectionStore.visibleColumns.initial_key}
-                <div class="text-brand-text-secondary truncate pr-2 min-w-0 text-xs font-mono">
+                <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-mono">
                   {song.initial_key || "—"}
                 </div>
               {/if}
               {#if collectionStore.visibleColumns.bitrate}
-                <div class="text-brand-text-secondary truncate pr-2 min-w-0 text-xs font-mono">
+                <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-mono">
                   {song.bitrate ? `${song.bitrate}k` : "—"}
                 </div>
               {/if}
               {#if collectionStore.visibleColumns.samplerate}
-                <div class="text-brand-text-secondary truncate pr-2 min-w-0 text-xs font-mono">
+                <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-mono">
                   {formatSampleRate(song.samplerate)}
                 </div>
               {/if}
               {#if collectionStore.visibleColumns.bitdepth}
-                <div class="text-brand-text-secondary truncate pr-2 min-w-0 text-xs font-mono">
+                <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-mono">
                   {formatBitDepth(song.bitdepth)}
                 </div>
               {/if}
               {#if collectionStore.visibleColumns.channels}
-                <div class="text-brand-text-secondary truncate pr-2 min-w-0 text-xs font-medium">
+                <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium">
                   {formatChannels(song.channels)}
                 </div>
               {/if}
               {#if collectionStore.visibleColumns.filesize}
-                <div class="text-brand-text-secondary truncate pr-2 min-w-0 text-xs font-mono">
+                <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-mono">
                   {formatFileSize(song.filesize)}
                 </div>
               {/if}
@@ -962,34 +962,34 @@
               {/if}
 
               {#if collectionStore.visibleColumns.playcount}
-                <div class="text-center text-brand-text-secondary font-medium">
+                <div class="text-center text-brand-text-primary font-medium">
                   {song.playcount ?? 0}
                 </div>
               {/if}
               {#if collectionStore.visibleColumns.skipcount}
-                <div class="text-center text-brand-text-secondary font-mono text-xs">
+                <div class="text-center text-brand-text-primary font-mono text-xs">
                   {song.skipcount ?? 0}
                 </div>
               {/if}
               {#if collectionStore.visibleColumns.lastplayed}
-                <div class="text-center text-brand-text-secondary font-mono text-xs whitespace-nowrap">
+                <div class="text-center text-brand-text-primary font-mono text-xs whitespace-nowrap">
                   {formatDate(song.lastplayed)}
                 </div>
               {/if}
               {#if collectionStore.visibleColumns.added}
-                <div class="text-center text-brand-text-secondary font-mono text-xs whitespace-nowrap">
+                <div class="text-center text-brand-text-primary font-mono text-xs whitespace-nowrap">
                   {formatDate(song.added)}
                 </div>
               {/if}
 
               {#if collectionStore.visibleColumns.duration}
-                <div class="text-center text-brand-text-secondary font-medium">
+                <div class="text-center text-brand-text-primary font-medium">
                   {formatDuration(song.length_nanosec)}
                 </div>
               {/if}
 
               {#if collectionStore.visibleColumns.path}
-                <div class="text-brand-text-secondary truncate pr-4 min-w-0 text-xs font-mono" title={song.path}>
+                <div class="text-brand-text-primary truncate pr-4 min-w-0 text-xs font-mono" title={song.path}>
                   {song.path || "—"}
                 </div>
               {/if}
@@ -998,7 +998,7 @@
                 <div class="flex items-center justify-center gap-2.5">
                   <button
                     onclick={() => handleAddSongToPlaylist(song.id)}
-                    class="text-brand-text-secondary hover:text-brand-accent-text transition-colors cursor-pointer"
+                    class="text-brand-text-primary hover:text-brand-accent-text transition-colors cursor-pointer"
                     title={playlistsStore.activeCustomPlaylist
                       ? i18n.t('collection.addPlaylistTooltip', { name: playlistsStore.activeCustomPlaylist.name })
                       : i18n.t('collection.addPlaylistTooltipDefault')}
@@ -1007,7 +1007,7 @@
                   </button>
                   <button
                     onclick={() => openTagEditor(song.id)}
-                    class="text-brand-text-secondary hover:text-brand-accent-text transition-colors cursor-pointer"
+                    class="text-brand-text-primary hover:text-brand-accent-text transition-colors cursor-pointer"
                     title={i18n.t('collection.editTagsTooltip')}
                   >
                     <Edit3 class="w-4 h-4" />

--- a/src/lib/components/AutoPlaylistDetailView.svelte
+++ b/src/lib/components/AutoPlaylistDetailView.svelte
@@ -637,7 +637,7 @@ import { shuffleArray } from "../utils/shuffle";
   <div class="flex-1 min-h-0 px-6 py-6 flex flex-col" class:pb-28={!!playerStore.currentSong}>
     <div class="flex-1 min-h-0 border border-brand-border/60 rounded-xl bg-brand-sidebar/30 backdrop-blur-md relative overflow-auto" use:rememberScroll={`autoplaylist:${view.kind}:${view.genre ?? view.decade ?? ""}`}>
       <!-- Header -->
-      <div class="sticky top-0 z-20 flex flex-col bg-brand-sidebar border-b border-brand-border text-xs text-brand-text-secondary uppercase tracking-wider font-semibold select-none">
+      <div class="sticky top-0 z-20 flex flex-col bg-brand-sidebar border-b border-brand-border text-xs text-brand-text-primary uppercase tracking-wider font-semibold select-none">
         <div role="row" class="grid items-center py-3 px-4" style={gridColsStyle}>
           <SortableHeader
             active={sortField === "track" || sortField === "default"}
@@ -887,7 +887,7 @@ import { shuffleArray } from "../utils/shuffle";
       <!-- Rows -->
       <div class="divide-y divide-brand-border/40">
         {#if loading}
-          <div class="py-16 text-center text-brand-text-secondary text-sm">
+          <div class="py-16 text-center text-brand-text-primary text-sm">
             {i18n.t('home.loading')}
           </div>
         {:else if sortedSongs.length === 0}
@@ -914,7 +914,7 @@ import { shuffleArray } from "../utils/shuffle";
                 {selectedSongIds.has(song.id) ? 'bg-brand-accent/20 text-brand-accent-text-hover' : (playerStore.currentSong && playerStore.currentSong.id === song.id ? 'bg-brand-accent/10 text-brand-accent-text-hover' : 'hover:bg-brand-sidebar/40')}"
               style={gridColsStyle}
             >
-              <div class="text-center text-brand-text-secondary font-medium relative min-w-0">
+              <div class="text-center text-brand-text-primary font-medium relative min-w-0">
                 <div class="relative w-9 h-4 mx-auto flex items-center justify-center">
                   {#if playerStore.currentSong && playerStore.currentSong.id === song.id && playerStore.state === 'playing'}
                     <div class="flex items-center justify-center gap-0.5 h-4 w-4 absolute inset-0 group-hover:opacity-0 transition-opacity">
@@ -941,98 +941,98 @@ import { shuffleArray } from "../utils/shuffle";
                 </div>
               {/if}
               {#if collectionStore.visibleColumns.artist}
-                <div class="text-brand-text-secondary truncate pr-4 min-w-0">
+                <div class="text-brand-text-primary truncate pr-4 min-w-0">
                   {#if song.artist}
                     <LinkButton
                       onclick={(e) => { e.stopPropagation(); collectionStore.viewArtist(song.album_artist?.trim() || song.artist || ""); }}
-                      class="text-brand-text-secondary truncate min-w-0"
+                      class="text-brand-text-primary truncate min-w-0"
                       title={i18n.t('collection.filterByArtist', { artist: song.artist })}
                     >
                       {song.artist}
                     </LinkButton>
                   {:else}
-                    <span class="text-brand-text-secondary truncate min-w-0">{i18n.t('collection.unknownArtist')}</span>
+                    <span class="text-brand-text-primary truncate min-w-0">{i18n.t('collection.unknownArtist')}</span>
                   {/if}
                 </div>
               {/if}
               {#if collectionStore.visibleColumns.album}
-                <div class="text-brand-text-secondary truncate pr-4 min-w-0">
+                <div class="text-brand-text-primary truncate pr-4 min-w-0">
                   {#if song.album}
                     <LinkButton
                       onclick={(e) => { e.stopPropagation(); collectionStore.viewAlbum(song.album || ""); }}
-                      class="text-brand-text-secondary truncate min-w-0"
+                      class="text-brand-text-primary truncate min-w-0"
                       title={i18n.t('collection.filterByAlbum', { album: song.album })}
                     >
                       {song.album}
                     </LinkButton>
                   {:else}
-                    <span class="text-brand-text-secondary truncate min-w-0">{i18n.t('collection.unknownAlbum')}</span>
+                    <span class="text-brand-text-primary truncate min-w-0">{i18n.t('collection.unknownAlbum')}</span>
                   {/if}
                 </div>
               {/if}
 
               {#if collectionStore.visibleColumns.composer}
-                <div class="text-brand-text-secondary truncate pr-4 min-w-0 text-xs font-medium" title={song.composer}>
+                <div class="text-brand-text-primary truncate pr-4 min-w-0 text-xs font-medium" title={song.composer}>
                   {song.composer || "—"}
                 </div>
               {/if}
               {#if collectionStore.visibleColumns.album_artist}
-                <div class="text-brand-text-secondary truncate pr-4 min-w-0 text-xs font-medium" title={song.album_artist}>
+                <div class="text-brand-text-primary truncate pr-4 min-w-0 text-xs font-medium" title={song.album_artist}>
                   {song.album_artist || "—"}
                 </div>
               {/if}
               {#if collectionStore.visibleColumns.format}
-                <div class="text-brand-text-secondary truncate pr-2 min-w-0 text-xs font-semibold uppercase">
+                <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-semibold uppercase">
                   {song.filetype ? song.filetype.toUpperCase() : "—"}
                 </div>
               {/if}
               {#if collectionStore.visibleColumns.year}
-                <div class="text-brand-text-secondary truncate pr-2 min-w-0 text-xs font-medium">
+                <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium">
                   {song.year || "—"}
                 </div>
               {/if}
               {#if collectionStore.visibleColumns.genre}
-                <div class="text-brand-text-secondary truncate pr-2 min-w-0 text-xs font-medium" title={song.genre}>
+                <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium" title={song.genre}>
                   {song.genre || "—"}
                 </div>
               {/if}
               {#if collectionStore.visibleColumns.grouping}
-                <div class="text-brand-text-secondary truncate pr-2 min-w-0 text-xs font-medium" title={song.grouping}>
+                <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium" title={song.grouping}>
                   {song.grouping || "—"}
                 </div>
               {/if}
               {#if collectionStore.visibleColumns.bpm}
-                <div class="text-brand-text-secondary truncate pr-2 min-w-0 text-xs font-mono">
+                <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-mono">
                   {song.bpm || "—"}
                 </div>
               {/if}
               {#if collectionStore.visibleColumns.initial_key}
-                <div class="text-brand-text-secondary truncate pr-2 min-w-0 text-xs font-mono">
+                <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-mono">
                   {song.initial_key || "—"}
                 </div>
               {/if}
               {#if collectionStore.visibleColumns.bitrate}
-                <div class="text-brand-text-secondary truncate pr-2 min-w-0 text-xs font-mono">
+                <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-mono">
                   {song.bitrate ? `${song.bitrate}k` : "—"}
                 </div>
               {/if}
               {#if collectionStore.visibleColumns.samplerate}
-                <div class="text-brand-text-secondary truncate pr-2 min-w-0 text-xs font-mono">
+                <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-mono">
                   {formatSampleRate(song.samplerate)}
                 </div>
               {/if}
               {#if collectionStore.visibleColumns.bitdepth}
-                <div class="text-brand-text-secondary truncate pr-2 min-w-0 text-xs font-mono">
+                <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-mono">
                   {formatBitDepth(song.bitdepth)}
                 </div>
               {/if}
               {#if collectionStore.visibleColumns.channels}
-                <div class="text-brand-text-secondary truncate pr-2 min-w-0 text-xs font-medium">
+                <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium">
                   {formatChannels(song.channels)}
                 </div>
               {/if}
               {#if collectionStore.visibleColumns.filesize}
-                <div class="text-brand-text-secondary truncate pr-2 min-w-0 text-xs font-mono">
+                <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-mono">
                   {formatFileSize(song.filesize)}
                 </div>
               {/if}
@@ -1042,32 +1042,32 @@ import { shuffleArray } from "../utils/shuffle";
                 </div>
               {/if}
               {#if collectionStore.visibleColumns.playcount}
-                <div class="text-center text-brand-text-secondary text-xs min-w-0">
+                <div class="text-center text-brand-text-primary text-xs min-w-0">
                   {song.playcount || 0}
                 </div>
               {/if}
               {#if collectionStore.visibleColumns.skipcount}
-                <div class="text-center text-brand-text-secondary text-xs min-w-0">
+                <div class="text-center text-brand-text-primary text-xs min-w-0">
                   {song.skipcount || 0}
                 </div>
               {/if}
               {#if collectionStore.visibleColumns.lastplayed}
-                <div class="text-center text-brand-text-secondary font-mono text-xs whitespace-nowrap">
+                <div class="text-center text-brand-text-primary font-mono text-xs whitespace-nowrap">
                   {formatDate(song.lastplayed)}
                 </div>
               {/if}
               {#if collectionStore.visibleColumns.added}
-                <div class="text-center text-brand-text-secondary font-mono text-xs whitespace-nowrap">
+                <div class="text-center text-brand-text-primary font-mono text-xs whitespace-nowrap">
                   {formatDate(song.added)}
                 </div>
               {/if}
               {#if collectionStore.visibleColumns.duration}
-                <div class="text-center text-brand-text-secondary text-xs min-w-0">
+                <div class="text-center text-brand-text-primary text-xs min-w-0">
                   {formatDuration(song.length_nanosec)}
                 </div>
               {/if}
               {#if collectionStore.visibleColumns.path}
-                <div class="text-brand-text-secondary truncate pr-4 min-w-0 text-xs font-mono" title={song.path}>
+                <div class="text-brand-text-primary truncate pr-4 min-w-0 text-xs font-mono" title={song.path}>
                   {song.path || "—"}
                 </div>
               {/if}
@@ -1077,7 +1077,7 @@ import { shuffleArray } from "../utils/shuffle";
                   <div class="flex items-center justify-center gap-2.5">
                     <button
                       onclick={(e) => { e.stopPropagation(); handleAddSongToPlaylist(song.id); }}
-                      class="text-brand-text-secondary hover:text-brand-accent-text transition-colors cursor-pointer"
+                      class="text-brand-text-primary hover:text-brand-accent-text transition-colors cursor-pointer"
                       title={playlistsStore.activeCustomPlaylist
                         ? i18n.t('collection.addPlaylistTooltip', { name: playlistsStore.activeCustomPlaylist.name })
                         : i18n.t('collection.addPlaylistTooltipDefault')}
@@ -1086,7 +1086,7 @@ import { shuffleArray } from "../utils/shuffle";
                     </button>
                     <button
                       onclick={(e) => { e.stopPropagation(); openTagEditor(song.id); }}
-                      class="text-brand-text-secondary hover:text-brand-accent-text transition-colors cursor-pointer"
+                      class="text-brand-text-primary hover:text-brand-accent-text transition-colors cursor-pointer"
                       title={i18n.t('collection.editTagsTooltip')}
                     >
                       <Edit3 class="w-4 h-4" />
@@ -1101,7 +1101,7 @@ import { shuffleArray } from "../utils/shuffle";
     </div>
 
     {#if autoPlay && (kind === "genre" || kind === "decade") && playlistId !== undefined && playerStore.isAutoPlayExhausted(playlistId)}
-      <div class="mt-4 p-3 rounded-lg bg-brand-sidebar/60 border border-brand-border/40 text-center text-xs text-brand-text-secondary flex items-center justify-center gap-2 select-none">
+      <div class="mt-4 p-3 rounded-lg bg-brand-sidebar/60 border border-brand-border/40 text-center text-xs text-brand-text-primary flex items-center justify-center gap-2 select-none">
         <CheckCircle2 class="w-4 h-4 text-brand-accent shrink-0" />
         <span>{i18n.t('playlists.allMatchingTracksAdded')}</span>
       </div>

--- a/src/lib/components/PlaylistView.svelte
+++ b/src/lib/components/PlaylistView.svelte
@@ -945,7 +945,7 @@
     <div class="flex-1 min-h-0 p-6 flex flex-col" class:pb-28={!!playerStore.currentSong}>
       <div class="flex-1 min-h-0 border border-brand-border/60 rounded-xl bg-brand-sidebar/30 backdrop-blur-md relative overflow-auto" use:rememberScroll={`playlist:${playlistsStore.activePlaylistId}`}>
       <!-- Header -->
-      <div class="sticky top-0 z-20 flex flex-col bg-brand-sidebar border-b border-brand-border text-xs text-brand-text-secondary uppercase tracking-wider font-semibold select-none">
+      <div class="sticky top-0 z-20 flex flex-col bg-brand-sidebar border-b border-brand-border text-xs text-brand-text-primary uppercase tracking-wider font-semibold select-none">
         <div role="row" class="grid items-center py-3 px-4" style={gridColsStyle}>
           <SortableHeader
             active={sortField === "position"}
@@ -1231,9 +1231,9 @@
               }"
             style={gridColsStyle}
           >
-            <div class="text-center text-brand-text-secondary font-medium relative min-w-0 cursor-grab active:cursor-grabbing">
+            <div class="text-center text-brand-text-primary font-medium relative min-w-0 cursor-grab active:cursor-grabbing">
               <div class="relative w-5 h-4 mx-auto flex items-center justify-center">
-                <GripVertical class="w-3.5 h-3.5 opacity-0 group-hover:opacity-60 text-brand-text-secondary transition-opacity shrink-0 absolute -left-3 top-0.5 pointer-events-none" />
+                <GripVertical class="w-3.5 h-3.5 opacity-0 group-hover:opacity-60 text-brand-text-primary transition-opacity shrink-0 absolute -left-3 top-0.5 pointer-events-none" />
                 {#if isItemPlaying && playerStore.state === "playing"}
                   <div class="flex items-center justify-center gap-0.5 h-4 w-4 absolute inset-0 group-hover:opacity-0 transition-opacity">
                     <NowPlayingBars />
@@ -1255,7 +1255,7 @@
             </div>
 
             {#if collectionStore.visibleColumns.title}
-              <div class="font-medium truncate pr-4 min-w-0 {isSelected || (!unavailable && playerStore.playlistItemUuid === item.uuid) ? 'text-brand-accent-text-hover' : unavailable ? 'text-brand-text-secondary' : 'text-brand-text-primary'}">
+              <div class="font-medium truncate pr-4 min-w-0 {isSelected || (!unavailable && playerStore.playlistItemUuid === item.uuid) ? 'text-brand-accent-text-hover' : unavailable ? 'text-brand-text-primary' : 'text-brand-text-primary'}">
                 <div class="flex items-center gap-2 max-w-full">
                   {#if trueUnavailable}
                     <span title={i18n.t("playlists.fileNotFoundTooltip")}>
@@ -1294,105 +1294,105 @@
             {/if}
 
             {#if collectionStore.visibleColumns.artist}
-              <div class="text-brand-text-secondary truncate pr-4 min-w-0">
+              <div class="text-brand-text-primary truncate pr-4 min-w-0">
                 {#if trueUnavailable}
-                  <span class="text-brand-text-secondary italic text-xs">{i18n.t("playlists.fileNotFoundText")}</span>
+                  <span class="text-brand-text-primary italic text-xs">{i18n.t("playlists.fileNotFoundText")}</span>
                 {:else if disconnected}
-                  <span class="text-brand-text-secondary italic text-xs">{i18n.t("collection.driveDisconnectedText")}</span>
+                  <span class="text-brand-text-primary italic text-xs">{i18n.t("collection.driveDisconnectedText")}</span>
                 {:else if item.song?.artist}
                   <LinkButton
                     onclick={(e) => { e.stopPropagation(); collectionStore.viewArtist(item.song?.album_artist?.trim() || item.song?.artist || ""); }}
-                    class="text-brand-text-secondary truncate min-w-0"
+                    class="text-brand-text-primary truncate min-w-0"
                     title={i18n.t("collection.filterByArtist", { artist: item.song.artist })}
                   >
                     {item.song.artist}
                   </LinkButton>
                 {:else}
-                  <span class="text-brand-text-secondary truncate min-w-0">{i18n.t("collection.unknownArtist")}</span>
+                  <span class="text-brand-text-primary truncate min-w-0">{i18n.t("collection.unknownArtist")}</span>
                 {/if}
               </div>
             {/if}
 
             {#if collectionStore.visibleColumns.album}
-              <div class="text-brand-text-secondary truncate pr-4 min-w-0">
+              <div class="text-brand-text-primary truncate pr-4 min-w-0">
                 {#if unavailable}
-                  <span class="text-brand-text-secondary italic text-xs truncate min-w-0">{item.song?.album ?? ""}</span>
+                  <span class="text-brand-text-primary italic text-xs truncate min-w-0">{item.song?.album ?? ""}</span>
                 {:else if item.song?.album}
                   <LinkButton
                     onclick={(e) => { e.stopPropagation(); collectionStore.viewAlbum(item.song?.album || ""); }}
-                    class="text-brand-text-secondary truncate min-w-0"
+                    class="text-brand-text-primary truncate min-w-0"
                     title={i18n.t("collection.filterByAlbum", { album: item.song.album })}
                   >
                     {item.song.album}
                   </LinkButton>
                 {:else}
-                  <span class="text-brand-text-secondary truncate min-w-0">{i18n.t("collection.unknownAlbum")}</span>
+                  <span class="text-brand-text-primary truncate min-w-0">{i18n.t("collection.unknownAlbum")}</span>
                 {/if}
               </div>
             {/if}
 
             {#if collectionStore.visibleColumns.composer}
-              <div class="text-brand-text-secondary truncate pr-4 min-w-0 text-xs font-medium" title={item.song?.composer}>
+              <div class="text-brand-text-primary truncate pr-4 min-w-0 text-xs font-medium" title={item.song?.composer}>
                 {item.song?.composer || "—"}
               </div>
             {/if}
             {#if collectionStore.visibleColumns.album_artist}
-              <div class="text-brand-text-secondary truncate pr-4 min-w-0 text-xs font-medium" title={item.song?.album_artist}>
+              <div class="text-brand-text-primary truncate pr-4 min-w-0 text-xs font-medium" title={item.song?.album_artist}>
                 {item.song?.album_artist || "—"}
               </div>
             {/if}
             {#if collectionStore.visibleColumns.format}
-              <div class="text-brand-text-secondary truncate pr-2 min-w-0 text-xs font-semibold uppercase">
+              <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-semibold uppercase">
                 {item.song?.filetype ? item.song.filetype.toUpperCase() : "—"}
               </div>
             {/if}
             {#if collectionStore.visibleColumns.year}
-              <div class="text-brand-text-secondary truncate pr-2 min-w-0 text-xs font-medium">
+              <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium">
                 {item.song?.year || "—"}
               </div>
             {/if}
             {#if collectionStore.visibleColumns.genre}
-              <div class="text-brand-text-secondary truncate pr-2 min-w-0 text-xs font-medium" title={item.song?.genre}>
+              <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium" title={item.song?.genre}>
                 {item.song?.genre || "—"}
               </div>
             {/if}
             {#if collectionStore.visibleColumns.grouping}
-              <div class="text-brand-text-secondary truncate pr-2 min-w-0 text-xs font-medium" title={item.song?.grouping}>
+              <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium" title={item.song?.grouping}>
                 {item.song?.grouping || "—"}
               </div>
             {/if}
             {#if collectionStore.visibleColumns.bpm}
-              <div class="text-brand-text-secondary truncate pr-2 min-w-0 text-xs font-mono">
+              <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-mono">
                 {item.song?.bpm || "—"}
               </div>
             {/if}
             {#if collectionStore.visibleColumns.initial_key}
-              <div class="text-brand-text-secondary truncate pr-2 min-w-0 text-xs font-mono">
+              <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-mono">
                 {item.song?.initial_key || "—"}
               </div>
             {/if}
             {#if collectionStore.visibleColumns.bitrate}
-              <div class="text-brand-text-secondary truncate pr-2 min-w-0 text-xs font-mono">
+              <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-mono">
                 {item.song?.bitrate ? `${item.song.bitrate}k` : "—"}
               </div>
             {/if}
             {#if collectionStore.visibleColumns.samplerate}
-              <div class="text-brand-text-secondary truncate pr-2 min-w-0 text-xs font-mono">
+              <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-mono">
                 {formatSampleRate(item.song?.samplerate)}
               </div>
             {/if}
             {#if collectionStore.visibleColumns.bitdepth}
-              <div class="text-brand-text-secondary truncate pr-2 min-w-0 text-xs font-mono">
+              <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-mono">
                 {formatBitDepth(item.song?.bitdepth)}
               </div>
             {/if}
             {#if collectionStore.visibleColumns.channels}
-              <div class="text-brand-text-secondary truncate pr-2 min-w-0 text-xs font-medium">
+              <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium">
                 {formatChannels(item.song?.channels)}
               </div>
             {/if}
             {#if collectionStore.visibleColumns.filesize}
-              <div class="text-brand-text-secondary truncate pr-2 min-w-0 text-xs font-mono">
+              <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-mono">
                 {formatFileSize(item.song?.filesize)}
               </div>
             {/if}
@@ -1404,32 +1404,32 @@
               </div>
             {/if}
             {#if collectionStore.visibleColumns.playcount}
-              <div class="text-center text-brand-text-secondary text-xs min-w-0">
+              <div class="text-center text-brand-text-primary text-xs min-w-0">
                 {item.song?.playcount || 0}
               </div>
             {/if}
             {#if collectionStore.visibleColumns.skipcount}
-              <div class="text-center text-brand-text-secondary text-xs min-w-0">
+              <div class="text-center text-brand-text-primary text-xs min-w-0">
                 {item.song?.skipcount || 0}
               </div>
             {/if}
             {#if collectionStore.visibleColumns.lastplayed}
-              <div class="text-center text-brand-text-secondary font-mono text-xs whitespace-nowrap">
+              <div class="text-center text-brand-text-primary font-mono text-xs whitespace-nowrap">
                 {formatDate(item.song?.lastplayed)}
               </div>
             {/if}
             {#if collectionStore.visibleColumns.added}
-              <div class="text-center text-brand-text-secondary font-mono text-xs whitespace-nowrap">
+              <div class="text-center text-brand-text-primary font-mono text-xs whitespace-nowrap">
                 {formatDate(item.song?.added)}
               </div>
             {/if}
             {#if collectionStore.visibleColumns.duration}
-              <div class="text-center text-brand-text-secondary text-xs min-w-0">
+              <div class="text-center text-brand-text-primary text-xs min-w-0">
                 {formatDuration(item.song?.length_nanosec)}
               </div>
             {/if}
             {#if collectionStore.visibleColumns.path}
-              <div class="text-brand-text-secondary truncate pr-4 min-w-0 text-xs font-mono" title={item.song?.path}>
+              <div class="text-brand-text-primary truncate pr-4 min-w-0 text-xs font-mono" title={item.song?.path}>
                 {item.song?.path || "—"}
               </div>
             {/if}
@@ -1439,7 +1439,7 @@
                 <div class="flex items-center justify-center gap-2.5">
                   <button
                     onclick={(e) => { e.stopPropagation(); item.song?.id && !unavailable && openTagEditor(item.song.id); }}
-                    class="text-brand-text-secondary/60 hover:text-brand-accent-text transition-colors disabled:opacity-30 cursor-pointer"
+                    class="text-brand-text-primary/60 hover:text-brand-accent-text transition-colors disabled:opacity-30 cursor-pointer"
                     title={i18n.t("collection.editTagsTooltip")}
                     disabled={!item.song || unavailable}
                   >
@@ -1447,7 +1447,7 @@
                   </button>
                   <button
                     onclick={(e) => { e.stopPropagation(); handleRemoveItem(item.uuid); }}
-                    class="text-brand-text-secondary/60 hover:text-red-400 transition-colors cursor-pointer"
+                    class="text-brand-text-primary/60 hover:text-red-400 transition-colors cursor-pointer"
                     title={i18n.t("playlists.removeFromPlaylist")}
                   >
                     <Trash2 class="w-4 h-4" />
@@ -1459,8 +1459,8 @@
         {/each}
 
         {#if filteredTracks.length === 0}
-          <div class="py-12 text-center text-brand-text-secondary/45 select-none">
-            <ListMusic class="w-12 h-12 mx-auto mb-2 text-brand-text-secondary/30" />
+          <div class="py-12 text-center text-brand-text-primary/45 select-none">
+            <ListMusic class="w-12 h-12 mx-auto mb-2 text-brand-text-primary/30" />
             {#if filterQuery}
               {i18n.t("playlists.noFilterResults", { query: filterQuery })}
             {:else if isQueue}
@@ -1499,7 +1499,7 @@
         <div class="h-4 w-px bg-brand-border/60"></div>
         <button
           onclick={() => { selectedUuids = new Set(); lastSelectedIndex = null; }}
-          class="text-brand-text-secondary hover:text-brand-text-primary transition-colors cursor-pointer"
+          class="text-brand-text-primary hover:text-brand-text-primary transition-colors cursor-pointer"
         >
           {i18n.t("playlists.clearSelection")}
         </button>
@@ -1507,9 +1507,9 @@
     {/if}
   {:else}
     <!-- No playlist selected -->
-    <div class="flex-1 flex flex-col items-center justify-center text-brand-text-secondary/60">
-      <ListMusic class="w-16 h-16 mb-4 text-brand-text-secondary/30" />
-      <h2 class="text-lg font-bold text-brand-text-secondary/80 mb-1">{i18n.t("playlists.noPlaylistsTitle")}</h2>
+    <div class="flex-1 flex flex-col items-center justify-center text-brand-text-primary/60">
+      <ListMusic class="w-16 h-16 mb-4 text-brand-text-primary/30" />
+      <h2 class="text-lg font-bold text-brand-text-primary/80 mb-1">{i18n.t("playlists.noPlaylistsTitle")}</h2>
       <p class="text-sm">{i18n.t("playlists.noPlaylistsText")}</p>
     </div>
   {/if}


### PR DESCRIPTION
## Summary
- Adds a full-bleed, blurred backdrop of the album cover behind the album detail hero and song table (design experiment inspired by Plex's media detail pages).
- Resolves the backdrop image via the same manual → automatic → embedded precedence used by `CoverArt.svelte` / the theme store, falling back to a representative song id (`sample_song_id` or the first loaded song) for embedded-only art.
- The song table panel is now a frosted "mask" (translucent + `backdrop-blur`) rather than a flat opaque card, so the backdrop shows through subtly behind it.
- Falls back to the existing solid background when there's no art available.

## Test plan
- [x] `npx svelte-check` — 0 errors, 0 warnings.
- [x] Manual check in the running desktop app (this repo's Tauri IPC isn't available in the sandboxed browser preview, so this was tuned iteratively against user-provided screenshots rather than automated verification).