### PR TITLE
Exclude Queue from artist playlists, guard reserved playlist names

### DIFF
--- a/src-tauri/src/playlist.rs
+++ b/src-tauri/src/playlist.rs
@@ -20,6 +20,23 @@ const MIN_LIBRARY_SONGS_FOR_AUTO_PLAYLIST: i64 = 25;
 /// library (e.g. 500+ songs in a single decade).
 const NO_SONG_LIMIT: i64 = -1;
 
+/// Names reserved for the app's single built-in Queue playlist: the literal
+/// DB name ("Queue" — see `queuePlaylist` in playlists.svelte.ts, which
+/// identifies it purely by this string) plus every locale's translated
+/// `playerBar.queueTitle` label (see src/lib/locales/*.ts), so a playlist
+/// can't be named something a user would mistake for the real Queue in any
+/// supported language. Keep this list in sync with `queueTitle` across
+/// locale files.
+const RESERVED_PLAYLIST_NAMES: &[&str] = &[
+    "queue",          // en: playerBar.queueTitle
+    "file d'attente", // fr: playerBar.queueTitle
+];
+
+fn is_reserved_playlist_name(name: &str) -> bool {
+    let trimmed = name.trim().to_lowercase();
+    RESERVED_PLAYLIST_NAMES.contains(&trimmed.as_str())
+}
+
 // ---------------------------------------------------------------------------
 // Undo/Redo stack operations
 // ---------------------------------------------------------------------------
@@ -111,6 +128,23 @@ impl PlaylistManager {
 
     pub fn create_playlist(&self, name: &str) -> Result<Playlist> {
         let conn = self.db.pool.get()?;
+        // The one legitimate "Queue" playlist is bootstrapped through this same
+        // method (see ensureQueuePlaylist in playlists.svelte.ts) — allow that
+        // single creation, but reject it (and any other reserved name) once a
+        // Queue playlist already exists, so users can't create a duplicate.
+        if is_reserved_playlist_name(name) {
+            let queue_exists: bool = conn.query_row(
+                "SELECT EXISTS(SELECT 1 FROM playlists WHERE LOWER(TRIM(name)) = 'queue')",
+                [],
+                |row| row.get(0),
+            )?;
+            if queue_exists || !name.trim().eq_ignore_ascii_case("queue") {
+                return Err(anyhow!(
+                    "\"{}\" is reserved for the app's built-in Queue playlist",
+                    name.trim()
+                ));
+            }
+        }
         let now = chrono::Utc::now().timestamp();
         conn.execute(
             "INSERT INTO playlists (name, updated) VALUES (?1, ?2)",
@@ -132,6 +166,15 @@ impl PlaylistManager {
     }
 
     pub fn rename_playlist(&self, id: i64, name: &str) -> Result<()> {
+        // Renaming never legitimately produces the Queue playlist (it's only
+        // ever created directly, see create_playlist above), so any reserved
+        // name is rejected outright here.
+        if is_reserved_playlist_name(name) {
+            return Err(anyhow!(
+                "\"{}\" is reserved for the app's built-in Queue playlist",
+                name.trim()
+            ));
+        }
         let conn = self.db.pool.get()?;
         conn.execute(
             "UPDATE playlists SET name = ?1, updated = ?2 WHERE id = ?3",
@@ -1394,6 +1437,39 @@ mod tests {
         ));
         let db = Database::new(temp_dir.clone()).unwrap();
         (db, temp_dir)
+    }
+
+    #[test]
+    fn test_reserved_playlist_names() {
+        let (db, temp_dir) = setup_test_db();
+        let db_arc = std::sync::Arc::new(db);
+        let manager = PlaylistManager::new(db_arc.clone()).unwrap();
+
+        // Bootstrapping the real Queue playlist (as ensureQueuePlaylist does) succeeds once.
+        let queue = manager.create_playlist("Queue").unwrap();
+
+        // A second attempt at any reserved name (any case/whitespace, any locale) is rejected.
+        assert!(manager.create_playlist("queue").is_err());
+        assert!(manager.create_playlist("  QUEUE  ").is_err());
+        assert!(manager.create_playlist("File d'attente").is_err());
+
+        // Renaming another playlist to a reserved name is always rejected.
+        let other = manager.create_playlist("Chill Mix").unwrap();
+        assert!(manager.rename_playlist(other.id, "Queue").is_err());
+        assert!(manager.rename_playlist(other.id, "File D'Attente").is_err());
+        let playlists = manager.get_playlists().unwrap();
+        assert_eq!(
+            playlists.iter().find(|p| p.id == other.id).unwrap().name,
+            "Chill Mix"
+        );
+
+        // The real Queue playlist itself is untouched.
+        assert_eq!(
+            playlists.iter().find(|p| p.id == queue.id).unwrap().name,
+            "Queue"
+        );
+
+        let _ = std::fs::remove_dir_all(&temp_dir);
     }
 
     #[test]

--- a/src/lib/components/ArtistDetailView.svelte
+++ b/src/lib/components/ArtistDetailView.svelte
@@ -56,7 +56,7 @@
       .then(([fetchedSongs, fetchedPlaylists]) => {
         if (requested !== artistName) return;
         songs = fetchedSongs;
-        playlists = fetchedPlaylists;
+        playlists = fetchedPlaylists.filter((p) => p.name.toLowerCase() !== "queue");
       })
       .catch((err) => {
         console.error("Failed to load artist detail:", err);

--- a/src/lib/components/PlaylistView.svelte
+++ b/src/lib/components/PlaylistView.svelte
@@ -159,7 +159,12 @@
   async function saveRename() {
     if (!isEditingTitle) return;
     if (activePlaylist && editTitleValue.trim() !== "" && editTitleValue.trim() !== activePlaylist.name) {
-      await playlistsStore.renamePlaylist(activePlaylist.id, editTitleValue.trim());
+      try {
+        await playlistsStore.renamePlaylist(activePlaylist.id, editTitleValue.trim());
+      } catch (err) {
+        console.error("Failed to rename playlist:", err);
+        return;
+      }
     }
     isEditingTitle = false;
   }

--- a/src/lib/components/PlaylistsCollectionView.svelte
+++ b/src/lib/components/PlaylistsCollectionView.svelte
@@ -239,9 +239,13 @@
   }
 
   async function handleCreateBlankPlaylist() {
-    const playlist = await playlistsStore.createPlaylist(i18n.t("playlists.untitledPlaylistName"));
-    if (playlist) {
-      collectionStore.viewPlaylist(playlist.id);
+    try {
+      const playlist = await playlistsStore.createPlaylist(i18n.t("playlists.untitledPlaylistName"));
+      if (playlist) {
+        collectionStore.viewPlaylist(playlist.id);
+      }
+    } catch (err) {
+      console.error("Failed to create playlist:", err);
     }
   }
 

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -360,6 +360,7 @@ export const en = {
   playlists: {
     title: "Playlists",
     untitledPlaylistName: "Untitled Playlist",
+    reservedPlaylistName: "\"{name}\" is reserved for the built-in Queue playlist. Please choose a different name.",
     noPlaylistsTitle: "No playlists",
     noPlaylistsText: "Click \"New Playlist\" above to create your first one.",
     showingOnePlaylist: "Showing 1 playlist",

--- a/src/lib/locales/fr.ts
+++ b/src/lib/locales/fr.ts
@@ -359,6 +359,7 @@ export const fr = {
   playlists: {
     title: "Listes de lecture",
     untitledPlaylistName: "Liste sans titre",
+    reservedPlaylistName: "« {name} » est réservé à la file d'attente intégrée. Veuillez choisir un autre nom.",
     noPlaylistsTitle: "Aucune liste de lecture",
     noPlaylistsText: "Cliquez sur « Nouvelle liste » ci-dessus pour créer la première.",
     showingOnePlaylist: "Affichage de 1 liste de lecture",

--- a/src/lib/stores/playlists.svelte.ts
+++ b/src/lib/stores/playlists.svelte.ts
@@ -5,6 +5,15 @@ import { applySongStats, type SongStatsPayload } from "../utils/stats";
 import { toastStore } from "./toast.svelte";
 import { i18n } from "./i18n.svelte";
 
+/** Marker substring from the backend's reserved-name rejection (playlist.rs,
+ * is_reserved_playlist_name) — always in English regardless of locale, since
+ * it's matched here rather than shown directly to the user. */
+const RESERVED_PLAYLIST_NAME_MARKER = "is reserved for the app's built-in Queue playlist";
+
+function isReservedPlaylistNameError(err: unknown): boolean {
+  return String(err).includes(RESERVED_PLAYLIST_NAME_MARKER);
+}
+
 class PlaylistsStore {
   playlists = $state<Playlist[]>([]);
   activePlaylistId = $state<number | null>(null);
@@ -179,7 +188,15 @@ class PlaylistsStore {
   }
 
   async createPlaylist(name: string): Promise<Playlist> {
-    const playlist: Playlist = await invoke("create_playlist", { name });
+    let playlist: Playlist;
+    try {
+      playlist = await invoke("create_playlist", { name });
+    } catch (err) {
+      if (isReservedPlaylistNameError(err)) {
+        toastStore.show(i18n.t("playlists.reservedPlaylistName", { name: name.trim() }), "error");
+      }
+      throw err;
+    }
     await this.refreshPlaylists();
     await this.selectPlaylist(playlist.id);
     await this.pinPlaylist(playlist.id);
@@ -236,7 +253,14 @@ class PlaylistsStore {
   }
 
   async renamePlaylist(id: number, name: string) {
-    await invoke("rename_playlist", { id, name });
+    try {
+      await invoke("rename_playlist", { id, name });
+    } catch (err) {
+      if (isReservedPlaylistNameError(err)) {
+        toastStore.show(i18n.t("playlists.reservedPlaylistName", { name: name.trim() }), "error");
+      }
+      throw err;
+    }
     await this.refreshPlaylists();
   }
 


### PR DESCRIPTION
## 📋 Summary
Fixes #293. The "Playlists featuring" section on the Artist Detail page listed the Queue (the app's internal/special playlist) alongside real playlists — every other playlist-listing view already excludes it by name, this one didn't.

While fixing that, we confirmed nothing stopped a user from creating or renaming a playlist to "Queue" (or its French equivalent, "File d'attente"). Since the app identifies the real Queue purely by that literal name (`playlists.svelte.ts`'s `queuePlaylist`/`ensureQueuePlaylist`), a duplicate would silently collide with that lookup. Added a safety net for that.

## 🔍 Implementation Notes
- **Queue exclusion**: `ArtistDetailView.svelte` now filters `fetchedPlaylists` with the same `p.name.toLowerCase() !== "queue"` pattern used in `PlaylistsCollectionView.svelte`, `PlaylistCard.svelte`, `PlaylistRowCard.svelte`, and `PlaylistView.svelte`.
- **Reserved-name guard (backend, source of truth)**: `playlist.rs` adds `RESERVED_PLAYLIST_NAMES` covering the literal DB name `"queue"` plus every locale's translated `playerBar.queueTitle` (currently French `"file d'attente"`).
  - `create_playlist` allows the app's one legitimate bootstrap of "Queue" (via `ensureQueuePlaylist`) but rejects any further reserved-name creation once a Queue playlist exists.
  - `rename_playlist` rejects renaming to any reserved name outright, since the real Queue is never renamed through that path.
- **Frontend surfacing**: `playlists.svelte.ts`'s `createPlaylist`/`renamePlaylist` catch the backend rejection and show a new localized error toast (`playlists.reservedPlaylistName` in `en.ts`/`fr.ts`), then rethrow so existing per-caller recovery (e.g. keeping a modal open) still works. Added missing `try/catch` at two call sites (`PlaylistView.svelte` inline rename, `PlaylistsCollectionView.svelte` blank-playlist creation) that previously had none.

## 🧪 Test Plan
- [x] `bun run check` (svelte-check) — 0 errors
- [x] `bunx vitest run` on `playlists.test.ts`, `PlaylistView`, `PlaylistsCollectionView`, `ArtistDetailView` — all pass
- [x] `cargo test --lib playlist::` — 12/12 pass, including new `test_reserved_playlist_names`
- [x] Manually verified in the app: attempted to rename a playlist to "Queue" — rejected with the new error toast (see screenshot in conversation)

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed — n/a (no docs screenshot covers this flow)