### PR TITLE
Fix sidebar flicker; correct scale-cancelling regression from #276

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -21,7 +21,8 @@
         "decorations": true,
         "transparent": false,
         "center": true,
-        "dragDropEnabled": false
+        "dragDropEnabled": false,
+        "additionalBrowserArgs": "--disable-gpu-compositing"
       }
     ],
     "security": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -21,8 +21,7 @@
         "decorations": true,
         "transparent": false,
         "center": true,
-        "dragDropEnabled": false,
-        "additionalBrowserArgs": "--disable-gpu-compositing"
+        "dragDropEnabled": false
       }
     ],
     "security": {

--- a/src/lib/components/AlbumDetailView.svelte
+++ b/src/lib/components/AlbumDetailView.svelte
@@ -515,8 +515,8 @@
       <img
         src={backdropUrl}
         alt=""
-        class="w-full h-full object-cover scale-150 blur-2xl"
-        style="will-change: filter; transform: translateZ(0);"
+        class="w-full h-full object-cover blur-2xl"
+        style="will-change: filter; transform: translateZ(0) scale(1.5);"
       />
       <div class="absolute inset-0 bg-gradient-to-b from-transparent via-transparent to-brand-main"></div>
     </div>

--- a/src/lib/components/AlbumRowCard.svelte
+++ b/src/lib/components/AlbumRowCard.svelte
@@ -53,7 +53,7 @@
   ondblclick={handleDblClick}
   oncontextmenu={(e) => customContextMenu?.(e)}
   onkeydown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); handleClick(e as unknown as MouseEvent); } }}
-  class="group flex items-center gap-3 px-3 py-2.5 rounded-lg bg-brand-sidebar border border-brand-border/60 hover:border-brand-accent/40 hover:shadow-md hover:shadow-brand-accent/10 transition-all duration-200 cursor-pointer select-none"
+  class="group flex items-center gap-3 px-3 py-2.5 rounded-lg bg-brand-sidebar border border-brand-border/60 hover:border-brand-accent/40 transition-colors duration-200 cursor-pointer select-none"
 >
   <div class="relative shrink-0 overflow-hidden">
     <CoverArt

--- a/src/lib/components/AlbumRowCard.svelte
+++ b/src/lib/components/AlbumRowCard.svelte
@@ -53,7 +53,7 @@
   ondblclick={handleDblClick}
   oncontextmenu={(e) => customContextMenu?.(e)}
   onkeydown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); handleClick(e as unknown as MouseEvent); } }}
-  class="group flex items-center gap-3 px-3 py-2.5 rounded-lg bg-brand-sidebar border border-brand-border/60 hover:border-brand-accent/40 transition-colors duration-200 cursor-pointer select-none"
+  class="group flex items-center gap-3 px-3 py-2.5 rounded-lg bg-brand-sidebar border border-brand-border/60 hover:outline hover:outline-2 hover:-outline-offset-2 hover:outline-brand-accent transition-colors duration-200 cursor-pointer select-none"
 >
   <div class="relative shrink-0 overflow-hidden">
     <CoverArt

--- a/src/lib/components/AlbumRowCard.svelte
+++ b/src/lib/components/AlbumRowCard.svelte
@@ -53,7 +53,7 @@
   ondblclick={handleDblClick}
   oncontextmenu={(e) => customContextMenu?.(e)}
   onkeydown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); handleClick(e as unknown as MouseEvent); } }}
-  class="group flex items-center gap-3 px-3 py-2.5 rounded-lg bg-brand-sidebar border border-brand-border/60 hover:outline hover:outline-2 hover:-outline-offset-2 hover:outline-brand-accent transition-colors duration-200 cursor-pointer select-none"
+  class="group flex items-center gap-3 px-3 py-2.5 rounded-lg bg-brand-sidebar border border-brand-border/60 outline-2 -outline-offset-2 outline-transparent hover:outline-brand-accent transition-[outline-color,border-color] duration-200 cursor-pointer select-none"
 >
   <div class="relative shrink-0 overflow-hidden">
     <CoverArt

--- a/src/lib/components/ArtistCard.svelte
+++ b/src/lib/components/ArtistCard.svelte
@@ -32,7 +32,7 @@
   tabindex="0"
   onclick={(e) => customClick?.(e)}
   onkeydown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); customClick?.(e as unknown as MouseEvent); } }}
-  class="artist-card group bg-brand-sidebar border border-brand-border/60 rounded-xl p-4 flex flex-col items-center text-center hover:border-brand-accent/40 transition-all duration-200 cursor-pointer select-none"
+  class="artist-card group bg-brand-sidebar border border-brand-border/60 rounded-xl p-4 flex flex-col items-center text-center outline-2 -outline-offset-2 outline-transparent hover:outline-brand-accent transition-[outline-color,border-color] duration-200 cursor-pointer select-none"
 >
   <div class="aspect-square w-full mb-3 bg-brand-main relative flex items-center justify-center">
     <CoverStack

--- a/src/lib/components/ArtistRowCard.svelte
+++ b/src/lib/components/ArtistRowCard.svelte
@@ -26,7 +26,7 @@
   tabindex="0"
   onclick={(e) => customClick?.(e)}
   onkeydown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); customClick?.(e as unknown as MouseEvent); } }}
-  class="group flex items-center gap-3 px-3 py-2.5 rounded-lg bg-brand-sidebar border border-brand-border/60 hover:outline hover:outline-2 hover:-outline-offset-2 hover:outline-brand-accent transition-colors duration-200 cursor-pointer select-none"
+  class="group flex items-center gap-3 px-3 py-2.5 rounded-lg bg-brand-sidebar border border-brand-border/60 outline-2 -outline-offset-2 outline-transparent hover:outline-brand-accent transition-[outline-color,border-color] duration-200 cursor-pointer select-none"
 >
   <div class="relative shrink-0 overflow-hidden">
     <CoverArt

--- a/src/lib/components/ArtistRowCard.svelte
+++ b/src/lib/components/ArtistRowCard.svelte
@@ -26,7 +26,7 @@
   tabindex="0"
   onclick={(e) => customClick?.(e)}
   onkeydown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); customClick?.(e as unknown as MouseEvent); } }}
-  class="group flex items-center gap-3 px-3 py-2.5 rounded-lg bg-brand-sidebar border border-brand-border/60 hover:border-brand-accent/40 transition-colors duration-200 cursor-pointer select-none"
+  class="group flex items-center gap-3 px-3 py-2.5 rounded-lg bg-brand-sidebar border border-brand-border/60 hover:outline hover:outline-2 hover:-outline-offset-2 hover:outline-brand-accent transition-colors duration-200 cursor-pointer select-none"
 >
   <div class="relative shrink-0 overflow-hidden">
     <CoverArt

--- a/src/lib/components/ArtistRowCard.svelte
+++ b/src/lib/components/ArtistRowCard.svelte
@@ -26,7 +26,7 @@
   tabindex="0"
   onclick={(e) => customClick?.(e)}
   onkeydown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); customClick?.(e as unknown as MouseEvent); } }}
-  class="group flex items-center gap-3 px-3 py-2.5 rounded-lg bg-brand-sidebar border border-brand-border/60 hover:border-brand-accent/40 hover:shadow-md hover:shadow-brand-accent/10 transition-all duration-200 cursor-pointer select-none"
+  class="group flex items-center gap-3 px-3 py-2.5 rounded-lg bg-brand-sidebar border border-brand-border/60 hover:border-brand-accent/40 transition-colors duration-200 cursor-pointer select-none"
 >
   <div class="relative shrink-0 overflow-hidden">
     <CoverArt

--- a/src/lib/components/AutoPlaylistRowCard.svelte
+++ b/src/lib/components/AutoPlaylistRowCard.svelte
@@ -48,7 +48,7 @@
 <!-- svelte-ignore a11y_click_events_have_key_events -->
 <div
   onclick={onClick}
-  class="group flex items-center gap-3 px-3 py-2.5 rounded-lg bg-brand-sidebar border border-brand-border/60 hover:border-brand-accent/40 hover:shadow-md hover:shadow-brand-accent/10 transition-all duration-200 cursor-pointer select-none"
+  class="group flex items-center gap-3 px-3 py-2.5 rounded-lg bg-brand-sidebar border border-brand-border/60 hover:border-brand-accent/40 transition-colors duration-200 cursor-pointer select-none"
 >
   <div
     class="relative shrink-0 w-11 h-11 flex items-center justify-center overflow-hidden border {kind === 'decade'

--- a/src/lib/components/AutoPlaylistRowCard.svelte
+++ b/src/lib/components/AutoPlaylistRowCard.svelte
@@ -48,7 +48,7 @@
 <!-- svelte-ignore a11y_click_events_have_key_events -->
 <div
   onclick={onClick}
-  class="group flex items-center gap-3 px-3 py-2.5 rounded-lg bg-brand-sidebar border border-brand-border/60 hover:border-brand-accent/40 transition-colors duration-200 cursor-pointer select-none"
+  class="group flex items-center gap-3 px-3 py-2.5 rounded-lg bg-brand-sidebar border border-brand-border/60 hover:outline hover:outline-2 hover:-outline-offset-2 hover:outline-brand-accent transition-colors duration-200 cursor-pointer select-none"
 >
   <div
     class="relative shrink-0 w-11 h-11 flex items-center justify-center overflow-hidden border {kind === 'decade'

--- a/src/lib/components/AutoPlaylistRowCard.svelte
+++ b/src/lib/components/AutoPlaylistRowCard.svelte
@@ -48,7 +48,7 @@
 <!-- svelte-ignore a11y_click_events_have_key_events -->
 <div
   onclick={onClick}
-  class="group flex items-center gap-3 px-3 py-2.5 rounded-lg bg-brand-sidebar border border-brand-border/60 hover:outline hover:outline-2 hover:-outline-offset-2 hover:outline-brand-accent transition-colors duration-200 cursor-pointer select-none"
+  class="group flex items-center gap-3 px-3 py-2.5 rounded-lg bg-brand-sidebar border border-brand-border/60 outline-2 -outline-offset-2 outline-transparent hover:outline-brand-accent transition-[outline-color,border-color] duration-200 cursor-pointer select-none"
 >
   <div
     class="relative shrink-0 w-11 h-11 flex items-center justify-center overflow-hidden border {kind === 'decade'

--- a/src/lib/components/HomeRowList.svelte
+++ b/src/lib/components/HomeRowList.svelte
@@ -134,7 +134,7 @@
         onclick={() => openItem(item)}
         oncontextmenu={(e) => handleContextMenu(e, item)}
         onkeydown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); openItem(item); } }}
-        class="group flex items-center gap-3 px-3 py-2.5 rounded-lg bg-brand-sidebar border border-brand-border/60 hover:outline hover:outline-2 hover:-outline-offset-2 hover:outline-brand-accent transition-colors duration-200 cursor-pointer select-none"
+        class="group flex items-center gap-3 px-3 py-2.5 rounded-lg bg-brand-sidebar border border-brand-border/60 outline-2 -outline-offset-2 outline-transparent hover:outline-brand-accent transition-[outline-color,border-color] duration-200 cursor-pointer select-none"
       >
         {#if variant === "rank"}
           <span class="w-5 shrink-0 text-center text-sm font-bold text-brand-text-secondary tabular-nums">

--- a/src/lib/components/HomeRowList.svelte
+++ b/src/lib/components/HomeRowList.svelte
@@ -134,7 +134,7 @@
         onclick={() => openItem(item)}
         oncontextmenu={(e) => handleContextMenu(e, item)}
         onkeydown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); openItem(item); } }}
-        class="group flex items-center gap-3 px-3 py-2.5 rounded-lg bg-brand-sidebar border border-brand-border/60 hover:border-brand-accent/40 transition-colors duration-200 cursor-pointer select-none"
+        class="group flex items-center gap-3 px-3 py-2.5 rounded-lg bg-brand-sidebar border border-brand-border/60 hover:outline hover:outline-2 hover:-outline-offset-2 hover:outline-brand-accent transition-colors duration-200 cursor-pointer select-none"
       >
         {#if variant === "rank"}
           <span class="w-5 shrink-0 text-center text-sm font-bold text-brand-text-secondary tabular-nums">

--- a/src/lib/components/HomeRowList.svelte
+++ b/src/lib/components/HomeRowList.svelte
@@ -134,7 +134,7 @@
         onclick={() => openItem(item)}
         oncontextmenu={(e) => handleContextMenu(e, item)}
         onkeydown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); openItem(item); } }}
-        class="group flex items-center gap-3 px-3 py-2.5 rounded-lg bg-brand-sidebar border border-brand-border/60 hover:border-brand-accent/40 hover:shadow-md hover:shadow-brand-accent/10 transition-all duration-200 cursor-pointer select-none"
+        class="group flex items-center gap-3 px-3 py-2.5 rounded-lg bg-brand-sidebar border border-brand-border/60 hover:border-brand-accent/40 transition-colors duration-200 cursor-pointer select-none"
       >
         {#if variant === "rank"}
           <span class="w-5 shrink-0 text-center text-sm font-bold text-brand-text-secondary tabular-nums">

--- a/src/lib/components/Miniplayer.svelte
+++ b/src/lib/components/Miniplayer.svelte
@@ -241,7 +241,10 @@
   {/if}
   <!-- Ambient Tint / Cover Art Glow Background -->
   {#if playerStore.currentSong}
-    <div class="absolute inset-0 z-0 opacity-25 blur-2xl pointer-events-none scale-125">
+    <div
+      class="absolute inset-0 z-0 opacity-25 blur-2xl pointer-events-none"
+      style="will-change: filter; transform: translateZ(0) scale(1.25);"
+    >
       <CoverArt
         songId={playerStore.currentSong?.id}
         artEmbedded={playerStore.currentSong?.art_embedded}

--- a/src/lib/components/Miniplayer.svelte
+++ b/src/lib/components/Miniplayer.svelte
@@ -259,7 +259,7 @@
   <div class="relative z-10 w-full h-full flex flex-col items-center justify-between pointer-events-auto">
     <!-- Centered Sharp Active Album Art Card -->
     <div class="flex-1 w-full flex items-center justify-center min-h-0 py-2">
-      <div class="relative aspect-square h-full max-h-full max-w-[90%] rounded-none overflow-hidden shadow-xl border border-brand-border/30 bg-brand-sidebar flex items-center justify-center {isHovered ? 'scale-[0.98]' : ''} transition-transform duration-300">
+      <div class="relative aspect-square h-full max-h-full max-w-[90%] rounded-none overflow-hidden border border-brand-border/30 bg-brand-sidebar flex items-center justify-center {isHovered ? 'scale-[0.98]' : ''} transition-transform duration-300">
         <CoverArt
           songId={playerStore.currentSong?.id}
           artEmbedded={playerStore.currentSong?.art_embedded}
@@ -349,7 +349,7 @@
         {#if playerStore.state === 'playing'}
           <button
             onclick={() => playerStore.pause()}
-            class="w-10 h-10 rounded-full bg-brand-accent hover:bg-brand-accent-hover text-brand-accent-contrast flex items-center justify-center hover:scale-105 transition-transform shadow-lg cursor-pointer flex-shrink-0"
+            class="w-10 h-10 rounded-full bg-brand-accent hover:bg-brand-accent-hover text-brand-accent-contrast flex items-center justify-center hover:scale-105 transition-transform cursor-pointer flex-shrink-0"
             title={i18n.t('playerBar.pause')}
           >
             <Pause class="w-5 h-5 fill-current" />
@@ -357,7 +357,7 @@
         {:else}
           <button
             onclick={() => playerStore.resume()}
-            class="w-10 h-10 rounded-full bg-brand-accent hover:bg-brand-accent-hover text-brand-accent-contrast flex items-center justify-center hover:scale-105 transition-transform shadow-lg cursor-pointer flex-shrink-0"
+            class="w-10 h-10 rounded-full bg-brand-accent hover:bg-brand-accent-hover text-brand-accent-contrast flex items-center justify-center hover:scale-105 transition-transform cursor-pointer flex-shrink-0"
             title={i18n.t('playerBar.play')}
           >
             <Play class="w-5 h-5 fill-current ml-0.5" />
@@ -471,7 +471,6 @@
     background: #ffffff;
     border: 2px solid var(--color-accent);
     cursor: pointer;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
     transition: transform 0.1s, border-color 0.2s;
   }
 
@@ -487,7 +486,6 @@
     border-radius: 50%;
     background: #ffffff;
     cursor: pointer;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
     transition: transform 0.1s, border-color 0.2s;
   }
 

--- a/src/lib/components/Miniplayer.svelte
+++ b/src/lib/components/Miniplayer.svelte
@@ -349,7 +349,7 @@
         {#if playerStore.state === 'playing'}
           <button
             onclick={() => playerStore.pause()}
-            class="w-10 h-10 rounded-full bg-brand-accent hover:bg-brand-accent-hover text-brand-accent-contrast flex items-center justify-center hover:scale-105 transition-transform cursor-pointer flex-shrink-0"
+            class="w-10 h-10 rounded-full bg-brand-accent hover:bg-brand-accent-hover text-brand-accent-contrast flex items-center justify-center transition-colors cursor-pointer flex-shrink-0"
             title={i18n.t('playerBar.pause')}
           >
             <Pause class="w-5 h-5 fill-current" />
@@ -357,7 +357,7 @@
         {:else}
           <button
             onclick={() => playerStore.resume()}
-            class="w-10 h-10 rounded-full bg-brand-accent hover:bg-brand-accent-hover text-brand-accent-contrast flex items-center justify-center hover:scale-105 transition-transform cursor-pointer flex-shrink-0"
+            class="w-10 h-10 rounded-full bg-brand-accent hover:bg-brand-accent-hover text-brand-accent-contrast flex items-center justify-center transition-colors cursor-pointer flex-shrink-0"
             title={i18n.t('playerBar.play')}
           >
             <Play class="w-5 h-5 fill-current ml-0.5" />
@@ -471,11 +471,10 @@
     background: #ffffff;
     border: 2px solid var(--color-accent);
     cursor: pointer;
-    transition: transform 0.1s, border-color 0.2s;
+    transition: border-color 0.2s;
   }
 
   .volume-slider::-webkit-slider-thumb:hover {
-    transform: scale(1.25);
     border-color: var(--color-accent-hover);
   }
 
@@ -486,11 +485,10 @@
     border-radius: 50%;
     background: #ffffff;
     cursor: pointer;
-    transition: transform 0.1s, border-color 0.2s;
+    transition: border-color 0.2s;
   }
 
   .volume-slider::-moz-range-thumb:hover {
-    transform: scale(1.25);
     border-color: var(--color-accent-hover);
   }
 </style>

--- a/src/lib/components/PlayerBar.svelte
+++ b/src/lib/components/PlayerBar.svelte
@@ -275,7 +275,7 @@
       {#if playerStore.state === 'playing'}
         <button
           onclick={() => playerStore.pause()}
-          class="w-8 h-8 rounded-full bg-brand-accent hover:bg-brand-accent-hover text-brand-accent-contrast flex items-center justify-center hover:scale-105 transition-all shadow-md"
+          class="w-8 h-8 rounded-full bg-brand-accent hover:bg-brand-accent-hover text-brand-accent-contrast flex items-center justify-center hover:scale-105 transition-all"
           title={i18n.t('playerBar.pause')}
         >
           <Pause class="w-4 h-4 fill-current" />
@@ -283,7 +283,7 @@
       {:else}
         <button
           onclick={() => playerStore.resume()}
-          class="w-8 h-8 rounded-full bg-brand-accent hover:bg-brand-accent-hover text-brand-accent-contrast flex items-center justify-center hover:scale-105 transition-all shadow-md"
+          class="w-8 h-8 rounded-full bg-brand-accent hover:bg-brand-accent-hover text-brand-accent-contrast flex items-center justify-center hover:scale-105 transition-all"
           title={i18n.t('playerBar.play')}
         >
           <Play class="w-4 h-4 fill-current ml-0.5" />
@@ -447,7 +447,6 @@
     background: #ffffff;
     border: 2px solid var(--color-accent);
     cursor: pointer;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
     transition: transform 0.1s, border-color 0.2s;
   }
 
@@ -464,7 +463,6 @@
     border-radius: 50%;
     background: #ffffff;
     cursor: pointer;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
     transition: transform 0.1s, border-color 0.2s;
   }
 

--- a/src/lib/components/PlayerBar.svelte
+++ b/src/lib/components/PlayerBar.svelte
@@ -275,7 +275,7 @@
       {#if playerStore.state === 'playing'}
         <button
           onclick={() => playerStore.pause()}
-          class="w-8 h-8 rounded-full bg-brand-accent hover:bg-brand-accent-hover text-brand-accent-contrast flex items-center justify-center hover:scale-105 transition-all"
+          class="w-8 h-8 rounded-full bg-brand-accent hover:bg-brand-accent-hover text-brand-accent-contrast flex items-center justify-center transition-colors"
           title={i18n.t('playerBar.pause')}
         >
           <Pause class="w-4 h-4 fill-current" />
@@ -283,7 +283,7 @@
       {:else}
         <button
           onclick={() => playerStore.resume()}
-          class="w-8 h-8 rounded-full bg-brand-accent hover:bg-brand-accent-hover text-brand-accent-contrast flex items-center justify-center hover:scale-105 transition-all"
+          class="w-8 h-8 rounded-full bg-brand-accent hover:bg-brand-accent-hover text-brand-accent-contrast flex items-center justify-center transition-colors"
           title={i18n.t('playerBar.play')}
         >
           <Play class="w-4 h-4 fill-current ml-0.5" />
@@ -447,11 +447,10 @@
     background: #ffffff;
     border: 2px solid var(--color-accent);
     cursor: pointer;
-    transition: transform 0.1s, border-color 0.2s;
+    transition: border-color 0.2s;
   }
 
   .volume-slider::-webkit-slider-thumb:hover {
-    transform: scale(1.25);
     border-color: var(--color-accent-hover);
   }
 
@@ -463,11 +462,10 @@
     border-radius: 50%;
     background: #ffffff;
     cursor: pointer;
-    transition: transform 0.1s, border-color 0.2s;
+    transition: border-color 0.2s;
   }
 
   .volume-slider::-moz-range-thumb:hover {
-    transform: scale(1.25);
     border-color: var(--color-accent-hover);
   }
 </style>

--- a/src/lib/components/PlaylistRowCard.svelte
+++ b/src/lib/components/PlaylistRowCard.svelte
@@ -38,7 +38,7 @@
 <!-- svelte-ignore a11y_click_events_have_key_events -->
 <div
   onclick={onClick}
-  class="group flex items-center gap-3 px-3 py-2.5 rounded-lg bg-brand-sidebar border border-brand-border/60 hover:border-brand-accent/40 hover:shadow-md hover:shadow-brand-accent/10 transition-all duration-200 cursor-pointer select-none"
+  class="group flex items-center gap-3 px-3 py-2.5 rounded-lg bg-brand-sidebar border border-brand-border/60 hover:border-brand-accent/40 transition-colors duration-200 cursor-pointer select-none"
 >
   <div
     class="relative shrink-0 w-11 h-11 flex items-center justify-center overflow-hidden border {isQueue

--- a/src/lib/components/PlaylistRowCard.svelte
+++ b/src/lib/components/PlaylistRowCard.svelte
@@ -38,7 +38,7 @@
 <!-- svelte-ignore a11y_click_events_have_key_events -->
 <div
   onclick={onClick}
-  class="group flex items-center gap-3 px-3 py-2.5 rounded-lg bg-brand-sidebar border border-brand-border/60 hover:border-brand-accent/40 transition-colors duration-200 cursor-pointer select-none"
+  class="group flex items-center gap-3 px-3 py-2.5 rounded-lg bg-brand-sidebar border border-brand-border/60 hover:outline hover:outline-2 hover:-outline-offset-2 hover:outline-brand-accent transition-colors duration-200 cursor-pointer select-none"
 >
   <div
     class="relative shrink-0 w-11 h-11 flex items-center justify-center overflow-hidden border {isQueue

--- a/src/lib/components/PlaylistRowCard.svelte
+++ b/src/lib/components/PlaylistRowCard.svelte
@@ -38,7 +38,7 @@
 <!-- svelte-ignore a11y_click_events_have_key_events -->
 <div
   onclick={onClick}
-  class="group flex items-center gap-3 px-3 py-2.5 rounded-lg bg-brand-sidebar border border-brand-border/60 hover:outline hover:outline-2 hover:-outline-offset-2 hover:outline-brand-accent transition-colors duration-200 cursor-pointer select-none"
+  class="group flex items-center gap-3 px-3 py-2.5 rounded-lg bg-brand-sidebar border border-brand-border/60 outline-2 -outline-offset-2 outline-transparent hover:outline-brand-accent transition-[outline-color,border-color] duration-200 cursor-pointer select-none"
 >
   <div
     class="relative shrink-0 w-11 h-11 flex items-center justify-center overflow-hidden border {isQueue


### PR DESCRIPTION
## Summary
Started as the miniplayer/album-backdrop flicker fix (same family as #276/#279), but testing surfaced a second, separate rendering bug: hovering certain controls (Home row cards, playbar buttons, volume slider) while music plays could trigger phantom rectangular "ghost bands" rendered into the sidebar's empty space, on a completely unrelated part of the screen.

## Confirmed fixes
- `Miniplayer.svelte`: pin the cover-art glow background to its own GPU layer (`will-change: filter` + `transform: translateZ(0) scale(1.25)`), same technique as #276's album backdrop fix.
- `AlbumDetailView.svelte`: corrected a regression from #276 where an inline `transform: translateZ(0)` silently cancelled the `scale-150` Tailwind class on the same element (inline styles win over classes for the same property) — combined into one explicit `transform` value.
- `HomeRowList.svelte`, `AlbumRowCard.svelte`, `ArtistRowCard.svelte`, `AutoPlaylistRowCard.svelte`, `PlaylistRowCard.svelte`, `ArtistCard.svelte`: replaced `hover:shadow-md hover:shadow-brand-accent/10` (a confirmed ghost-band trigger) with an always-painted, transparent-at-rest `outline` that only transitions `outline-color` on hover — more prominent than a border-color change, doesn't shift layout, and avoids re-spawning a fresh paint region each hover (which caused a white flash before this fix).
- `PlayerBar.svelte` / `Miniplayer.svelte`: removed static shadows (`shadow-md`/`shadow-lg`/`shadow-xl`) and hover-triggered scale transforms (`hover:scale-105`, volume slider thumb `scale(1.25)`) that were also confirmed ghost-band triggers. Play/Pause and the volume thumb now give hover feedback via color transition only.

## Investigated, not resolved
The ghost-band bug is still reproducible after all of the above — it turns out any repaint near the affected region (even a plain hover color change) has a chance to trigger it, and during normal playback the spectrum visualizer canvas (~30fps), position ticks (250ms), and reactive logo pulse repaint continuously enough on their own to expose it regardless of which control is hovered. This points at a WebView2/Chromium compositor damage-tracking issue (see [MicrosoftEdge/WebView2Feedback#5574](https://github.com/MicrosoftEdge/WebView2Feedback/issues/5574) for the closest documented analog), not something fixable purely in app CSS.

Tried and reverted: `--disable-gpu-compositing` via `additionalBrowserArgs` in `tauri.conf.json` — did not fix the ghost bands and visibly degraded rendering quality across the app's blur effects, so not a worthwhile tradeoff. The remaining ghost-band behavior is a known issue to revisit later (e.g. if Microsoft ships a compositor fix, or if a lower-level workaround is found).

## Test plan
- [x] Play a track with the miniplayer visible; confirm no flicker in the ambient cover-art glow
- [x] Confirm the album detail backdrop still has proper overscan margin (no vignette line) on high-contrast art
- [x] Hover Top Artists / Top 5 Most Played / Recently Added rows; hover reads clearly via the inset outline, no layout shift, no white flash
- [x] Hover playbar Play/Pause and volume slider; smooth color-only feedback
- [x] Ghost bands in the sidebar during playback — reduced in frequency, not eliminated; tracked as a known issue