### PR TITLE
feat: move dynamic artwork theme first, rename to ✨ Luminous, and format System theme as {icon} System

### DIFF
--- a/src/lib/components/FoldersView.svelte
+++ b/src/lib/components/FoldersView.svelte
@@ -822,7 +822,6 @@
               >
                 <div class="flex items-center justify-between w-full">
                   <span class="font-semibold text-sm text-brand-text-primary flex items-center gap-1.5">
-                    {theme.isCustom ? theme.name : i18n.t('themes.' + theme.id, {}, theme.name)}
                     {#if theme.id === 'system'}
                       <span title={themeStore.systemColorScheme === 'dark' ? i18n.t('settings.systemThemeDark') : i18n.t('settings.systemThemeLight')}>
                         {#if themeStore.systemColorScheme === 'dark'}
@@ -832,6 +831,7 @@
                         {/if}
                       </span>
                     {/if}
+                    {theme.isCustom ? theme.name : i18n.t('themes.' + theme.id, {}, theme.name)}
                   </span>
                 </div>
                 <!-- Miniature colors preview matching 1-6 Theme Builder archetype order -->

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -715,11 +715,11 @@ export const en = {
     suppressSameAlbumHint: "Skip auto-crossfade between consecutive songs from the same album"
   },
   themes: {
+    "dynamic-artwork": "✨ Luminous",
     system: "System",
     "ruby-red": "Ruby Red",
     "nordic-blue": "Nordic Blue",
-    "retro-amber": "Retro Amber",
-    "dynamic-artwork": "Dynamic Artwork"
+    "retro-amber": "Retro Amber"
   },
   artistDetail: {
     backToArtists: "View Artists",

--- a/src/lib/locales/fr.ts
+++ b/src/lib/locales/fr.ts
@@ -712,11 +712,11 @@ export const fr = {
     suppressSameAlbumHint: "Ignorer le fondu enchaîné entre les chansons d'un même album"
   },
   themes: {
+    "dynamic-artwork": "✨ Luminous",
     system: "Système",
     "ruby-red": "Rouge rubis",
     "nordic-blue": "Bleu nordique",
-    "retro-amber": "Ambre rétro",
-    "dynamic-artwork": "Pochette dynamique"
+    "retro-amber": "Ambre rétro"
   },
   artistDetail: {
     backToArtists: "Voir les artistes",

--- a/src/lib/stores/theme.svelte.ts
+++ b/src/lib/stores/theme.svelte.ts
@@ -155,6 +155,20 @@ const NORDIC_BLUE_COLORS: ThemeColors = {
 
 export const PREDEFINED_THEMES: Theme[] = [
   {
+    id: "dynamic-artwork",
+    name: "✨ Luminous",
+    colors: {
+      "bg-main": "var(--color-artwork-primary)",
+      "bg-sidebar": "var(--color-artwork-sidebar)",
+      "bg-playerbar": "var(--color-artwork-playerbar)",
+      "color-accent": "var(--color-artwork-accent)",
+      "color-accent-hover": "var(--color-artwork-accent-hover)",
+      "color-text-primary": "#ffffff",
+      "color-text-secondary": "#e2e8f0",
+      "color-border": "var(--color-artwork-border)"
+    }
+  },
+  {
     id: "system",
     name: "System",
     colors: { ...LUMINOUS_DARK_COLORS }
@@ -173,20 +187,6 @@ export const PREDEFINED_THEMES: Theme[] = [
     id: "retro-amber",
     name: "Retro Amber",
     colors: generatePaletteFromSeed(RETRO_AMBER_SEED)
-  },
-  {
-    id: "dynamic-artwork",
-    name: "Dynamic Artwork",
-    colors: {
-      "bg-main": "var(--color-artwork-primary)",
-      "bg-sidebar": "var(--color-artwork-sidebar)",
-      "bg-playerbar": "var(--color-artwork-playerbar)",
-      "color-accent": "var(--color-artwork-accent)",
-      "color-accent-hover": "var(--color-artwork-accent-hover)",
-      "color-text-primary": "#ffffff",
-      "color-text-secondary": "#e2e8f0",
-      "color-border": "var(--color-artwork-border)"
-    }
   }
 ];
 

--- a/src/lib/stores/theme.test.ts
+++ b/src/lib/stores/theme.test.ts
@@ -14,6 +14,11 @@ import { checkWcagCompliance, pickAccessibleOnColor, hexToRgb, rgbToHsl, hslToRg
 import { invoke } from "@tauri-apps/api/core";
 
 describe("PREDEFINED_THEMES", () => {
+  it("has dynamic-artwork (✨ Luminous) as the first theme in the list", () => {
+    expect(PREDEFINED_THEMES[0].id).toBe("dynamic-artwork");
+    expect(PREDEFINED_THEMES[0].name).toBe("✨ Luminous");
+  });
+
   it("does not include the removed Luminous Violet theme", () => {
     expect(PREDEFINED_THEMES.some(t => t.id === "luminous-violet")).toBe(false);
   });

--- a/src/lib/utils/scrollMemory.ts
+++ b/src/lib/utils/scrollMemory.ts
@@ -29,7 +29,8 @@ function attachScrollMemory(node: HTMLElement, key: string): () => void {
   };
 
   restore();
-  let rafId = requestAnimationFrame(function tick(frame = 0) {
+  let rafId: number;
+  rafId = requestAnimationFrame(function tick(frame = 0) {
     restore();
     if (frame + 1 < RESTORE_RETRY_FRAMES) {
       rafId = requestAnimationFrame(() => tick(frame + 1));

--- a/src/lib/utils/scrollMemory.ts
+++ b/src/lib/utils/scrollMemory.ts
@@ -51,7 +51,7 @@ function attachScrollMemory(node: HTMLElement, key: string): () => void {
   node.addEventListener("scroll", onScroll, { passive: true });
 
   return () => {
-    cancelAnimationFrame(rafId);
+    if (rafId !== undefined) cancelAnimationFrame(rafId);
     node.removeEventListener("scroll", onScroll);
   };
 }


### PR DESCRIPTION
## 📋 Summary
Reorders predefined themes in Luminous to place the dynamic artwork theme first in the list, renames the dynamic artwork theme to "✨ Luminous", and updates the System theme card header to render the status icon before the text ("{icon} System").

## 🔍 Implementation Notes
- **Theme reordering & renaming**: Updated `PREDEFINED_THEMES` in `src/lib/stores/theme.svelte.ts` so `dynamic-artwork` is at index 0 and named `"✨ Luminous"`. Updated translations in `src/lib/locales/en.ts` and `src/lib/locales/fr.ts`.
- **System theme header icon**: Updated `FoldersView.svelte` to place the `{#if theme.id === 'system'}` icon element before the theme name span in the card header.
- **ScrollMemory utility fix**: Fixed a TDZ `ReferenceError: Cannot access 'rafId' before initialization` in `src/lib/utils/scrollMemory.ts` when `requestAnimationFrame` executes synchronously in Vitest.

## 🧪 Test Plan
- [x] `bun run check` (0 errors, 0 warnings)
- [x] `bun run test -- theme.test.ts` (64 passed)
- [x] `bun run test -- scrollMemory.test.ts` (5 passed)
- [x] `cargo check` (src-tauri compiled cleanly)
- [x] Manually verified theme layout and ordering

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed
