### PR TITLE
feat: resizable table columns with shared persistence (#300)

### DIFF
--- a/src/lib/components/AlbumDetailView.svelte
+++ b/src/lib/components/AlbumDetailView.svelte
@@ -30,6 +30,8 @@
   import { formatDate, formatFileSize, formatSampleRate, formatBitDepth, formatChannels } from "../utils/formatters";
   import { formatDateAdded } from "../utils/date";
   import { rememberScroll } from "../utils/scrollMemory";
+  import { SONG_TABLE_COLUMNS } from "../utils/songColumns";
+  import { columnResize } from "../utils/columnResize";
 
   let { albumName }: { albumName: string } = $props();
 
@@ -324,37 +326,27 @@
     });
   });
 
+  // Default column widths (px or fr) — used when no saved width exists for a column.
+  const ALBUM_COL_DEFAULTS: Partial<Record<keyof typeof collectionStore.visibleColumns, string>> = {
+    track: "48px", title: "2fr", artist: "1.5fr", album: "1.5fr",
+    composer: "1.5fr", album_artist: "1.5fr", format: "64px", year: "60px",
+    genre: "1.2fr", grouping: "1.2fr", bpm: "60px", initial_key: "60px",
+    bitrate: "70px", samplerate: "75px", bitdepth: "65px", channels: "70px",
+    filesize: "75px", rating: "96px", playcount: "70px", skipcount: "70px",
+    lastplayed: "90px", added: "90px", duration: "80px", path: "2fr", actions: "80px",
+  };
+
   // Mirrors CollectionView/PlaylistView/AutoPlaylistDetailView's identical
   // formula so all four song-table views share one column configuration.
   let gridColsStyle = $derived.by(() => {
     const vc = collectionStore.visibleColumns;
+    const cw = collectionStore.columnWidths;
     const cols: string[] = ["36px"]; // play indicator always present
-    if (vc.track) cols.push("48px");
-    if (vc.title) cols.push("2fr");
-    if (vc.artist) cols.push("1.5fr");
-    if (vc.album) cols.push("1.5fr");
-    if (vc.composer) cols.push("1.5fr");
-    if (vc.album_artist) cols.push("1.5fr");
-    if (vc.format) cols.push("64px");
-    if (vc.year) cols.push("60px");
-    if (vc.genre) cols.push("1.2fr");
-    if (vc.grouping) cols.push("1.2fr");
-    if (vc.bpm) cols.push("60px");
-    if (vc.initial_key) cols.push("60px");
-    if (vc.bitrate) cols.push("70px");
-    if (vc.samplerate) cols.push("75px");
-    if (vc.bitdepth) cols.push("65px");
-    if (vc.channels) cols.push("70px");
-    if (vc.filesize) cols.push("75px");
-    if (vc.rating) cols.push("96px");
-    if (vc.playcount) cols.push("70px");
-    if (vc.skipcount) cols.push("70px");
-    if (vc.lastplayed) cols.push("90px");
-    if (vc.added) cols.push("90px");
-    if (vc.duration) cols.push("80px");
-    if (vc.path) cols.push("2fr");
-    if (vc.actions) cols.push("80px");
-
+    for (const { key } of SONG_TABLE_COLUMNS) {
+      if (!vc[key]) continue;
+      const saved = cw[key];
+      cols.push(saved !== undefined ? `${saved}px` : (ALBUM_COL_DEFAULTS[key] ?? "80px"));
+    }
     return `grid-template-columns: ${cols.join(" ")}`;
   });
 
@@ -633,247 +625,295 @@
         <div class="grid items-center py-2.5 px-4" style={gridColsStyle}>
           <div class="text-center w-9"></div>
           {#if collectionStore.visibleColumns.track}
+            <div use:columnResize={{ column: "track", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
             <SortableHeader
               active={sortField === "track"}
               {sortAsc}
               onclick={() => toggleSort("track")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-1rem)]">{i18n.t('collection.tableHeaderTrack')} {arrow}</span>{/snippet}
             </SortableHeader>
+            </div>
           {/if}
           {#if collectionStore.visibleColumns.title}
+            <div use:columnResize={{ column: "title", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
             <SortableHeader
               active={sortField === "title"}
               {sortAsc}
               onclick={() => toggleSort("title")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-1rem)]">{i18n.t('collection.tableHeaderTitle')} {arrow}</span>{/snippet}
             </SortableHeader>
+            </div>
           {/if}
           {#if collectionStore.visibleColumns.artist}
+            <div use:columnResize={{ column: "artist", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
             <SortableHeader
               active={sortField === "artist"}
               {sortAsc}
               onclick={() => toggleSort("artist")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-1rem)]">{i18n.t('collection.tableHeaderArtist')} {arrow}</span>{/snippet}
             </SortableHeader>
+            </div>
           {/if}
           {#if collectionStore.visibleColumns.album}
+            <div use:columnResize={{ column: "album", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
             <SortableHeader
               active={sortField === "album"}
               {sortAsc}
               onclick={() => toggleSort("album")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-1rem)]">{i18n.t('collection.tableHeaderAlbum')} {arrow}</span>{/snippet}
             </SortableHeader>
+            </div>
           {/if}
           {#if collectionStore.visibleColumns.composer}
+            <div use:columnResize={{ column: "composer", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
             <SortableHeader
               active={sortField === "composer"}
               {sortAsc}
               onclick={() => toggleSort("composer")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderComposer')} {arrow}</span>{/snippet}
             </SortableHeader>
+            </div>
           {/if}
           {#if collectionStore.visibleColumns.album_artist}
+            <div use:columnResize={{ column: "album_artist", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
             <SortableHeader
               active={sortField === "album_artist"}
               {sortAsc}
               onclick={() => toggleSort("album_artist")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderAlbumArtist')} {arrow}</span>{/snippet}
             </SortableHeader>
+            </div>
           {/if}
           {#if collectionStore.visibleColumns.format}
+            <div use:columnResize={{ column: "format", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
             <SortableHeader
               active={sortField === "filetype"}
               {sortAsc}
               onclick={() => toggleSort("filetype")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderFormat')} {arrow}</span>{/snippet}
             </SortableHeader>
+            </div>
           {/if}
           {#if collectionStore.visibleColumns.year}
+            <div use:columnResize={{ column: "year", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
             <SortableHeader
               active={sortField === "year"}
               {sortAsc}
               onclick={() => toggleSort("year")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderYear')} {arrow}</span>{/snippet}
             </SortableHeader>
+            </div>
           {/if}
           {#if collectionStore.visibleColumns.genre}
+            <div use:columnResize={{ column: "genre", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
             <SortableHeader
               active={sortField === "genre"}
               {sortAsc}
               onclick={() => toggleSort("genre")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderGenre')} {arrow}</span>{/snippet}
             </SortableHeader>
+            </div>
           {/if}
           {#if collectionStore.visibleColumns.grouping}
+            <div use:columnResize={{ column: "grouping", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
             <SortableHeader
               active={sortField === "grouping"}
               {sortAsc}
               onclick={() => toggleSort("grouping")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderGrouping')} {arrow}</span>{/snippet}
             </SortableHeader>
+            </div>
           {/if}
           {#if collectionStore.visibleColumns.bpm}
+            <div use:columnResize={{ column: "bpm", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
             <SortableHeader
               active={sortField === "bpm"}
               {sortAsc}
               onclick={() => toggleSort("bpm")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderBpm')} {arrow}</span>{/snippet}
             </SortableHeader>
+            </div>
           {/if}
           {#if collectionStore.visibleColumns.initial_key}
+            <div use:columnResize={{ column: "initial_key", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
             <SortableHeader
               active={sortField === "initial_key"}
               {sortAsc}
               onclick={() => toggleSort("initial_key")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderInitialKey')} {arrow}</span>{/snippet}
             </SortableHeader>
+            </div>
           {/if}
           {#if collectionStore.visibleColumns.bitrate}
+            <div use:columnResize={{ column: "bitrate", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
             <SortableHeader
               active={sortField === "bitrate"}
               {sortAsc}
               onclick={() => toggleSort("bitrate")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderBitrate')} {arrow}</span>{/snippet}
             </SortableHeader>
+            </div>
           {/if}
           {#if collectionStore.visibleColumns.samplerate}
+            <div use:columnResize={{ column: "samplerate", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
             <SortableHeader
               active={sortField === "samplerate"}
               {sortAsc}
               onclick={() => toggleSort("samplerate")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderSampleRate')} {arrow}</span>{/snippet}
             </SortableHeader>
+            </div>
           {/if}
           {#if collectionStore.visibleColumns.bitdepth}
+            <div use:columnResize={{ column: "bitdepth", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
             <SortableHeader
               active={sortField === "bitdepth"}
               {sortAsc}
               onclick={() => toggleSort("bitdepth")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderBitDepth')} {arrow}</span>{/snippet}
             </SortableHeader>
+            </div>
           {/if}
           {#if collectionStore.visibleColumns.channels}
+            <div use:columnResize={{ column: "channels", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
             <SortableHeader
               active={sortField === "channels"}
               {sortAsc}
               onclick={() => toggleSort("channels")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderChannels')} {arrow}</span>{/snippet}
             </SortableHeader>
+            </div>
           {/if}
           {#if collectionStore.visibleColumns.filesize}
+            <div use:columnResize={{ column: "filesize", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
             <SortableHeader
               active={sortField === "filesize"}
               {sortAsc}
               onclick={() => toggleSort("filesize")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderFileSize')} {arrow}</span>{/snippet}
             </SortableHeader>
+            </div>
           {/if}
           {#if collectionStore.visibleColumns.rating}
+            <div use:columnResize={{ column: "rating", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
             <SortableHeader
               active={sortField === "rating"}
               {sortAsc}
               onclick={() => toggleSort("rating")}
-              class="flex items-center justify-center hover:text-brand-text-primary transition-colors cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+              class="flex items-center justify-center hover:text-brand-text-primary transition-colors cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate">{i18n.t('collection.tableHeaderRating')} {arrow}</span>{/snippet}
             </SortableHeader>
+            </div>
           {/if}
           {#if collectionStore.visibleColumns.playcount}
+            <div use:columnResize={{ column: "playcount", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
             <SortableHeader
               active={sortField === "playcount"}
               {sortAsc}
               onclick={() => toggleSort("playcount")}
-              class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+              class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate">{i18n.t('collection.tableHeaderPlays')} {arrow}</span>{/snippet}
             </SortableHeader>
+            </div>
           {/if}
           {#if collectionStore.visibleColumns.skipcount}
+            <div use:columnResize={{ column: "skipcount", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
             <SortableHeader
               active={sortField === "skipcount"}
               {sortAsc}
               onclick={() => toggleSort("skipcount")}
-              class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+              class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate">{i18n.t('collection.tableHeaderSkips')} {arrow}</span>{/snippet}
             </SortableHeader>
+            </div>
           {/if}
           {#if collectionStore.visibleColumns.lastplayed}
+            <div use:columnResize={{ column: "lastplayed", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
             <SortableHeader
               active={sortField === "lastplayed"}
               {sortAsc}
               onclick={() => toggleSort("lastplayed")}
-              class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+              class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate">{i18n.t('collection.tableHeaderLastPlayed')} {arrow}</span>{/snippet}
             </SortableHeader>
+            </div>
           {/if}
           {#if collectionStore.visibleColumns.added}
+            <div use:columnResize={{ column: "added", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
             <SortableHeader
               active={sortField === "added"}
               {sortAsc}
               onclick={() => toggleSort("added")}
-              class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+              class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate">{i18n.t('collection.tableHeaderAdded')} {arrow}</span>{/snippet}
             </SortableHeader>
+            </div>
           {/if}
           {#if collectionStore.visibleColumns.duration}
+            <div use:columnResize={{ column: "duration", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
             <SortableHeader
               active={sortField === "length_nanosec"}
               {sortAsc}
               onclick={() => toggleSort("length_nanosec")}
-              class="flex items-center justify-center hover:text-brand-text-primary transition-colors cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+              class="flex items-center justify-center hover:text-brand-text-primary transition-colors cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<Clock class="w-3.5 h-3.5 shrink-0" /> {arrow}{/snippet}
             </SortableHeader>
+            </div>
           {/if}
           {#if collectionStore.visibleColumns.path}
+            <div use:columnResize={{ column: "path", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
             <SortableHeader
               active={sortField === "path"}
               {sortAsc}
               onclick={() => toggleSort("path")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderPath')} {arrow}</span>{/snippet}
             </SortableHeader>
+            </div>
           {/if}
           {#if collectionStore.visibleColumns.actions}
-            <div class="text-center">{i18n.t('collection.tableHeaderActions')}</div>
+            <div use:columnResize={{ column: "actions", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden text-center">{i18n.t('collection.tableHeaderActions')}</div>
           {/if}
         </div>
       </div>
@@ -1160,3 +1200,4 @@
     display: none;
   }
 </style>
+

--- a/src/lib/components/ArtistDetailView.svelte
+++ b/src/lib/components/ArtistDetailView.svelte
@@ -27,6 +27,8 @@
   import { rememberScroll } from "../utils/scrollMemory";
   import { formatDate, formatFileSize, formatSampleRate, formatBitDepth, formatChannels } from "../utils/formatters";
   import { formatDateAdded } from "../utils/date";
+  import { SONG_TABLE_COLUMNS } from "../utils/songColumns";
+  import { columnResize } from "../utils/columnResize";
 
   let { artistName }: { artistName: string } = $props();
 
@@ -239,35 +241,25 @@
 
   // Mirrors AlbumDetailView/CollectionView/PlaylistView/AutoPlaylistDetailView's
   // identical formula so this table's columns match what's shown everywhere else.
+  // Default column widths (px or fr) — used when no saved width exists for a column.
+  const ARTIST_COL_DEFAULTS: Partial<Record<keyof typeof collectionStore.visibleColumns, string>> = {
+    track: "48px", title: "2fr", artist: "1.5fr", album: "1.5fr",
+    composer: "1.5fr", album_artist: "1.5fr", format: "64px", year: "60px",
+    genre: "1.2fr", grouping: "1.2fr", bpm: "60px", initial_key: "60px",
+    bitrate: "70px", samplerate: "75px", bitdepth: "65px", channels: "70px",
+    filesize: "75px", rating: "96px", playcount: "70px", skipcount: "70px",
+    lastplayed: "90px", added: "90px", duration: "80px", path: "2fr", actions: "80px",
+  };
+
   let gridColsStyle = $derived.by(() => {
     const vc = collectionStore.visibleColumns;
+    const cw = collectionStore.columnWidths;
     const cols: string[] = ["36px"]; // play indicator always present
-    if (vc.track) cols.push("48px");
-    if (vc.title) cols.push("2fr");
-    if (vc.artist) cols.push("1.5fr");
-    if (vc.album) cols.push("1.5fr");
-    if (vc.composer) cols.push("1.5fr");
-    if (vc.album_artist) cols.push("1.5fr");
-    if (vc.format) cols.push("64px");
-    if (vc.year) cols.push("60px");
-    if (vc.genre) cols.push("1.2fr");
-    if (vc.grouping) cols.push("1.2fr");
-    if (vc.bpm) cols.push("60px");
-    if (vc.initial_key) cols.push("60px");
-    if (vc.bitrate) cols.push("70px");
-    if (vc.samplerate) cols.push("75px");
-    if (vc.bitdepth) cols.push("65px");
-    if (vc.channels) cols.push("70px");
-    if (vc.filesize) cols.push("75px");
-    if (vc.rating) cols.push("96px");
-    if (vc.playcount) cols.push("70px");
-    if (vc.skipcount) cols.push("70px");
-    if (vc.lastplayed) cols.push("90px");
-    if (vc.added) cols.push("90px");
-    if (vc.duration) cols.push("80px");
-    if (vc.path) cols.push("2fr");
-    if (vc.actions) cols.push("80px");
-
+    for (const { key } of SONG_TABLE_COLUMNS) {
+      if (!vc[key]) continue;
+      const saved = cw[key];
+      cols.push(saved !== undefined ? `${saved}px` : (ARTIST_COL_DEFAULTS[key] ?? "80px"));
+    }
     return `grid-template-columns: ${cols.join(" ")}`;
   });
 
@@ -405,247 +397,295 @@
             <div class="grid items-center py-2.5 px-4" style={gridColsStyle}>
               <div class="text-center w-9"></div>
               {#if collectionStore.visibleColumns.track}
+                <div use:columnResize={{ column: "track", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
                 <SortableHeader
                   active={singleSortField === "track"}
                   sortAsc={singleSortAsc}
                   onclick={() => toggleSingleSort("track")}
-                  class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+                  class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
                 >
                   {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-1rem)]">{i18n.t('collection.tableHeaderTrack')} {arrow}</span>{/snippet}
                 </SortableHeader>
+                </div>
               {/if}
               {#if collectionStore.visibleColumns.title}
+                <div use:columnResize={{ column: "title", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
                 <SortableHeader
                   active={singleSortField === "title"}
                   sortAsc={singleSortAsc}
                   onclick={() => toggleSingleSort("title")}
-                  class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+                  class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
                 >
                   {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-1rem)]">{i18n.t('collection.tableHeaderTitle')} {arrow}</span>{/snippet}
                 </SortableHeader>
+                </div>
               {/if}
               {#if collectionStore.visibleColumns.artist}
+                <div use:columnResize={{ column: "artist", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
                 <SortableHeader
                   active={singleSortField === "artist"}
                   sortAsc={singleSortAsc}
                   onclick={() => toggleSingleSort("artist")}
-                  class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+                  class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
                 >
                   {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-1rem)]">{i18n.t('collection.tableHeaderArtist')} {arrow}</span>{/snippet}
                 </SortableHeader>
+                </div>
               {/if}
               {#if collectionStore.visibleColumns.album}
+                <div use:columnResize={{ column: "album", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
                 <SortableHeader
                   active={singleSortField === "album"}
                   sortAsc={singleSortAsc}
                   onclick={() => toggleSingleSort("album")}
-                  class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+                  class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
                 >
                   {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-1rem)]">{i18n.t('collection.tableHeaderAlbum')} {arrow}</span>{/snippet}
                 </SortableHeader>
+                </div>
               {/if}
               {#if collectionStore.visibleColumns.composer}
+                <div use:columnResize={{ column: "composer", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
                 <SortableHeader
                   active={singleSortField === "composer"}
                   sortAsc={singleSortAsc}
                   onclick={() => toggleSingleSort("composer")}
-                  class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+                  class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
                 >
                   {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderComposer')} {arrow}</span>{/snippet}
                 </SortableHeader>
+                </div>
               {/if}
               {#if collectionStore.visibleColumns.album_artist}
+                <div use:columnResize={{ column: "album_artist", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
                 <SortableHeader
                   active={singleSortField === "album_artist"}
                   sortAsc={singleSortAsc}
                   onclick={() => toggleSingleSort("album_artist")}
-                  class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+                  class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
                 >
                   {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderAlbumArtist')} {arrow}</span>{/snippet}
                 </SortableHeader>
+                </div>
               {/if}
               {#if collectionStore.visibleColumns.format}
+                <div use:columnResize={{ column: "format", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
                 <SortableHeader
                   active={singleSortField === "filetype"}
                   sortAsc={singleSortAsc}
                   onclick={() => toggleSingleSort("filetype")}
-                  class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+                  class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
                 >
                   {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderFormat')} {arrow}</span>{/snippet}
                 </SortableHeader>
+                </div>
               {/if}
               {#if collectionStore.visibleColumns.year}
+                <div use:columnResize={{ column: "year", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
                 <SortableHeader
                   active={singleSortField === "year"}
                   sortAsc={singleSortAsc}
                   onclick={() => toggleSingleSort("year")}
-                  class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+                  class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
                 >
                   {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderYear')} {arrow}</span>{/snippet}
                 </SortableHeader>
+                </div>
               {/if}
               {#if collectionStore.visibleColumns.genre}
+                <div use:columnResize={{ column: "genre", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
                 <SortableHeader
                   active={singleSortField === "genre"}
                   sortAsc={singleSortAsc}
                   onclick={() => toggleSingleSort("genre")}
-                  class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+                  class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
                 >
                   {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderGenre')} {arrow}</span>{/snippet}
                 </SortableHeader>
+                </div>
               {/if}
               {#if collectionStore.visibleColumns.grouping}
+                <div use:columnResize={{ column: "grouping", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
                 <SortableHeader
                   active={singleSortField === "grouping"}
                   sortAsc={singleSortAsc}
                   onclick={() => toggleSingleSort("grouping")}
-                  class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+                  class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
                 >
                   {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderGrouping')} {arrow}</span>{/snippet}
                 </SortableHeader>
+                </div>
               {/if}
               {#if collectionStore.visibleColumns.bpm}
+                <div use:columnResize={{ column: "bpm", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
                 <SortableHeader
                   active={singleSortField === "bpm"}
                   sortAsc={singleSortAsc}
                   onclick={() => toggleSingleSort("bpm")}
-                  class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+                  class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
                 >
                   {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderBpm')} {arrow}</span>{/snippet}
                 </SortableHeader>
+                </div>
               {/if}
               {#if collectionStore.visibleColumns.initial_key}
+                <div use:columnResize={{ column: "initial_key", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
                 <SortableHeader
                   active={singleSortField === "initial_key"}
                   sortAsc={singleSortAsc}
                   onclick={() => toggleSingleSort("initial_key")}
-                  class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+                  class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
                 >
                   {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderInitialKey')} {arrow}</span>{/snippet}
                 </SortableHeader>
+                </div>
               {/if}
               {#if collectionStore.visibleColumns.bitrate}
+                <div use:columnResize={{ column: "bitrate", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
                 <SortableHeader
                   active={singleSortField === "bitrate"}
                   sortAsc={singleSortAsc}
                   onclick={() => toggleSingleSort("bitrate")}
-                  class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+                  class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
                 >
                   {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderBitrate')} {arrow}</span>{/snippet}
                 </SortableHeader>
+                </div>
               {/if}
               {#if collectionStore.visibleColumns.samplerate}
+                <div use:columnResize={{ column: "samplerate", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
                 <SortableHeader
                   active={singleSortField === "samplerate"}
                   sortAsc={singleSortAsc}
                   onclick={() => toggleSingleSort("samplerate")}
-                  class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+                  class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
                 >
                   {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderSampleRate')} {arrow}</span>{/snippet}
                 </SortableHeader>
+                </div>
               {/if}
               {#if collectionStore.visibleColumns.bitdepth}
+                <div use:columnResize={{ column: "bitdepth", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
                 <SortableHeader
                   active={singleSortField === "bitdepth"}
                   sortAsc={singleSortAsc}
                   onclick={() => toggleSingleSort("bitdepth")}
-                  class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+                  class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
                 >
                   {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderBitDepth')} {arrow}</span>{/snippet}
                 </SortableHeader>
+                </div>
               {/if}
               {#if collectionStore.visibleColumns.channels}
+                <div use:columnResize={{ column: "channels", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
                 <SortableHeader
                   active={singleSortField === "channels"}
                   sortAsc={singleSortAsc}
                   onclick={() => toggleSingleSort("channels")}
-                  class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+                  class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
                 >
                   {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderChannels')} {arrow}</span>{/snippet}
                 </SortableHeader>
+                </div>
               {/if}
               {#if collectionStore.visibleColumns.filesize}
+                <div use:columnResize={{ column: "filesize", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
                 <SortableHeader
                   active={singleSortField === "filesize"}
                   sortAsc={singleSortAsc}
                   onclick={() => toggleSingleSort("filesize")}
-                  class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+                  class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
                 >
                   {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderFileSize')} {arrow}</span>{/snippet}
                 </SortableHeader>
+                </div>
               {/if}
               {#if collectionStore.visibleColumns.rating}
+                <div use:columnResize={{ column: "rating", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
                 <SortableHeader
                   active={singleSortField === "rating"}
                   sortAsc={singleSortAsc}
                   onclick={() => toggleSingleSort("rating")}
-                  class="flex items-center justify-center hover:text-brand-text-primary transition-colors cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+                  class="flex items-center justify-center hover:text-brand-text-primary transition-colors cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
                 >
                   {#snippet label(arrow)}<span class="truncate">{i18n.t('collection.tableHeaderRating')} {arrow}</span>{/snippet}
                 </SortableHeader>
+                </div>
               {/if}
               {#if collectionStore.visibleColumns.playcount}
+                <div use:columnResize={{ column: "playcount", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
                 <SortableHeader
                   active={singleSortField === "playcount"}
                   sortAsc={singleSortAsc}
                   onclick={() => toggleSingleSort("playcount")}
-                  class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+                  class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
                 >
                   {#snippet label(arrow)}<span class="truncate">{i18n.t('collection.tableHeaderPlays')} {arrow}</span>{/snippet}
                 </SortableHeader>
+                </div>
               {/if}
               {#if collectionStore.visibleColumns.skipcount}
+                <div use:columnResize={{ column: "skipcount", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
                 <SortableHeader
                   active={singleSortField === "skipcount"}
                   sortAsc={singleSortAsc}
                   onclick={() => toggleSingleSort("skipcount")}
-                  class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+                  class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
                 >
                   {#snippet label(arrow)}<span class="truncate">{i18n.t('collection.tableHeaderSkips')} {arrow}</span>{/snippet}
                 </SortableHeader>
+                </div>
               {/if}
               {#if collectionStore.visibleColumns.lastplayed}
+                <div use:columnResize={{ column: "lastplayed", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
                 <SortableHeader
                   active={singleSortField === "lastplayed"}
                   sortAsc={singleSortAsc}
                   onclick={() => toggleSingleSort("lastplayed")}
-                  class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+                  class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
                 >
                   {#snippet label(arrow)}<span class="truncate">{i18n.t('collection.tableHeaderLastPlayed')} {arrow}</span>{/snippet}
                 </SortableHeader>
+                </div>
               {/if}
               {#if collectionStore.visibleColumns.added}
+                <div use:columnResize={{ column: "added", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
                 <SortableHeader
                   active={singleSortField === "added"}
                   sortAsc={singleSortAsc}
                   onclick={() => toggleSingleSort("added")}
-                  class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+                  class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
                 >
                   {#snippet label(arrow)}<span class="truncate">{i18n.t('collection.tableHeaderAdded')} {arrow}</span>{/snippet}
                 </SortableHeader>
+                </div>
               {/if}
               {#if collectionStore.visibleColumns.duration}
+                <div use:columnResize={{ column: "duration", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
                 <SortableHeader
                   active={singleSortField === "length_nanosec"}
                   sortAsc={singleSortAsc}
                   onclick={() => toggleSingleSort("length_nanosec")}
-                  class="flex items-center justify-center hover:text-brand-text-primary transition-colors cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+                  class="flex items-center justify-center hover:text-brand-text-primary transition-colors cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
                 >
                   {#snippet label(arrow)}<Clock class="w-3.5 h-3.5 shrink-0" /> {arrow}{/snippet}
                 </SortableHeader>
+                </div>
               {/if}
               {#if collectionStore.visibleColumns.path}
+                <div use:columnResize={{ column: "path", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
                 <SortableHeader
                   active={singleSortField === "path"}
                   sortAsc={singleSortAsc}
                   onclick={() => toggleSingleSort("path")}
-                  class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+                  class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
                 >
                   {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderPath')} {arrow}</span>{/snippet}
                 </SortableHeader>
+                </div>
               {/if}
               {#if collectionStore.visibleColumns.actions}
-                <div class="text-center">{i18n.t('collection.tableHeaderActions')}</div>
+                <div use:columnResize={{ column: "actions", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden text-center">{i18n.t('collection.tableHeaderActions')}</div>
               {/if}
             </div>
           </div>

--- a/src/lib/components/AutoPlaylistDetailView.svelte
+++ b/src/lib/components/AutoPlaylistDetailView.svelte
@@ -35,40 +35,33 @@ import { shuffleArray } from "../utils/shuffle";
   import { rememberScroll } from "../utils/scrollMemory";
   import Modal from "./Modal.svelte";
   import Button from "./Button.svelte";
+  import { SONG_TABLE_COLUMNS } from "../utils/songColumns";
+  import { columnResize } from "../utils/columnResize";
 
   let { view }: { view: AutoPlaylistRef } = $props();
 
   let kind = $derived(view.kind);
 
+  // Default column widths (px or fr) — used when no saved width exists for a column.
+  const AUTOPLAYLIST_COL_DEFAULTS: Partial<Record<keyof typeof collectionStore.visibleColumns, string>> = {
+    title: "2fr", artist: "1.5fr", album: "1.5fr",
+    composer: "1.5fr", album_artist: "1.5fr", format: "64px", year: "60px",
+    genre: "1.2fr", grouping: "1.2fr", bpm: "60px", initial_key: "60px",
+    bitrate: "70px", samplerate: "75px", bitdepth: "65px", channels: "70px",
+    filesize: "75px", rating: "96px", playcount: "70px", skipcount: "70px",
+    lastplayed: "90px", added: "90px", duration: "80px", path: "2fr", actions: "80px",
+  };
+
   let gridColsStyle = $derived.by(() => {
     const cols: string[] = ["56px"]; // play indicator + position number, always present
     const vc = collectionStore.visibleColumns;
-
-    if (vc.title) cols.push("2fr");
-    if (vc.artist) cols.push("1.5fr");
-    if (vc.album) cols.push("1.5fr");
-    if (vc.composer) cols.push("1.5fr");
-    if (vc.album_artist) cols.push("1.5fr");
-    if (vc.format) cols.push("64px");
-    if (vc.year) cols.push("60px");
-    if (vc.genre) cols.push("1.2fr");
-    if (vc.grouping) cols.push("1.2fr");
-    if (vc.bpm) cols.push("60px");
-    if (vc.initial_key) cols.push("60px");
-    if (vc.bitrate) cols.push("70px");
-    if (vc.samplerate) cols.push("75px");
-    if (vc.bitdepth) cols.push("65px");
-    if (vc.channels) cols.push("70px");
-    if (vc.filesize) cols.push("75px");
-    if (vc.rating) cols.push("96px");
-    if (vc.playcount) cols.push("70px");
-    if (vc.skipcount) cols.push("70px");
-    if (vc.lastplayed) cols.push("90px");
-    if (vc.added) cols.push("90px");
-    if (vc.duration) cols.push("80px");
-    if (vc.path) cols.push("2fr");
-    if (vc.actions) cols.push("80px");
-
+    const cw = collectionStore.columnWidths;
+    for (const { key } of SONG_TABLE_COLUMNS) {
+      if (key === "track") continue; // autoplaylist uses position instead of track#
+      if (!vc[key]) continue;
+      const saved = cw[key];
+      cols.push(saved !== undefined ? `${saved}px` : (AUTOPLAYLIST_COL_DEFAULTS[key] ?? "80px"));
+    }
     return `grid-template-columns: ${cols.join(" ")}`;
   });
   let genre = $derived(view.genre);
@@ -680,238 +673,284 @@ import { shuffleArray } from "../utils/shuffle";
             {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-1rem)]">{i18n.t('playlists.tableHeaderTrack')} {arrow}</span>{/snippet}
           </SortableHeader>
           {#if collectionStore.visibleColumns.title}
+            <div use:columnResize={{ column: "title", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
             <SortableHeader
               active={sortField === "title"}
               {sortAsc}
               onclick={() => toggleSort("title")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-1rem)]">{i18n.t('playlists.tableHeaderTitle')} {arrow}</span>{/snippet}
             </SortableHeader>
+            </div>
           {/if}
           {#if collectionStore.visibleColumns.artist}
+            <div use:columnResize={{ column: "artist", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
             <SortableHeader
               active={sortField === "artist"}
               {sortAsc}
               onclick={() => toggleSort("artist")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-1rem)]">{i18n.t('playlists.tableHeaderArtist')} {arrow}</span>{/snippet}
             </SortableHeader>
+            </div>
           {/if}
           {#if collectionStore.visibleColumns.album}
+            <div use:columnResize={{ column: "album", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
             <SortableHeader
               active={sortField === "album"}
               {sortAsc}
               onclick={() => toggleSort("album")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-1rem)]">{i18n.t('collection.tableHeaderAlbum')} {arrow}</span>{/snippet}
             </SortableHeader>
+            </div>
           {/if}
 
           {#if collectionStore.visibleColumns.composer}
+            <div use:columnResize={{ column: "composer", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
             <SortableHeader
               active={sortField === "composer"}
               {sortAsc}
               onclick={() => toggleSort("composer")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderComposer')} {arrow}</span>{/snippet}
             </SortableHeader>
+            </div>
           {/if}
           {#if collectionStore.visibleColumns.album_artist}
+            <div use:columnResize={{ column: "album_artist", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
             <SortableHeader
               active={sortField === "album_artist"}
               {sortAsc}
               onclick={() => toggleSort("album_artist")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderAlbumArtist')} {arrow}</span>{/snippet}
             </SortableHeader>
+            </div>
           {/if}
           {#if collectionStore.visibleColumns.format}
+            <div use:columnResize={{ column: "format", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
             <SortableHeader
               active={sortField === "filetype"}
               {sortAsc}
               onclick={() => toggleSort("filetype")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderFormat')} {arrow}</span>{/snippet}
             </SortableHeader>
+            </div>
           {/if}
           {#if collectionStore.visibleColumns.year}
+            <div use:columnResize={{ column: "year", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
             <SortableHeader
               active={sortField === "year"}
               {sortAsc}
               onclick={() => toggleSort("year")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderYear')} {arrow}</span>{/snippet}
             </SortableHeader>
+            </div>
           {/if}
           {#if collectionStore.visibleColumns.genre}
+            <div use:columnResize={{ column: "genre", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
             <SortableHeader
               active={sortField === "genre"}
               {sortAsc}
               onclick={() => toggleSort("genre")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderGenre')} {arrow}</span>{/snippet}
             </SortableHeader>
+            </div>
           {/if}
           {#if collectionStore.visibleColumns.grouping}
+            <div use:columnResize={{ column: "grouping", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
             <SortableHeader
               active={sortField === "grouping"}
               {sortAsc}
               onclick={() => toggleSort("grouping")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderGrouping')} {arrow}</span>{/snippet}
             </SortableHeader>
+            </div>
           {/if}
           {#if collectionStore.visibleColumns.bpm}
+            <div use:columnResize={{ column: "bpm", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
             <SortableHeader
               active={sortField === "bpm"}
               {sortAsc}
               onclick={() => toggleSort("bpm")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderBpm')} {arrow}</span>{/snippet}
             </SortableHeader>
+            </div>
           {/if}
           {#if collectionStore.visibleColumns.initial_key}
+            <div use:columnResize={{ column: "initial_key", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
             <SortableHeader
               active={sortField === "initial_key"}
               {sortAsc}
               onclick={() => toggleSort("initial_key")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderInitialKey')} {arrow}</span>{/snippet}
             </SortableHeader>
+            </div>
           {/if}
           {#if collectionStore.visibleColumns.bitrate}
+            <div use:columnResize={{ column: "bitrate", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
             <SortableHeader
               active={sortField === "bitrate"}
               {sortAsc}
               onclick={() => toggleSort("bitrate")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderBitrate')} {arrow}</span>{/snippet}
             </SortableHeader>
+            </div>
           {/if}
           {#if collectionStore.visibleColumns.samplerate}
+            <div use:columnResize={{ column: "samplerate", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
             <SortableHeader
               active={sortField === "samplerate"}
               {sortAsc}
               onclick={() => toggleSort("samplerate")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderSampleRate')} {arrow}</span>{/snippet}
             </SortableHeader>
+            </div>
           {/if}
           {#if collectionStore.visibleColumns.bitdepth}
+            <div use:columnResize={{ column: "bitdepth", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
             <SortableHeader
               active={sortField === "bitdepth"}
               {sortAsc}
               onclick={() => toggleSort("bitdepth")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderBitDepth')} {arrow}</span>{/snippet}
             </SortableHeader>
+            </div>
           {/if}
           {#if collectionStore.visibleColumns.channels}
+            <div use:columnResize={{ column: "channels", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
             <SortableHeader
               active={sortField === "channels"}
               {sortAsc}
               onclick={() => toggleSort("channels")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderChannels')} {arrow}</span>{/snippet}
             </SortableHeader>
+            </div>
           {/if}
           {#if collectionStore.visibleColumns.filesize}
+            <div use:columnResize={{ column: "filesize", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
             <SortableHeader
               active={sortField === "filesize"}
               {sortAsc}
               onclick={() => toggleSort("filesize")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderFileSize')} {arrow}</span>{/snippet}
             </SortableHeader>
+            </div>
           {/if}
           {#if collectionStore.visibleColumns.rating}
+            <div use:columnResize={{ column: "rating", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
             <SortableHeader
               active={sortField === "rating"}
               {sortAsc}
               onclick={() => toggleSort("rating")}
-              class="flex items-center justify-center hover:text-brand-text-primary transition-colors cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+              class="flex items-center justify-center hover:text-brand-text-primary transition-colors cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate">{i18n.t('collection.tableHeaderRating')} {arrow}</span>{/snippet}
             </SortableHeader>
+            </div>
           {/if}
           {#if collectionStore.visibleColumns.playcount}
+            <div use:columnResize={{ column: "playcount", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
             <SortableHeader
               active={sortField === "playcount"}
               {sortAsc}
               onclick={() => toggleSort("playcount")}
-              class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+              class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate">{i18n.t('collection.tableHeaderPlays')} {arrow}</span>{/snippet}
             </SortableHeader>
+            </div>
           {/if}
           {#if collectionStore.visibleColumns.skipcount}
+            <div use:columnResize={{ column: "skipcount", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
             <SortableHeader
               active={sortField === "skipcount"}
               {sortAsc}
               onclick={() => toggleSort("skipcount")}
-              class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+              class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate">{i18n.t('collection.tableHeaderSkips')} {arrow}</span>{/snippet}
             </SortableHeader>
+            </div>
           {/if}
           {#if collectionStore.visibleColumns.lastplayed}
+            <div use:columnResize={{ column: "lastplayed", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
             <SortableHeader
               active={sortField === "lastplayed"}
               {sortAsc}
               onclick={() => toggleSort("lastplayed")}
-              class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+              class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate">{i18n.t('collection.tableHeaderLastPlayed')} {arrow}</span>{/snippet}
             </SortableHeader>
+            </div>
           {/if}
           {#if collectionStore.visibleColumns.added}
+            <div use:columnResize={{ column: "added", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
             <SortableHeader
               active={sortField === "added"}
               {sortAsc}
               onclick={() => toggleSort("added")}
-              class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+              class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate">{i18n.t('collection.tableHeaderAdded')} {arrow}</span>{/snippet}
             </SortableHeader>
+            </div>
           {/if}
           {#if collectionStore.visibleColumns.duration}
+            <div use:columnResize={{ column: "duration", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
             <SortableHeader
               active={sortField === "length_nanosec"}
               {sortAsc}
               onclick={() => toggleSort("length_nanosec")}
-              class="flex items-center justify-center hover:text-brand-text-primary transition-colors cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+              class="flex items-center justify-center hover:text-brand-text-primary transition-colors cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<Clock class="w-4 h-4 shrink-0" /> {arrow}{/snippet}
             </SortableHeader>
+            </div>
           {/if}
           {#if collectionStore.visibleColumns.path}
+            <div use:columnResize={{ column: "path", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
             <SortableHeader
               active={sortField === "path"}
               {sortAsc}
               onclick={() => toggleSort("path")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderPath')} {arrow}</span>{/snippet}
             </SortableHeader>
+            </div>
           {/if}
           {#if collectionStore.visibleColumns.actions}
-            <div class="text-center">{i18n.t('collection.tableHeaderActions')}</div>
+            <div use:columnResize={{ column: "actions", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden text-center">{i18n.t('collection.tableHeaderActions')}</div>
           {/if}
         </div>
       </div>
@@ -1281,3 +1320,4 @@ import { shuffleArray } from "../utils/shuffle";
     display: none;
   }
 </style>
+

--- a/src/lib/components/CollectionView.svelte
+++ b/src/lib/components/CollectionView.svelte
@@ -32,6 +32,7 @@
   import { formatDateAdded } from "../utils/date";
   import { SONG_TABLE_COLUMNS } from "../utils/songColumns";
   import { rememberScroll, watchScrollMemory } from "../utils/scrollMemory";
+  import { columnResize } from "../utils/columnResize";
 
   // activeSubTab and activeTab are managed globally via collectionStore
 
@@ -298,36 +299,25 @@
     });
   });
 
+  // Default column widths (px or fr) — used when no saved width exists for a column.
+  const COLLECTION_COL_DEFAULTS: Partial<Record<keyof typeof collectionStore.visibleColumns, string>> = {
+    track: "48px", title: "2fr", artist: "1.5fr", album: "1.5fr",
+    composer: "1.5fr", album_artist: "1.5fr", format: "64px", year: "60px",
+    genre: "1.2fr", grouping: "1.2fr", bpm: "60px", initial_key: "60px",
+    bitrate: "70px", samplerate: "75px", bitdepth: "65px", channels: "70px",
+    filesize: "75px", rating: "96px", playcount: "70px", skipcount: "70px",
+    lastplayed: "90px", added: "90px", duration: "80px", path: "2fr", actions: "80px",
+  };
+
   let gridColsStyle = $derived.by(() => {
     const vc = collectionStore.visibleColumns;
+    const cw = collectionStore.columnWidths;
     const cols: string[] = ["36px"]; // play indicator always present
-    if (vc.track) cols.push("48px");
-    if (vc.title) cols.push("2fr");
-    if (vc.artist) cols.push("1.5fr");
-    if (vc.album) cols.push("1.5fr");
-
-    if (vc.composer) cols.push("1.5fr");
-    if (vc.album_artist) cols.push("1.5fr");
-    if (vc.format) cols.push("64px");
-    if (vc.year) cols.push("60px");
-    if (vc.genre) cols.push("1.2fr");
-    if (vc.grouping) cols.push("1.2fr");
-    if (vc.bpm) cols.push("60px");
-    if (vc.initial_key) cols.push("60px");
-    if (vc.bitrate) cols.push("70px");
-    if (vc.samplerate) cols.push("75px");
-    if (vc.bitdepth) cols.push("65px");
-    if (vc.channels) cols.push("70px");
-    if (vc.filesize) cols.push("75px");
-    if (vc.rating) cols.push("96px");
-    if (vc.playcount) cols.push("70px");
-    if (vc.skipcount) cols.push("70px");
-    if (vc.lastplayed) cols.push("90px");
-    if (vc.added) cols.push("90px");
-    if (vc.duration) cols.push("80px");
-    if (vc.path) cols.push("2fr");
-    if (vc.actions) cols.push("80px");
-
+    for (const { key } of SONG_TABLE_COLUMNS) {
+      if (!vc[key]) continue;
+      const saved = cw[key];
+      cols.push(saved !== undefined ? `${saved}px` : (COLLECTION_COL_DEFAULTS[key] ?? "80px"));
+    }
     return `grid-template-columns: ${cols.join(" ")}`;
   });
 
@@ -468,247 +458,295 @@
           <div class="grid items-center py-3 px-4" style="{gridColsStyle}; padding-right: calc(1rem + {scrollbarWidth}px)">
             <div class="text-center w-9"></div>
             {#if collectionStore.visibleColumns.track}
+              <div use:columnResize={{ column: "track", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
               <SortableHeader
                 active={sortField === "track"}
                 {sortAsc}
                 onclick={() => toggleSort("track")}
-                class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+                class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
               >
                 {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-1rem)]">{i18n.t('collection.tableHeaderTrack')} {arrow}</span>{/snippet}
               </SortableHeader>
+              </div>
             {/if}
             {#if collectionStore.visibleColumns.title}
+              <div use:columnResize={{ column: "title", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
               <SortableHeader
                 active={sortField === "title"}
                 {sortAsc}
                 onclick={() => toggleSort("title")}
-                class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+                class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
               >
                 {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-1rem)]">{i18n.t('collection.tableHeaderTitle')} {arrow}</span>{/snippet}
               </SortableHeader>
+              </div>
             {/if}
             {#if collectionStore.visibleColumns.artist}
+              <div use:columnResize={{ column: "artist", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
               <SortableHeader
                 active={sortField === "artist"}
                 {sortAsc}
                 onclick={() => toggleSort("artist")}
-                class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+                class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
               >
                 {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-1rem)]">{i18n.t('collection.tableHeaderArtist')} {arrow}</span>{/snippet}
               </SortableHeader>
+              </div>
             {/if}
             {#if collectionStore.visibleColumns.album}
+              <div use:columnResize={{ column: "album", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
               <SortableHeader
                 active={sortField === "album"}
                 {sortAsc}
                 onclick={() => toggleSort("album")}
-                class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+                class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
               >
                 {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-1rem)]">{i18n.t('collection.tableHeaderAlbum')} {arrow}</span>{/snippet}
               </SortableHeader>
+              </div>
             {/if}
             {#if collectionStore.visibleColumns.composer}
+              <div use:columnResize={{ column: "composer", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
               <SortableHeader
                 active={sortField === "composer"}
                 {sortAsc}
                 onclick={() => toggleSort("composer")}
-                class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+                class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
               >
                 {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderComposer')} {arrow}</span>{/snippet}
               </SortableHeader>
+              </div>
             {/if}
             {#if collectionStore.visibleColumns.album_artist}
+              <div use:columnResize={{ column: "album_artist", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
               <SortableHeader
                 active={sortField === "album_artist"}
                 {sortAsc}
                 onclick={() => toggleSort("album_artist")}
-                class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+                class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
               >
                 {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderAlbumArtist')} {arrow}</span>{/snippet}
               </SortableHeader>
+              </div>
             {/if}
             {#if collectionStore.visibleColumns.format}
+              <div use:columnResize={{ column: "format", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
               <SortableHeader
                 active={sortField === "filetype"}
                 {sortAsc}
                 onclick={() => toggleSort("filetype")}
-                class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+                class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
               >
                 {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderFormat')} {arrow}</span>{/snippet}
               </SortableHeader>
+              </div>
             {/if}
             {#if collectionStore.visibleColumns.year}
+              <div use:columnResize={{ column: "year", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
               <SortableHeader
                 active={sortField === "year"}
                 {sortAsc}
                 onclick={() => toggleSort("year")}
-                class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+                class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
               >
                 {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderYear')} {arrow}</span>{/snippet}
               </SortableHeader>
+              </div>
             {/if}
             {#if collectionStore.visibleColumns.genre}
+              <div use:columnResize={{ column: "genre", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
               <SortableHeader
                 active={sortField === "genre"}
                 {sortAsc}
                 onclick={() => toggleSort("genre")}
-                class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+                class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
               >
                 {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderGenre')} {arrow}</span>{/snippet}
               </SortableHeader>
+              </div>
             {/if}
             {#if collectionStore.visibleColumns.grouping}
+              <div use:columnResize={{ column: "grouping", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
               <SortableHeader
                 active={sortField === "grouping"}
                 {sortAsc}
                 onclick={() => toggleSort("grouping")}
-                class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+                class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
               >
                 {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderGrouping')} {arrow}</span>{/snippet}
               </SortableHeader>
+              </div>
             {/if}
             {#if collectionStore.visibleColumns.bpm}
+              <div use:columnResize={{ column: "bpm", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
               <SortableHeader
                 active={sortField === "bpm"}
                 {sortAsc}
                 onclick={() => toggleSort("bpm")}
-                class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+                class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
               >
                 {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderBpm')} {arrow}</span>{/snippet}
               </SortableHeader>
+              </div>
             {/if}
             {#if collectionStore.visibleColumns.initial_key}
+              <div use:columnResize={{ column: "initial_key", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
               <SortableHeader
                 active={sortField === "initial_key"}
                 {sortAsc}
                 onclick={() => toggleSort("initial_key")}
-                class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+                class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
               >
                 {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderInitialKey')} {arrow}</span>{/snippet}
               </SortableHeader>
+              </div>
             {/if}
             {#if collectionStore.visibleColumns.bitrate}
+              <div use:columnResize={{ column: "bitrate", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
               <SortableHeader
                 active={sortField === "bitrate"}
                 {sortAsc}
                 onclick={() => toggleSort("bitrate")}
-                class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+                class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
               >
                 {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderBitrate')} {arrow}</span>{/snippet}
               </SortableHeader>
+              </div>
             {/if}
             {#if collectionStore.visibleColumns.samplerate}
+              <div use:columnResize={{ column: "samplerate", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
               <SortableHeader
                 active={sortField === "samplerate"}
                 {sortAsc}
                 onclick={() => toggleSort("samplerate")}
-                class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+                class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
               >
                 {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderSampleRate')} {arrow}</span>{/snippet}
               </SortableHeader>
+              </div>
             {/if}
             {#if collectionStore.visibleColumns.bitdepth}
+              <div use:columnResize={{ column: "bitdepth", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
               <SortableHeader
                 active={sortField === "bitdepth"}
                 {sortAsc}
                 onclick={() => toggleSort("bitdepth")}
-                class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+                class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
               >
                 {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderBitDepth')} {arrow}</span>{/snippet}
               </SortableHeader>
+              </div>
             {/if}
             {#if collectionStore.visibleColumns.channels}
+              <div use:columnResize={{ column: "channels", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
               <SortableHeader
                 active={sortField === "channels"}
                 {sortAsc}
                 onclick={() => toggleSort("channels")}
-                class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+                class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
               >
                 {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderChannels')} {arrow}</span>{/snippet}
               </SortableHeader>
+              </div>
             {/if}
             {#if collectionStore.visibleColumns.filesize}
+              <div use:columnResize={{ column: "filesize", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
               <SortableHeader
                 active={sortField === "filesize"}
                 {sortAsc}
                 onclick={() => toggleSort("filesize")}
-                class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+                class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
               >
                 {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderFileSize')} {arrow}</span>{/snippet}
               </SortableHeader>
+              </div>
             {/if}
             {#if collectionStore.visibleColumns.rating}
+              <div use:columnResize={{ column: "rating", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
               <SortableHeader
                 active={sortField === "rating"}
                 {sortAsc}
                 onclick={() => toggleSort("rating")}
-                class="flex items-center justify-center hover:text-brand-text-primary transition-colors cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+                class="flex items-center justify-center hover:text-brand-text-primary transition-colors cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
               >
                 {#snippet label(arrow)}<span class="truncate">{i18n.t('collection.tableHeaderRating')} {arrow}</span>{/snippet}
               </SortableHeader>
+              </div>
             {/if}
             {#if collectionStore.visibleColumns.playcount}
+              <div use:columnResize={{ column: "playcount", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
               <SortableHeader
                 active={sortField === "playcount"}
                 {sortAsc}
                 onclick={() => toggleSort("playcount")}
-                class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+                class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
               >
                 {#snippet label(arrow)}<span class="truncate">{i18n.t('collection.tableHeaderPlays')} {arrow}</span>{/snippet}
               </SortableHeader>
+              </div>
             {/if}
             {#if collectionStore.visibleColumns.skipcount}
+              <div use:columnResize={{ column: "skipcount", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
               <SortableHeader
                 active={sortField === "skipcount"}
                 {sortAsc}
                 onclick={() => toggleSort("skipcount")}
-                class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+                class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
               >
                 {#snippet label(arrow)}<span class="truncate">{i18n.t('collection.tableHeaderSkips')} {arrow}</span>{/snippet}
               </SortableHeader>
+              </div>
             {/if}
             {#if collectionStore.visibleColumns.lastplayed}
+              <div use:columnResize={{ column: "lastplayed", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
               <SortableHeader
                 active={sortField === "lastplayed"}
                 {sortAsc}
                 onclick={() => toggleSort("lastplayed")}
-                class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+                class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
               >
                 {#snippet label(arrow)}<span class="truncate">{i18n.t('collection.tableHeaderLastPlayed')} {arrow}</span>{/snippet}
               </SortableHeader>
+              </div>
             {/if}
             {#if collectionStore.visibleColumns.added}
+              <div use:columnResize={{ column: "added", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
               <SortableHeader
                 active={sortField === "added"}
                 {sortAsc}
                 onclick={() => toggleSort("added")}
-                class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+                class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
               >
                 {#snippet label(arrow)}<span class="truncate">{i18n.t('collection.tableHeaderAdded')} {arrow}</span>{/snippet}
               </SortableHeader>
+              </div>
             {/if}
             {#if collectionStore.visibleColumns.duration}
+              <div use:columnResize={{ column: "duration", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
               <SortableHeader
                 active={sortField === "length_nanosec"}
                 {sortAsc}
                 onclick={() => toggleSort("length_nanosec")}
-                class="flex items-center justify-center hover:text-brand-text-primary transition-colors cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+                class="flex items-center justify-center hover:text-brand-text-primary transition-colors cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
               >
                 {#snippet label(arrow)}<Clock class="w-4 h-4 shrink-0" /> {arrow}{/snippet}
               </SortableHeader>
+              </div>
             {/if}
             {#if collectionStore.visibleColumns.path}
+              <div use:columnResize={{ column: "path", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
               <SortableHeader
                 active={sortField === "path"}
                 {sortAsc}
                 onclick={() => toggleSort("path")}
-                class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+                class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
               >
                 {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderPath')} {arrow}</span>{/snippet}
               </SortableHeader>
+              </div>
             {/if}
             {#if collectionStore.visibleColumns.actions}
-              <div class="text-center">{i18n.t('collection.tableHeaderActions')}</div>
+              <div use:columnResize={{ column: "actions", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden text-center">{i18n.t('collection.tableHeaderActions')}</div>
             {/if}
           </div>
         </div>
@@ -1249,3 +1287,4 @@
     border-radius: 3px;
   }
 </style>
+

--- a/src/lib/components/PlaylistView.svelte
+++ b/src/lib/components/PlaylistView.svelte
@@ -59,37 +59,29 @@
   import { formatDate, formatFileSize, formatSampleRate, formatBitDepth, formatChannels } from "../utils/formatters";
   import { formatDateAdded } from "../utils/date";
   import { CONTEXT_MENU_WIDTH_PX } from "../constants";
+  import { SONG_TABLE_COLUMNS } from "../utils/songColumns";
+  import { columnResize } from "../utils/columnResize";
+
+  // Default column widths (px or fr) — used when no saved width exists for a column.
+  const PLAYLIST_COL_DEFAULTS: Partial<Record<keyof typeof collectionStore.visibleColumns, string>> = {
+    title: "2fr", artist: "1.5fr", album: "1.5fr",
+    composer: "1.5fr", album_artist: "1.5fr", format: "64px", year: "60px",
+    genre: "1.2fr", grouping: "1.2fr", bpm: "60px", initial_key: "60px",
+    bitrate: "70px", samplerate: "75px", bitdepth: "65px", channels: "70px",
+    filesize: "75px", rating: "96px", playcount: "70px", skipcount: "70px",
+    lastplayed: "90px", added: "90px", duration: "80px", path: "2fr", actions: "80px",
+  };
 
   let gridColsStyle = $derived.by(() => {
     const cols: string[] = ["48px"]; // position column always present
     const vc = collectionStore.visibleColumns;
-
-    if (vc.title) cols.push("2fr");
-    if (vc.artist) cols.push("1.5fr");
-    if (vc.album) cols.push("1.5fr");
-
-    if (vc.composer) cols.push("1.5fr");
-    if (vc.album_artist) cols.push("1.5fr");
-    if (vc.format) cols.push("64px");
-    if (vc.year) cols.push("60px");
-    if (vc.genre) cols.push("1.2fr");
-    if (vc.grouping) cols.push("1.2fr");
-    if (vc.bpm) cols.push("60px");
-    if (vc.initial_key) cols.push("60px");
-    if (vc.bitrate) cols.push("70px");
-    if (vc.samplerate) cols.push("75px");
-    if (vc.bitdepth) cols.push("65px");
-    if (vc.channels) cols.push("70px");
-    if (vc.filesize) cols.push("75px");
-    if (vc.rating) cols.push("96px");
-    if (vc.playcount) cols.push("70px");
-    if (vc.skipcount) cols.push("70px");
-    if (vc.lastplayed) cols.push("90px");
-    if (vc.added) cols.push("90px");
-    if (vc.duration) cols.push("80px");
-    if (vc.path) cols.push("2fr");
-    if (vc.actions) cols.push("80px");
-
+    const cw = collectionStore.columnWidths;
+    for (const { key } of SONG_TABLE_COLUMNS) {
+      if (key === "track") continue; // playlist uses position instead of track#
+      if (!vc[key]) continue;
+      const saved = cw[key];
+      cols.push(saved !== undefined ? `${saved}px` : (PLAYLIST_COL_DEFAULTS[key] ?? "80px"));
+    }
     return `grid-template-columns: ${cols.join(" ")}`;
   });
   import {
@@ -965,238 +957,284 @@
             {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-1rem)]">{i18n.t("playlists.tableHeaderTrack")} {arrow}</span>{/snippet}
           </SortableHeader>
           {#if collectionStore.visibleColumns.title}
+            <div use:columnResize={{ column: "title", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
             <SortableHeader
               active={sortField === "title"}
               {sortAsc}
               onclick={() => toggleSort("title")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-1rem)]">{i18n.t("playlists.tableHeaderTitle")} {arrow}</span>{/snippet}
             </SortableHeader>
+            </div>
           {/if}
           {#if collectionStore.visibleColumns.artist}
+            <div use:columnResize={{ column: "artist", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
             <SortableHeader
               active={sortField === "artist"}
               {sortAsc}
               onclick={() => toggleSort("artist")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-1rem)]">{i18n.t("playlists.tableHeaderArtist")} {arrow}</span>{/snippet}
             </SortableHeader>
+            </div>
           {/if}
           {#if collectionStore.visibleColumns.album}
+            <div use:columnResize={{ column: "album", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
             <SortableHeader
               active={sortField === "album"}
               {sortAsc}
               onclick={() => toggleSort("album")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-1rem)]">{i18n.t("collection.tableHeaderAlbum")} {arrow}</span>{/snippet}
             </SortableHeader>
+            </div>
           {/if}
 
           {#if collectionStore.visibleColumns.composer}
+            <div use:columnResize={{ column: "composer", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
             <SortableHeader
               active={sortField === "composer"}
               {sortAsc}
               onclick={() => toggleSort("composer")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderComposer')} {arrow}</span>{/snippet}
             </SortableHeader>
+            </div>
           {/if}
           {#if collectionStore.visibleColumns.album_artist}
+            <div use:columnResize={{ column: "album_artist", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
             <SortableHeader
               active={sortField === "album_artist"}
               {sortAsc}
               onclick={() => toggleSort("album_artist")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderAlbumArtist')} {arrow}</span>{/snippet}
             </SortableHeader>
+            </div>
           {/if}
           {#if collectionStore.visibleColumns.format}
+            <div use:columnResize={{ column: "format", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
             <SortableHeader
               active={sortField === "filetype"}
               {sortAsc}
               onclick={() => toggleSort("filetype")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderFormat')} {arrow}</span>{/snippet}
             </SortableHeader>
+            </div>
           {/if}
           {#if collectionStore.visibleColumns.year}
+            <div use:columnResize={{ column: "year", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
             <SortableHeader
               active={sortField === "year"}
               {sortAsc}
               onclick={() => toggleSort("year")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderYear')} {arrow}</span>{/snippet}
             </SortableHeader>
+            </div>
           {/if}
           {#if collectionStore.visibleColumns.genre}
+            <div use:columnResize={{ column: "genre", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
             <SortableHeader
               active={sortField === "genre"}
               {sortAsc}
               onclick={() => toggleSort("genre")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderGenre')} {arrow}</span>{/snippet}
             </SortableHeader>
+            </div>
           {/if}
           {#if collectionStore.visibleColumns.grouping}
+            <div use:columnResize={{ column: "grouping", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
             <SortableHeader
               active={sortField === "grouping"}
               {sortAsc}
               onclick={() => toggleSort("grouping")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderGrouping')} {arrow}</span>{/snippet}
             </SortableHeader>
+            </div>
           {/if}
           {#if collectionStore.visibleColumns.bpm}
+            <div use:columnResize={{ column: "bpm", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
             <SortableHeader
               active={sortField === "bpm"}
               {sortAsc}
               onclick={() => toggleSort("bpm")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderBpm')} {arrow}</span>{/snippet}
             </SortableHeader>
+            </div>
           {/if}
           {#if collectionStore.visibleColumns.initial_key}
+            <div use:columnResize={{ column: "initial_key", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
             <SortableHeader
               active={sortField === "initial_key"}
               {sortAsc}
               onclick={() => toggleSort("initial_key")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderInitialKey')} {arrow}</span>{/snippet}
             </SortableHeader>
+            </div>
           {/if}
           {#if collectionStore.visibleColumns.bitrate}
+            <div use:columnResize={{ column: "bitrate", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
             <SortableHeader
               active={sortField === "bitrate"}
               {sortAsc}
               onclick={() => toggleSort("bitrate")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderBitrate')} {arrow}</span>{/snippet}
             </SortableHeader>
+            </div>
           {/if}
           {#if collectionStore.visibleColumns.samplerate}
+            <div use:columnResize={{ column: "samplerate", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
             <SortableHeader
               active={sortField === "samplerate"}
               {sortAsc}
               onclick={() => toggleSort("samplerate")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderSampleRate')} {arrow}</span>{/snippet}
             </SortableHeader>
+            </div>
           {/if}
           {#if collectionStore.visibleColumns.bitdepth}
+            <div use:columnResize={{ column: "bitdepth", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
             <SortableHeader
               active={sortField === "bitdepth"}
               {sortAsc}
               onclick={() => toggleSort("bitdepth")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderBitDepth')} {arrow}</span>{/snippet}
             </SortableHeader>
+            </div>
           {/if}
           {#if collectionStore.visibleColumns.channels}
+            <div use:columnResize={{ column: "channels", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
             <SortableHeader
               active={sortField === "channels"}
               {sortAsc}
               onclick={() => toggleSort("channels")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderChannels')} {arrow}</span>{/snippet}
             </SortableHeader>
+            </div>
           {/if}
           {#if collectionStore.visibleColumns.filesize}
+            <div use:columnResize={{ column: "filesize", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
             <SortableHeader
               active={sortField === "filesize"}
               {sortAsc}
               onclick={() => toggleSort("filesize")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderFileSize')} {arrow}</span>{/snippet}
             </SortableHeader>
+            </div>
           {/if}
           {#if collectionStore.visibleColumns.rating}
+            <div use:columnResize={{ column: "rating", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
             <SortableHeader
               active={sortField === "rating"}
               {sortAsc}
               onclick={() => toggleSort("rating")}
-              class="flex items-center justify-center hover:text-brand-text-primary transition-colors cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+              class="flex items-center justify-center hover:text-brand-text-primary transition-colors cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate">{i18n.t('collection.tableHeaderRating')} {arrow}</span>{/snippet}
             </SortableHeader>
+            </div>
           {/if}
           {#if collectionStore.visibleColumns.playcount}
+            <div use:columnResize={{ column: "playcount", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
             <SortableHeader
               active={sortField === "playcount"}
               {sortAsc}
               onclick={() => toggleSort("playcount")}
-              class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+              class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate">{i18n.t('collection.tableHeaderPlays')} {arrow}</span>{/snippet}
             </SortableHeader>
+            </div>
           {/if}
           {#if collectionStore.visibleColumns.skipcount}
+            <div use:columnResize={{ column: "skipcount", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
             <SortableHeader
               active={sortField === "skipcount"}
               {sortAsc}
               onclick={() => toggleSort("skipcount")}
-              class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+              class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate">{i18n.t('collection.tableHeaderSkips')} {arrow}</span>{/snippet}
             </SortableHeader>
+            </div>
           {/if}
           {#if collectionStore.visibleColumns.lastplayed}
+            <div use:columnResize={{ column: "lastplayed", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
             <SortableHeader
               active={sortField === "lastplayed"}
               {sortAsc}
               onclick={() => toggleSort("lastplayed")}
-              class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+              class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate">{i18n.t('collection.tableHeaderLastPlayed')} {arrow}</span>{/snippet}
             </SortableHeader>
+            </div>
           {/if}
           {#if collectionStore.visibleColumns.added}
+            <div use:columnResize={{ column: "added", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
             <SortableHeader
               active={sortField === "added"}
               {sortAsc}
               onclick={() => toggleSort("added")}
-              class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+              class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate">{i18n.t('collection.tableHeaderAdded')} {arrow}</span>{/snippet}
             </SortableHeader>
+            </div>
           {/if}
           {#if collectionStore.visibleColumns.duration}
+            <div use:columnResize={{ column: "duration", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
             <SortableHeader
               active={sortField === "length_nanosec"}
               {sortAsc}
               onclick={() => toggleSort("length_nanosec")}
-              class="flex items-center justify-center hover:text-brand-text-primary transition-colors cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+              class="flex items-center justify-center hover:text-brand-text-primary transition-colors cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<Clock class="w-4 h-4 shrink-0" /> {arrow}{/snippet}
             </SortableHeader>
+            </div>
           {/if}
           {#if collectionStore.visibleColumns.path}
+            <div use:columnResize={{ column: "path", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
             <SortableHeader
               active={sortField === "path"}
               {sortAsc}
               onclick={() => toggleSort("path")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderPath')} {arrow}</span>{/snippet}
             </SortableHeader>
+            </div>
           {/if}
           {#if collectionStore.visibleColumns.actions}
-            <div class="text-center">{i18n.t("collection.tableHeaderActions")}</div>
+            <div use:columnResize={{ column: "actions", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden text-center">{i18n.t('collection.tableHeaderActions')}</div>
           {/if}
         </div>
       </div>
@@ -1695,3 +1733,4 @@
     display: none;
   }
 </style>
+

--- a/src/lib/stores/collection.svelte.ts
+++ b/src/lib/stores/collection.svelte.ts
@@ -57,6 +57,14 @@ export interface VisibleColumns {
   skipcount: boolean;
 }
 
+/**
+ * Saved pixel widths for song-table columns, keyed by `VisibleColumns` property name.
+ * Only columns that have been explicitly resized have an entry; others fall back to
+ * their compile-time defaults.  A single shared map is used for all four table views
+ * (Collection, AlbumDetail, Playlist, AutoPlaylist).
+ */
+export type ColumnWidths = Partial<Record<keyof VisibleColumns, number>>;
+
 /** An auto-playlist reference (Favourites, Recently Added, genre, decade, or BPM), for the auto-playlist detail view. */
 export interface AutoPlaylistRef {
   kind: "favourites" | "recently_added" | "history" | "genre" | "decade" | "bpm";
@@ -177,6 +185,36 @@ class CollectionStore {
     this.visibleColumns[column] = !this.visibleColumns[column];
     if (typeof window !== "undefined") {
       localStorage.setItem("luminous_visible_columns", JSON.stringify(this.visibleColumns));
+    }
+  }
+
+  columnWidths = $state<ColumnWidths>(
+    (() => {
+      if (typeof window !== "undefined") {
+        const saved = localStorage.getItem("luminous_column_widths");
+        if (saved) {
+          try {
+            return JSON.parse(saved) as ColumnWidths;
+          } catch (e) {
+            console.error("Failed to parse column widths:", e);
+          }
+        }
+      }
+      return {};
+    })()
+  );
+
+  setColumnWidth(column: keyof VisibleColumns, widthPx: number) {
+    this.columnWidths[column] = widthPx;
+    if (typeof window !== "undefined") {
+      localStorage.setItem("luminous_column_widths", JSON.stringify(this.columnWidths));
+    }
+  }
+
+  resetColumnWidth(column: keyof VisibleColumns) {
+    delete this.columnWidths[column];
+    if (typeof window !== "undefined") {
+      localStorage.setItem("luminous_column_widths", JSON.stringify(this.columnWidths));
     }
   }
 

--- a/src/lib/utils/columnResize.ts
+++ b/src/lib/utils/columnResize.ts
@@ -25,8 +25,53 @@ function ensureStyles() {
     .col-resize-handle.col-resize-dragging {
       border-right-color: var(--color-brand-accent, #6366f1);
     }
+
+    /* Full-height vertical drag marker — appended to <body> during a drag */
+    .col-resize-marker {
+      position: fixed;
+      top: 0;
+      bottom: 0;
+      width: 2px;
+      pointer-events: none;
+      z-index: 9999;
+      background: var(--color-brand-accent, #6366f1);
+      box-shadow: 0 0 6px 1px color-mix(in srgb, var(--color-brand-accent, #6366f1) 60%, transparent);
+      opacity: 0;
+      transition: opacity 80ms ease;
+    }
+    .col-resize-marker.col-resize-marker-visible {
+      opacity: 1;
+    }
   `;
   document.head.appendChild(style);
+}
+
+/** Singleton drag marker shared across all column resize instances. */
+let marker: HTMLDivElement | null = null;
+
+function getMarker(): HTMLDivElement {
+  if (!marker) {
+    marker = document.createElement("div");
+    marker.className = "col-resize-marker";
+    marker.setAttribute("aria-hidden", "true");
+    document.body.appendChild(marker);
+  }
+  return marker;
+}
+
+function showMarker(x: number) {
+  const m = getMarker();
+  m.style.left = `${x}px`;
+  // Trigger the CSS transition by setting the class on the next frame
+  requestAnimationFrame(() => m.classList.add("col-resize-marker-visible"));
+}
+
+function moveMarker(x: number) {
+  if (marker) marker.style.left = `${x}px`;
+}
+
+function hideMarker() {
+  marker?.classList.remove("col-resize-marker-visible");
 }
 
 export interface ColumnResizeOptions {
@@ -76,6 +121,12 @@ export function columnResize(
   let startX = 0;
   let startWidth = 0;
 
+  function markerXForWidth(width: number): number {
+    // Place the marker at the right edge of the column as it would be after resize
+    const nodeLeft = node.getBoundingClientRect().left;
+    return nodeLeft + width - 1; // -1 so the 2px line is centred on the border
+  }
+
   function onPointerDown(e: PointerEvent) {
     // Only respond to primary button
     if (e.button !== 0) return;
@@ -89,6 +140,8 @@ export function columnResize(
 
     handle.classList.add("col-resize-dragging");
     handle.setPointerCapture(e.pointerId);
+
+    showMarker(markerXForWidth(startWidth));
   }
 
   function onPointerMove(e: PointerEvent) {
@@ -99,12 +152,14 @@ export function columnResize(
     // the actual grid column value is updated only on pointerup to avoid
     // triggering excessive store writes and re-renders.
     node.style.width = `${newWidth}px`;
+    moveMarker(markerXForWidth(newWidth));
   }
 
   function onPointerUp(e: PointerEvent) {
     if (!dragging) return;
     dragging = false;
     handle.classList.remove("col-resize-dragging");
+    hideMarker();
 
     const delta = e.clientX - startX;
     const finalWidth = Math.max(MIN_WIDTH_PX, startWidth + delta);

--- a/src/lib/utils/columnResize.ts
+++ b/src/lib/utils/columnResize.ts
@@ -1,0 +1,140 @@
+import type { VisibleColumns } from "../stores/collection.svelte";
+
+/** Minimum column width in pixels — users can intentionally squeeze columns very small. */
+const MIN_WIDTH_PX = 40;
+
+/** Singleton style injection so the CSS is added only once per page load. */
+let styleInjected = false;
+function ensureStyles() {
+  if (styleInjected || typeof document === "undefined") return;
+  styleInjected = true;
+  const style = document.createElement("style");
+  style.textContent = `
+    .col-resize-handle {
+      position: absolute;
+      top: 0;
+      right: -3px;
+      width: 6px;
+      height: 100%;
+      cursor: col-resize;
+      z-index: 20;
+      border-right: 2px solid transparent;
+      transition: border-color 120ms ease;
+    }
+    .col-resize-handle:hover,
+    .col-resize-handle.col-resize-dragging {
+      border-right-color: var(--color-brand-accent, #6366f1);
+    }
+  `;
+  document.head.appendChild(style);
+}
+
+export interface ColumnResizeOptions {
+  /** The column key — passed back to `onResize` and `onReset`. */
+  column: keyof VisibleColumns;
+  /**
+   * Called when the user finishes dragging with the new pixel width.
+   * Note: if the column was previously `fr`-based, the caller must read the
+   * *rendered* width at drag start (passed as the initial width) and switch
+   * to a `px` value from that point on.
+   */
+  onResize: (column: keyof VisibleColumns, widthPx: number) => void;
+  /** Called when the user double-clicks the handle to reset the column to its default width. */
+  onReset?: (column: keyof VisibleColumns) => void;
+}
+
+/**
+ * Svelte action that attaches a drag handle to the right edge of a header cell.
+ *
+ * Usage:
+ * ```svelte
+ * <div use:columnResize={{ column: "title", onResize: handleResize, onReset: handleReset }}
+ *      style="position: relative;">
+ *   Title
+ * </div>
+ * ```
+ *
+ * The header cell must have `position: relative` (or any non-static positioning)
+ * for the absolutely-positioned handle overlay to work correctly.
+ */
+export function columnResize(
+  node: HTMLElement,
+  opts: ColumnResizeOptions
+): { update: (newOpts: ColumnResizeOptions) => void; destroy: () => void } {
+  ensureStyles();
+
+  let currentOpts = opts;
+
+  // Inject the drag handle div
+  const handle = document.createElement("div");
+  handle.className = "col-resize-handle";
+  handle.setAttribute("aria-hidden", "true");
+  node.appendChild(handle);
+
+  // --- Drag state ---
+  let dragging = false;
+  let startX = 0;
+  let startWidth = 0;
+
+  function onPointerDown(e: PointerEvent) {
+    // Only respond to primary button
+    if (e.button !== 0) return;
+    e.preventDefault();
+    e.stopPropagation();
+
+    dragging = true;
+    startX = e.clientX;
+    // Measure the current rendered width of the header cell (works for both px and fr columns)
+    startWidth = node.getBoundingClientRect().width;
+
+    handle.classList.add("col-resize-dragging");
+    handle.setPointerCapture(e.pointerId);
+  }
+
+  function onPointerMove(e: PointerEvent) {
+    if (!dragging) return;
+    const delta = e.clientX - startX;
+    const newWidth = Math.max(MIN_WIDTH_PX, startWidth + delta);
+    // Live-update the node width so the user sees feedback immediately;
+    // the actual grid column value is updated only on pointerup to avoid
+    // triggering excessive store writes and re-renders.
+    node.style.width = `${newWidth}px`;
+  }
+
+  function onPointerUp(e: PointerEvent) {
+    if (!dragging) return;
+    dragging = false;
+    handle.classList.remove("col-resize-dragging");
+
+    const delta = e.clientX - startX;
+    const finalWidth = Math.max(MIN_WIDTH_PX, startWidth + delta);
+    // Clear the inline width — the grid will now take over with the stored px value
+    node.style.width = "";
+
+    currentOpts.onResize(currentOpts.column, Math.round(finalWidth));
+  }
+
+  function onDoubleClick(e: MouseEvent) {
+    e.preventDefault();
+    e.stopPropagation();
+    currentOpts.onReset?.(currentOpts.column);
+  }
+
+  handle.addEventListener("pointerdown", onPointerDown);
+  handle.addEventListener("pointermove", onPointerMove);
+  handle.addEventListener("pointerup", onPointerUp);
+  handle.addEventListener("dblclick", onDoubleClick);
+
+  return {
+    update(newOpts: ColumnResizeOptions) {
+      currentOpts = newOpts;
+    },
+    destroy() {
+      handle.removeEventListener("pointerdown", onPointerDown);
+      handle.removeEventListener("pointermove", onPointerMove);
+      handle.removeEventListener("pointerup", onPointerUp);
+      handle.removeEventListener("dblclick", onDoubleClick);
+      handle.remove();
+    },
+  };
+}


### PR DESCRIPTION
## 📋 Summary
Addresses #300

Implements drag-to-resize table column width functionality with persistence and view synchronization across all song table views (`CollectionView`, `AlbumDetailView`, `ArtistDetailView`, `PlaylistView`, `AutoPlaylistDetailView`).

## 🔍 Implementation Notes
- **Shared Persistence**: Saved column widths are persisted to `localStorage` under `luminous_column_widths` via `collectionStore`. All song table views share the same column widths.
- **Svelte Action (`src/lib/utils/columnResize.ts`)**:
  - Uses pointer capture (`setPointerCapture`) for smooth dragging.
  - Measures rendered width at drag start so fluid `fr` columns smoothly snap to explicit pixel widths upon first resize.
  - Enforces a 40px minimum column width.
  - Double-click resets a column to its default width.
  - Displays a full-height vertical glowing drag marker fixed to the viewport during dragging.
- **Import/Directory Conventions**: Placed `columnResize.ts` in `src/lib/utils/` to adhere to existing codebase conventions.

## 🧪 Test Plan
- [x] `bun run check` (svelte-check) — 0 errors, 0 warnings
- [x] `bun run test -- --run` (frontend) — 35 passed (319 tests)
- [x] Manually verified drag-to-resize, vertical marker indicator, double-click reset, cross-view synchronization, and localStorage persistence.

## 📸 Screenshots
N/A

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed
