### PR TITLE
chore: clean up self-referential package.json dependency and upgrade thiserror to v2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3083,7 +3083,7 @@ dependencies = [
  "tauri-plugin-window-state",
  "tauri-runtime",
  "tempfile",
- "thiserror 1.0.69",
+ "thiserror 2.0.19",
  "tokio",
  "uuid",
  "walkdir",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "@tauri-apps/plugin-process": "^2",
     "@tauri-apps/plugin-updater": "^2",
     "lucide-svelte": "^1.0.1",
-    "luminous": ".",
     "svelte-virtual-list-ts": "^0.0.3",
     "tailwindcss": "^4.3.2"
   },

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -91,7 +91,7 @@ reqwest = { version = "0.13", default-features = false, features = ["json", "str
 uuid = { version = "1", features = ["v4"] }
 
 # --- Error handling ---
-thiserror = "1"
+thiserror = "2"
 anyhow = "1"
 
 # --- Logging ---


### PR DESCRIPTION
## 📋 Summary
Cleaned up dependency tree issues in both frontend (`package.json`) and backend (`src-tauri/Cargo.toml`):
- Removed circular self-referential dependency `"luminous": "."` from `package.json`.
- Upgraded `thiserror` dependency from `"1"` to `"2"` in `src-tauri/Cargo.toml` to align with `tauri v2.11` and eliminate duplicate `thiserror v1` compilation.

## 🔍 Implementation Notes
- **`package.json`**: Removed `"luminous": "."` under `"dependencies"`.
- **`src-tauri/Cargo.toml`**: Updated `thiserror = "1"` to `thiserror = "2"`. `Cargo.lock` updated accordingly.

## 🧪 Test Plan
- [x] `bun run check` (svelte-check) - 0 errors, 0 warnings
- [x] `bun run test:run` (frontend unit tests) - 35 test files / 321 tests passed
- [x] `cargo check` & `cargo test --lib` (src-tauri) - 103 backend tests passed

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed
