### PR TITLE
fix: remove font-mono from date added and last played columns

### DIFF
--- a/src/lib/components/AlbumDetailView.svelte
+++ b/src/lib/components/AlbumDetailView.svelte
@@ -965,12 +965,12 @@
                 </div>
               {/if}
               {#if collectionStore.visibleColumns.lastplayed}
-                <div class="text-center text-brand-text-primary font-mono text-xs whitespace-nowrap">
+                <div class="text-center text-brand-text-primary text-xs whitespace-nowrap">
                   {formatDate(song.lastplayed)}
                 </div>
               {/if}
               {#if collectionStore.visibleColumns.added}
-                <div class="text-center text-brand-text-primary font-mono text-xs whitespace-nowrap">
+                <div class="text-center text-brand-text-primary text-xs whitespace-nowrap">
                   {formatDate(song.added)}
                 </div>
               {/if}

--- a/src/lib/components/AutoPlaylistDetailView.svelte
+++ b/src/lib/components/AutoPlaylistDetailView.svelte
@@ -1055,12 +1055,12 @@ import { shuffleArray } from "../utils/shuffle";
                 </div>
               {/if}
               {#if collectionStore.visibleColumns.lastplayed}
-                <div class="text-center text-brand-text-primary font-mono text-xs whitespace-nowrap">
+                <div class="text-center text-brand-text-primary text-xs whitespace-nowrap">
                   {formatDate(song.lastplayed)}
                 </div>
               {/if}
               {#if collectionStore.visibleColumns.added}
-                <div class="text-center text-brand-text-primary font-mono text-xs whitespace-nowrap">
+                <div class="text-center text-brand-text-primary text-xs whitespace-nowrap">
                   {formatDate(song.added)}
                 </div>
               {/if}

--- a/src/lib/components/CollectionView.svelte
+++ b/src/lib/components/CollectionView.svelte
@@ -877,12 +877,12 @@
                   </div>
                 {/if}
                 {#if collectionStore.visibleColumns.lastplayed}
-                  <div class="text-center text-brand-text-secondary font-mono text-xs whitespace-nowrap">
+                  <div class="text-center text-brand-text-secondary text-xs whitespace-nowrap">
                     {formatDate(song.lastplayed)}
                   </div>
                 {/if}
                 {#if collectionStore.visibleColumns.added}
-                  <div class="text-center text-brand-text-secondary font-mono text-xs whitespace-nowrap">
+                  <div class="text-center text-brand-text-secondary text-xs whitespace-nowrap">
                     {formatDate(song.added)}
                   </div>
                 {/if}

--- a/src/lib/components/CollectionView.test.ts
+++ b/src/lib/components/CollectionView.test.ts
@@ -219,4 +219,15 @@ describe("CollectionView.svelte", () => {
     expect(getByText("▲ Date Added")).toBeInTheDocument();
     expect(getByText("▼ Date Added")).toBeInTheDocument();
   });
+
+  it("does not use font-mono for the date added column in songs view", () => {
+    collectionStore.activeSubTab = "songs";
+    collectionStore.visibleColumns.added = true;
+    mockSongs[0].added = 1700000000;
+    const { getByText } = render(CollectionView);
+
+    const addedCell = getByText("11/14/2023").closest("div");
+    expect(addedCell).not.toBeNull();
+    expect(addedCell).not.toHaveClass("font-mono");
+  });
 });

--- a/src/lib/components/PlaylistView.svelte
+++ b/src/lib/components/PlaylistView.svelte
@@ -1417,12 +1417,12 @@
               </div>
             {/if}
             {#if collectionStore.visibleColumns.lastplayed}
-              <div class="text-center text-brand-text-primary font-mono text-xs whitespace-nowrap">
+              <div class="text-center text-brand-text-primary text-xs whitespace-nowrap">
                 {formatDate(item.song?.lastplayed)}
               </div>
             {/if}
             {#if collectionStore.visibleColumns.added}
-              <div class="text-center text-brand-text-primary font-mono text-xs whitespace-nowrap">
+              <div class="text-center text-brand-text-primary text-xs whitespace-nowrap">
                 {formatDate(item.song?.added)}
               </div>
             {/if}


### PR DESCRIPTION
## 📋 Summary
Removes `font-mono` styling from the Date Added (`added`) and Last Played (`lastplayed`) columns across all track table views so dates match the standard proportional font used for other metadata columns like Year and Genre.

## 🔍 Implementation Notes
- Removed `font-mono` class from date column cells in:
  - `CollectionView.svelte`
  - `AlbumDetailView.svelte`
  - `AutoPlaylistDetailView.svelte`
  - `PlaylistView.svelte`
- Added unit test in `CollectionView.test.ts` to assert that the Date Added column cell does not use the `font-mono` class.

## 🧪 Test Plan
- [x] `bun run check` (svelte-check)
- [x] `bun run test:run` (frontend)
- [x] Manually verified in the app

## ✅ Checklist
- [x] No unrelated changes bundled in
