### PR TITLE
Pin glass-surface backdrop-filter to its own GPU layer to fix flicker

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -119,6 +119,12 @@
   -webkit-backdrop-filter: blur(20px) saturate(180%) !important;
   border-color: var(--glass-border-color, var(--color-border));
   box-shadow: var(--glass-shadow, none);
+  /* Pin this panel's backdrop-filter output to its own GPU layer so it's
+     cached instead of re-rasterized on every composite frame triggered
+     elsewhere in the window (see AlbumDetailView's backdrop <img> fix for
+     the same underlying flicker). */
+  will-change: backdrop-filter;
+  transform: translateZ(0);
 }
 
 :global(.bg-brand-sidebar.glass-surface),


### PR DESCRIPTION
## Summary
- Follow-up to #276 (album detail backdrop flicker). Same root cause, different surface: any element using live `backdrop-filter` (or a static `blur()`'d `<img>`) that isn't pinned to its own stable GPU compositing layer gets re-rasterized on every full-frame composite the webview performs for any reason elsewhere in the window — visible as an occasional flicker.
- `.glass-surface` (`src/app.css`) is the shared class backing the sidebar, top nav header, player bar footer, and right panel under the System/glass theme. Applying the fix there covers all of them in one place.

## Changes
- `app.css`: add `will-change: backdrop-filter` + `transform: translateZ(0)` to `.glass-surface` so its blurred output is cached as a stable layer instead of recomputed per composite.

## Test plan
- [x] Switch to the System (glass) theme
- [x] Confirm the sidebar no longer flickers occasionally (as reported)
- [x] Spot-check the header, player bar, and right panel for the same issue while interacting with unrelated UI elsewhere in the window