### PR TITLE
Fix dead click on albumless songs in Home's Recently Added

### DIFF
--- a/src/lib/components/HomeRowList.svelte
+++ b/src/lib/components/HomeRowList.svelte
@@ -96,6 +96,8 @@
   function openItem(item: HomeItem) {
     if (item.type === "song" && item.song.album) {
       collectionStore.viewAlbum(item.song.album);
+    } else if (item.type === "song") {
+      playerStore.playSong(item.song.id);
     } else if (item.type === "album") {
       collectionStore.viewAlbum(item.album.album || "");
     } else if (item.type === "playlist") {


### PR DESCRIPTION
## Summary
- `HomeRowList.openItem()` had no fallback when a song row lacked an album — clicks silently did nothing. Since the backend collapses any multi-track recently-added album into an `Album` card, nearly every `Song` row surfaced in "Recently Added" is albumless, so this affected essentially every song click in that section.
- Added an `else` branch that calls `playerStore.playSong(item.song.id)`, mirroring the existing context-menu play action and `CarouselCard`'s play-overlay fallback.

Fixes #296

## Test plan
- [x] `bun run check` (svelte-check) passes with 0 errors
- [x] Manual verification in dev server: click an albumless song row in Home's Recently Added and confirm it starts playing (not verifiable via the sandboxed browser preview here — Luminous's Tauri IPC isn't available there)