### PR TITLE
feat: add overlapping disc icons to box set covers

### DIFF
--- a/src/lib/components/AlbumCard.svelte
+++ b/src/lib/components/AlbumCard.svelte
@@ -8,6 +8,7 @@
   import { i18n } from "../stores/i18n.svelte";
   import { queueAlbumAsPlaylist } from "../utils/playlist";
   import FavouriteCornerFlag from "./FavouriteCornerFlag.svelte";
+  import BoxSetDiscIcons from "./BoxSetDiscIcons.svelte";
  
   interface Props {
     album: AlbumItem;
@@ -69,6 +70,9 @@
     />
     {#if album.rating === 5}
       <FavouriteCornerFlag size="md" />
+    {/if}
+    {#if album.disc_count > 1}
+      <BoxSetDiscIcons discCount={album.disc_count} size="md" />
     {/if}
   </div>
   <div class="p-3.5 flex flex-col flex-1">

--- a/src/lib/components/AlbumDetailView.svelte
+++ b/src/lib/components/AlbumDetailView.svelte
@@ -9,6 +9,7 @@
   import CoverArt from "./CoverArt.svelte";
   import SongRating from "./SongRating.svelte";
   import FavouriteCornerFlag from "./FavouriteCornerFlag.svelte";
+  import BoxSetDiscIcons from "./BoxSetDiscIcons.svelte";
   import TagEditor from "./TagEditor.svelte";
   import AlbumTagEditor from "./AlbumTagEditor.svelte";
   import SongContextMenu from "./SongContextMenu.svelte";
@@ -614,6 +615,9 @@
           />
           {#if albumItem && albumItem.rating === 5}
             <FavouriteCornerFlag size="lg" />
+          {/if}
+          {#if albumItem && albumItem.disc_count > 1}
+            <BoxSetDiscIcons discCount={albumItem.disc_count} size="md" />
           {/if}
         </div>
       </div>

--- a/src/lib/components/BoxSetDiscIcons.svelte
+++ b/src/lib/components/BoxSetDiscIcons.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+  import { Disc } from "lucide-svelte";
+  import { i18n } from "../stores/i18n.svelte";
+
+  interface Props {
+    discCount: number;
+    size?: "xs" | "sm" | "md" | "lg";
+    class?: string;
+  }
+
+  let { discCount, size = "md", class: customClass = "" }: Props = $props();
+
+  type SizeKey = "xs" | "sm" | "md" | "lg";
+
+  const sizeClasses: Record<SizeKey, { icon: string; overlap: string }> = {
+    xs: { icon: "w-3.5 h-3.5", overlap: "-ml-1.5" },
+    sm: { icon: "w-4 h-4", overlap: "-ml-2" },
+    md: { icon: "w-6 h-6", overlap: "-ml-3" },
+    lg: { icon: "w-8 h-8", overlap: "-ml-4" },
+  };
+
+  // Cap the stack visually — beyond this it just reads as clutter.
+  const MAX_VISIBLE_DISCS = 6;
+
+  let currentSize = $derived(sizeClasses[size ?? "md"]);
+  let visibleDiscs = $derived(Math.min(Math.max(discCount, 1), MAX_VISIBLE_DISCS));
+</script>
+
+{#if discCount > 1}
+  <div
+    class="absolute bottom-1.5 left-1.5 z-10 pointer-events-none flex items-center {customClass}"
+    title={i18n.t('artistDetail.discSet', { count: discCount })}
+    aria-label={i18n.t('artistDetail.discSet', { count: discCount })}
+    data-testid="box-set-disc-icons"
+  >
+    {#each Array(visibleDiscs) as _, i (i)}
+      <Disc
+        class="{currentSize.icon} text-white fill-black/40 drop-shadow-[0_1px_2px_rgba(0,0,0,0.8)] {i > 0 ? currentSize.overlap : ''}"
+        style="z-index: {visibleDiscs - i}"
+      />
+    {/each}
+  </div>
+{/if}


### PR DESCRIPTION
## 📋 Summary
Sets (albums where `disc_count > 1`) now show overlapping monochrome CD icons in the bottom-left corner of their cover art, similar to the existing favourite-album corner flag. This surfaces disc count visually alongside the existing "{n}-Disc Set" text label.

## 🔍 Implementation Notes
- New [`BoxSetDiscIcons.svelte`](src/lib/components/BoxSetDiscIcons.svelte) renders up to 6 overlapping `lucide-svelte` `Disc` icons (monochrome white stroke/dark fill + drop shadow so it reads on any cover art), capped visually to avoid clutter on very large sets — the tooltip/aria-label always shows the true count via the existing `artistDetail.discSet` i18n key.
- Wired into `AlbumCard.svelte` (used by the collection grid and the artist "Sets" row) and `AlbumDetailView.svelte` (full album cover), both gated on `disc_count > 1` so single albums are unaffected.
- Sized `md` in both places per user feedback, so the badge is visually consistent between the card grid and the detail view despite the detail view's larger cover.

## 🧪 Test Plan
- [x] Manually verified in the app — confirmed the icon renders correctly on a real box set (Imagine Dragons "Night Visions (Expanded...)") in the Sets row, and again on AlbumDetailView after the size fix.
- [ ] `bun run check` (svelte-check)
- [ ] `bun run test -- --run` (frontend)
- [ ] `cargo test` (src-tauri, if Rust changed) — not applicable, no Rust changes

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed — not done yet, can follow up if desired