### PR TITLE
fix(playlists): let header scroll with content instead of staying pinned

### DIFF
--- a/src/lib/components/AutoPlaylistDetailView.svelte
+++ b/src/lib/components/AutoPlaylistDetailView.svelte
@@ -504,7 +504,10 @@ import { shuffleArray } from "../utils/shuffle";
 
 </script>
 
-<div class="flex-1 flex flex-col overflow-hidden bg-brand-main text-brand-text-secondary h-full">
+<div
+  class="flex-1 flex flex-col overflow-y-auto carousel-scroll bg-brand-main text-brand-text-secondary h-full"
+  use:rememberScroll={`autoplaylist:${view.kind}:${view.genre ?? view.decade ?? ""}`}
+>
   <!-- Auto-Playlist Hero & Summary Banner Header -->
   <div class="relative z-30 w-full border-b border-brand-border/60 bg-brand-main/60 backdrop-blur-md px-6 pt-6 pb-6 shrink-0">
     <div class="flex items-stretch justify-between gap-6 relative z-10">
@@ -634,8 +637,8 @@ import { shuffleArray } from "../utils/shuffle";
     </div>
   </div>
 
-  <div class="flex-1 min-h-0 px-6 py-6 flex flex-col" class:pb-28={!!playerStore.currentSong}>
-    <div class="flex-1 min-h-0 border border-brand-border/60 rounded-xl bg-brand-sidebar/30 backdrop-blur-md relative overflow-auto" use:rememberScroll={`autoplaylist:${view.kind}:${view.genre ?? view.decade ?? ""}`}>
+  <div class="px-6 py-6 flex flex-col" class:pb-28={!!playerStore.currentSong}>
+    <div class="border border-brand-border/60 rounded-xl bg-brand-sidebar/30 backdrop-blur-md relative overflow-hidden">
       <!-- Header -->
       <div class="sticky top-0 z-20 flex flex-col bg-brand-sidebar border-b border-brand-border text-xs text-brand-text-primary uppercase tracking-wider font-semibold select-none">
         <div role="row" class="grid items-center py-3 px-4" style={gridColsStyle}>
@@ -1239,3 +1242,13 @@ import { shuffleArray } from "../utils/shuffle";
     </form>
   </Modal>
 {/if}
+
+<style>
+  :global(.carousel-scroll) {
+    scrollbar-width: none;
+    -ms-overflow-style: none;
+  }
+  :global(.carousel-scroll::-webkit-scrollbar) {
+    display: none;
+  }
+</style>

--- a/src/lib/components/PlaylistView.svelte
+++ b/src/lib/components/PlaylistView.svelte
@@ -758,7 +758,10 @@
   {/if}
 
   {#if activePlaylist}
-    <div class="flex-1 flex flex-col min-h-0 relative z-10">
+    <div
+      class="flex-1 flex flex-col min-h-0 relative z-10 overflow-y-auto carousel-scroll"
+      use:rememberScroll={`playlist:${playlistsStore.activePlaylistId}`}
+    >
     <!-- Stacked Cover Art Hero & Summary Banner Header -->
     <div class="relative z-30 w-full overflow-hidden border-b border-brand-border/60 bg-brand-main/60 backdrop-blur-md px-6 pt-6 pb-6 shrink-0">
       <div class="flex items-stretch justify-between gap-6 relative z-10">
@@ -942,8 +945,8 @@
     </div>
 
     <!-- Tracks List Container -->
-    <div class="flex-1 min-h-0 p-6 flex flex-col" class:pb-28={!!playerStore.currentSong}>
-      <div class="flex-1 min-h-0 border border-brand-border/60 rounded-xl bg-brand-sidebar/30 backdrop-blur-md relative overflow-auto" use:rememberScroll={`playlist:${playlistsStore.activePlaylistId}`}>
+    <div class="p-6 flex flex-col" class:pb-28={!!playerStore.currentSong}>
+      <div class="border border-brand-border/60 rounded-xl bg-brand-sidebar/30 backdrop-blur-md relative overflow-hidden">
       <!-- Header -->
       <div class="sticky top-0 z-20 flex flex-col bg-brand-sidebar border-b border-brand-border text-xs text-brand-text-primary uppercase tracking-wider font-semibold select-none">
         <div role="row" class="grid items-center py-3 px-4" style={gridColsStyle}>
@@ -1676,3 +1679,13 @@
     </form>
   </Modal>
 {/if}
+
+<style>
+  :global(.carousel-scroll) {
+    scrollbar-width: none;
+    -ms-overflow-style: none;
+  }
+  :global(.carousel-scroll::-webkit-scrollbar) {
+    display: none;
+  }
+</style>

--- a/src/lib/utils/scrollMemory.ts
+++ b/src/lib/utils/scrollMemory.ts
@@ -7,18 +7,49 @@
 // these components via {#if}/{#await} blocks).
 const positions = new Map<string, number>();
 
+// How many animation frames to keep re-asserting the restored scrollTop for.
+// Views whose rows come from an async IPC fetch (e.g. playlist tracks) often
+// still have stale/empty content on the frame right after mount — a single
+// rAF isn't enough to outlast that round trip — so we keep retrying for a
+// short window instead of just once.
+const RESTORE_RETRY_FRAMES = 20;
+
 function attachScrollMemory(node: HTMLElement, key: string): () => void {
+  let userScrolled = false;
+  let lastRestoredValue: number | null = null;
+
   const restore = () => {
+    if (userScrolled) return;
     node.scrollTop = positions.get(key) ?? 0;
+    // Read back the actual (possibly clamped, e.g. if content hasn't grown to
+    // its final height yet) value the browser applied, not the raw target —
+    // otherwise the resulting 'scroll' event won't match and looks like a
+    // real user scroll, permanently disabling further retries below.
+    lastRestoredValue = node.scrollTop;
   };
-  // Restore immediately for content whose layout is already correct, and again
-  // next frame for content (e.g. virtualized lists) whose height settles late.
+
   restore();
-  const raf = requestAnimationFrame(restore);
-  const onScroll = () => positions.set(key, node.scrollTop);
+  let rafId = requestAnimationFrame(function tick(frame = 0) {
+    restore();
+    if (frame + 1 < RESTORE_RETRY_FRAMES) {
+      rafId = requestAnimationFrame(() => tick(frame + 1));
+    }
+  });
+
+  // Distinguishes the user actually grabbing the scrollbar/wheel from the
+  // 'scroll' events our own programmatic restore() calls above trigger.
+  const onScroll = () => {
+    if (lastRestoredValue !== null && node.scrollTop === lastRestoredValue) {
+      lastRestoredValue = null;
+      return;
+    }
+    userScrolled = true;
+    positions.set(key, node.scrollTop);
+  };
   node.addEventListener("scroll", onScroll, { passive: true });
+
   return () => {
-    cancelAnimationFrame(raf);
+    cancelAnimationFrame(rafId);
     node.removeEventListener("scroll", onScroll);
   };
 }


### PR DESCRIPTION
## Summary
- Playlist, Queue, and auto-playlist (genre/decade/favourites/history/recently-added) detail views pinned the hero banner outside the scrollable area, which ate vertical space and reduced the number of visible song rows.
- Moved the scroll container to wrap the hero header + track list in both `PlaylistView.svelte` and `AutoPlaylistDetailView.svelte`, matching the pattern already used in `AlbumDetailView.svelte` — the header now scrolls away with the content and only the table's column header stays sticky.

## Test plan
- [x] Run the app locally, open a custom playlist, the Queue, and a genre/decade/favourites/history/recently-added auto-playlist; confirm the hero header scrolls out of view as you scroll the track list, and the column header stays sticky at the top.
- [x] Confirm the floating multi-select toolbar still stays pinned to the bottom of the viewport while scrolling (not affected by the scroll container change).
- [ ] Confirm scroll position is remembered per playlist when navigating away and back.