### PR TITLE
feat: add hamburger menu to navbar for toggling compact sidebar

### DIFF
--- a/src/lib/components/TopNavigation.svelte
+++ b/src/lib/components/TopNavigation.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { ChevronLeft, ChevronRight, Search, FolderOpen, PanelLeft, PanelBottom, PanelRight, User, Disc, ListMusic, Music, History, X, Sparkles } from "lucide-svelte";
+  import { Menu, ChevronLeft, ChevronRight, Search, FolderOpen, PanelLeft, PanelBottom, PanelRight, User, Disc, ListMusic, Music, History, X, Sparkles } from "lucide-svelte";
   import { parseSearchRules, hasAdvancedSearchTerms, isSmartPlaylistSpec } from "../utils/filterParser";
   import { invoke } from "@tauri-apps/api/core";
   import { collectionStore, type AutoPlaylistRef } from "../stores/collection.svelte";
@@ -232,6 +232,13 @@
 <header in:fade={{ duration: 600 }} class="w-full h-20 bg-brand-sidebar flex items-center px-6 gap-6 z-50 overflow-visible {themeStore.isGlassTheme ? 'glass-surface' : ''}">
   <!-- History Navigation Controls -->
   <div class="flex items-center gap-2">
+    <button
+      onclick={() => collectionStore.toggleSidebarCompact()}
+      class="p-2 rounded-lg text-brand-text-secondary hover:bg-brand-main hover:text-brand-text-primary transition-colors cursor-pointer"
+      title={i18n.t('topNav.toggleSidebarCompact', {}, 'Toggle sidebar (compact / expanded)')}
+    >
+      <Menu class="w-5 h-5" />
+    </button>
     <button
       onclick={() => collectionStore.goBack()}
       disabled={!collectionStore.canGoBack}

--- a/src/lib/components/TopNavigation.test.ts
+++ b/src/lib/components/TopNavigation.test.ts
@@ -44,4 +44,17 @@ describe("TopNavigation.svelte", () => {
     expect(collectionStore.immersiveMode).toBe(true);
     expect(immersiveBtn.className).toContain("bg-brand-accent text-white");
   });
+
+  it("toggles sidebar compact state when clicking the hamburger menu button", async () => {
+    collectionStore.sidebarOpen = true;
+    collectionStore.setSidebarWidth(256);
+    const { getByTitle } = render(TopNavigation);
+    const hamburgerBtn = getByTitle("Toggle sidebar (compact / expanded)");
+
+    await fireEvent.click(hamburgerBtn);
+    expect(collectionStore.sidebarWidth).toBe(64);
+
+    await fireEvent.click(hamburgerBtn);
+    expect(collectionStore.sidebarWidth).toBe(256);
+  });
 });

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -32,6 +32,7 @@ export const en = {
     searchSuggestions: "Suggestions",
     noSuggestions: "No matching suggestions",
     toggleSidebar: "Toggle Menu Sidebar",
+    toggleSidebarCompact: "Toggle sidebar (compact / expanded)",
     toggleImmersive: "Toggle Immersive Album Art Screen",
     toggleRightPanel: "Toggle Detail Panel",
     resizeSidebar: "Resize Left Sidebar",

--- a/src/lib/locales/fr.ts
+++ b/src/lib/locales/fr.ts
@@ -32,6 +32,7 @@ export const fr = {
     searchSuggestions: "Suggestions",
     noSuggestions: "Aucune suggestion correspondante",
     toggleSidebar: "Basculer le menu latéral",
+    toggleSidebarCompact: "Basculer la barre latérale (compacte / étendue)",
     toggleImmersive: "Basculer l'écran de pochette immersif",
     toggleRightPanel: "Basculer le panneau de détails",
     resizeSidebar: "Redimensionner la barre latérale gauche",

--- a/src/lib/stores/collection.svelte.ts
+++ b/src/lib/stores/collection.svelte.ts
@@ -18,7 +18,7 @@ import type {
 import { applySongStats, type SongStatsPayload, applyAlbumStats, type AlbumStatsPayload } from "../utils/stats";
 import { playlistsStore } from "./playlists.svelte";
 import { toastStore } from "./toast.svelte";
-import { MAX_RECENT_SEARCHES } from "../constants";
+import { MAX_RECENT_SEARCHES, SIDEBAR_MIN_WIDTH_PX, SIDEBAR_COLLAPSED_WIDTH_PX } from "../constants";
 
 export type ActiveTab = "home" | "collection" | "playlists" | "settings" | "lyrics" | "help";
 export type ActiveSubTab = "songs" | "albums" | "artists";
@@ -400,6 +400,7 @@ class CollectionStore {
   sidebarOpen = $state<boolean>(true);
   rightPanelOpen = $state<boolean>(true);
   sidebarWidth = $state<number>(256);
+  lastExpandedSidebarWidth = $state<number>(256);
   rightPanelWidth = $state<number>(288);
   immersiveMode = $state<boolean>(false);
   isMiniplayer = $state<boolean>(false);
@@ -443,7 +444,17 @@ class CollectionStore {
         if (savedRight !== null) this.rightPanelOpen = savedRight === "true";
 
         const savedSidebarWidth = localStorage.getItem("layout_sidebarWidth");
-        if (savedSidebarWidth) this.sidebarWidth = parseInt(savedSidebarWidth, 10);
+        if (savedSidebarWidth) {
+          const w = parseInt(savedSidebarWidth, 10);
+          this.sidebarWidth = w;
+          if (w >= SIDEBAR_MIN_WIDTH_PX) {
+            this.lastExpandedSidebarWidth = w;
+          }
+        }
+        const savedLastExpanded = localStorage.getItem("layout_lastExpandedSidebarWidth");
+        if (savedLastExpanded) {
+          this.lastExpandedSidebarWidth = parseInt(savedLastExpanded, 10);
+        }
 
         const savedRightWidth = localStorage.getItem("layout_rightPanelWidth");
         if (savedRightWidth) this.rightPanelWidth = parseInt(savedRightWidth, 10);
@@ -935,6 +946,22 @@ class CollectionStore {
     }
   }
 
+  toggleSidebarCompact() {
+    if (!this.sidebarOpen) {
+      this.sidebarOpen = true;
+      if (typeof window !== "undefined") {
+        localStorage.setItem("layout_sidebarOpen", "true");
+      }
+    }
+
+    if (this.sidebarWidth < SIDEBAR_MIN_WIDTH_PX) {
+      const targetWidth = Math.max(SIDEBAR_MIN_WIDTH_PX, this.lastExpandedSidebarWidth || 256);
+      this.setSidebarWidth(targetWidth);
+    } else {
+      this.setSidebarWidth(SIDEBAR_COLLAPSED_WIDTH_PX);
+    }
+  }
+
   toggleImmersiveMode() {
     this.immersiveMode = !this.immersiveMode;
     if (typeof window !== "undefined") {
@@ -1115,6 +1142,12 @@ class CollectionStore {
 
   setSidebarWidth(width: number) {
     this.sidebarWidth = width;
+    if (width >= SIDEBAR_MIN_WIDTH_PX) {
+      this.lastExpandedSidebarWidth = width;
+      if (typeof window !== "undefined") {
+        localStorage.setItem("layout_lastExpandedSidebarWidth", width.toString());
+      }
+    }
     if (typeof window !== "undefined") {
       localStorage.setItem("layout_sidebarWidth", width.toString());
     }

--- a/src/lib/stores/collection.test.ts
+++ b/src/lib/stores/collection.test.ts
@@ -268,6 +268,27 @@ describe("CollectionStore", () => {
     expect(collectionStore.immersiveMode).toBe(false);
   });
 
+  it("toggles sidebar compact state between 64px and expanded width", () => {
+    collectionStore.sidebarOpen = true;
+    collectionStore.setSidebarWidth(256);
+    expect(collectionStore.sidebarWidth).toBe(256);
+
+    // Toggle compact -> collapses to 64px
+    collectionStore.toggleSidebarCompact();
+    expect(collectionStore.sidebarWidth).toBe(64);
+
+    // Toggle compact again -> expands to 256px
+    collectionStore.toggleSidebarCompact();
+    expect(collectionStore.sidebarWidth).toBe(256);
+
+    // If sidebar was hidden, toggleSidebarCompact opens and expands it
+    collectionStore.sidebarOpen = false;
+    collectionStore.sidebarWidth = 64;
+    collectionStore.toggleSidebarCompact();
+    expect(collectionStore.sidebarOpen).toBe(true);
+    expect(collectionStore.sidebarWidth).toBe(256);
+  });
+
   it("sends remembered size/position as the toggle target when geometry capture is supported, ignoring any command return value", async () => {
     collectionStore.setMiniplayerGeometry(310, 370, 20, 30);
     collectionStore.setSavedWindowGeometry(1400, 900, 50, 60);


### PR DESCRIPTION
## 📋 Summary
Adds a hamburger menu button to the left of the `goBack` / `goForward` navigation buttons in the top navbar (`TopNavigation.svelte`) to toggle the left sidebar between compact (64px, icon-only) and expanded (256px or user-resized width) modes.

## 🔍 Implementation Notes
- **`src/lib/stores/collection.svelte.ts`**:
  - Added `lastExpandedSidebarWidth` state property (default 256px), restored from `localStorage`.
  - Added `toggleSidebarCompact()` method to toggle between `SIDEBAR_COLLAPSED_WIDTH_PX` (64px) and `lastExpandedSidebarWidth`.
  - Updated `setSidebarWidth()` to track the last expanded width when `>= SIDEBAR_MIN_WIDTH_PX`.
- **`src/lib/components/TopNavigation.svelte`**:
  - Imported `Menu` icon from `lucide-svelte`.
  - Rendered hamburger button in the History Navigation controls section to the left of `ChevronLeft`.
- **Locales & Tests**:
  - Added `toggleSidebarCompact` string to `en.ts` and `fr.ts`.
  - Added unit tests in `collection.test.ts` and `TopNavigation.test.ts`.

## 🧪 Test Plan
- [x] `bun run check` (svelte-check) - 0 errors, 0 warnings
- [x] `bun run test -- --run` (frontend) - 35 test files passed, 321 unit tests passed
- [x] Manually verified in the app layout

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Unit tests updated and passing
