### PR TITLE
feat: remove album count from ArtistDetailView subheading

### DIFF
--- a/src/lib/components/ArtistDetailView.svelte
+++ b/src/lib/components/ArtistDetailView.svelte
@@ -187,9 +187,6 @@
   let eps = $derived(albums.filter((a) => classifyRelease(a.track_count, a.disc_count, a.total_duration_nanosec) === "ep"));
   let singles = $derived(albums.filter((a) => classifyRelease(a.track_count, a.disc_count, a.total_duration_nanosec) === "single"));
 
-  let albumsText = $derived(
-    fullAlbums.length === 1 ? i18n.t("collection.oneAlbum") : i18n.t("collection.albumsCount", { count: fullAlbums.length })
-  );
   let songsText = $derived(
     songs.length === 1 ? i18n.t("playlists.oneSong") : i18n.t("playlists.songsCount", { count: songs.length })
   );
@@ -322,7 +319,7 @@
 
         <!-- Summary Metadata Line -->
         <div class="flex items-center gap-3 text-xs text-brand-text-secondary font-medium">
-          <span>{i18n.t('artistDetail.statsLine', { genre: genreLabel, albums: albumsText, songs: songsText, duration: totalDurationLabel })}</span>
+          <span>{i18n.t('artistDetail.statsLine', { genre: genreLabel, songs: songsText, duration: totalDurationLabel })}</span>
         </div>
 
         <!-- Action Buttons: Play All & Shuffle Play -->

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -738,7 +738,7 @@ export const en = {
   artistDetail: {
     backToArtists: "View Artists",
     unknownGenre: "Unknown genre",
-    statsLine: "{genre} · {albums} • {songs} • {duration} total",
+    statsLine: "{genre} · {songs} • {duration} total",
     playAll: "Play",
     shuffleAndPlay: "Shuffle Play",
     discography: "Discography",

--- a/src/lib/locales/fr.ts
+++ b/src/lib/locales/fr.ts
@@ -735,7 +735,7 @@ export const fr = {
   artistDetail: {
     backToArtists: "Voir les artistes",
     unknownGenre: "Genre inconnu",
-    statsLine: "{genre} · {albums} • {songs} • {duration} au total",
+    statsLine: "{genre} · {songs} • {duration} au total",
     playAll: "Lire",
     shuffleAndPlay: "Lecture aléatoire",
     discography: "Discographie",


### PR DESCRIPTION
## 📋 Summary
Removes the album count from the `ArtistDetailView` hero header subheading to streamline artist summary metadata (`Genre · Songs • Total Duration`).

## 🔍 Implementation Notes
- **`src/lib/components/ArtistDetailView.svelte`**:
  - Removed `albumsText` derived variable.
  - Updated `i18n.t('artistDetail.statsLine', ...)` invocation to pass `genre`, `songs`, and `duration` without `albums`.
- **`src/lib/locales/en.ts`** & **`src/lib/locales/fr.ts`**:
  - Updated `artistDetail.statsLine` template string to remove `{albums}` and its middle separator dot (`"{genre} · {songs} • {duration} total"`).

## 🧪 Test Plan
- [x] `bun run check` (svelte-check) — 0 errors, 0 warnings
- [x] `bun run test:run` (frontend) — 35 test files passed, 319 tests passed
- [x] `cargo test` (src-tauri) — 43 unit tests & BDD scenarios passed
- [x] Manually verified in artist detail view

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed
