### PR TITLE
fix: allow saving empty genre & disc tags in album bulk edit & refactor artist release carousels

### DIFF
--- a/src-tauri/src/commands/tageditor.rs
+++ b/src-tauri/src/commands/tageditor.rs
@@ -113,7 +113,7 @@ pub async fn save_song_tags(
     album: String,
     album_artist: String,
     composer: String,
-    genre: String,
+    genre: Option<String>,
     track: Option<u32>,
     disc: Option<u32>,
     year: Option<u32>,
@@ -146,7 +146,8 @@ pub async fn save_song_tags(
     let album_c = album.clone();
     let album_artist_c = album_artist.clone();
     let composer_c = composer.clone();
-    let genre_c = genre.clone();
+    let genre_str = genre.unwrap_or_default();
+    let genre_c = genre_str.clone();
     let grouping_c = grouping.clone();
     let initial_key_c = initial_key.clone();
 
@@ -193,7 +194,7 @@ pub async fn save_song_tags(
             album,
             album_artist,
             composer,
-            genre,
+            genre_str,
             track,
             disc,
             year,
@@ -214,8 +215,9 @@ pub async fn save_album_tags(
     song_ids: Vec<i64>,
     album: String,
     album_artist: String,
-    genre: String,
+    genre: Option<String>,
     year: Option<u32>,
+    disc: Option<u32>,
 ) -> Result<u32, String> {
     if song_ids.is_empty() {
         return Ok(0);
@@ -234,7 +236,6 @@ pub async fn save_album_tags(
         artist: String,
         composer: String,
         track: Option<u32>,
-        disc: Option<u32>,
         grouping: String,
         bpm: Option<f32>,
         initial_key: String,
@@ -243,7 +244,7 @@ pub async fn save_album_tags(
     let mut songs_data = Vec::with_capacity(song_ids.len());
     for &song_id in &song_ids {
         let res = conn.query_row(
-            "SELECT path, title, artist, composer, track, disc, grouping, bpm, initial_key
+            "SELECT path, title, artist, composer, track, grouping, bpm, initial_key
              FROM songs WHERE id = ?1",
             rusqlite::params![song_id],
             |row| {
@@ -253,10 +254,9 @@ pub async fn save_album_tags(
                     artist: row.get(2).unwrap_or_default(),
                     composer: row.get(3).unwrap_or_default(),
                     track: row.get(4).ok(),
-                    disc: row.get(5).ok(),
-                    grouping: row.get(6).unwrap_or_default(),
-                    bpm: row.get(7).ok(),
-                    initial_key: row.get(8).unwrap_or_default(),
+                    grouping: row.get(5).unwrap_or_default(),
+                    bpm: row.get(6).ok(),
+                    initial_key: row.get(7).unwrap_or_default(),
                 })
             },
         );
@@ -267,7 +267,8 @@ pub async fn save_album_tags(
 
     let album_c = album.clone();
     let album_artist_c = album_artist.clone();
-    let genre_c = genre.clone();
+    let genre_str = genre.unwrap_or_default();
+    let genre_c = genre_str.clone();
 
     let updated_count = tauri::async_runtime::spawn_blocking(move || {
         let mut count = 0u32;
@@ -282,7 +283,7 @@ pub async fn save_album_tags(
                 &item.composer,
                 &genre_c,
                 item.track,
-                item.disc,
+                disc,
                 year,
                 &item.grouping,
                 item.bpm,
@@ -304,9 +305,10 @@ pub async fn save_album_tags(
                 album = ?1,
                 album_artist = ?2,
                 genre = ?3,
-                year = ?4
-             WHERE id = ?5",
-            rusqlite::params![album, album_artist, genre, year, song_id],
+                year = ?4,
+                disc = ?5
+             WHERE id = ?6",
+            rusqlite::params![album, album_artist, genre_str, year, disc, song_id],
         )
         .map_err(|e| e.to_string())?;
     }

--- a/src/lib/components/AlbumDetailView.svelte
+++ b/src/lib/components/AlbumDetailView.svelte
@@ -298,7 +298,7 @@
   let gridColsStyle = $derived.by(() => {
     const vc = collectionStore.visibleColumns;
     const cols: string[] = ["36px"]; // play indicator always present
-    if (vc.track) cols.push("40px");
+    if (vc.track) cols.push("48px");
     if (vc.title) cols.push("2fr");
     if (vc.artist) cols.push("1.5fr");
     if (vc.album) cols.push("1.5fr");
@@ -872,7 +872,7 @@
               </div>
 
               {#if collectionStore.visibleColumns.track}
-                <div class="text-brand-text-primary truncate pr-4 min-w-0 font-medium">
+                <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium">
                   {formatTrackNumber(song.track, song.disc, discCount, index)}
                 </div>
               {/if}
@@ -1001,7 +1001,7 @@
               {/if}
 
               {#if collectionStore.visibleColumns.duration}
-                <div class="text-center text-brand-text-primary font-medium">
+                <div class="text-center text-brand-text-primary text-xs font-medium">
                   {formatDuration(song.length_nanosec)}
                 </div>
               {/if}
@@ -1055,6 +1055,7 @@
     initialAlbumArtist={songs[0].album_artist || songs[0].artist}
     initialGenre={songs[0].genre}
     initialYear={songs[0].year}
+    initialDisc={songs[0].disc}
     onClose={() => { showAlbumTagEditor = false; }}
     onSave={handleTagEditorSaved}
   />

--- a/src/lib/components/AlbumTagEditor.svelte
+++ b/src/lib/components/AlbumTagEditor.svelte
@@ -11,10 +11,11 @@
 
   interface Props {
     songIds: number[];
-    initialAlbum?: string;
-    initialAlbumArtist?: string;
-    initialGenre?: string;
+    initialAlbum?: string | null;
+    initialAlbumArtist?: string | null;
+    initialGenre?: string | null;
     initialYear?: number | null;
+    initialDisc?: number | null;
     onClose: () => void;
     onSave?: () => void;
   }
@@ -25,18 +26,21 @@
     initialAlbumArtist = "",
     initialGenre = "",
     initialYear = null,
+    initialDisc = null,
     onClose,
     onSave
   }: Props = $props();
 
   // svelte-ignore state_referenced_locally
-  let album = $state(initialAlbum);
+  let album = $state(initialAlbum ?? "");
   // svelte-ignore state_referenced_locally
-  let albumArtist = $state(initialAlbumArtist);
+  let albumArtist = $state(initialAlbumArtist ?? "");
   // svelte-ignore state_referenced_locally
-  let genre = $state(initialGenre);
+  let genre = $state(initialGenre ?? "");
   // svelte-ignore state_referenced_locally
   let year = $state<number | null>(initialYear);
+  // svelte-ignore state_referenced_locally
+  let disc = $state<number | null>(initialDisc);
 
   let isSaving = $state(false);
 
@@ -45,10 +49,11 @@
     try {
       await invoke("save_album_tags", {
         songIds,
-        album,
-        albumArtist,
-        genre,
+        album: album ?? "",
+        albumArtist: albumArtist ?? "",
+        genre: genre ?? "",
         year,
+        disc,
       });
 
       await collectionStore.refreshStats();
@@ -103,13 +108,40 @@
           </FormField>
 
           <!-- Genre -->
-          <FormField label={i18n.t('albumTagEditor.genreField')} for="album-tag-genre">
+          <FormField label={i18n.t('albumTagEditor.genreField')} for="album-tag-genre" span2>
             <Input id="album-tag-genre" bind:value={genre} disabled={isSaving} size="sm" class="w-full" />
           </FormField>
 
           <!-- Year -->
           <FormField label={i18n.t('albumTagEditor.yearField')} for="album-tag-year">
-            <Input id="album-tag-year" type="number" bind:value={year} disabled={isSaving} size="sm" class="w-full" />
+            <Input
+              id="album-tag-year"
+              type="number"
+              value={year ?? ""}
+              disabled={isSaving}
+              oninput={(e) => {
+                const val = parseInt(e.currentTarget.value, 10);
+                year = isNaN(val) ? null : val;
+              }}
+              size="sm"
+              class="w-full"
+            />
+          </FormField>
+
+          <!-- Disc -->
+          <FormField label={i18n.t('albumTagEditor.discField')} for="album-tag-disc">
+            <Input
+              id="album-tag-disc"
+              type="number"
+              value={disc ?? ""}
+              disabled={isSaving}
+              oninput={(e) => {
+                const val = parseInt(e.currentTarget.value, 10);
+                disc = isNaN(val) ? null : val;
+              }}
+              size="sm"
+              class="w-full"
+            />
           </FormField>
         </div>
       </div>

--- a/src/lib/components/AlbumTagEditor.test.ts
+++ b/src/lib/components/AlbumTagEditor.test.ts
@@ -36,6 +36,7 @@ describe("AlbumTagEditor.svelte", () => {
       initialAlbumArtist: "Test Artist",
       initialGenre: "Pop",
       initialYear: 2024,
+      initialDisc: 1,
       onClose,
     });
 
@@ -45,11 +46,13 @@ describe("AlbumTagEditor.svelte", () => {
     const artistInput = getByLabelText("Album Artist") as HTMLInputElement;
     const genreInput = getByLabelText("Genre") as HTMLInputElement;
     const yearInput = getByLabelText("Release Year") as HTMLInputElement;
+    const discInput = getByLabelText("Disc #") as HTMLInputElement;
 
     expect(albumInput.value).toBe("Test Album");
     expect(artistInput.value).toBe("Test Artist");
     expect(genreInput.value).toBe("Pop");
     expect(yearInput.value).toBe("2024");
+    expect(discInput.value).toBe("1");
   });
 
   it("calls onClose when cancel button is clicked", async () => {
@@ -73,6 +76,7 @@ describe("AlbumTagEditor.svelte", () => {
       initialAlbumArtist: "Old Artist",
       initialGenre: "Rock",
       initialYear: 2020,
+      initialDisc: 2,
       onClose,
       onSave,
     });
@@ -90,6 +94,77 @@ describe("AlbumTagEditor.svelte", () => {
         albumArtist: "Old Artist",
         genre: "Rock",
         year: 2020,
+        disc: 2,
+      });
+      expect(onSave).toHaveBeenCalled();
+      expect(onClose).toHaveBeenCalled();
+    });
+  });
+
+  it("handles null initial genre and saves empty string for genre", async () => {
+    const onClose = vi.fn();
+    const onSave = vi.fn();
+    const { getByLabelText, getByRole } = render(AlbumTagEditor, {
+      songIds: [101],
+      initialAlbum: "Test Album",
+      initialAlbumArtist: "Test Artist",
+      initialGenre: null,
+      initialYear: 2024,
+      initialDisc: null,
+      onClose,
+      onSave,
+    });
+
+    const genreInput = getByLabelText("Genre") as HTMLInputElement;
+    expect(genreInput.value).toBe("");
+
+    const saveBtn = getByRole("button", { name: /save tags/i });
+    await fireEvent.click(saveBtn);
+
+    await waitFor(() => {
+      expect(invoke).toHaveBeenCalledWith("save_album_tags", {
+        songIds: [101],
+        album: "Test Album",
+        albumArtist: "Test Artist",
+        genre: "",
+        year: 2024,
+        disc: null,
+      });
+      expect(onSave).toHaveBeenCalled();
+      expect(onClose).toHaveBeenCalled();
+    });
+  });
+
+  it("allows clearing the Disc input field to save null disc", async () => {
+    const onClose = vi.fn();
+    const onSave = vi.fn();
+    const { getByLabelText, getByRole } = render(AlbumTagEditor, {
+      songIds: [101],
+      initialAlbum: "Test Album",
+      initialAlbumArtist: "Test Artist",
+      initialGenre: "Pop",
+      initialYear: 2024,
+      initialDisc: 1,
+      onClose,
+      onSave,
+    });
+
+    const discInput = getByLabelText("Disc #") as HTMLInputElement;
+    expect(discInput.value).toBe("1");
+
+    await fireEvent.input(discInput, { target: { value: "" } });
+
+    const saveBtn = getByRole("button", { name: /save tags/i });
+    await fireEvent.click(saveBtn);
+
+    await waitFor(() => {
+      expect(invoke).toHaveBeenCalledWith("save_album_tags", {
+        songIds: [101],
+        album: "Test Album",
+        albumArtist: "Test Artist",
+        genre: "Pop",
+        year: 2024,
+        disc: null,
       });
       expect(onSave).toHaveBeenCalled();
       expect(onClose).toHaveBeenCalled();

--- a/src/lib/components/ArtistDetailView.svelte
+++ b/src/lib/components/ArtistDetailView.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { untrack } from "svelte";
   import { invoke } from "@tauri-apps/api/core";
   import { collectionStore } from "../stores/collection.svelte";
   import { playerStore } from "../stores/player.svelte";
@@ -113,15 +112,6 @@
     songs.length === 1 ? i18n.t("playlists.oneSong") : i18n.t("playlists.songsCount", { count: songs.length })
   );
 
-  let discographyFilter = $state<"sets" | "albums" | "eps" | "singles">("albums");
-  let showAll = $state(false);
-  const POPULAR_CAP = 8;
-
-  function setDiscographyFilter(filter: "sets" | "albums" | "eps" | "singles") {
-    discographyFilter = filter;
-    showAll = false;
-  }
-
   // Some artists have no proper album releases at all (every track is a loose
   // single with no album tag), so getArtistAlbums() returns nothing and the
   // Albums/Singles/Popular filters all end up empty. Fall back to showing the
@@ -131,30 +121,6 @@
   let looseSongs = $derived(
     albums.length === 0 ? [...songs].sort((a, b) => (a.title || "").localeCompare(b.title || "")) : []
   );
-  let singlesCount = $derived(singles.length + looseSongs.length);
-
-  // Land on whichever category actually has releases when switching artists,
-  // rather than defaulting to a possibly-empty "Albums" tab (e.g. an
-  // EP-only or singles-only artist). Keyed on artistName so a manual tab
-  // pick while browsing the same artist isn't overridden.
-  $effect(() => {
-    const _artist = artistName;
-    discographyFilter = untrack(() => {
-      if (fullAlbums.length > 0) return "albums";
-      if (sets.length > 0) return "sets";
-      if (eps.length > 0) return "eps";
-      if (singlesCount > 0) return "singles";
-      return "albums";
-    });
-    showAll = false;
-  });
-
-  let discographySource = $derived(
-    discographyFilter === "sets" ? sets : discographyFilter === "eps" ? eps : discographyFilter === "singles" ? singles : fullAlbums
-  );
-  let discographyItems = $derived(showAll ? discographySource : discographySource.slice(0, POPULAR_CAP));
-
-  let displayedLooseSongs = $derived(showAll ? looseSongs : looseSongs.slice(0, POPULAR_CAP));
 
   function openAlbum(album: AlbumItem) {
     collectionStore.viewAlbum(album.album || "");
@@ -235,76 +201,67 @@
     </div>
   </div>
 
-  <!-- Discography -->
-  <div class="px-6 pt-8">
-    <div class="flex items-center justify-between mb-4">
-      <h2 class="text-xl font-semibold text-brand-text-primary">{i18n.t('artistDetail.discography')}</h2>
-      {#if discographySource.length > POPULAR_CAP || looseSongs.length > POPULAR_CAP}
-        <button
-          onclick={() => { showAll = !showAll; }}
-          class="text-xs text-brand-text-secondary hover:text-brand-text-primary transition-colors cursor-pointer"
-        >
-          {showAll ? i18n.t('artistDetail.showLess') : i18n.t('artistDetail.showAll')}
-        </button>
-      {/if}
-    </div>
-
-    {#if albums.length > 0 || looseSongs.length > 0}
-      <div class="flex items-center gap-2 mb-4">
-        {#if sets.length > 0}
-          <button
-            onclick={() => setDiscographyFilter("sets")}
-            class="px-3 py-1 rounded-full text-xs font-medium border transition-all cursor-pointer flex-shrink-0 {discographyFilter === 'sets' ? 'bg-brand-accent border-brand-accent text-brand-accent-contrast font-semibold shadow-sm' : 'border-transparent text-brand-text-secondary hover:text-brand-text-primary hover:bg-brand-sidebar'}"
-          >
-            {i18n.t('artistDetail.setsFilter', { count: sets.length })}
-          </button>
-        {/if}
-        {#if fullAlbums.length > 0}
-          <button
-            onclick={() => setDiscographyFilter("albums")}
-            class="px-3 py-1 rounded-full text-xs font-medium border transition-all cursor-pointer flex-shrink-0 {discographyFilter === 'albums' ? 'bg-brand-accent border-brand-accent text-brand-accent-contrast font-semibold shadow-sm' : 'border-transparent text-brand-text-secondary hover:text-brand-text-primary hover:bg-brand-sidebar'}"
-          >
-            {i18n.t('artistDetail.albumsFilter', { count: fullAlbums.length })}
-          </button>
-        {/if}
-        {#if eps.length > 0}
-          <button
-            onclick={() => setDiscographyFilter("eps")}
-            class="px-3 py-1 rounded-full text-xs font-medium border transition-all cursor-pointer flex-shrink-0 {discographyFilter === 'eps' ? 'bg-brand-accent border-brand-accent text-brand-accent-contrast font-semibold shadow-sm' : 'border-transparent text-brand-text-secondary hover:text-brand-text-primary hover:bg-brand-sidebar'}"
-          >
-            {i18n.t('artistDetail.epsFilter', { count: eps.length })}
-          </button>
-        {/if}
-        {#if singlesCount > 0}
-          <button
-            onclick={() => setDiscographyFilter("singles")}
-            class="px-3 py-1 rounded-full text-xs font-medium border transition-all cursor-pointer flex-shrink-0 {discographyFilter === 'singles' ? 'bg-brand-accent border-brand-accent text-brand-accent-contrast font-semibold shadow-sm' : 'border-transparent text-brand-text-secondary hover:text-brand-text-primary hover:bg-brand-sidebar'}"
-          >
-            {i18n.t('artistDetail.singlesFilter', { count: singlesCount })}
-          </button>
-        {/if}
-      </div>
-    {/if}
-
-    {#if discographyItems.length > 0}
-      <HorizontalScrollRow>
-        {#each discographyItems as album (album.album)}
+  <!-- Release Categories (Sets, Albums, EPs, Singles) -->
+  <div class="px-6 pt-6 flex flex-col gap-8">
+    {#if sets.length > 0}
+      <HorizontalScrollRow title={i18n.t('artistDetail.setsFilter', { count: sets.length })}>
+        {#each sets as album (album.album)}
           <AlbumCard
             {album}
             widthClass="w-48 shrink-0"
-            showArtist={false}
             onclick={() => openAlbum(album)}
             oncontextmenu={(e) => handleAlbumContextMenu(e, album)}
           />
         {/each}
       </HorizontalScrollRow>
-    {:else if displayedLooseSongs.length > 0}
-      <HorizontalScrollRow>
-        {#each displayedLooseSongs as song (song.id)}
+    {/if}
+
+    {#if fullAlbums.length > 0}
+      <HorizontalScrollRow title={i18n.t('artistDetail.albumsFilter', { count: fullAlbums.length })}>
+        {#each fullAlbums as album (album.album)}
+          <AlbumCard
+            {album}
+            widthClass="w-48 shrink-0"
+            onclick={() => openAlbum(album)}
+            oncontextmenu={(e) => handleAlbumContextMenu(e, album)}
+          />
+        {/each}
+      </HorizontalScrollRow>
+    {/if}
+
+    {#if eps.length > 0}
+      <HorizontalScrollRow title={i18n.t('artistDetail.epsFilter', { count: eps.length })}>
+        {#each eps as album (album.album)}
+          <AlbumCard
+            {album}
+            widthClass="w-48 shrink-0"
+            onclick={() => openAlbum(album)}
+            oncontextmenu={(e) => handleAlbumContextMenu(e, album)}
+          />
+        {/each}
+      </HorizontalScrollRow>
+    {/if}
+
+    {#if singles.length > 0}
+      <HorizontalScrollRow title={i18n.t('artistDetail.singlesFilter', { count: singles.length })}>
+        {#each singles as album (album.album)}
+          <AlbumCard
+            {album}
+            widthClass="w-48 shrink-0"
+            onclick={() => openAlbum(album)}
+            oncontextmenu={(e) => handleAlbumContextMenu(e, album)}
+          />
+        {/each}
+      </HorizontalScrollRow>
+    {:else if looseSongs.length > 0}
+      <HorizontalScrollRow title={i18n.t('artistDetail.singlesFilter', { count: looseSongs.length })}>
+        {#each looseSongs as song (song.id)}
           <CarouselCard item={{ type: "song", song }} />
         {/each}
       </HorizontalScrollRow>
-    {:else if !loading}
+    {/if}
+
+    {#if albums.length === 0 && looseSongs.length === 0 && !loading}
       <p class="text-xs text-brand-text-secondary py-8 text-center">{i18n.t('artistDetail.noReleasesFound')}</p>
     {/if}
   </div>

--- a/src/lib/components/CollectionView.svelte
+++ b/src/lib/components/CollectionView.svelte
@@ -300,7 +300,7 @@
   let gridColsStyle = $derived.by(() => {
     const vc = collectionStore.visibleColumns;
     const cols: string[] = ["36px"]; // play indicator always present
-    if (vc.track) cols.push("40px");
+    if (vc.track) cols.push("48px");
     if (vc.title) cols.push("2fr");
     if (vc.artist) cols.push("1.5fr");
     if (vc.album) cols.push("1.5fr");
@@ -760,7 +760,7 @@
                   </button>
                 </div>
                 {#if collectionStore.visibleColumns.track}
-                  <div class="text-brand-text-secondary truncate pr-4 min-w-0 font-medium">
+                  <div class="text-brand-text-secondary truncate pr-2 min-w-0 text-xs font-medium">
                     {song.track !== undefined && song.track !== null ? song.track : "—"}
                   </div>
                 {/if}

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -650,6 +650,7 @@ export const en = {
     albumArtistField: "Album Artist",
     genreField: "Genre",
     yearField: "Release Year",
+    discField: "Disc #",
     tracksAffected: "Applies to {count} songs",
     cancelBtn: "Cancel",
     saveBtn: "Save Tags",

--- a/src/lib/locales/fr.ts
+++ b/src/lib/locales/fr.ts
@@ -647,6 +647,7 @@ export const fr = {
     albumArtistField: "Artiste de l'album",
     genreField: "Genre",
     yearField: "Année de sortie",
+    discField: "N° de disque",
     tracksAffected: "S'applique à {count} chansons",
     cancelBtn: "Annuler",
     saveBtn: "Enregistrer",


### PR DESCRIPTION
## 📋 Summary
This PR fixes an issue where saving album metadata tags with an empty Genre field resulted in a Tauri IPC deserialization error, adds support for bulk editing Disc number tags (supporting empty disc values), adjusts Track # and Duration column styling/widths, and refactors release sections in the Artist Detail view to display separate carousel rows for Sets, Albums, EPs, and Singles.

## 🔍 Implementation Notes

- **Backend (`src-tauri/src/commands/tageditor.rs`)**:
  - Changed `genre` parameter type from `String` to `Option<String>` in `save_album_tags` (and `save_song_tags`). Handled `genre.unwrap_or_default()` so empty strings and `null` values serialize without type errors.
  - Added `disc: Option<u32>` parameter to `save_album_tags`. When `disc` is `None` (`null`), lofty removes the disc tag frame from audio files on disk and SQLite updates `disc = NULL` across all album tracks.

- **Frontend Component (`src/lib/components/AlbumTagEditor.svelte`)**:
  - Added `initialDisc` prop and a **Disc #** number input field.
  - Normalized initial props and input clearing so empty string inputs convert to `null` for `disc` and `year`.
  - Added localized strings for `discField` in `en.ts` and `fr.ts`.

- **Track Table Styling (`AlbumDetailView.svelte` & `CollectionView.svelte`)**:
  - Increased Track # column width from `40px` to `48px` to fit multi-disc track numbers cleanly (`1-01`).
  - Adjusted Track # cell font size to `text-xs` (matching `year` and `genre`).
  - Aligned Duration cell font family in `AlbumDetailView.svelte` to match standard table columns (`text-xs font-medium`).

- **Artist Detail View Refactor (`ArtistDetailView.svelte`)**:
  - Removed generic "Discography" header and pill tab filters.
  - Rendered release categories (`Sets`, `Albums`, `EPs`, `Singles`) as individual `<HorizontalScrollRow>` carousels with category section headers.
  - Removed `showArtist={false}` from `<AlbumCard>` in `ArtistDetailView` so album cards render artist/album artist names beneath titles.

## 🧪 Test Plan
- [x] `bun run check` (svelte-check) — 0 errors, 0 warnings
- [x] `bun run test:run -- AlbumTagEditor.test.ts AlbumCard.test.ts AlbumDetailView.test.ts CollectionView.test.ts` — 27 tests passed
- [x] `cargo check` (src-tauri) — 0 compilation errors
- [x] `cargo test` (src-tauri) — All Rust unit and BDD tests passed
- [x] Manually verified tag editing, empty genre/disc tag saving, Track column formatting, and Artist Detail view carousel rows.

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed
