### PR TITLE
style: remove hand/pointer cursor for native desktop UX

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -62,6 +62,31 @@
     user-select: none;
   }
 
+  /* Desktop application cursor defaults: remove hand/pointer cursor everywhere */
+  *, ::before, ::after {
+    cursor: default;
+  }
+
+  button, a, select, input, label, summary, [role="button"] {
+    cursor: default;
+  }
+
+  input[type="text"],
+  input[type="search"],
+  input[type="number"],
+  input[type="password"],
+  input[type="email"],
+  input[type="url"],
+  textarea,
+  [contenteditable="true"] {
+    cursor: text;
+  }
+
+  /* Force override cursor-pointer class if present anywhere */
+  .cursor-pointer {
+    cursor: default !important;
+  }
+
   /* Custom scrollbar styling */
   ::-webkit-scrollbar {
     width: 8px;
@@ -169,7 +194,6 @@
   border-radius: 50%;
   background: #ffffff;
   border: 2px solid var(--color-accent);
-  cursor: pointer;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
   transition: transform 0.1s, border-color 0.2s;
 }
@@ -185,7 +209,6 @@
   border: 2px solid var(--color-accent);
   border-radius: 50%;
   background: #ffffff;
-  cursor: pointer;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
   transition: transform 0.1s, border-color 0.2s;
 }

--- a/src/lib/components/AlbumCard.svelte
+++ b/src/lib/components/AlbumCard.svelte
@@ -59,7 +59,7 @@
   onclick={handleCardClick}
   ondblclick={handleCardDblClick}
   oncontextmenu={(e) => customContextMenu?.(e)}
-  class="{widthClass} bg-brand-sidebar border border-brand-border/60 rounded-b-xl overflow-hidden flex flex-col group hover:border-brand-accent/40 transition-all duration-200 cursor-pointer select-none"
+  class="{widthClass} bg-brand-sidebar border border-brand-border/60 rounded-b-xl overflow-hidden flex flex-col group hover:border-brand-accent/40 transition-all duration-200 select-none"
 >
   <div
     class="aspect-square bg-brand-main flex items-center justify-center text-brand-accent-text relative overflow-hidden w-full"

--- a/src/lib/components/AlbumDetailView.svelte
+++ b/src/lib/components/AlbumDetailView.svelte
@@ -540,7 +540,7 @@
           {#if rawGenre}
             <button
               onclick={openGenrePlaylist}
-              class="hover:underline hover:text-brand-accent-text transition-colors cursor-pointer"
+              class="hover:underline hover:text-brand-accent-text transition-colors"
               title={i18n.t('albumDetail.goToGenrePlaylistTooltip', { genre: rawGenre })}
             >
               {genreLabel}
@@ -630,7 +630,7 @@
               active={sortField === "track"}
               {sortAsc}
               onclick={() => toggleSort("track")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-1rem)]">{i18n.t('collection.tableHeaderTrack')} {arrow}</span>{/snippet}
             </SortableHeader>
@@ -642,7 +642,7 @@
               active={sortField === "title"}
               {sortAsc}
               onclick={() => toggleSort("title")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-1rem)]">{i18n.t('collection.tableHeaderTitle')} {arrow}</span>{/snippet}
             </SortableHeader>
@@ -654,7 +654,7 @@
               active={sortField === "artist"}
               {sortAsc}
               onclick={() => toggleSort("artist")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-1rem)]">{i18n.t('collection.tableHeaderArtist')} {arrow}</span>{/snippet}
             </SortableHeader>
@@ -666,7 +666,7 @@
               active={sortField === "album"}
               {sortAsc}
               onclick={() => toggleSort("album")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-1rem)]">{i18n.t('collection.tableHeaderAlbum')} {arrow}</span>{/snippet}
             </SortableHeader>
@@ -678,7 +678,7 @@
               active={sortField === "composer"}
               {sortAsc}
               onclick={() => toggleSort("composer")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderComposer')} {arrow}</span>{/snippet}
             </SortableHeader>
@@ -690,7 +690,7 @@
               active={sortField === "album_artist"}
               {sortAsc}
               onclick={() => toggleSort("album_artist")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderAlbumArtist')} {arrow}</span>{/snippet}
             </SortableHeader>
@@ -702,7 +702,7 @@
               active={sortField === "filetype"}
               {sortAsc}
               onclick={() => toggleSort("filetype")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderFormat')} {arrow}</span>{/snippet}
             </SortableHeader>
@@ -714,7 +714,7 @@
               active={sortField === "year"}
               {sortAsc}
               onclick={() => toggleSort("year")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderYear')} {arrow}</span>{/snippet}
             </SortableHeader>
@@ -726,7 +726,7 @@
               active={sortField === "genre"}
               {sortAsc}
               onclick={() => toggleSort("genre")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderGenre')} {arrow}</span>{/snippet}
             </SortableHeader>
@@ -738,7 +738,7 @@
               active={sortField === "grouping"}
               {sortAsc}
               onclick={() => toggleSort("grouping")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderGrouping')} {arrow}</span>{/snippet}
             </SortableHeader>
@@ -750,7 +750,7 @@
               active={sortField === "bpm"}
               {sortAsc}
               onclick={() => toggleSort("bpm")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderBpm')} {arrow}</span>{/snippet}
             </SortableHeader>
@@ -762,7 +762,7 @@
               active={sortField === "initial_key"}
               {sortAsc}
               onclick={() => toggleSort("initial_key")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderInitialKey')} {arrow}</span>{/snippet}
             </SortableHeader>
@@ -774,7 +774,7 @@
               active={sortField === "bitrate"}
               {sortAsc}
               onclick={() => toggleSort("bitrate")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderBitrate')} {arrow}</span>{/snippet}
             </SortableHeader>
@@ -786,7 +786,7 @@
               active={sortField === "samplerate"}
               {sortAsc}
               onclick={() => toggleSort("samplerate")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderSampleRate')} {arrow}</span>{/snippet}
             </SortableHeader>
@@ -798,7 +798,7 @@
               active={sortField === "bitdepth"}
               {sortAsc}
               onclick={() => toggleSort("bitdepth")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderBitDepth')} {arrow}</span>{/snippet}
             </SortableHeader>
@@ -810,7 +810,7 @@
               active={sortField === "channels"}
               {sortAsc}
               onclick={() => toggleSort("channels")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderChannels')} {arrow}</span>{/snippet}
             </SortableHeader>
@@ -822,7 +822,7 @@
               active={sortField === "filesize"}
               {sortAsc}
               onclick={() => toggleSort("filesize")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderFileSize')} {arrow}</span>{/snippet}
             </SortableHeader>
@@ -834,7 +834,7 @@
               active={sortField === "rating"}
               {sortAsc}
               onclick={() => toggleSort("rating")}
-              class="flex items-center justify-center hover:text-brand-text-primary transition-colors cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+              class="flex items-center justify-center hover:text-brand-text-primary transition-colors font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate">{i18n.t('collection.tableHeaderRating')} {arrow}</span>{/snippet}
             </SortableHeader>
@@ -846,7 +846,7 @@
               active={sortField === "playcount"}
               {sortAsc}
               onclick={() => toggleSort("playcount")}
-              class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+              class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate">{i18n.t('collection.tableHeaderPlays')} {arrow}</span>{/snippet}
             </SortableHeader>
@@ -858,7 +858,7 @@
               active={sortField === "skipcount"}
               {sortAsc}
               onclick={() => toggleSort("skipcount")}
-              class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+              class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate">{i18n.t('collection.tableHeaderSkips')} {arrow}</span>{/snippet}
             </SortableHeader>
@@ -870,7 +870,7 @@
               active={sortField === "lastplayed"}
               {sortAsc}
               onclick={() => toggleSort("lastplayed")}
-              class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+              class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate">{i18n.t('collection.tableHeaderLastPlayed')} {arrow}</span>{/snippet}
             </SortableHeader>
@@ -882,7 +882,7 @@
               active={sortField === "added"}
               {sortAsc}
               onclick={() => toggleSort("added")}
-              class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+              class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate">{i18n.t('collection.tableHeaderAdded')} {arrow}</span>{/snippet}
             </SortableHeader>
@@ -894,7 +894,7 @@
               active={sortField === "length_nanosec"}
               {sortAsc}
               onclick={() => toggleSort("length_nanosec")}
-              class="flex items-center justify-center hover:text-brand-text-primary transition-colors cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+              class="flex items-center justify-center hover:text-brand-text-primary transition-colors font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<Clock class="w-3.5 h-3.5 shrink-0" /> {arrow}{/snippet}
             </SortableHeader>
@@ -906,7 +906,7 @@
               active={sortField === "path"}
               {sortAsc}
               onclick={() => toggleSort("path")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderPath')} {arrow}</span>{/snippet}
             </SortableHeader>
@@ -942,7 +942,7 @@
               style={gridColsStyle}
               title={disconnected ? i18n.t('collection.driveDisconnectedTooltip') : undefined}
               class="grid items-center hover:bg-brand-sidebar/40 group transition-colors py-2 px-4 text-sm
-                {disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}
+                {disabled ? 'opacity-50 cursor-not-allowed' : ''}
                 {selectedSongIds.has(song.id) ? 'bg-brand-accent/20 border-l-2 border-brand-accent text-brand-accent-text-hover' : (playerStore.currentSong && playerStore.currentSong.id === song.id ? 'bg-brand-accent/10 text-brand-accent-text-hover' : '')}"
             >
               <div class="text-center flex justify-center relative w-9 h-6 items-center">
@@ -953,7 +953,7 @@
                 {/if}
                 <button
                   onclick={(e) => { e.stopPropagation(); if (!disabled) handlePlaySong(song); }}
-                  class="absolute flex items-center justify-center opacity-0 group-hover:opacity-100 text-brand-accent-text hover:text-brand-accent-text-hover transition-all duration-150 cursor-pointer disabled:opacity-0 disabled:cursor-not-allowed"
+                  class="absolute flex items-center justify-center opacity-0 group-hover:opacity-100 text-brand-accent-text hover:text-brand-accent-text-hover transition-all duration-150 disabled:opacity-0 disabled:cursor-not-allowed"
                   disabled={disabled}
                   title={disconnected ? i18n.t('collection.driveDisconnectedTooltip') : i18n.t('collection.playSong')}
                 >
@@ -1106,7 +1106,7 @@
                 <div class="flex items-center justify-center gap-2.5">
                   <button
                     onclick={() => handleAddSongToPlaylist(song.id)}
-                    class="text-brand-text-primary hover:text-brand-accent-text transition-colors cursor-pointer"
+                    class="text-brand-text-primary hover:text-brand-accent-text transition-colors"
                     title={playlistsStore.activeCustomPlaylist
                       ? i18n.t('collection.addPlaylistTooltip', { name: playlistsStore.activeCustomPlaylist.name })
                       : i18n.t('collection.addPlaylistTooltipDefault')}
@@ -1115,7 +1115,7 @@
                   </button>
                   <button
                     onclick={() => openTagEditor(song.id)}
-                    class="text-brand-text-primary hover:text-brand-accent-text transition-colors cursor-pointer"
+                    class="text-brand-text-primary hover:text-brand-accent-text transition-colors"
                     title={i18n.t('collection.editTagsTooltip')}
                   >
                     <Edit3 class="w-4 h-4" />

--- a/src/lib/components/AlbumRowCard.svelte
+++ b/src/lib/components/AlbumRowCard.svelte
@@ -53,7 +53,7 @@
   ondblclick={handleDblClick}
   oncontextmenu={(e) => customContextMenu?.(e)}
   onkeydown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); handleClick(e as unknown as MouseEvent); } }}
-  class="group flex items-center gap-3 px-3 py-2.5 rounded-lg bg-brand-sidebar border border-brand-border/60 outline-2 -outline-offset-2 outline-transparent hover:outline-brand-accent transition-[outline-color,border-color] duration-200 cursor-pointer select-none"
+  class="group flex items-center gap-3 px-3 py-2.5 rounded-lg bg-brand-sidebar border border-brand-border/60 outline-2 -outline-offset-2 outline-transparent hover:outline-brand-accent transition-[outline-color,border-color] duration-200 select-none"
 >
   <div class="relative shrink-0 overflow-hidden">
     <CoverArt

--- a/src/lib/components/ArtistCard.svelte
+++ b/src/lib/components/ArtistCard.svelte
@@ -32,7 +32,7 @@
   tabindex="0"
   onclick={(e) => customClick?.(e)}
   onkeydown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); customClick?.(e as unknown as MouseEvent); } }}
-  class="artist-card group bg-brand-sidebar border border-brand-border/60 rounded-xl p-4 flex flex-col items-center text-center outline-2 -outline-offset-2 outline-transparent hover:outline-brand-accent transition-[outline-color,border-color] duration-200 cursor-pointer select-none"
+  class="artist-card group bg-brand-sidebar border border-brand-border/60 rounded-xl p-4 flex flex-col items-center text-center outline-2 -outline-offset-2 outline-transparent hover:outline-brand-accent transition-[outline-color,border-color] duration-200 select-none"
 >
   <div class="aspect-square w-full mb-3 bg-brand-main relative flex items-center justify-center">
     <CoverStack

--- a/src/lib/components/ArtistDetailView.svelte
+++ b/src/lib/components/ArtistDetailView.svelte
@@ -399,7 +399,7 @@
                   active={singleSortField === "track"}
                   sortAsc={singleSortAsc}
                   onclick={() => toggleSingleSort("track")}
-                  class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+                  class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
                 >
                   {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-1rem)]">{i18n.t('collection.tableHeaderTrack')} {arrow}</span>{/snippet}
                 </SortableHeader>
@@ -411,7 +411,7 @@
                   active={singleSortField === "title"}
                   sortAsc={singleSortAsc}
                   onclick={() => toggleSingleSort("title")}
-                  class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+                  class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
                 >
                   {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-1rem)]">{i18n.t('collection.tableHeaderTitle')} {arrow}</span>{/snippet}
                 </SortableHeader>
@@ -423,7 +423,7 @@
                   active={singleSortField === "artist"}
                   sortAsc={singleSortAsc}
                   onclick={() => toggleSingleSort("artist")}
-                  class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+                  class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
                 >
                   {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-1rem)]">{i18n.t('collection.tableHeaderArtist')} {arrow}</span>{/snippet}
                 </SortableHeader>
@@ -435,7 +435,7 @@
                   active={singleSortField === "album"}
                   sortAsc={singleSortAsc}
                   onclick={() => toggleSingleSort("album")}
-                  class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+                  class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
                 >
                   {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-1rem)]">{i18n.t('collection.tableHeaderAlbum')} {arrow}</span>{/snippet}
                 </SortableHeader>
@@ -447,7 +447,7 @@
                   active={singleSortField === "composer"}
                   sortAsc={singleSortAsc}
                   onclick={() => toggleSingleSort("composer")}
-                  class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+                  class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
                 >
                   {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderComposer')} {arrow}</span>{/snippet}
                 </SortableHeader>
@@ -459,7 +459,7 @@
                   active={singleSortField === "album_artist"}
                   sortAsc={singleSortAsc}
                   onclick={() => toggleSingleSort("album_artist")}
-                  class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+                  class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
                 >
                   {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderAlbumArtist')} {arrow}</span>{/snippet}
                 </SortableHeader>
@@ -471,7 +471,7 @@
                   active={singleSortField === "filetype"}
                   sortAsc={singleSortAsc}
                   onclick={() => toggleSingleSort("filetype")}
-                  class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+                  class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
                 >
                   {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderFormat')} {arrow}</span>{/snippet}
                 </SortableHeader>
@@ -483,7 +483,7 @@
                   active={singleSortField === "year"}
                   sortAsc={singleSortAsc}
                   onclick={() => toggleSingleSort("year")}
-                  class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+                  class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
                 >
                   {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderYear')} {arrow}</span>{/snippet}
                 </SortableHeader>
@@ -495,7 +495,7 @@
                   active={singleSortField === "genre"}
                   sortAsc={singleSortAsc}
                   onclick={() => toggleSingleSort("genre")}
-                  class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+                  class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
                 >
                   {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderGenre')} {arrow}</span>{/snippet}
                 </SortableHeader>
@@ -507,7 +507,7 @@
                   active={singleSortField === "grouping"}
                   sortAsc={singleSortAsc}
                   onclick={() => toggleSingleSort("grouping")}
-                  class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+                  class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
                 >
                   {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderGrouping')} {arrow}</span>{/snippet}
                 </SortableHeader>
@@ -519,7 +519,7 @@
                   active={singleSortField === "bpm"}
                   sortAsc={singleSortAsc}
                   onclick={() => toggleSingleSort("bpm")}
-                  class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+                  class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
                 >
                   {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderBpm')} {arrow}</span>{/snippet}
                 </SortableHeader>
@@ -531,7 +531,7 @@
                   active={singleSortField === "initial_key"}
                   sortAsc={singleSortAsc}
                   onclick={() => toggleSingleSort("initial_key")}
-                  class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+                  class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
                 >
                   {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderInitialKey')} {arrow}</span>{/snippet}
                 </SortableHeader>
@@ -543,7 +543,7 @@
                   active={singleSortField === "bitrate"}
                   sortAsc={singleSortAsc}
                   onclick={() => toggleSingleSort("bitrate")}
-                  class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+                  class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
                 >
                   {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderBitrate')} {arrow}</span>{/snippet}
                 </SortableHeader>
@@ -555,7 +555,7 @@
                   active={singleSortField === "samplerate"}
                   sortAsc={singleSortAsc}
                   onclick={() => toggleSingleSort("samplerate")}
-                  class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+                  class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
                 >
                   {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderSampleRate')} {arrow}</span>{/snippet}
                 </SortableHeader>
@@ -567,7 +567,7 @@
                   active={singleSortField === "bitdepth"}
                   sortAsc={singleSortAsc}
                   onclick={() => toggleSingleSort("bitdepth")}
-                  class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+                  class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
                 >
                   {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderBitDepth')} {arrow}</span>{/snippet}
                 </SortableHeader>
@@ -579,7 +579,7 @@
                   active={singleSortField === "channels"}
                   sortAsc={singleSortAsc}
                   onclick={() => toggleSingleSort("channels")}
-                  class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+                  class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
                 >
                   {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderChannels')} {arrow}</span>{/snippet}
                 </SortableHeader>
@@ -591,7 +591,7 @@
                   active={singleSortField === "filesize"}
                   sortAsc={singleSortAsc}
                   onclick={() => toggleSingleSort("filesize")}
-                  class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+                  class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
                 >
                   {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderFileSize')} {arrow}</span>{/snippet}
                 </SortableHeader>
@@ -603,7 +603,7 @@
                   active={singleSortField === "rating"}
                   sortAsc={singleSortAsc}
                   onclick={() => toggleSingleSort("rating")}
-                  class="flex items-center justify-center hover:text-brand-text-primary transition-colors cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+                  class="flex items-center justify-center hover:text-brand-text-primary transition-colors font-semibold uppercase tracking-wider min-w-0 w-full"
                 >
                   {#snippet label(arrow)}<span class="truncate">{i18n.t('collection.tableHeaderRating')} {arrow}</span>{/snippet}
                 </SortableHeader>
@@ -615,7 +615,7 @@
                   active={singleSortField === "playcount"}
                   sortAsc={singleSortAsc}
                   onclick={() => toggleSingleSort("playcount")}
-                  class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+                  class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
                 >
                   {#snippet label(arrow)}<span class="truncate">{i18n.t('collection.tableHeaderPlays')} {arrow}</span>{/snippet}
                 </SortableHeader>
@@ -627,7 +627,7 @@
                   active={singleSortField === "skipcount"}
                   sortAsc={singleSortAsc}
                   onclick={() => toggleSingleSort("skipcount")}
-                  class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+                  class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
                 >
                   {#snippet label(arrow)}<span class="truncate">{i18n.t('collection.tableHeaderSkips')} {arrow}</span>{/snippet}
                 </SortableHeader>
@@ -639,7 +639,7 @@
                   active={singleSortField === "lastplayed"}
                   sortAsc={singleSortAsc}
                   onclick={() => toggleSingleSort("lastplayed")}
-                  class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+                  class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
                 >
                   {#snippet label(arrow)}<span class="truncate">{i18n.t('collection.tableHeaderLastPlayed')} {arrow}</span>{/snippet}
                 </SortableHeader>
@@ -651,7 +651,7 @@
                   active={singleSortField === "added"}
                   sortAsc={singleSortAsc}
                   onclick={() => toggleSingleSort("added")}
-                  class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+                  class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
                 >
                   {#snippet label(arrow)}<span class="truncate">{i18n.t('collection.tableHeaderAdded')} {arrow}</span>{/snippet}
                 </SortableHeader>
@@ -663,7 +663,7 @@
                   active={singleSortField === "length_nanosec"}
                   sortAsc={singleSortAsc}
                   onclick={() => toggleSingleSort("length_nanosec")}
-                  class="flex items-center justify-center hover:text-brand-text-primary transition-colors cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+                  class="flex items-center justify-center hover:text-brand-text-primary transition-colors font-semibold uppercase tracking-wider min-w-0 w-full"
                 >
                   {#snippet label(arrow)}<Clock class="w-3.5 h-3.5 shrink-0" /> {arrow}{/snippet}
                 </SortableHeader>
@@ -675,7 +675,7 @@
                   active={singleSortField === "path"}
                   sortAsc={singleSortAsc}
                   onclick={() => toggleSingleSort("path")}
-                  class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+                  class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
                 >
                   {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderPath')} {arrow}</span>{/snippet}
                 </SortableHeader>
@@ -701,7 +701,7 @@
                 style={gridColsStyle}
                 title={disconnected ? i18n.t('collection.driveDisconnectedTooltip') : undefined}
                 class="grid items-center hover:bg-brand-sidebar/40 group transition-colors py-2 px-4 text-sm
-                  {disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}
+                  {disabled ? 'opacity-50 cursor-not-allowed' : ''}
                   {playerStore.currentSong && playerStore.currentSong.id === song.id ? 'bg-brand-accent/10 text-brand-accent-text-hover' : ''}"
               >
                 <div class="text-center flex justify-center relative w-9 h-6 items-center">
@@ -712,7 +712,7 @@
                   {/if}
                   <button
                     onclick={(e) => { e.stopPropagation(); if (!disabled) handlePlaySingle(song); }}
-                    class="absolute flex items-center justify-center opacity-0 group-hover:opacity-100 text-brand-accent-text hover:text-brand-accent-text-hover transition-all duration-150 cursor-pointer disabled:opacity-0 disabled:cursor-not-allowed"
+                    class="absolute flex items-center justify-center opacity-0 group-hover:opacity-100 text-brand-accent-text hover:text-brand-accent-text-hover transition-all duration-150 disabled:opacity-0 disabled:cursor-not-allowed"
                     disabled={disabled}
                     title={disconnected ? i18n.t('collection.driveDisconnectedTooltip') : i18n.t('collection.playSong')}
                   >
@@ -862,7 +862,7 @@
                   <div class="flex items-center justify-center gap-2.5">
                     <button
                       onclick={(e) => { e.stopPropagation(); handleAddSingleToPlaylist(song.id); }}
-                      class="text-brand-text-primary hover:text-brand-accent-text transition-colors cursor-pointer"
+                      class="text-brand-text-primary hover:text-brand-accent-text transition-colors"
                       title={playlistsStore.activeCustomPlaylist
                         ? i18n.t('collection.addPlaylistTooltip', { name: playlistsStore.activeCustomPlaylist.name })
                         : i18n.t('collection.addPlaylistTooltipDefault')}
@@ -871,7 +871,7 @@
                     </button>
                     <button
                       onclick={(e) => { e.stopPropagation(); openTagEditor(song.id); }}
-                      class="text-brand-text-primary hover:text-brand-accent-text transition-colors cursor-pointer"
+                      class="text-brand-text-primary hover:text-brand-accent-text transition-colors"
                       title={i18n.t('collection.editTagsTooltip')}
                     >
                       <Edit3 class="w-4 h-4" />

--- a/src/lib/components/ArtistRowCard.svelte
+++ b/src/lib/components/ArtistRowCard.svelte
@@ -26,7 +26,7 @@
   tabindex="0"
   onclick={(e) => customClick?.(e)}
   onkeydown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); customClick?.(e as unknown as MouseEvent); } }}
-  class="group flex items-center gap-3 px-3 py-2.5 rounded-lg bg-brand-sidebar border border-brand-border/60 outline-2 -outline-offset-2 outline-transparent hover:outline-brand-accent transition-[outline-color,border-color] duration-200 cursor-pointer select-none"
+  class="group flex items-center gap-3 px-3 py-2.5 rounded-lg bg-brand-sidebar border border-brand-border/60 outline-2 -outline-offset-2 outline-transparent hover:outline-brand-accent transition-[outline-color,border-color] duration-200 select-none"
 >
   <div class="relative shrink-0 overflow-hidden">
     <CoverArt

--- a/src/lib/components/AutoPlaylistCard.svelte
+++ b/src/lib/components/AutoPlaylistCard.svelte
@@ -112,7 +112,7 @@
 <!-- svelte-ignore a11y_click_events_have_key_events -->
 <div
   onclick={onClick}
-  class="{widthClass} bg-brand-sidebar border border-brand-border/60 rounded-xl p-4 flex flex-col text-left hover:border-brand-accent/40 transition-all duration-200 cursor-pointer group"
+  class="{widthClass} bg-brand-sidebar border border-brand-border/60 rounded-xl p-4 flex flex-col text-left hover:border-brand-accent/40 transition-all duration-200 group"
 >
   <div class="aspect-square w-full mb-3 bg-brand-main relative flex items-center justify-center">
     {#if (kind === "genre" || kind === "decade" || kind === "bpm") && topCovers.length > 0}
@@ -156,7 +156,7 @@
 
   <button
     onclick={(e) => { e.stopPropagation(); onClick(); }}
-    class="font-semibold text-sm text-brand-text-primary hover:text-brand-accent-text hover:underline transition-all duration-150 text-left truncate w-full cursor-pointer"
+    class="font-semibold text-sm text-brand-text-primary hover:text-brand-accent-text hover:underline transition-all duration-150 text-left truncate w-full"
     title={displayLabel}
   >
     {displayLabel}

--- a/src/lib/components/AutoPlaylistDetailView.svelte
+++ b/src/lib/components/AutoPlaylistDetailView.svelte
@@ -573,7 +573,7 @@ import { shuffleArray } from "../utils/shuffle";
             {#if filterQuery}
               <button
                 onclick={() => { filterQuery = ""; }}
-                class="absolute right-3 top-1/2 -translate-y-1/2 text-brand-text-secondary/60 hover:text-brand-text-primary p-0.5 cursor-pointer"
+                class="absolute right-3 top-1/2 -translate-y-1/2 text-brand-text-secondary/60 hover:text-brand-text-primary p-0.5"
                 title={i18n.t("playlists.clearFilter")}
               >
                 <X class="w-3.5 h-3.5" />
@@ -591,7 +591,7 @@ import { shuffleArray } from "../utils/shuffle";
             <button
               onclick={toggleOverflowMenu}
               title={i18n.t("playlists.moreActionsTooltip")}
-              class="flex items-center justify-center w-10 h-10 rounded-full border border-brand-border text-brand-text-secondary hover:text-brand-accent-text hover:bg-brand-sidebar transition-colors cursor-pointer shadow-xs"
+              class="flex items-center justify-center w-10 h-10 rounded-full border border-brand-border text-brand-text-secondary hover:text-brand-accent-text hover:bg-brand-sidebar transition-colors shadow-xs"
             >
               <MoreHorizontal class="w-4 h-4" />
             </button>
@@ -668,7 +668,7 @@ import { shuffleArray } from "../utils/shuffle";
             active={sortField === "track" || sortField === "default"}
             {sortAsc}
             onclick={() => toggleSort("track")}
-            class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+            class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 font-semibold uppercase tracking-wider min-w-0"
           >
             {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-1rem)]">{i18n.t('playlists.tableHeaderTrack')} {arrow}</span>{/snippet}
           </SortableHeader>
@@ -678,7 +678,7 @@ import { shuffleArray } from "../utils/shuffle";
               active={sortField === "title"}
               {sortAsc}
               onclick={() => toggleSort("title")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-1rem)]">{i18n.t('playlists.tableHeaderTitle')} {arrow}</span>{/snippet}
             </SortableHeader>
@@ -690,7 +690,7 @@ import { shuffleArray } from "../utils/shuffle";
               active={sortField === "artist"}
               {sortAsc}
               onclick={() => toggleSort("artist")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-1rem)]">{i18n.t('playlists.tableHeaderArtist')} {arrow}</span>{/snippet}
             </SortableHeader>
@@ -702,7 +702,7 @@ import { shuffleArray } from "../utils/shuffle";
               active={sortField === "album"}
               {sortAsc}
               onclick={() => toggleSort("album")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-1rem)]">{i18n.t('collection.tableHeaderAlbum')} {arrow}</span>{/snippet}
             </SortableHeader>
@@ -715,7 +715,7 @@ import { shuffleArray } from "../utils/shuffle";
               active={sortField === "composer"}
               {sortAsc}
               onclick={() => toggleSort("composer")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderComposer')} {arrow}</span>{/snippet}
             </SortableHeader>
@@ -727,7 +727,7 @@ import { shuffleArray } from "../utils/shuffle";
               active={sortField === "album_artist"}
               {sortAsc}
               onclick={() => toggleSort("album_artist")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderAlbumArtist')} {arrow}</span>{/snippet}
             </SortableHeader>
@@ -739,7 +739,7 @@ import { shuffleArray } from "../utils/shuffle";
               active={sortField === "filetype"}
               {sortAsc}
               onclick={() => toggleSort("filetype")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderFormat')} {arrow}</span>{/snippet}
             </SortableHeader>
@@ -751,7 +751,7 @@ import { shuffleArray } from "../utils/shuffle";
               active={sortField === "year"}
               {sortAsc}
               onclick={() => toggleSort("year")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderYear')} {arrow}</span>{/snippet}
             </SortableHeader>
@@ -763,7 +763,7 @@ import { shuffleArray } from "../utils/shuffle";
               active={sortField === "genre"}
               {sortAsc}
               onclick={() => toggleSort("genre")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderGenre')} {arrow}</span>{/snippet}
             </SortableHeader>
@@ -775,7 +775,7 @@ import { shuffleArray } from "../utils/shuffle";
               active={sortField === "grouping"}
               {sortAsc}
               onclick={() => toggleSort("grouping")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderGrouping')} {arrow}</span>{/snippet}
             </SortableHeader>
@@ -787,7 +787,7 @@ import { shuffleArray } from "../utils/shuffle";
               active={sortField === "bpm"}
               {sortAsc}
               onclick={() => toggleSort("bpm")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderBpm')} {arrow}</span>{/snippet}
             </SortableHeader>
@@ -799,7 +799,7 @@ import { shuffleArray } from "../utils/shuffle";
               active={sortField === "initial_key"}
               {sortAsc}
               onclick={() => toggleSort("initial_key")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderInitialKey')} {arrow}</span>{/snippet}
             </SortableHeader>
@@ -811,7 +811,7 @@ import { shuffleArray } from "../utils/shuffle";
               active={sortField === "bitrate"}
               {sortAsc}
               onclick={() => toggleSort("bitrate")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderBitrate')} {arrow}</span>{/snippet}
             </SortableHeader>
@@ -823,7 +823,7 @@ import { shuffleArray } from "../utils/shuffle";
               active={sortField === "samplerate"}
               {sortAsc}
               onclick={() => toggleSort("samplerate")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderSampleRate')} {arrow}</span>{/snippet}
             </SortableHeader>
@@ -835,7 +835,7 @@ import { shuffleArray } from "../utils/shuffle";
               active={sortField === "bitdepth"}
               {sortAsc}
               onclick={() => toggleSort("bitdepth")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderBitDepth')} {arrow}</span>{/snippet}
             </SortableHeader>
@@ -847,7 +847,7 @@ import { shuffleArray } from "../utils/shuffle";
               active={sortField === "channels"}
               {sortAsc}
               onclick={() => toggleSort("channels")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderChannels')} {arrow}</span>{/snippet}
             </SortableHeader>
@@ -859,7 +859,7 @@ import { shuffleArray } from "../utils/shuffle";
               active={sortField === "filesize"}
               {sortAsc}
               onclick={() => toggleSort("filesize")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderFileSize')} {arrow}</span>{/snippet}
             </SortableHeader>
@@ -871,7 +871,7 @@ import { shuffleArray } from "../utils/shuffle";
               active={sortField === "rating"}
               {sortAsc}
               onclick={() => toggleSort("rating")}
-              class="flex items-center justify-center hover:text-brand-text-primary transition-colors cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+              class="flex items-center justify-center hover:text-brand-text-primary transition-colors font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate">{i18n.t('collection.tableHeaderRating')} {arrow}</span>{/snippet}
             </SortableHeader>
@@ -883,7 +883,7 @@ import { shuffleArray } from "../utils/shuffle";
               active={sortField === "playcount"}
               {sortAsc}
               onclick={() => toggleSort("playcount")}
-              class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+              class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate">{i18n.t('collection.tableHeaderPlays')} {arrow}</span>{/snippet}
             </SortableHeader>
@@ -895,7 +895,7 @@ import { shuffleArray } from "../utils/shuffle";
               active={sortField === "skipcount"}
               {sortAsc}
               onclick={() => toggleSort("skipcount")}
-              class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+              class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate">{i18n.t('collection.tableHeaderSkips')} {arrow}</span>{/snippet}
             </SortableHeader>
@@ -907,7 +907,7 @@ import { shuffleArray } from "../utils/shuffle";
               active={sortField === "lastplayed"}
               {sortAsc}
               onclick={() => toggleSort("lastplayed")}
-              class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+              class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate">{i18n.t('collection.tableHeaderLastPlayed')} {arrow}</span>{/snippet}
             </SortableHeader>
@@ -919,7 +919,7 @@ import { shuffleArray } from "../utils/shuffle";
               active={sortField === "added"}
               {sortAsc}
               onclick={() => toggleSort("added")}
-              class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+              class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate">{i18n.t('collection.tableHeaderAdded')} {arrow}</span>{/snippet}
             </SortableHeader>
@@ -931,7 +931,7 @@ import { shuffleArray } from "../utils/shuffle";
               active={sortField === "length_nanosec"}
               {sortAsc}
               onclick={() => toggleSort("length_nanosec")}
-              class="flex items-center justify-center hover:text-brand-text-primary transition-colors cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+              class="flex items-center justify-center hover:text-brand-text-primary transition-colors font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<Clock class="w-4 h-4 shrink-0" /> {arrow}{/snippet}
             </SortableHeader>
@@ -943,7 +943,7 @@ import { shuffleArray } from "../utils/shuffle";
               active={sortField === "path"}
               {sortAsc}
               onclick={() => toggleSort("path")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderPath')} {arrow}</span>{/snippet}
             </SortableHeader>
@@ -981,7 +981,7 @@ import { shuffleArray } from "../utils/shuffle";
               oncontextmenu={(e) => handleContextMenu(e, song)}
               title={disconnected ? i18n.t('collection.driveDisconnectedTooltip') : undefined}
               class="grid items-center py-2.5 px-4 group transition-all duration-150 select-none text-sm border-b border-brand-border/40
-                {disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}
+                {disabled ? 'opacity-50 cursor-not-allowed' : ''}
                 {selectedSongIds.has(song.id) ? 'bg-brand-accent/20 text-brand-accent-text-hover' : (playerStore.currentSong && playerStore.currentSong.id === song.id ? 'bg-brand-accent/10 text-brand-accent-text-hover' : 'hover:bg-brand-sidebar/40')}"
               style={gridColsStyle}
             >
@@ -998,7 +998,7 @@ import { shuffleArray } from "../utils/shuffle";
                   {/if}
                   <button
                     onclick={(e) => { e.stopPropagation(); if (!disabled) handlePlaySong(song); }}
-                    class="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 text-brand-accent-text hover:text-brand-accent-text-hover transition-opacity cursor-pointer disabled:opacity-0 disabled:cursor-not-allowed"
+                    class="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 text-brand-accent-text hover:text-brand-accent-text-hover transition-opacity disabled:opacity-0 disabled:cursor-not-allowed"
                     disabled={disabled}
                     title={disconnected ? i18n.t('collection.driveDisconnectedTooltip') : i18n.t('collection.playSong')}
                   >
@@ -1148,7 +1148,7 @@ import { shuffleArray } from "../utils/shuffle";
                   <div class="flex items-center justify-center gap-2.5">
                     <button
                       onclick={(e) => { e.stopPropagation(); handleAddSongToPlaylist(song.id); }}
-                      class="text-brand-text-primary hover:text-brand-accent-text transition-colors cursor-pointer"
+                      class="text-brand-text-primary hover:text-brand-accent-text transition-colors"
                       title={playlistsStore.activeCustomPlaylist
                         ? i18n.t('collection.addPlaylistTooltip', { name: playlistsStore.activeCustomPlaylist.name })
                         : i18n.t('collection.addPlaylistTooltipDefault')}
@@ -1157,7 +1157,7 @@ import { shuffleArray } from "../utils/shuffle";
                     </button>
                     <button
                       onclick={(e) => { e.stopPropagation(); openTagEditor(song.id); }}
-                      class="text-brand-text-primary hover:text-brand-accent-text transition-colors cursor-pointer"
+                      class="text-brand-text-primary hover:text-brand-accent-text transition-colors"
                       title={i18n.t('collection.editTagsTooltip')}
                     >
                       <Edit3 class="w-4 h-4" />
@@ -1278,7 +1278,7 @@ import { shuffleArray } from "../utils/shuffle";
         <FolderPlus class="w-4 h-4 text-brand-accent-text" />
         <h3 class="text-sm font-bold text-brand-text-primary">{i18n.t("playlists.saveAsCustomTitle", {}, "Save as Custom Playlist")}</h3>
       </div>
-      <button onclick={() => showSaveModal = false} class="text-brand-text-secondary hover:text-brand-text-primary transition-colors cursor-pointer">
+      <button onclick={() => showSaveModal = false} class="text-brand-text-secondary hover:text-brand-text-primary transition-colors">
         <X class="w-4 h-4" />
       </button>
     </div>

--- a/src/lib/components/AutoPlaylistRowCard.svelte
+++ b/src/lib/components/AutoPlaylistRowCard.svelte
@@ -48,7 +48,7 @@
 <!-- svelte-ignore a11y_click_events_have_key_events -->
 <div
   onclick={onClick}
-  class="group flex items-center gap-3 px-3 py-2.5 rounded-lg bg-brand-sidebar border border-brand-border/60 outline-2 -outline-offset-2 outline-transparent hover:outline-brand-accent transition-[outline-color,border-color] duration-200 cursor-pointer select-none"
+  class="group flex items-center gap-3 px-3 py-2.5 rounded-lg bg-brand-sidebar border border-brand-border/60 outline-2 -outline-offset-2 outline-transparent hover:outline-brand-accent transition-[outline-color,border-color] duration-200 select-none"
 >
   <div
     class="relative shrink-0 w-11 h-11 flex items-center justify-center overflow-hidden border {kind === 'decade'

--- a/src/lib/components/Button.svelte
+++ b/src/lib/components/Button.svelte
@@ -49,7 +49,7 @@
   {type}
   {disabled}
   {title}
-  class="flex items-center justify-center rounded-full font-semibold transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed {sizeClasses[size]} {variantClasses[variant]} {className}"
+  class="flex items-center justify-center rounded-full font-semibold transition-colors disabled:opacity-50 disabled:cursor-not-allowed {sizeClasses[size]} {variantClasses[variant]} {className}"
 >
   {@render children()}
 </button>

--- a/src/lib/components/CollectionView.svelte
+++ b/src/lib/components/CollectionView.svelte
@@ -463,7 +463,7 @@
                 active={sortField === "track"}
                 {sortAsc}
                 onclick={() => toggleSort("track")}
-                class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+                class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
               >
                 {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-1rem)]">{i18n.t('collection.tableHeaderTrack')} {arrow}</span>{/snippet}
               </SortableHeader>
@@ -475,7 +475,7 @@
                 active={sortField === "title"}
                 {sortAsc}
                 onclick={() => toggleSort("title")}
-                class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+                class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
               >
                 {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-1rem)]">{i18n.t('collection.tableHeaderTitle')} {arrow}</span>{/snippet}
               </SortableHeader>
@@ -487,7 +487,7 @@
                 active={sortField === "artist"}
                 {sortAsc}
                 onclick={() => toggleSort("artist")}
-                class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+                class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
               >
                 {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-1rem)]">{i18n.t('collection.tableHeaderArtist')} {arrow}</span>{/snippet}
               </SortableHeader>
@@ -499,7 +499,7 @@
                 active={sortField === "album"}
                 {sortAsc}
                 onclick={() => toggleSort("album")}
-                class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+                class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
               >
                 {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-1rem)]">{i18n.t('collection.tableHeaderAlbum')} {arrow}</span>{/snippet}
               </SortableHeader>
@@ -511,7 +511,7 @@
                 active={sortField === "composer"}
                 {sortAsc}
                 onclick={() => toggleSort("composer")}
-                class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+                class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
               >
                 {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderComposer')} {arrow}</span>{/snippet}
               </SortableHeader>
@@ -523,7 +523,7 @@
                 active={sortField === "album_artist"}
                 {sortAsc}
                 onclick={() => toggleSort("album_artist")}
-                class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+                class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
               >
                 {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderAlbumArtist')} {arrow}</span>{/snippet}
               </SortableHeader>
@@ -535,7 +535,7 @@
                 active={sortField === "filetype"}
                 {sortAsc}
                 onclick={() => toggleSort("filetype")}
-                class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+                class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
               >
                 {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderFormat')} {arrow}</span>{/snippet}
               </SortableHeader>
@@ -547,7 +547,7 @@
                 active={sortField === "year"}
                 {sortAsc}
                 onclick={() => toggleSort("year")}
-                class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+                class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
               >
                 {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderYear')} {arrow}</span>{/snippet}
               </SortableHeader>
@@ -559,7 +559,7 @@
                 active={sortField === "genre"}
                 {sortAsc}
                 onclick={() => toggleSort("genre")}
-                class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+                class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
               >
                 {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderGenre')} {arrow}</span>{/snippet}
               </SortableHeader>
@@ -571,7 +571,7 @@
                 active={sortField === "grouping"}
                 {sortAsc}
                 onclick={() => toggleSort("grouping")}
-                class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+                class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
               >
                 {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderGrouping')} {arrow}</span>{/snippet}
               </SortableHeader>
@@ -583,7 +583,7 @@
                 active={sortField === "bpm"}
                 {sortAsc}
                 onclick={() => toggleSort("bpm")}
-                class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+                class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
               >
                 {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderBpm')} {arrow}</span>{/snippet}
               </SortableHeader>
@@ -595,7 +595,7 @@
                 active={sortField === "initial_key"}
                 {sortAsc}
                 onclick={() => toggleSort("initial_key")}
-                class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+                class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
               >
                 {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderInitialKey')} {arrow}</span>{/snippet}
               </SortableHeader>
@@ -607,7 +607,7 @@
                 active={sortField === "bitrate"}
                 {sortAsc}
                 onclick={() => toggleSort("bitrate")}
-                class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+                class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
               >
                 {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderBitrate')} {arrow}</span>{/snippet}
               </SortableHeader>
@@ -619,7 +619,7 @@
                 active={sortField === "samplerate"}
                 {sortAsc}
                 onclick={() => toggleSort("samplerate")}
-                class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+                class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
               >
                 {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderSampleRate')} {arrow}</span>{/snippet}
               </SortableHeader>
@@ -631,7 +631,7 @@
                 active={sortField === "bitdepth"}
                 {sortAsc}
                 onclick={() => toggleSort("bitdepth")}
-                class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+                class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
               >
                 {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderBitDepth')} {arrow}</span>{/snippet}
               </SortableHeader>
@@ -643,7 +643,7 @@
                 active={sortField === "channels"}
                 {sortAsc}
                 onclick={() => toggleSort("channels")}
-                class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+                class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
               >
                 {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderChannels')} {arrow}</span>{/snippet}
               </SortableHeader>
@@ -655,7 +655,7 @@
                 active={sortField === "filesize"}
                 {sortAsc}
                 onclick={() => toggleSort("filesize")}
-                class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+                class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
               >
                 {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderFileSize')} {arrow}</span>{/snippet}
               </SortableHeader>
@@ -667,7 +667,7 @@
                 active={sortField === "rating"}
                 {sortAsc}
                 onclick={() => toggleSort("rating")}
-                class="flex items-center justify-center hover:text-brand-text-primary transition-colors cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+                class="flex items-center justify-center hover:text-brand-text-primary transition-colors font-semibold uppercase tracking-wider min-w-0 w-full"
               >
                 {#snippet label(arrow)}<span class="truncate">{i18n.t('collection.tableHeaderRating')} {arrow}</span>{/snippet}
               </SortableHeader>
@@ -679,7 +679,7 @@
                 active={sortField === "playcount"}
                 {sortAsc}
                 onclick={() => toggleSort("playcount")}
-                class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+                class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
               >
                 {#snippet label(arrow)}<span class="truncate">{i18n.t('collection.tableHeaderPlays')} {arrow}</span>{/snippet}
               </SortableHeader>
@@ -691,7 +691,7 @@
                 active={sortField === "skipcount"}
                 {sortAsc}
                 onclick={() => toggleSort("skipcount")}
-                class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+                class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
               >
                 {#snippet label(arrow)}<span class="truncate">{i18n.t('collection.tableHeaderSkips')} {arrow}</span>{/snippet}
               </SortableHeader>
@@ -703,7 +703,7 @@
                 active={sortField === "lastplayed"}
                 {sortAsc}
                 onclick={() => toggleSort("lastplayed")}
-                class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+                class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
               >
                 {#snippet label(arrow)}<span class="truncate">{i18n.t('collection.tableHeaderLastPlayed')} {arrow}</span>{/snippet}
               </SortableHeader>
@@ -715,7 +715,7 @@
                 active={sortField === "added"}
                 {sortAsc}
                 onclick={() => toggleSort("added")}
-                class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+                class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
               >
                 {#snippet label(arrow)}<span class="truncate">{i18n.t('collection.tableHeaderAdded')} {arrow}</span>{/snippet}
               </SortableHeader>
@@ -727,7 +727,7 @@
                 active={sortField === "length_nanosec"}
                 {sortAsc}
                 onclick={() => toggleSort("length_nanosec")}
-                class="flex items-center justify-center hover:text-brand-text-primary transition-colors cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+                class="flex items-center justify-center hover:text-brand-text-primary transition-colors font-semibold uppercase tracking-wider min-w-0 w-full"
               >
                 {#snippet label(arrow)}<Clock class="w-4 h-4 shrink-0" /> {arrow}{/snippet}
               </SortableHeader>
@@ -739,7 +739,7 @@
                 active={sortField === "path"}
                 {sortAsc}
                 onclick={() => toggleSort("path")}
-                class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+                class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
               >
                 {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderPath')} {arrow}</span>{/snippet}
               </SortableHeader>
@@ -784,7 +784,7 @@
                 style={gridColsStyle}
                 title={disconnected ? i18n.t('collection.driveDisconnectedTooltip') : undefined}
                 class="grid items-center border-b border-brand-border/40 hover:bg-brand-sidebar/40 group transition-colors py-2.5 px-4 text-sm
-                  {disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}
+                  {disabled ? 'opacity-50 cursor-not-allowed' : ''}
                   {selectedSongIds.has(song.id) ? 'bg-brand-accent/20 border-l-2 border-brand-accent text-brand-accent-text-hover' : (playerStore.currentSong && playerStore.currentSong.id === song.id ? 'bg-brand-accent/10 text-brand-accent-text-hover' : '')}"
               >
                 <div class="text-center flex justify-center relative w-9 h-6 items-center">
@@ -795,7 +795,7 @@
                   {/if}
                   <button
                     onclick={() => !disabled && handlePlaySong(song)}
-                    class="absolute flex items-center justify-center opacity-0 group-hover:opacity-100 text-brand-accent-text hover:text-brand-accent-text-hover transition-all duration-150 cursor-pointer disabled:opacity-0 disabled:cursor-not-allowed"
+                    class="absolute flex items-center justify-center opacity-0 group-hover:opacity-100 text-brand-accent-text hover:text-brand-accent-text-hover transition-all duration-150 disabled:opacity-0 disabled:cursor-not-allowed"
                     disabled={disabled}
                     title={disconnected ? i18n.t('collection.driveDisconnectedTooltip') : i18n.t('collection.playSong')}
                   >
@@ -956,7 +956,7 @@
                   <div class="flex items-center justify-center gap-2.5">
                     <button
                       onclick={() => handleAddSongToPlaylist(song.id)}
-                      class="text-brand-text-secondary hover:text-brand-accent-text transition-colors cursor-pointer"
+                      class="text-brand-text-secondary hover:text-brand-accent-text transition-colors"
                       title={playlistsStore.activeCustomPlaylist
                         ? i18n.t('collection.addPlaylistTooltip', { name: playlistsStore.activeCustomPlaylist.name })
                         : i18n.t('collection.addPlaylistTooltipDefault')}
@@ -965,7 +965,7 @@
                     </button>
                     <button
                       onclick={() => openTagEditor(song.id)}
-                      class="text-brand-text-secondary hover:text-brand-accent-text transition-colors cursor-pointer"
+                      class="text-brand-text-secondary hover:text-brand-accent-text transition-colors"
                       title={i18n.t('collection.editTagsTooltip')}
                     >
                       <Edit3 class="w-4 h-4" />
@@ -1001,7 +1001,7 @@
             <div class="inline-flex items-center gap-0.5 bg-brand-sidebar border border-brand-border rounded-full p-1">
               <button
                 onclick={() => setActiveViewMode("cards")}
-                class="flex items-center justify-center w-7 h-7 rounded-full transition-colors cursor-pointer {activeViewMode === 'cards' ? 'bg-brand-accent text-white' : 'text-brand-text-secondary hover:text-brand-text-primary'}"
+                class="flex items-center justify-center w-7 h-7 rounded-full transition-colors {activeViewMode === 'cards' ? 'bg-brand-accent text-white' : 'text-brand-text-secondary hover:text-brand-text-primary'}"
                 title={i18n.t('collection.viewCards')}
                 aria-label={i18n.t('collection.viewCards')}
                 aria-pressed={activeViewMode === "cards"}
@@ -1010,7 +1010,7 @@
               </button>
               <button
                 onclick={() => setActiveViewMode("rows")}
-                class="flex items-center justify-center w-7 h-7 rounded-full transition-colors cursor-pointer {activeViewMode === 'rows' ? 'bg-brand-accent text-white' : 'text-brand-text-secondary hover:text-brand-text-primary'}"
+                class="flex items-center justify-center w-7 h-7 rounded-full transition-colors {activeViewMode === 'rows' ? 'bg-brand-accent text-white' : 'text-brand-text-secondary hover:text-brand-text-primary'}"
                 title={i18n.t('collection.viewRows')}
                 aria-label={i18n.t('collection.viewRows')}
                 aria-pressed={activeViewMode === "rows"}
@@ -1245,14 +1245,14 @@
     <div class="h-4 w-px bg-brand-border/60"></div>
     <button
       onclick={handlePlaySelected}
-      class="flex items-center gap-1.5 hover:text-brand-accent-text transition-colors cursor-pointer"
+      class="flex items-center gap-1.5 hover:text-brand-accent-text transition-colors"
     >
       <Play class="w-3.5 h-3.5 fill-current text-brand-accent-text" />
       <span>{i18n.t('playlists.playSelected')}</span>
     </button>
     <button
       onclick={handleBulkAddToPlaylist}
-      class="flex items-center gap-1.5 hover:text-brand-accent-text transition-colors cursor-pointer"
+      class="flex items-center gap-1.5 hover:text-brand-accent-text transition-colors"
     >
       <Plus class="w-3.5 h-3.5 text-brand-accent-text" />
       <span>
@@ -1264,7 +1264,7 @@
     <div class="h-4 w-px bg-brand-border/60"></div>
     <button
       onclick={() => { selectedSongIds = new Set(); }}
-      class="text-brand-text-secondary hover:text-brand-text-primary transition-colors cursor-pointer"
+      class="text-brand-text-secondary hover:text-brand-text-primary transition-colors"
     >
       {i18n.t('playlists.clearSelection')}
     </button>

--- a/src/lib/components/ColumnSelector.svelte
+++ b/src/lib/components/ColumnSelector.svelte
@@ -110,7 +110,7 @@
   <button
     bind:this={buttonEl}
     onclick={toggleMenu}
-    class="flex items-center justify-center gap-2 border border-brand-border text-brand-text-secondary focus:outline-none transition-colors cursor-pointer font-semibold rounded-full
+    class="flex items-center justify-center gap-2 border border-brand-border text-brand-text-secondary focus:outline-none transition-colors font-semibold rounded-full
       {iconOnly
         ? 'w-10 h-10 hover:text-brand-accent-text hover:bg-brand-sidebar shadow-xs'
         : 'bg-brand-sidebar hover:bg-brand-main hover:text-brand-text-primary transition-all ' + (size === 'sm' ? 'px-2.5 h-7 text-[11px] gap-1.5' : 'px-5 py-2 text-sm')}"
@@ -134,7 +134,7 @@
         <div class="px-2 py-2 text-[11px] text-brand-text-secondary/60 italic">No columns visible</div>
       {:else}
         {#each visibleInOrder as col (col.key)}
-          <label class="flex items-center gap-2 px-2 py-1 hover:bg-brand-main/60 rounded-lg text-xs cursor-pointer text-brand-text-primary">
+          <label class="flex items-center gap-2 px-2 py-1 hover:bg-brand-main/60 rounded-lg text-xs text-brand-text-primary">
             <input type="checkbox" checked={collectionStore.visibleColumns[col.key]} onchange={() => collectionStore.toggleColumn(col.key)} class="rounded accent-brand-accent" />
             {i18n.t(col.label)}
           </label>
@@ -146,7 +146,7 @@
         Metatags
       </div>
       {#each METATAG_COLS as col (col.key)}
-        <label class="flex items-center gap-2 px-2 py-1 hover:bg-brand-main/60 rounded-lg text-xs cursor-pointer {collectionStore.visibleColumns[col.key] ? 'text-brand-text-primary' : 'text-brand-text-secondary/70'}">
+        <label class="flex items-center gap-2 px-2 py-1 hover:bg-brand-main/60 rounded-lg text-xs {collectionStore.visibleColumns[col.key] ? 'text-brand-text-primary' : 'text-brand-text-secondary/70'}">
           <input type="checkbox" checked={collectionStore.visibleColumns[col.key]} onchange={() => collectionStore.toggleColumn(col.key)} class="rounded accent-brand-accent" />
           {i18n.t(col.label)}
         </label>
@@ -157,7 +157,7 @@
         Luminous
       </div>
       {#each LUMINOUS_COLS as col (col.key)}
-        <label class="flex items-center gap-2 px-2 py-1 hover:bg-brand-main/60 rounded-lg text-xs cursor-pointer {collectionStore.visibleColumns[col.key] ? 'text-brand-text-primary' : 'text-brand-text-secondary/70'}">
+        <label class="flex items-center gap-2 px-2 py-1 hover:bg-brand-main/60 rounded-lg text-xs {collectionStore.visibleColumns[col.key] ? 'text-brand-text-primary' : 'text-brand-text-secondary/70'}">
           <input type="checkbox" checked={collectionStore.visibleColumns[col.key]} onchange={() => collectionStore.toggleColumn(col.key)} class="rounded accent-brand-accent" />
           {i18n.t(col.label)}
         </label>

--- a/src/lib/components/ConfirmDialog.svelte
+++ b/src/lib/components/ConfirmDialog.svelte
@@ -37,7 +37,7 @@
       <AlertTriangle class="w-4 h-4 {danger ? 'text-red-400' : 'text-brand-accent-text'}" />
       <h3 class="text-sm font-bold">{title}</h3>
     </div>
-    <button onclick={onCancel} class="text-brand-text-secondary hover:text-brand-text-primary transition-colors cursor-pointer">
+    <button onclick={onCancel} class="text-brand-text-secondary hover:text-brand-text-primary transition-colors">
       <X class="w-4 h-4" />
     </button>
   </div>

--- a/src/lib/components/ContextMenuItem.svelte
+++ b/src/lib/components/ContextMenuItem.svelte
@@ -21,10 +21,10 @@
   class="w-full text-left px-3 py-1.5 flex items-center gap-2.5 transition-colors {disabled
     ? 'opacity-40 cursor-not-allowed text-brand-text-secondary'
     : destructive
-      ? 'hover:bg-red-500/10 hover:text-red-400 text-red-400 cursor-pointer'
+      ? 'hover:bg-red-500/10 hover:text-red-400 text-red-400'
       : accent
-        ? 'hover:bg-brand-accent/15 hover:text-brand-accent-text cursor-pointer'
-        : 'hover:bg-brand-main hover:text-brand-text-primary cursor-pointer'}"
+        ? 'hover:bg-brand-accent/15 hover:text-brand-accent-text'
+        : 'hover:bg-brand-main hover:text-brand-text-primary'}"
   role="menuitem"
 >
   <Icon

--- a/src/lib/components/Equalizer.svelte
+++ b/src/lib/components/Equalizer.svelte
@@ -366,14 +366,14 @@
       <!-- Mode segmented control -->
       <div class="flex items-center bg-brand-main border border-brand-border rounded-[2rem] p-0.5" role="group" aria-label={i18n.t('equalizer.modeLabel')}>
         <button
-          class="text-xs font-semibold px-4 py-1.5 rounded-full transition-colors cursor-pointer {mode === 'graphic10' ? 'bg-brand-accent text-brand-accent-contrast shadow-sm' : 'text-brand-text-secondary hover:text-brand-text-primary'}"
+          class="text-xs font-semibold px-4 py-1.5 rounded-full transition-colors {mode === 'graphic10' ? 'bg-brand-accent text-brand-accent-contrast shadow-sm' : 'text-brand-text-secondary hover:text-brand-text-primary'}"
           onclick={() => handleModeChange("graphic10")}
           aria-pressed={mode === "graphic10"}
         >
           {i18n.t('equalizer.modeGraphic')}
         </button>
         <button
-          class="text-xs font-semibold px-4 py-1.5 rounded-full transition-colors cursor-pointer {mode === 'parametric20' ? 'bg-brand-accent text-brand-accent-contrast shadow-sm' : 'text-brand-text-secondary hover:text-brand-text-primary'}"
+          class="text-xs font-semibold px-4 py-1.5 rounded-full transition-colors {mode === 'parametric20' ? 'bg-brand-accent text-brand-accent-contrast shadow-sm' : 'text-brand-text-secondary hover:text-brand-text-primary'}"
           onclick={() => handleModeChange("parametric20")}
           aria-pressed={mode === "parametric20"}
         >
@@ -418,7 +418,7 @@
 
       {#if mode === "parametric20"}
         <button
-          class="text-xs font-semibold px-4 py-1.5 bg-brand-main border border-brand-border rounded-full text-brand-text-secondary hover:text-brand-text-primary transition-colors cursor-pointer"
+          class="text-xs font-semibold px-4 py-1.5 bg-brand-main border border-brand-border rounded-full text-brand-text-secondary hover:text-brand-text-primary transition-colors"
           onclick={resetParametric}
         >
           {i18n.t('equalizer.resetBands')}
@@ -494,7 +494,7 @@
       <div class="grid grid-cols-10 md:grid-cols-[repeat(20,minmax(0,1fr))] gap-1 md:gap-1.5 h-64 md:h-72 items-center bg-brand-main/50 border border-brand-border/50 rounded-xl p-3 md:p-4">
         {#each parametric as band, idx}
           <div
-            class="flex flex-col items-center justify-between h-full group rounded-md transition-colors cursor-pointer {selectedBand === idx ? 'bg-brand-accent/10 ring-1 ring-brand-accent/50' : 'hover:bg-brand-sidebar/30'}"
+            class="flex flex-col items-center justify-between h-full group rounded-md transition-colors {selectedBand === idx ? 'bg-brand-accent/10 ring-1 ring-brand-accent/50' : 'hover:bg-brand-sidebar/30'}"
             onclick={() => (selectedBand = idx)}
             role="button"
             tabindex="0"
@@ -547,7 +547,7 @@
             step="0.1"
             bind:value={parametric[selectedBand].q}
             oninput={() => pushParametricBand(selectedBand)}
-            class="w-full accent-brand-accent bg-brand-main h-1.5 rounded-lg appearance-none cursor-pointer"
+            class="w-full accent-brand-accent bg-brand-main h-1.5 rounded-lg appearance-none"
           />
         </div>
       {/if}
@@ -594,7 +594,7 @@
           <span class="text-[10px] font-bold text-brand-text-secondary uppercase tracking-wider text-center">{i18n.t('loudness.mode')}</span>
           <div class="flex items-center bg-brand-main border border-brand-border rounded-[2rem] p-0.5 mt-1 mx-auto w-full max-w-[200px]" role="group" aria-label={i18n.t('loudness.mode')}>
             <button
-              class="flex-1 text-xs font-semibold px-4 py-1.5 rounded-full transition-colors cursor-pointer {loudnessMode === 'track' ? 'bg-brand-accent text-brand-accent-contrast shadow-sm' : 'text-brand-text-secondary hover:text-brand-text-primary'}"
+              class="flex-1 text-xs font-semibold px-4 py-1.5 rounded-full transition-colors {loudnessMode === 'track' ? 'bg-brand-accent text-brand-accent-contrast shadow-sm' : 'text-brand-text-secondary hover:text-brand-text-primary'}"
               onclick={() => handleLoudnessModeChange("track")}
               aria-pressed={loudnessMode === "track"}
               disabled={!loudnessStore.enabled}
@@ -602,7 +602,7 @@
               {i18n.t('loudness.modeTrack')}
             </button>
             <button
-              class="flex-1 text-xs font-semibold px-4 py-1.5 rounded-full transition-colors cursor-pointer {loudnessMode === 'album' ? 'bg-brand-accent text-brand-accent-contrast shadow-sm' : 'text-brand-text-secondary hover:text-brand-text-primary'}"
+              class="flex-1 text-xs font-semibold px-4 py-1.5 rounded-full transition-colors {loudnessMode === 'album' ? 'bg-brand-accent text-brand-accent-contrast shadow-sm' : 'text-brand-text-secondary hover:text-brand-text-primary'}"
               onclick={() => handleLoudnessModeChange("album")}
               aria-pressed={loudnessMode === "album"}
               disabled={!loudnessStore.enabled}
@@ -673,7 +673,7 @@
             step="100"
             bind:value={fadePauseDurationMs}
             onchange={saveFadeSettings}
-            class="themed-range w-full h-1.5 rounded-lg cursor-pointer"
+            class="themed-range w-full h-1.5 rounded-lg"
             style={rangeFillStyle(fadePauseDurationMs, 0, 1000)}
           />
           <div class="px-[7px]">
@@ -711,7 +711,7 @@
             step="0.25"
             bind:value={crossfadeAutoDurationSecs}
             onchange={saveFadeSettings}
-            class="themed-range w-full h-1.5 rounded-lg cursor-pointer"
+            class="themed-range w-full h-1.5 rounded-lg"
             style={rangeFillStyle(crossfadeAutoDurationSecs, 0.0, 8.0)}
           />
           <div class="px-[7px]">

--- a/src/lib/components/FoldersView.svelte
+++ b/src/lib/components/FoldersView.svelte
@@ -292,37 +292,37 @@
     <div class="flex bg-brand-sidebar border border-brand-border rounded-xl p-0.5 text-xs shadow-sm">
       <button
         onclick={() => { settingsTab = "general"; }}
-        class="px-4 py-1.5 rounded-lg font-semibold transition-all cursor-pointer {settingsTab === 'general' ? 'bg-brand-accent text-brand-accent-contrast shadow-md' : 'text-brand-text-secondary hover:text-brand-text-primary'}"
+        class="px-4 py-1.5 rounded-lg font-semibold transition-all {settingsTab === 'general' ? 'bg-brand-accent text-brand-accent-contrast shadow-md' : 'text-brand-text-secondary hover:text-brand-text-primary'}"
       >
         {i18n.t('settings.tabGeneral')}
       </button>
       <button
         onclick={() => { settingsTab = "folders"; }}
-        class="px-4 py-1.5 rounded-lg font-semibold transition-all cursor-pointer {settingsTab === 'folders' ? 'bg-brand-accent text-brand-accent-contrast shadow-md' : 'text-brand-text-secondary hover:text-brand-text-primary'}"
+        class="px-4 py-1.5 rounded-lg font-semibold transition-all {settingsTab === 'folders' ? 'bg-brand-accent text-brand-accent-contrast shadow-md' : 'text-brand-text-secondary hover:text-brand-text-primary'}"
       >
         {i18n.t('settings.tabFolders')}
       </button>
       <button
         onclick={() => { settingsTab = "tools"; }}
-        class="px-4 py-1.5 rounded-lg font-semibold transition-all cursor-pointer {settingsTab === 'tools' ? 'bg-brand-accent text-brand-accent-contrast shadow-md' : 'text-brand-text-secondary hover:text-brand-text-primary'}"
+        class="px-4 py-1.5 rounded-lg font-semibold transition-all {settingsTab === 'tools' ? 'bg-brand-accent text-brand-accent-contrast shadow-md' : 'text-brand-text-secondary hover:text-brand-text-primary'}"
       >
         {i18n.t('settings.tabTools')}
       </button>
       <button
         onclick={() => { settingsTab = "themes"; editingThemeId = null; }}
-        class="px-4 py-1.5 rounded-lg font-semibold transition-all cursor-pointer {settingsTab === 'themes' ? 'bg-brand-accent text-brand-accent-contrast shadow-md' : 'text-brand-text-secondary hover:text-brand-text-primary'}"
+        class="px-4 py-1.5 rounded-lg font-semibold transition-all {settingsTab === 'themes' ? 'bg-brand-accent text-brand-accent-contrast shadow-md' : 'text-brand-text-secondary hover:text-brand-text-primary'}"
       >
         {i18n.t('settings.tabThemes')}
       </button>
       <button
         onclick={() => { settingsTab = "equalizer"; }}
-        class="px-4 py-1.5 rounded-lg font-semibold transition-all cursor-pointer {settingsTab === 'equalizer' ? 'bg-brand-accent text-brand-accent-contrast shadow-md' : 'text-brand-text-secondary hover:text-brand-text-primary'}"
+        class="px-4 py-1.5 rounded-lg font-semibold transition-all {settingsTab === 'equalizer' ? 'bg-brand-accent text-brand-accent-contrast shadow-md' : 'text-brand-text-secondary hover:text-brand-text-primary'}"
       >
         {i18n.t('settings.tabEqualizer')}
       </button>
       <button
         onclick={() => { settingsTab = "about"; }}
-        class="px-4 py-1.5 rounded-lg font-semibold transition-all cursor-pointer {settingsTab === 'about' ? 'bg-brand-accent text-brand-accent-contrast shadow-md' : 'text-brand-text-secondary hover:text-brand-text-primary'}"
+        class="px-4 py-1.5 rounded-lg font-semibold transition-all {settingsTab === 'about' ? 'bg-brand-accent text-brand-accent-contrast shadow-md' : 'text-brand-text-secondary hover:text-brand-text-primary'}"
       >
         {i18n.t('settings.tabAbout')}
       </button>
@@ -422,7 +422,7 @@
             </div>
             <button
               onclick={copyVersion}
-              class="px-3 py-1 rounded-full text-xs font-bold bg-brand-accent/20 text-brand-accent-text border border-brand-accent/30 hover:bg-brand-accent/30 transition-colors cursor-pointer flex items-center gap-1.5"
+              class="px-3 py-1 rounded-full text-xs font-bold bg-brand-accent/20 text-brand-accent-text border border-brand-accent/30 hover:bg-brand-accent/30 transition-colors flex items-center gap-1.5"
               title={i18n.t('settings.copyVersionHint')}
             >
               {#if versionCopied}
@@ -590,7 +590,7 @@
               </div>
               <button
                 onclick={() => handleRemoveDirectory(dir.path)}
-                class="p-2 rounded-lg bg-brand-main hover:bg-red-950/20 text-brand-text-secondary hover:text-red-400 border border-brand-border hover:border-red-900/30 transition-colors cursor-pointer"
+                class="p-2 rounded-lg bg-brand-main hover:bg-red-950/20 text-brand-text-secondary hover:text-red-400 border border-brand-border hover:border-red-900/30 transition-colors"
                 title={i18n.t('settings.folderItemStopWatch')}
               >
                 <Trash2 class="w-4 h-4 text-brand-accent-text" />
@@ -755,9 +755,9 @@
             <div class="space-y-1 min-w-0">
               <h3 class="font-bold text-sm text-brand-text-primary">{i18n.t('settings.acoustidIntegration')}</h3>
               <p class="text-xs text-brand-text-secondary leading-relaxed">
-                {i18n.t('settings.acoustidDesc1')}<button onclick={() => openExternalUrl("https://acoustid.org")} class="text-brand-accent hover:underline cursor-pointer">AcoustID</button>{i18n.t('settings.acoustidDesc2')}
+                {i18n.t('settings.acoustidDesc1')}<button onclick={() => openExternalUrl("https://acoustid.org")} class="text-brand-accent hover:underline">AcoustID</button>{i18n.t('settings.acoustidDesc2')}
                 <br />
-                {i18n.t('settings.acoustidDesc3')}<button onclick={() => collectionStore.activeTab = 'help'} class="text-brand-accent hover:underline cursor-pointer">{i18n.t('settings.acoustidUserGuide')}</button>{i18n.t('settings.acoustidDesc4')}
+                {i18n.t('settings.acoustidDesc3')}<button onclick={() => collectionStore.activeTab = 'help'} class="text-brand-accent hover:underline">{i18n.t('settings.acoustidUserGuide')}</button>{i18n.t('settings.acoustidDesc4')}
               </p>
             </div>
           </div>
@@ -783,7 +783,7 @@
               <button 
                 type="button"
                 onclick={() => showAcoustidKey = !showAcoustidKey}
-                class="absolute right-3 top-1/2 -translate-y-1/2 text-brand-text-secondary hover:text-brand-text-primary transition-colors cursor-pointer"
+                class="absolute right-3 top-1/2 -translate-y-1/2 text-brand-text-secondary hover:text-brand-text-primary transition-colors"
                 title={showAcoustidKey ? "Hide key" : "Show key"}
               >
                 {#if showAcoustidKey}
@@ -818,7 +818,7 @@
               {@const previewColors = getPreviewColors(theme)}
               <button
                 onclick={() => themeStore.setTheme(theme.id)}
-                class="bg-brand-main/50 border-2 rounded-xl p-4 flex flex-col items-start gap-3 text-left transition-colors duration-200 group hover:border-brand-accent/40 cursor-pointer w-full relative {themeStore.activeThemeId === theme.id ? 'border-brand-accent shadow-md shadow-brand-accent/5' : 'border-brand-border/60'}"
+                class="bg-brand-main/50 border-2 rounded-xl p-4 flex flex-col items-start gap-3 text-left transition-colors duration-200 group hover:border-brand-accent/40 w-full relative {themeStore.activeThemeId === theme.id ? 'border-brand-accent shadow-md shadow-brand-accent/5' : 'border-brand-border/60'}"
               >
                 <div class="flex items-center justify-between w-full">
                   <span class="font-semibold text-sm text-brand-text-primary flex items-center gap-1.5">
@@ -859,7 +859,7 @@
                   onclick={() => themeStore.setTheme(theme.id)}
                   role="button"
                   tabindex="0"
-                  class="bg-brand-main/50 border-2 rounded-xl p-4 flex flex-col gap-3 text-left transition-colors cursor-pointer w-full {themeStore.activeThemeId === theme.id ? 'border-brand-accent shadow-md shadow-brand-accent/5' : 'border-brand-border/60 hover:border-brand-border'}"
+                  class="bg-brand-main/50 border-2 rounded-xl p-4 flex flex-col gap-3 text-left transition-colors w-full {themeStore.activeThemeId === theme.id ? 'border-brand-accent shadow-md shadow-brand-accent/5' : 'border-brand-border/60 hover:border-brand-border'}"
                 >
                   <div class="flex items-center justify-between w-full">
                     <span class="font-semibold text-sm text-brand-text-primary truncate">{theme.name}</span>
@@ -876,14 +876,14 @@
                   <div class="flex gap-2">
                     <button
                       onclick={(e) => { e.stopPropagation(); editingThemeId = theme.id; }}
-                      class="flex-1 px-2 py-1 rounded text-xs font-semibold bg-brand-accent hover:bg-brand-accent-hover text-brand-accent-contrast transition-colors cursor-pointer"
+                      class="flex-1 px-2 py-1 rounded text-xs font-semibold bg-brand-accent hover:bg-brand-accent-hover text-brand-accent-contrast transition-colors"
                       title={i18n.t('settings.editTheme')}
                     >
                       {i18n.t('settings.editThemeShort')}
                     </button>
                     <button
                       onclick={(e) => { e.stopPropagation(); themeStore.deleteCustomTheme(theme.id); }}
-                      class="p-1 rounded bg-brand-main hover:bg-red-950/20 text-brand-text-secondary hover:text-red-400 border border-brand-border hover:border-red-900/30 transition-colors cursor-pointer"
+                      class="p-1 rounded bg-brand-main hover:bg-red-950/20 text-brand-text-secondary hover:text-red-400 border border-brand-border hover:border-red-900/30 transition-colors"
                       title={i18n.t('settings.deleteTheme')}
                     >
                       <Trash2 class="w-3.5 h-3.5" />
@@ -936,7 +936,7 @@
                 <!-- Dark Muted (Main Background) -->
                 <div class="flex items-center gap-3">
                   <div class="flex items-center rounded border border-brand-border bg-brand-main overflow-hidden shrink-0">
-                    <input type="color" bind:value={customColors['bg-main']} class="w-9 h-9 cursor-pointer bg-transparent border-none shrink-0" />
+                    <input type="color" bind:value={customColors['bg-main']} class="w-9 h-9 bg-transparent border-none shrink-0" />
                     <input type="text" bind:value={customColors['bg-main']} maxlength="7" class="w-16 h-9 px-2 text-[11px] bg-transparent text-brand-text-primary outline-none font-mono uppercase" />
                   </div>
                   <div class="flex flex-col min-w-0">
@@ -948,7 +948,7 @@
                 <!-- Dark Vibrant (Sidebar Background) -->
                 <div class="flex items-center gap-3">
                   <div class="flex items-center rounded border border-brand-border bg-brand-main overflow-hidden shrink-0">
-                    <input type="color" bind:value={customColors['bg-sidebar']} class="w-9 h-9 cursor-pointer bg-transparent border-none shrink-0" />
+                    <input type="color" bind:value={customColors['bg-sidebar']} class="w-9 h-9 bg-transparent border-none shrink-0" />
                     <input type="text" bind:value={customColors['bg-sidebar']} maxlength="7" class="w-16 h-9 px-2 text-[11px] bg-transparent text-brand-text-primary outline-none font-mono uppercase" />
                   </div>
                   <div class="flex flex-col min-w-0">
@@ -960,7 +960,7 @@
                 <!-- Light Muted (Player Bar Background) -->
                 <div class="flex items-center gap-3">
                   <div class="flex items-center rounded border border-brand-border bg-brand-main overflow-hidden shrink-0">
-                    <input type="color" bind:value={customColors['bg-playerbar']} class="w-9 h-9 cursor-pointer bg-transparent border-none shrink-0" />
+                    <input type="color" bind:value={customColors['bg-playerbar']} class="w-9 h-9 bg-transparent border-none shrink-0" />
                     <input type="text" bind:value={customColors['bg-playerbar']} maxlength="7" class="w-16 h-9 px-2 text-[11px] bg-transparent text-brand-text-primary outline-none font-mono uppercase" />
                   </div>
                   <div class="flex flex-col min-w-0">
@@ -972,7 +972,7 @@
                 <!-- Vibrant (Accent Color) -->
                 <div class="flex items-center gap-3">
                   <div class="flex items-center rounded border border-brand-border bg-brand-main overflow-hidden shrink-0">
-                    <input type="color" bind:value={customColors['color-accent']} class="w-9 h-9 cursor-pointer bg-transparent border-none shrink-0" />
+                    <input type="color" bind:value={customColors['color-accent']} class="w-9 h-9 bg-transparent border-none shrink-0" />
                     <input type="text" bind:value={customColors['color-accent']} maxlength="7" class="w-16 h-9 px-2 text-[11px] bg-transparent text-brand-text-primary outline-none font-mono uppercase" />
                   </div>
                   <div class="flex flex-col min-w-0">
@@ -984,7 +984,7 @@
                 <!-- Light Vibrant (Accent Hover Color) -->
                 <div class="flex items-center gap-3">
                   <div class="flex items-center rounded border border-brand-border bg-brand-main overflow-hidden shrink-0">
-                    <input type="color" bind:value={customColors['color-accent-hover']} class="w-9 h-9 cursor-pointer bg-transparent border-none shrink-0" />
+                    <input type="color" bind:value={customColors['color-accent-hover']} class="w-9 h-9 bg-transparent border-none shrink-0" />
                     <input type="text" bind:value={customColors['color-accent-hover']} maxlength="7" class="w-16 h-9 px-2 text-[11px] bg-transparent text-brand-text-primary outline-none font-mono uppercase" />
                   </div>
                   <div class="flex flex-col min-w-0">
@@ -996,7 +996,7 @@
                 <!-- Muted (Border Color) -->
                 <div class="flex items-center gap-3">
                   <div class="flex items-center rounded border border-brand-border bg-brand-main overflow-hidden shrink-0">
-                    <input type="color" bind:value={customColors['color-border']} class="w-9 h-9 cursor-pointer bg-transparent border-none shrink-0" />
+                    <input type="color" bind:value={customColors['color-border']} class="w-9 h-9 bg-transparent border-none shrink-0" />
                     <input type="text" bind:value={customColors['color-border']} maxlength="7" class="w-16 h-9 px-2 text-[11px] bg-transparent text-brand-text-primary outline-none font-mono uppercase" />
                   </div>
                   <div class="flex flex-col min-w-0">
@@ -1032,7 +1032,7 @@
               {i18n.t('settings.aboutCreatedByPrefix', {}, 'Created by ')}
               <button
                 onclick={() => openExternalUrl("https://esoltys.dev/")}
-                class="text-brand-accent-text hover:text-brand-accent-text-hover font-bold hover:underline cursor-pointer transition-colors"
+                class="text-brand-accent-text hover:text-brand-accent-text-hover font-bold hover:underline transition-colors"
                 title="Eric Soltys — esoltys.dev"
               >
                 Eric Soltys 🍁
@@ -1046,7 +1046,7 @@
         <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
           <button
             onclick={() => openExternalUrl("https://esoltys.dev/luminous")}
-            class="bg-brand-sidebar/60 border border-brand-border hover:border-brand-accent/50 rounded-xl p-4 flex items-center gap-3 text-left transition-all group cursor-pointer"
+            class="bg-brand-sidebar/60 border border-brand-border hover:border-brand-accent/50 rounded-xl p-4 flex items-center gap-3 text-left transition-all group"
           >
             <div class="w-9 h-9 rounded-lg bg-brand-main border border-brand-border flex items-center justify-center text-brand-accent-text shrink-0 group-hover:scale-105 transition-transform">
               <Home class="w-5 h-5" />
@@ -1059,7 +1059,7 @@
 
           <button
             onclick={() => openExternalUrl("https://github.com/esoltys/luminous/blob/main/CREDITS.md")}
-            class="bg-brand-sidebar/60 border border-brand-border hover:border-brand-accent/50 rounded-xl p-4 flex items-center gap-3 text-left transition-all group cursor-pointer"
+            class="bg-brand-sidebar/60 border border-brand-border hover:border-brand-accent/50 rounded-xl p-4 flex items-center gap-3 text-left transition-all group"
           >
             <div class="w-9 h-9 rounded-lg bg-brand-main border border-brand-border flex items-center justify-center text-brand-accent-text shrink-0 group-hover:scale-105 transition-transform">
               <Info class="w-5 h-5" />
@@ -1072,7 +1072,7 @@
 
           <button
             onclick={() => openExternalUrl("https://github.com/esoltys/luminous/blob/main/LICENSE")}
-            class="bg-brand-sidebar/60 border border-brand-border hover:border-brand-accent/50 rounded-xl p-4 flex items-center gap-3 text-left transition-all group cursor-pointer"
+            class="bg-brand-sidebar/60 border border-brand-border hover:border-brand-accent/50 rounded-xl p-4 flex items-center gap-3 text-left transition-all group"
           >
             <div class="w-9 h-9 rounded-lg bg-brand-main border border-brand-border flex items-center justify-center text-brand-accent-text shrink-0 group-hover:scale-105 transition-transform">
               <Shield class="w-5 h-5" />
@@ -1085,7 +1085,7 @@
 
           <button
             onclick={() => openExternalUrl("https://github.com/esoltys/luminous")}
-            class="bg-brand-sidebar/60 border border-brand-border hover:border-brand-accent/50 rounded-xl p-4 flex items-center gap-3 text-left transition-all group cursor-pointer"
+            class="bg-brand-sidebar/60 border border-brand-border hover:border-brand-accent/50 rounded-xl p-4 flex items-center gap-3 text-left transition-all group"
           >
             <div class="w-9 h-9 rounded-lg bg-brand-main border border-brand-border flex items-center justify-center text-brand-accent-text shrink-0 group-hover:scale-105 transition-transform">
               <svg viewBox="0 0 24 24" fill="currentColor" class="w-5 h-5" aria-hidden="true">
@@ -1100,7 +1100,7 @@
 
           <button
             onclick={() => openExternalUrl("https://github.com/esoltys/luminous/discussions")}
-            class="bg-brand-sidebar/60 border border-brand-border hover:border-brand-accent/50 rounded-xl p-4 flex items-center gap-3 text-left transition-all group cursor-pointer"
+            class="bg-brand-sidebar/60 border border-brand-border hover:border-brand-accent/50 rounded-xl p-4 flex items-center gap-3 text-left transition-all group"
           >
             <div class="w-9 h-9 rounded-lg bg-brand-main border border-brand-border flex items-center justify-center text-brand-accent-text shrink-0 group-hover:scale-105 transition-transform">
               <MessageCircle class="w-5 h-5" />
@@ -1113,7 +1113,7 @@
 
           <button
             onclick={() => openExternalUrl("https://github.com/esoltys/luminous/issues")}
-            class="bg-brand-sidebar/60 border border-brand-border hover:border-brand-accent/50 rounded-xl p-4 flex items-center gap-3 text-left transition-all group cursor-pointer"
+            class="bg-brand-sidebar/60 border border-brand-border hover:border-brand-accent/50 rounded-xl p-4 flex items-center gap-3 text-left transition-all group"
           >
             <div class="w-9 h-9 rounded-lg bg-brand-main border border-brand-border flex items-center justify-center text-brand-accent-text shrink-0 group-hover:scale-105 transition-transform">
               <Bug class="w-5 h-5" />

--- a/src/lib/components/HeartToggle.svelte
+++ b/src/lib/components/HeartToggle.svelte
@@ -56,7 +56,7 @@
   bind:this={buttonEl}
   type="button"
   onclick={handleClick}
-  class="inline-flex transition-colors cursor-pointer {favorite
+  class="inline-flex transition-colors {favorite
     ? 'text-brand-accent-text'
     : 'text-brand-text-secondary/60 hover:text-brand-accent-text'}"
   title={favorite ? i18n.t('rating.unfavoriteTooltip') : i18n.t('rating.favoriteTooltip')}

--- a/src/lib/components/HomeRowList.svelte
+++ b/src/lib/components/HomeRowList.svelte
@@ -136,7 +136,7 @@
         onclick={() => openItem(item)}
         oncontextmenu={(e) => handleContextMenu(e, item)}
         onkeydown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); openItem(item); } }}
-        class="group flex items-center gap-3 px-3 py-2.5 rounded-lg bg-brand-sidebar border border-brand-border/60 outline-2 -outline-offset-2 outline-transparent hover:outline-brand-accent transition-[outline-color,border-color] duration-200 cursor-pointer select-none"
+        class="group flex items-center gap-3 px-3 py-2.5 rounded-lg bg-brand-sidebar border border-brand-border/60 outline-2 -outline-offset-2 outline-transparent hover:outline-brand-accent transition-[outline-color,border-color] duration-200 select-none"
       >
         {#if variant === "rank"}
           <span class="w-5 shrink-0 text-center text-sm font-bold text-brand-text-secondary tabular-nums">

--- a/src/lib/components/HorizontalScrollRow.svelte
+++ b/src/lib/components/HorizontalScrollRow.svelte
@@ -67,7 +67,7 @@
         <button
           onclick={() => scroll("left")}
           disabled={!canScrollLeft}
-          class="p-1.5 rounded-full text-brand-text-primary hover:bg-brand-sidebar transition-colors cursor-pointer disabled:opacity-30 disabled:cursor-not-allowed"
+          class="p-1.5 rounded-full text-brand-text-primary hover:bg-brand-sidebar transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
           title={i18n.t('common.scrollLeft')}
           aria-label={i18n.t('common.scrollLeft')}
         >
@@ -76,7 +76,7 @@
         <button
           onclick={() => scroll("right")}
           disabled={!canScrollRight}
-          class="p-1.5 rounded-full text-brand-text-primary hover:bg-brand-sidebar transition-colors cursor-pointer disabled:opacity-30 disabled:cursor-not-allowed"
+          class="p-1.5 rounded-full text-brand-text-primary hover:bg-brand-sidebar transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
           title={i18n.t('common.scrollRight')}
           aria-label={i18n.t('common.scrollRight')}
         >

--- a/src/lib/components/IconActionButton.svelte
+++ b/src/lib/components/IconActionButton.svelte
@@ -16,7 +16,7 @@
   {onclick}
   {disabled}
   {title}
-  class="flex items-center justify-center w-10 h-10 rounded-full border border-brand-border text-brand-text-secondary hover:text-brand-accent-text hover:bg-brand-sidebar transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed shadow-xs {extraClass}"
+  class="flex items-center justify-center w-10 h-10 rounded-full border border-brand-border text-brand-text-secondary hover:text-brand-accent-text hover:bg-brand-sidebar transition-colors disabled:opacity-50 disabled:cursor-not-allowed shadow-xs {extraClass}"
 >
   {@render icon()}
 </button>

--- a/src/lib/components/KeyboardShortcutsModal.svelte
+++ b/src/lib/components/KeyboardShortcutsModal.svelte
@@ -56,7 +56,7 @@
     </div>
     <button
       onclick={onClose}
-      class="text-brand-text-secondary hover:text-brand-text-primary p-1.5 rounded-lg hover:bg-brand-main/80 transition-colors cursor-pointer"
+      class="text-brand-text-secondary hover:text-brand-text-primary p-1.5 rounded-lg hover:bg-brand-main/80 transition-colors"
     >
       <X class="w-4 h-4" />
     </button>

--- a/src/lib/components/LinkButton.svelte
+++ b/src/lib/components/LinkButton.svelte
@@ -15,7 +15,7 @@
   type="button"
   {onclick}
   {title}
-  class="text-left cursor-pointer hover:underline hover:text-brand-accent-text transition-colors max-w-full {className}"
+  class="text-left hover:underline hover:text-brand-accent-text transition-colors max-w-full {className}"
 >
   {@render children()}
 </button>

--- a/src/lib/components/LyricsView.svelte
+++ b/src/lib/components/LyricsView.svelte
@@ -309,7 +309,7 @@
               <p
                 data-index={idx}
                 onclick={() => playerStore.seek(line.timeMs * 1_000_000)}
-                class="text-xl md:text-2xl font-bold cursor-pointer transition-all duration-300 transform {isActive ? 'text-brand-text-primary scale-105 filter drop-shadow-[0_0_8px_var(--color-brand-accent)] font-extrabold' : 'text-brand-text-secondary/30 hover:text-brand-text-secondary/60'}"
+                class="text-xl md:text-2xl font-bold transition-all duration-300 transform {isActive ? 'text-brand-text-primary scale-105 filter drop-shadow-[0_0_8px_var(--color-brand-accent)] font-extrabold' : 'text-brand-text-secondary/30 hover:text-brand-text-secondary/60'}"
               >
                 {line.text || "•••"}
               </p>

--- a/src/lib/components/Miniplayer.svelte
+++ b/src/lib/components/Miniplayer.svelte
@@ -326,7 +326,7 @@
         <!-- Shuffle Mode -->
         <button
           onclick={cycleShuffle}
-          class="p-1.5 transition-colors hover:text-brand-text-primary cursor-pointer flex items-center gap-1 {playerStore.shuffleMode !== 'off' ? 'text-brand-accent-text font-bold' : 'text-brand-text-secondary/60'}"
+          class="p-1.5 transition-colors hover:text-brand-text-primary flex items-center gap-1 {playerStore.shuffleMode !== 'off' ? 'text-brand-accent-text font-bold' : 'text-brand-text-secondary/60'}"
           title={`${i18n.t('playerBar.shuffle')}: ${shuffleModeLabel(playerStore.shuffleMode)} — ${shuffleModeDescription(playerStore.shuffleMode)}`}
         >
           {#if shuffleTypeIcon(playerStore.shuffleMode)}
@@ -339,7 +339,7 @@
         <!-- Skip Previous -->
         <button
           onclick={() => playerStore.previous()}
-          class="p-1.5 text-brand-text-secondary hover:text-brand-text-primary transition-colors cursor-pointer"
+          class="p-1.5 text-brand-text-secondary hover:text-brand-text-primary transition-colors"
           title={i18n.t('playerBar.previous')}
         >
           <SkipBack class="w-5 h-5 fill-current" />
@@ -349,7 +349,7 @@
         {#if playerStore.state === 'playing'}
           <button
             onclick={() => playerStore.pause()}
-            class="w-10 h-10 rounded-full bg-brand-accent hover:bg-brand-accent-hover text-brand-accent-contrast flex items-center justify-center transition-colors cursor-pointer flex-shrink-0"
+            class="w-10 h-10 rounded-full bg-brand-accent hover:bg-brand-accent-hover text-brand-accent-contrast flex items-center justify-center transition-colors flex-shrink-0"
             title={i18n.t('playerBar.pause')}
           >
             <Pause class="w-5 h-5 fill-current" />
@@ -357,7 +357,7 @@
         {:else}
           <button
             onclick={() => playerStore.resume()}
-            class="w-10 h-10 rounded-full bg-brand-accent hover:bg-brand-accent-hover text-brand-accent-contrast flex items-center justify-center transition-colors cursor-pointer flex-shrink-0"
+            class="w-10 h-10 rounded-full bg-brand-accent hover:bg-brand-accent-hover text-brand-accent-contrast flex items-center justify-center transition-colors flex-shrink-0"
             title={i18n.t('playerBar.play')}
           >
             <Play class="w-5 h-5 fill-current ml-0.5" />
@@ -367,7 +367,7 @@
         <!-- Skip Next -->
         <button
           onclick={() => playerStore.next()}
-          class="p-1.5 text-brand-text-secondary hover:text-brand-text-primary transition-colors cursor-pointer"
+          class="p-1.5 text-brand-text-secondary hover:text-brand-text-primary transition-colors"
           title={i18n.t('playerBar.next')}
         >
           <SkipForward class="w-5 h-5 fill-current" />
@@ -376,7 +376,7 @@
         <!-- Repeat Mode -->
         <button
           onclick={cycleRepeat}
-          class="p-1.5 transition-colors hover:text-brand-text-primary cursor-pointer flex items-center gap-1 {playerStore.repeatMode !== 'off' ? 'text-brand-accent-text font-bold' : 'text-brand-text-secondary/60'}"
+          class="p-1.5 transition-colors hover:text-brand-text-primary flex items-center gap-1 {playerStore.repeatMode !== 'off' ? 'text-brand-accent-text font-bold' : 'text-brand-text-secondary/60'}"
           title={`${i18n.t('playerBar.repeat')}: ${repeatModeLabel(playerStore.repeatMode)} — ${repeatModeDescription(playerStore.repeatMode)}`}
         >
           <Repeat class="w-4.5 h-4.5" />
@@ -403,7 +403,7 @@
       <div class="flex items-center gap-1.5">
         <button
           onclick={toggleMute}
-          class="p-1 text-brand-text-secondary/70 hover:text-brand-text-primary transition-colors cursor-pointer"
+          class="p-1 text-brand-text-secondary/70 hover:text-brand-text-primary transition-colors"
           title={i18n.t('playerBar.volume')}
         >
           {#if isMuted || playerStore.volume === 0}
@@ -422,7 +422,7 @@
           onchange={releaseVolumeFocus}
           onpointerup={releaseVolumeFocus}
           onkeyup={releaseVolumeFocus}
-          class="volume-slider w-14 h-1 rounded-lg cursor-pointer outline-none"
+          class="volume-slider w-14 h-1 rounded-lg outline-none"
           style={volumeSliderStyle}
           aria-label={i18n.t('playerBar.volumeSlider')}
           title={i18n.t('playerBar.volumeWithValue', { value: Math.round(volumePercent) })}
@@ -432,7 +432,7 @@
       <!-- Restore -->
       <button
         onclick={() => collectionStore.exitMiniplayerMode()}
-        class="p-1 text-brand-text-secondary hover:text-brand-text-primary hover:bg-brand-border/40 rounded transition-colors cursor-pointer"
+        class="p-1 text-brand-text-secondary hover:text-brand-text-primary hover:bg-brand-border/40 rounded transition-colors"
         title={i18n.t('miniplayer.exit', {}, 'Restore Full Window (Ctrl+M)')}
       >
         <Maximize2 class="w-3.5 h-3.5" />
@@ -470,7 +470,6 @@
     border-radius: 50%;
     background: #ffffff;
     border: 2px solid var(--color-accent);
-    cursor: pointer;
     transition: border-color 0.2s;
   }
 
@@ -484,7 +483,6 @@
     border: 2px solid var(--color-accent);
     border-radius: 50%;
     background: #ffffff;
-    cursor: pointer;
     transition: border-color 0.2s;
   }
 

--- a/src/lib/components/OrganizeFiles.svelte
+++ b/src/lib/components/OrganizeFiles.svelte
@@ -357,13 +357,13 @@
             <div class="flex items-center gap-1.5 bg-brand-sidebar p-1 rounded-lg border border-brand-border/50">
               <button
                 onclick={() => { scope = "selection"; }}
-                class="px-3 py-1 rounded-md transition-colors cursor-pointer {scope === 'selection' ? 'bg-brand-accent text-brand-accent-contrast font-bold shadow-sm' : 'text-brand-text-secondary hover:text-brand-text-primary'}"
+                class="px-3 py-1 rounded-md transition-colors {scope === 'selection' ? 'bg-brand-accent text-brand-accent-contrast font-bold shadow-sm' : 'text-brand-text-secondary hover:text-brand-text-primary'}"
               >
                 {i18n.t("organizer.scopeSelection", { count: songIds.length })}
               </button>
               <button
                 onclick={() => { scope = "library"; }}
-                class="px-3 py-1 rounded-md transition-colors cursor-pointer {scope === 'library' ? 'bg-brand-accent text-brand-accent-contrast font-bold shadow-sm' : 'text-brand-text-secondary hover:text-brand-text-primary'}"
+                class="px-3 py-1 rounded-md transition-colors {scope === 'library' ? 'bg-brand-accent text-brand-accent-contrast font-bold shadow-sm' : 'text-brand-text-secondary hover:text-brand-text-primary'}"
               >
                 {i18n.t("organizer.scopeLibrary", { count: items.length })}
               </button>
@@ -379,7 +379,7 @@
             </label>
             <button
               onclick={() => { template = DEFAULT_TEMPLATE; }}
-              class="text-[11px] text-brand-accent-text hover:underline cursor-pointer"
+              class="text-[11px] text-brand-accent-text hover:underline"
             >
               {i18n.t("organizer.defaultPattern")}
             </button>
@@ -401,7 +401,7 @@
               <button
                 type="button"
                 onclick={() => insertChip(chip.label)}
-                class="px-2 py-0.5 rounded-lg text-[11px] font-mono transition-colors cursor-pointer border bg-brand-sidebar hover:bg-brand-accent/15 border-brand-border/80 text-brand-text-primary hover:text-brand-accent-text font-medium"
+                class="px-2 py-0.5 rounded-lg text-[11px] font-mono transition-colors border bg-brand-sidebar hover:bg-brand-accent/15 border-brand-border/80 text-brand-text-primary hover:text-brand-accent-text font-medium"
                 title={chip.desc}
               >
                 {chip.label === '/' ? '/ (Folder)' : chip.label}
@@ -427,7 +427,7 @@
               />
               <button
                 onclick={selectDestinationDir}
-                class="px-3 py-1.5 bg-brand-sidebar border border-brand-border/80 hover:bg-brand-accent/15 hover:text-brand-accent-text text-brand-text-primary rounded-xl transition-colors cursor-pointer font-medium"
+                class="px-3 py-1.5 bg-brand-sidebar border border-brand-border/80 hover:bg-brand-accent/15 hover:text-brand-accent-text text-brand-text-primary rounded-xl transition-colors font-medium"
               >
                 {i18n.t("organizer.browse")}
               </button>
@@ -754,7 +754,7 @@
 
           <button
             onclick={() => onClose?.()}
-            class="p-1.5 rounded-lg text-brand-text-secondary hover:text-brand-text-primary hover:bg-brand-sidebar/80 transition-colors cursor-pointer"
+            class="p-1.5 rounded-lg text-brand-text-secondary hover:text-brand-text-primary hover:bg-brand-sidebar/80 transition-colors"
             title={i18n.t("organizer.close")}
           >
             <X class="w-4 h-4" />
@@ -777,7 +777,7 @@
             <button
               type="button"
               onclick={() => onClose?.()}
-              class="px-4 py-2 rounded-xl border border-brand-border/80 text-brand-text-primary hover:bg-brand-sidebar transition-colors cursor-pointer"
+              class="px-4 py-2 rounded-xl border border-brand-border/80 text-brand-text-primary hover:bg-brand-sidebar transition-colors"
             >
               {i18n.t("organizer.cancel")}
             </button>

--- a/src/lib/components/PlayerBar.svelte
+++ b/src/lib/components/PlayerBar.svelte
@@ -189,7 +189,7 @@
     <button
       onclick={handleCoverClick}
       disabled={!playerStore.currentSong}
-      class="group relative overflow-hidden focus:outline-hidden flex-shrink-0 cursor-pointer disabled:cursor-default disabled:pointer-events-none active:scale-95 transition-transform duration-200"
+      class="group relative overflow-hidden focus:outline-hidden flex-shrink-0 disabled:cursor-default disabled:pointer-events-none active:scale-95 transition-transform duration-200"
       title={coverTitle}
     >
       <CoverArt
@@ -249,7 +249,7 @@
         {#if playerStore.shuffleMode !== 'off'}
           <button
             onclick={cycleShuffle}
-            class="absolute right-full top-1/2 -translate-y-1/2 mr-1.5 text-[10px] font-semibold text-brand-accent-text hover:text-brand-text-primary transition-colors uppercase tracking-wide whitespace-nowrap cursor-pointer"
+            class="absolute right-full top-1/2 -translate-y-1/2 mr-1.5 text-[10px] font-semibold text-brand-accent-text hover:text-brand-text-primary transition-colors uppercase tracking-wide whitespace-nowrap"
             title={`${i18n.t('playerBar.shuffle')}: ${shuffleModeLabel(playerStore.shuffleMode)} — ${shuffleModeDescription(playerStore.shuffleMode)}`}
           >
             {i18n.t('playerBar.shuffle')} {shuffleModeLabel(playerStore.shuffleMode)}
@@ -309,7 +309,7 @@
         {#if playerStore.repeatMode !== 'off'}
           <button
             onclick={cycleRepeat}
-            class="absolute left-full top-1/2 -translate-y-1/2 ml-1.5 text-[10px] font-semibold text-brand-accent-text hover:text-brand-text-primary transition-colors uppercase tracking-wide whitespace-nowrap cursor-pointer"
+            class="absolute left-full top-1/2 -translate-y-1/2 ml-1.5 text-[10px] font-semibold text-brand-accent-text hover:text-brand-text-primary transition-colors uppercase tracking-wide whitespace-nowrap"
             title={`${i18n.t('playerBar.repeat')}: ${repeatModeLabel(playerStore.repeatMode)} — ${repeatModeDescription(playerStore.repeatMode)}`}
           >
             {i18n.t('playerBar.repeat')} {repeatModeLabel(playerStore.repeatMode)}
@@ -367,14 +367,14 @@
       onchange={releaseVolumeFocus}
       onpointerup={releaseVolumeFocus}
       onkeyup={releaseVolumeFocus}
-      class="volume-slider w-20 h-1 rounded-lg cursor-pointer outline-none"
+      class="volume-slider w-20 h-1 rounded-lg outline-none"
       style={volumeSliderStyle}
       aria-label={i18n.t('playerBar.volumeSlider')}
       title={i18n.t('playerBar.volumeWithValue', { value: Math.round(volumePercent) })}
     />
     <button
       onclick={() => collectionStore.toggleMiniplayerMode()}
-      class="text-brand-text-secondary hover:text-brand-accent-text transition-colors p-1.5 rounded hover:bg-brand-main/60 flex-shrink-0 cursor-pointer"
+      class="text-brand-text-secondary hover:text-brand-accent-text transition-colors p-1.5 rounded hover:bg-brand-main/60 flex-shrink-0"
       title={i18n.t('miniplayer.toggleTooltip', {}, 'Picture-in-Picture Mode (Ctrl+M)')}
     >
 
@@ -385,7 +385,7 @@
 
       <button 
         onclick={() => collectionStore.toggleImmersiveMode()}
-        class="text-brand-text-secondary hover:text-brand-accent-text transition-colors ml-2 p-1.5 rounded hover:bg-brand-main flex-shrink-0 cursor-pointer"
+        class="text-brand-text-secondary hover:text-brand-accent-text transition-colors ml-2 p-1.5 rounded hover:bg-brand-main flex-shrink-0"
         title={i18n.t('playerBar.restoreInterface', {}, 'Restore Full Interface')}
       >
         <PanelBottomOpen class="w-4.5 h-4.5" />
@@ -446,7 +446,6 @@
     border-radius: 50%;
     background: #ffffff;
     border: 2px solid var(--color-accent);
-    cursor: pointer;
     transition: border-color 0.2s;
   }
 
@@ -461,7 +460,6 @@
     border: 2px solid var(--color-accent);
     border-radius: 50%;
     background: #ffffff;
-    cursor: pointer;
     transition: border-color 0.2s;
   }
 

--- a/src/lib/components/PlaylistCard.svelte
+++ b/src/lib/components/PlaylistCard.svelte
@@ -71,7 +71,7 @@
 <!-- svelte-ignore a11y_click_events_have_key_events -->
 <div
   onclick={onClick}
-  class="{widthClass} bg-brand-sidebar border border-brand-border/60 rounded-xl p-4 flex flex-col text-left hover:border-brand-accent/40 transition-all duration-200 cursor-pointer group relative"
+  class="{widthClass} bg-brand-sidebar border border-brand-border/60 rounded-xl p-4 flex flex-col text-left hover:border-brand-accent/40 transition-all duration-200 group relative"
 >
   <div class="aspect-square w-full mb-3 bg-brand-main relative flex items-center justify-center overflow-hidden">
     {#if isQueue}
@@ -110,7 +110,7 @@
 
   <button
     onclick={(e) => { e.stopPropagation(); onClick(); }}
-    class="font-semibold text-sm text-brand-text-primary hover:text-brand-accent-text hover:underline transition-all duration-150 text-left truncate w-full cursor-pointer"
+    class="font-semibold text-sm text-brand-text-primary hover:text-brand-accent-text hover:underline transition-all duration-150 text-left truncate w-full"
     title={cardTitle}
   >
     {cardTitle}
@@ -129,7 +129,7 @@
     {#if !isActive}
       <button
         onclick={(e) => { e.stopPropagation(); playlistsStore.pinPlaylist(playlist.id); }}
-        class="mt-2.5 w-full py-1 px-2.5 text-xs font-semibold rounded-lg bg-brand-main/80 hover:bg-brand-accent hover:text-brand-accent-contrast border border-brand-border/60 text-brand-text-secondary hover:border-transparent transition-all duration-150 flex items-center justify-center gap-1.5 cursor-pointer shadow-xs"
+        class="mt-2.5 w-full py-1 px-2.5 text-xs font-semibold rounded-lg bg-brand-main/80 hover:bg-brand-accent hover:text-brand-accent-contrast border border-brand-border/60 text-brand-text-secondary hover:border-transparent transition-all duration-150 flex items-center justify-center gap-1.5 shadow-xs"
         title={i18n.t('playlists.makeActiveBtn')}
       >
         <Radio class="w-3.5 h-3.5 text-brand-accent-text group-hover:text-current" />

--- a/src/lib/components/PlaylistRowCard.svelte
+++ b/src/lib/components/PlaylistRowCard.svelte
@@ -38,7 +38,7 @@
 <!-- svelte-ignore a11y_click_events_have_key_events -->
 <div
   onclick={onClick}
-  class="group flex items-center gap-3 px-3 py-2.5 rounded-lg bg-brand-sidebar border border-brand-border/60 outline-2 -outline-offset-2 outline-transparent hover:outline-brand-accent transition-[outline-color,border-color] duration-200 cursor-pointer select-none"
+  class="group flex items-center gap-3 px-3 py-2.5 rounded-lg bg-brand-sidebar border border-brand-border/60 outline-2 -outline-offset-2 outline-transparent hover:outline-brand-accent transition-[outline-color,border-color] duration-200 select-none"
 >
   <div
     class="relative shrink-0 w-11 h-11 flex items-center justify-center overflow-hidden border {isQueue

--- a/src/lib/components/PlaylistView.svelte
+++ b/src/lib/components/PlaylistView.svelte
@@ -773,10 +773,10 @@
                 class="bg-brand-sidebar border border-brand-accent text-brand-text-primary px-3 py-1 text-2xl font-bold rounded-lg focus:outline-none"
                 use:focusAndSelect
               />
-              <button onclick={saveRename} class="p-1.5 text-brand-accent-text hover:text-brand-accent cursor-pointer" title={i18n.t('playlists.saveRenameTooltip')}>
+              <button onclick={saveRename} class="p-1.5 text-brand-accent-text hover:text-brand-accent" title={i18n.t('playlists.saveRenameTooltip')}>
                 <Check class="w-5 h-5" />
               </button>
-              <button onclick={cancelRename} class="p-1.5 text-brand-text-secondary hover:text-brand-text-primary cursor-pointer" title={i18n.t('playlists.cancel')}>
+              <button onclick={cancelRename} class="p-1.5 text-brand-text-secondary hover:text-brand-text-primary" title={i18n.t('playlists.cancel')}>
                 <X class="w-5 h-5" />
               </button>
             </div>
@@ -784,14 +784,14 @@
             <div class="flex items-center gap-3 group/title">
               <h1
                 ondblclick={startRename}
-                class="text-3xl sm:text-4xl font-heading font-bold text-brand-text-primary cursor-pointer hover:text-brand-accent-text transition-colors truncate py-0.5 leading-snug"
+                class="text-3xl sm:text-4xl font-heading font-bold text-brand-text-primary hover:text-brand-accent-text transition-colors truncate py-0.5 leading-snug"
                 title={i18n.t("playlists.renamePlaylistTooltip")}
               >
                 {activePlaylist.name}
               </h1>
               <button
                 onclick={startRename}
-                class="opacity-0 group-hover/title:opacity-100 text-brand-text-secondary hover:text-brand-text-primary transition-opacity p-1 cursor-pointer"
+                class="opacity-0 group-hover/title:opacity-100 text-brand-text-secondary hover:text-brand-text-primary transition-opacity p-1"
                 title={i18n.t("playlists.renamePlaylistTooltip")}
               >
                 <Pencil class="w-4 h-4" />
@@ -881,7 +881,7 @@
               {#if filterQuery}
                 <button
                   onclick={() => { filterQuery = ""; }}
-                  class="absolute right-3 top-1/2 -translate-y-1/2 text-brand-text-secondary/60 hover:text-brand-text-primary p-0.5 cursor-pointer"
+                  class="absolute right-3 top-1/2 -translate-y-1/2 text-brand-text-secondary/60 hover:text-brand-text-primary p-0.5"
                   title={i18n.t("playlists.clearFilter")}
                 >
                   <X class="w-3.5 h-3.5" />
@@ -900,7 +900,7 @@
                 bind:this={overflowButtonEl}
                 onclick={toggleOverflowMenu}
                 title={i18n.t("playlists.moreActionsTooltip")}
-                class="flex items-center justify-center w-10 h-10 rounded-full border border-brand-border text-brand-text-secondary hover:text-brand-accent-text hover:bg-brand-sidebar transition-colors cursor-pointer shadow-xs"
+                class="flex items-center justify-center w-10 h-10 rounded-full border border-brand-border text-brand-text-secondary hover:text-brand-accent-text hover:bg-brand-sidebar transition-colors shadow-xs"
               >
                 <MoreHorizontal class="w-4 h-4" />
               </button>
@@ -952,7 +952,7 @@
             active={sortField === "position"}
             {sortAsc}
             onclick={() => toggleSort("position")}
-            class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0"
+            class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 font-semibold uppercase tracking-wider min-w-0"
           >
             {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-1rem)]">{i18n.t("playlists.tableHeaderTrack")} {arrow}</span>{/snippet}
           </SortableHeader>
@@ -962,7 +962,7 @@
               active={sortField === "title"}
               {sortAsc}
               onclick={() => toggleSort("title")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-1rem)]">{i18n.t("playlists.tableHeaderTitle")} {arrow}</span>{/snippet}
             </SortableHeader>
@@ -974,7 +974,7 @@
               active={sortField === "artist"}
               {sortAsc}
               onclick={() => toggleSort("artist")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-1rem)]">{i18n.t("playlists.tableHeaderArtist")} {arrow}</span>{/snippet}
             </SortableHeader>
@@ -986,7 +986,7 @@
               active={sortField === "album"}
               {sortAsc}
               onclick={() => toggleSort("album")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-1rem)]">{i18n.t("collection.tableHeaderAlbum")} {arrow}</span>{/snippet}
             </SortableHeader>
@@ -999,7 +999,7 @@
               active={sortField === "composer"}
               {sortAsc}
               onclick={() => toggleSort("composer")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderComposer')} {arrow}</span>{/snippet}
             </SortableHeader>
@@ -1011,7 +1011,7 @@
               active={sortField === "album_artist"}
               {sortAsc}
               onclick={() => toggleSort("album_artist")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderAlbumArtist')} {arrow}</span>{/snippet}
             </SortableHeader>
@@ -1023,7 +1023,7 @@
               active={sortField === "filetype"}
               {sortAsc}
               onclick={() => toggleSort("filetype")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderFormat')} {arrow}</span>{/snippet}
             </SortableHeader>
@@ -1035,7 +1035,7 @@
               active={sortField === "year"}
               {sortAsc}
               onclick={() => toggleSort("year")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderYear')} {arrow}</span>{/snippet}
             </SortableHeader>
@@ -1047,7 +1047,7 @@
               active={sortField === "genre"}
               {sortAsc}
               onclick={() => toggleSort("genre")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderGenre')} {arrow}</span>{/snippet}
             </SortableHeader>
@@ -1059,7 +1059,7 @@
               active={sortField === "grouping"}
               {sortAsc}
               onclick={() => toggleSort("grouping")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderGrouping')} {arrow}</span>{/snippet}
             </SortableHeader>
@@ -1071,7 +1071,7 @@
               active={sortField === "bpm"}
               {sortAsc}
               onclick={() => toggleSort("bpm")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderBpm')} {arrow}</span>{/snippet}
             </SortableHeader>
@@ -1083,7 +1083,7 @@
               active={sortField === "initial_key"}
               {sortAsc}
               onclick={() => toggleSort("initial_key")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderInitialKey')} {arrow}</span>{/snippet}
             </SortableHeader>
@@ -1095,7 +1095,7 @@
               active={sortField === "bitrate"}
               {sortAsc}
               onclick={() => toggleSort("bitrate")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderBitrate')} {arrow}</span>{/snippet}
             </SortableHeader>
@@ -1107,7 +1107,7 @@
               active={sortField === "samplerate"}
               {sortAsc}
               onclick={() => toggleSort("samplerate")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderSampleRate')} {arrow}</span>{/snippet}
             </SortableHeader>
@@ -1119,7 +1119,7 @@
               active={sortField === "bitdepth"}
               {sortAsc}
               onclick={() => toggleSort("bitdepth")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderBitDepth')} {arrow}</span>{/snippet}
             </SortableHeader>
@@ -1131,7 +1131,7 @@
               active={sortField === "channels"}
               {sortAsc}
               onclick={() => toggleSort("channels")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderChannels')} {arrow}</span>{/snippet}
             </SortableHeader>
@@ -1143,7 +1143,7 @@
               active={sortField === "filesize"}
               {sortAsc}
               onclick={() => toggleSort("filesize")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderFileSize')} {arrow}</span>{/snippet}
             </SortableHeader>
@@ -1155,7 +1155,7 @@
               active={sortField === "rating"}
               {sortAsc}
               onclick={() => toggleSort("rating")}
-              class="flex items-center justify-center hover:text-brand-text-primary transition-colors cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+              class="flex items-center justify-center hover:text-brand-text-primary transition-colors font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate">{i18n.t('collection.tableHeaderRating')} {arrow}</span>{/snippet}
             </SortableHeader>
@@ -1167,7 +1167,7 @@
               active={sortField === "playcount"}
               {sortAsc}
               onclick={() => toggleSort("playcount")}
-              class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+              class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate">{i18n.t('collection.tableHeaderPlays')} {arrow}</span>{/snippet}
             </SortableHeader>
@@ -1179,7 +1179,7 @@
               active={sortField === "skipcount"}
               {sortAsc}
               onclick={() => toggleSort("skipcount")}
-              class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+              class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate">{i18n.t('collection.tableHeaderSkips')} {arrow}</span>{/snippet}
             </SortableHeader>
@@ -1191,7 +1191,7 @@
               active={sortField === "lastplayed"}
               {sortAsc}
               onclick={() => toggleSort("lastplayed")}
-              class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+              class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate">{i18n.t('collection.tableHeaderLastPlayed')} {arrow}</span>{/snippet}
             </SortableHeader>
@@ -1203,7 +1203,7 @@
               active={sortField === "added"}
               {sortAsc}
               onclick={() => toggleSort("added")}
-              class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+              class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate">{i18n.t('collection.tableHeaderAdded')} {arrow}</span>{/snippet}
             </SortableHeader>
@@ -1215,7 +1215,7 @@
               active={sortField === "length_nanosec"}
               {sortAsc}
               onclick={() => toggleSort("length_nanosec")}
-              class="flex items-center justify-center hover:text-brand-text-primary transition-colors cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+              class="flex items-center justify-center hover:text-brand-text-primary transition-colors font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<Clock class="w-4 h-4 shrink-0" /> {arrow}{/snippet}
             </SortableHeader>
@@ -1227,7 +1227,7 @@
               active={sortField === "path"}
               {sortAsc}
               onclick={() => toggleSort("path")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 cursor-pointer font-semibold uppercase tracking-wider min-w-0 w-full"
+              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
             >
               {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderPath')} {arrow}</span>{/snippet}
             </SortableHeader>
@@ -1292,7 +1292,7 @@
                 {/if}
                 <button
                   onclick={(e) => { e.stopPropagation(); if (!unavailable) handlePlayPlaylistItem(item); }}
-                  class="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 text-brand-accent-text hover:text-brand-accent-text-hover transition-opacity cursor-pointer disabled:opacity-0 disabled:cursor-not-allowed"
+                  class="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 text-brand-accent-text hover:text-brand-accent-text-hover transition-opacity disabled:opacity-0 disabled:cursor-not-allowed"
                   disabled={unavailable}
                   title={i18n.t("playlists.playTrack")}
                 >
@@ -1486,7 +1486,7 @@
                 <div class="flex items-center justify-center gap-2.5">
                   <button
                     onclick={(e) => { e.stopPropagation(); item.song?.id && !unavailable && openTagEditor(item.song.id); }}
-                    class="text-brand-text-primary/60 hover:text-brand-accent-text transition-colors disabled:opacity-30 cursor-pointer"
+                    class="text-brand-text-primary/60 hover:text-brand-accent-text transition-colors disabled:opacity-30"
                     title={i18n.t("collection.editTagsTooltip")}
                     disabled={!item.song || unavailable}
                   >
@@ -1494,7 +1494,7 @@
                   </button>
                   <button
                     onclick={(e) => { e.stopPropagation(); handleRemoveItem(item.uuid); }}
-                    class="text-brand-text-primary/60 hover:text-red-400 transition-colors cursor-pointer"
+                    class="text-brand-text-primary/60 hover:text-red-400 transition-colors"
                     title={i18n.t("playlists.removeFromPlaylist")}
                   >
                     <Trash2 class="w-4 h-4" />
@@ -1531,14 +1531,14 @@
         <div class="h-4 w-px bg-brand-border/60"></div>
         <button
           onclick={playSelected}
-          class="flex items-center gap-1.5 hover:text-brand-accent-text transition-colors cursor-pointer"
+          class="flex items-center gap-1.5 hover:text-brand-accent-text transition-colors"
         >
           <Play class="w-3.5 h-3.5 fill-current text-brand-accent-text" />
           <span>{i18n.t("playlists.playSelected")}</span>
         </button>
         <button
           onclick={removeSelected}
-          class="flex items-center gap-1.5 text-red-400 hover:text-red-300 transition-colors cursor-pointer"
+          class="flex items-center gap-1.5 text-red-400 hover:text-red-300 transition-colors"
         >
           <Trash2 class="w-3.5 h-3.5" />
           <span>{i18n.t("playlists.removeSelected")}</span>
@@ -1546,7 +1546,7 @@
         <div class="h-4 w-px bg-brand-border/60"></div>
         <button
           onclick={() => { selectedUuids = new Set(); lastSelectedIndex = null; }}
-          class="text-brand-text-primary hover:text-brand-text-primary transition-colors cursor-pointer"
+          class="text-brand-text-primary hover:text-brand-text-primary transition-colors"
         >
           {i18n.t("playlists.clearSelection")}
         </button>
@@ -1657,11 +1657,11 @@
         {i18n.t("playlists.exportModalTitle")}
       </h3>
       <div class="space-y-2.5 text-xs text-brand-text-secondary">
-        <label class="flex items-center gap-2 cursor-pointer hover:text-brand-text-primary transition-colors">
+        <label class="flex items-center gap-2 hover:text-brand-text-primary transition-colors">
           <input type="radio" name="exportPathType" bind:group={exportRelative} value={true} class="accent-brand-accent" />
           <span>{i18n.t("playlists.useRelativePaths")}</span>
         </label>
-        <label class="flex items-center gap-2 cursor-pointer hover:text-brand-text-primary transition-colors">
+        <label class="flex items-center gap-2 hover:text-brand-text-primary transition-colors">
           <input type="radio" name="exportPathType" bind:group={exportRelative} value={false} class="accent-brand-accent" />
           <span>{i18n.t("playlists.useAbsolutePaths")}</span>
         </label>
@@ -1669,13 +1669,13 @@
       <div class="flex justify-end gap-2 pt-2">
         <button
           onclick={() => { showExportOptionsModal = false; }}
-          class="px-3 py-1.5 rounded text-xs font-medium text-brand-text-secondary hover:bg-brand-main transition-colors cursor-pointer"
+          class="px-3 py-1.5 rounded text-xs font-medium text-brand-text-secondary hover:bg-brand-main transition-colors"
         >
           {i18n.t("playlists.cancelBtn")}
         </button>
         <button
           onclick={triggerExport}
-          class="px-3 py-1.5 rounded text-xs font-medium bg-brand-accent hover:bg-brand-accent-hover text-brand-accent-contrast transition-colors cursor-pointer"
+          class="px-3 py-1.5 rounded text-xs font-medium bg-brand-accent hover:bg-brand-accent-hover text-brand-accent-contrast transition-colors"
         >
           {i18n.t("playlists.exportBtn")}
         </button>
@@ -1691,7 +1691,7 @@
         <FolderPlus class="w-4 h-4 text-brand-accent-text" />
         <h3 class="text-sm font-bold text-brand-text-primary">{i18n.t("playlists.saveQueueAsPlaylist", {}, "Save as Custom Playlist")}</h3>
       </div>
-      <button onclick={() => showSaveQueueModal = false} class="text-brand-text-secondary hover:text-brand-text-primary transition-colors cursor-pointer">
+      <button onclick={() => showSaveQueueModal = false} class="text-brand-text-secondary hover:text-brand-text-primary transition-colors">
         <X class="w-4 h-4" />
       </button>
     </div>

--- a/src/lib/components/PlaylistsCollectionView.svelte
+++ b/src/lib/components/PlaylistsCollectionView.svelte
@@ -348,7 +348,7 @@
             <button
               onclick={handleRefreshAll}
               disabled={isRefreshingAll}
-              class="flex items-center justify-center w-9 h-9 rounded-full border border-brand-border bg-brand-sidebar text-brand-text-secondary hover:text-brand-accent-text hover:border-brand-accent/60 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed shadow-xs"
+              class="flex items-center justify-center w-9 h-9 rounded-full border border-brand-border bg-brand-sidebar text-brand-text-secondary hover:text-brand-accent-text hover:border-brand-accent/60 transition-colors disabled:opacity-50 disabled:cursor-not-allowed shadow-xs"
               title={i18n.t('playlists.refreshAllPlaylistsTooltip')}
               aria-label={i18n.t('playlists.refreshAllPlaylistsTooltip')}
             >
@@ -357,7 +357,7 @@
             <div class="inline-flex items-center gap-0.5 bg-brand-sidebar border border-brand-border rounded-full p-1">
               <button
                 onclick={() => setActiveViewMode("cards")}
-                class="flex items-center justify-center w-7 h-7 rounded-full transition-colors cursor-pointer {activeViewMode === 'cards' ? 'bg-brand-accent text-white' : 'text-brand-text-secondary hover:text-brand-text-primary'}"
+                class="flex items-center justify-center w-7 h-7 rounded-full transition-colors {activeViewMode === 'cards' ? 'bg-brand-accent text-white' : 'text-brand-text-secondary hover:text-brand-text-primary'}"
                 title={i18n.t('collection.viewCards')}
                 aria-label={i18n.t('collection.viewCards')}
                 aria-pressed={activeViewMode === "cards"}
@@ -366,7 +366,7 @@
               </button>
               <button
                 onclick={() => setActiveViewMode("rows")}
-                class="flex items-center justify-center w-7 h-7 rounded-full transition-colors cursor-pointer {activeViewMode === 'rows' ? 'bg-brand-accent text-white' : 'text-brand-text-secondary hover:text-brand-text-primary'}"
+                class="flex items-center justify-center w-7 h-7 rounded-full transition-colors {activeViewMode === 'rows' ? 'bg-brand-accent text-white' : 'text-brand-text-secondary hover:text-brand-text-primary'}"
                 title={i18n.t('collection.viewRows')}
                 aria-label={i18n.t('collection.viewRows')}
                 aria-pressed={activeViewMode === "rows"}

--- a/src/lib/components/PopulationModeTabs.svelte
+++ b/src/lib/components/PopulationModeTabs.svelte
@@ -49,7 +49,7 @@
       {disabled}
       title={i18n.t(m.tooltipKey)}
       onclick={() => onChange(m.value)}
-      class="px-2.5 py-1 rounded-full text-[11px] font-semibold whitespace-nowrap transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed
+      class="px-2.5 py-1 rounded-full text-[11px] font-semibold whitespace-nowrap transition-colors disabled:opacity-50 disabled:cursor-not-allowed
         {mode === m.value
         ? 'bg-brand-accent text-brand-accent-contrast shadow-sm'
         : 'text-brand-text-secondary/70 hover:text-brand-text-primary hover:bg-brand-sidebar'}"

--- a/src/lib/components/ReactiveLogoBrand.svelte
+++ b/src/lib/components/ReactiveLogoBrand.svelte
@@ -141,7 +141,7 @@
 <button
   type="button"
   onclick={togglePulsing}
-  class="bg-transparent border-none p-0 cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-accent rounded-full overflow-hidden isolate"
+  class="bg-transparent border-none p-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-accent rounded-full overflow-hidden isolate"
   title={isPulsingEnabled ? i18n.t('common.disableLogoPulse') : i18n.t('common.enableLogoPulse')}
   aria-label={i18n.t('common.toggleLogoPulsing')}
 >

--- a/src/lib/components/Select.svelte
+++ b/src/lib/components/Select.svelte
@@ -25,7 +25,7 @@
   {id}
   {value}
   {onchange}
-  class="appearance-none -webkit-appearance-none cursor-pointer {className}"
+  class="appearance-none -webkit-appearance-none {className}"
   style="background-image: url(&quot;data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20' fill='none'%3E%3Cpath stroke='%239ca3af' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='m6 8 4 4 4-4'/%3E%3C/svg%3E&quot;); background-position: right {chevronPosition} center; background-repeat: no-repeat; background-size: 1.25em;"
 >
   {@render children()}

--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -101,7 +101,7 @@
         <div class="pl-4 pr-1 py-1 space-y-0.5 border-l-2 border-brand-accent/30 ml-4 my-1">
           <button
             onclick={() => { collectionStore.activeTab = "collection"; collectionStore.activeSubTab = "artists"; collectionStore.selectedArtistName = null; collectionStore.selectedAlbumName = null; }}
-            class="w-full flex items-center justify-between px-2.5 py-1.5 rounded-md text-xs transition-colors cursor-pointer {collectionStore.activeTab === 'collection' && collectionStore.activeSubTab === 'artists' && !collectionStore.selectedArtistName && !collectionStore.selectedAlbumName ? 'bg-brand-accent/20 text-brand-accent-text font-semibold' : 'text-brand-text-secondary hover:text-brand-text-primary hover:bg-brand-accent/10'}"
+            class="w-full flex items-center justify-between px-2.5 py-1.5 rounded-md text-xs transition-colors {collectionStore.activeTab === 'collection' && collectionStore.activeSubTab === 'artists' && !collectionStore.selectedArtistName && !collectionStore.selectedAlbumName ? 'bg-brand-accent/20 text-brand-accent-text font-semibold' : 'text-brand-text-secondary hover:text-brand-text-primary hover:bg-brand-accent/10'}"
           >
             <div class="flex items-center gap-2 truncate">
               <Mic2 class="w-3.5 h-3.5" />
@@ -114,7 +114,7 @@
 
           <button
             onclick={() => { collectionStore.activeTab = "collection"; collectionStore.activeSubTab = "albums"; collectionStore.selectedArtistName = null; collectionStore.selectedAlbumName = null; }}
-            class="w-full flex items-center justify-between px-2.5 py-1.5 rounded-md text-xs transition-colors cursor-pointer {collectionStore.activeTab === 'collection' && collectionStore.activeSubTab === 'albums' && !collectionStore.selectedArtistName && !collectionStore.selectedAlbumName ? 'bg-brand-accent/20 text-brand-accent-text font-semibold' : 'text-brand-text-secondary hover:text-brand-text-primary hover:bg-brand-accent/10'}"
+            class="w-full flex items-center justify-between px-2.5 py-1.5 rounded-md text-xs transition-colors {collectionStore.activeTab === 'collection' && collectionStore.activeSubTab === 'albums' && !collectionStore.selectedArtistName && !collectionStore.selectedAlbumName ? 'bg-brand-accent/20 text-brand-accent-text font-semibold' : 'text-brand-text-secondary hover:text-brand-text-primary hover:bg-brand-accent/10'}"
           >
             <div class="flex items-center gap-2 truncate">
               <DiscAlbum class="w-3.5 h-3.5" />
@@ -127,7 +127,7 @@
 
           <button
             onclick={() => { collectionStore.activeTab = "collection"; collectionStore.activeSubTab = "songs"; collectionStore.selectedArtistName = null; collectionStore.selectedAlbumName = null; }}
-            class="w-full flex items-center justify-between px-2.5 py-1.5 rounded-md text-xs transition-colors cursor-pointer {collectionStore.activeTab === 'collection' && collectionStore.activeSubTab === 'songs' && !collectionStore.selectedArtistName && !collectionStore.selectedAlbumName ? 'bg-brand-accent/20 text-brand-accent-text font-semibold' : 'text-brand-text-secondary hover:text-brand-text-primary hover:bg-brand-accent/10'}"
+            class="w-full flex items-center justify-between px-2.5 py-1.5 rounded-md text-xs transition-colors {collectionStore.activeTab === 'collection' && collectionStore.activeSubTab === 'songs' && !collectionStore.selectedArtistName && !collectionStore.selectedAlbumName ? 'bg-brand-accent/20 text-brand-accent-text font-semibold' : 'text-brand-text-secondary hover:text-brand-text-primary hover:bg-brand-accent/10'}"
           >
             <div class="flex items-center gap-2 truncate">
               <Music class="w-3.5 h-3.5" />
@@ -161,7 +161,7 @@
         <div class="pl-4 pr-1 py-1 space-y-0.5 border-l-2 border-brand-accent/30 ml-4 my-1">
           <button
             onclick={() => openPlaylistsSubTab("auto")}
-            class="w-full flex items-center justify-between px-2.5 py-1.5 rounded-md text-xs transition-colors cursor-pointer {collectionStore.activeTab === 'playlists' && collectionStore.playlistsSubTab === 'auto' && !collectionStore.selectedPlaylistId && !collectionStore.selectedAutoPlaylist ? 'bg-brand-accent/20 text-brand-accent-text font-semibold' : 'text-brand-text-secondary hover:text-brand-text-primary hover:bg-brand-accent/10'}"
+            class="w-full flex items-center justify-between px-2.5 py-1.5 rounded-md text-xs transition-colors {collectionStore.activeTab === 'playlists' && collectionStore.playlistsSubTab === 'auto' && !collectionStore.selectedPlaylistId && !collectionStore.selectedAutoPlaylist ? 'bg-brand-accent/20 text-brand-accent-text font-semibold' : 'text-brand-text-secondary hover:text-brand-text-primary hover:bg-brand-accent/10'}"
           >
             <div class="flex items-center gap-2 truncate">
               <Sparkles class="w-3.5 h-3.5" />
@@ -174,7 +174,7 @@
 
           <button
             onclick={() => openPlaylistsSubTab("custom")}
-            class="w-full flex items-center justify-between px-2.5 py-1.5 rounded-md text-xs transition-colors cursor-pointer {collectionStore.activeTab === 'playlists' && collectionStore.playlistsSubTab === 'custom' && !collectionStore.selectedPlaylistId && !collectionStore.selectedAutoPlaylist ? 'bg-brand-accent/20 text-brand-accent-text font-semibold' : 'text-brand-text-secondary hover:text-brand-text-primary hover:bg-brand-accent/10'}"
+            class="w-full flex items-center justify-between px-2.5 py-1.5 rounded-md text-xs transition-colors {collectionStore.activeTab === 'playlists' && collectionStore.playlistsSubTab === 'custom' && !collectionStore.selectedPlaylistId && !collectionStore.selectedAutoPlaylist ? 'bg-brand-accent/20 text-brand-accent-text font-semibold' : 'text-brand-text-secondary hover:text-brand-text-primary hover:bg-brand-accent/10'}"
           >
             <div class="flex items-center gap-2 truncate">
               <ListMusic class="w-3.5 h-3.5" />
@@ -193,7 +193,7 @@
                 collectionStore.viewPlaylist(queuePl.id);
               }
             }}
-            class="w-full flex items-center justify-between px-2.5 py-1.5 rounded-md text-xs transition-colors cursor-pointer {collectionStore.activeTab === 'playlists' && collectionStore.selectedPlaylistId && playlistsStore.playlists.find((p) => p.id === collectionStore.selectedPlaylistId)?.name?.toLowerCase() === 'queue' ? 'bg-brand-accent/20 text-brand-accent-text font-semibold' : 'text-brand-text-secondary hover:text-brand-text-primary hover:bg-brand-accent/10'}"
+            class="w-full flex items-center justify-between px-2.5 py-1.5 rounded-md text-xs transition-colors {collectionStore.activeTab === 'playlists' && collectionStore.selectedPlaylistId && playlistsStore.playlists.find((p) => p.id === collectionStore.selectedPlaylistId)?.name?.toLowerCase() === 'queue' ? 'bg-brand-accent/20 text-brand-accent-text font-semibold' : 'text-brand-text-secondary hover:text-brand-text-primary hover:bg-brand-accent/10'}"
           >
             <div class="flex items-center gap-2 truncate">
               <Layers class="w-3.5 h-3.5" />

--- a/src/lib/components/SmartPlaylistBuilderModal.svelte
+++ b/src/lib/components/SmartPlaylistBuilderModal.svelte
@@ -257,7 +257,7 @@
       </div>
       <button
         onclick={onClose}
-        class="text-brand-text-secondary hover:text-brand-text-primary p-1.5 rounded-lg hover:bg-brand-main/80 transition-colors cursor-pointer"
+        class="text-brand-text-secondary hover:text-brand-text-primary p-1.5 rounded-lg hover:bg-brand-main/80 transition-colors"
       >
         <X class="w-4 h-4" />
       </button>
@@ -291,7 +291,7 @@
           <button
             type="button"
             onclick={addRule}
-            class="text-xs text-brand-accent-text hover:text-brand-accent-text-hover font-semibold flex items-center gap-1 transition-colors cursor-pointer"
+            class="text-xs text-brand-accent-text hover:text-brand-accent-text-hover font-semibold flex items-center gap-1 transition-colors"
           >
             <Plus class="w-3.5 h-3.5" />
             {i18n.t("smartPlaylistBuilder.addRule")}
@@ -342,7 +342,7 @@
                 <button
                   type="button"
                   onclick={() => removeRule(rule.id)}
-                  class="text-brand-text-secondary/60 hover:text-rose-400 p-1 rounded-lg transition-colors cursor-pointer"
+                  class="text-brand-text-secondary/60 hover:text-rose-400 p-1 rounded-lg transition-colors"
                   title={i18n.t("smartPlaylistBuilder.removeRuleTooltip")}
                 >
                   <X class="w-4 h-4" />

--- a/src/lib/components/SongSelectionToolbar.svelte
+++ b/src/lib/components/SongSelectionToolbar.svelte
@@ -26,14 +26,14 @@
   <div class="h-4 w-px bg-brand-border/60"></div>
   <button
     onclick={onPlaySelected}
-    class="flex items-center gap-1.5 hover:text-brand-accent-text transition-colors cursor-pointer"
+    class="flex items-center gap-1.5 hover:text-brand-accent-text transition-colors"
   >
     <Play class="w-3.5 h-3.5 fill-current text-brand-accent-text" />
     <span>{i18n.t('playlists.playSelected')}</span>
   </button>
   <button
     onclick={onAddToPlaylist}
-    class="flex items-center gap-1.5 hover:text-brand-accent-text transition-colors cursor-pointer"
+    class="flex items-center gap-1.5 hover:text-brand-accent-text transition-colors"
   >
     <Plus class="w-3.5 h-3.5 text-brand-accent-text" />
     <span>
@@ -45,7 +45,7 @@
   <div class="h-4 w-px bg-brand-border/60"></div>
   <button
     onclick={onClear}
-    class="text-brand-text-secondary hover:text-brand-text-primary transition-colors cursor-pointer"
+    class="text-brand-text-secondary hover:text-brand-text-primary transition-colors"
   >
     {i18n.t('playlists.clearSelection')}
   </button>

--- a/src/lib/components/StarRating.svelte
+++ b/src/lib/components/StarRating.svelte
@@ -54,7 +54,7 @@
       type="button"
       disabled={rating <= 0}
       onclick={handleClear}
-      class="block text-brand-text-secondary/50 hover:text-brand-text-secondary transition-colors cursor-pointer disabled:cursor-default disabled:pointer-events-none"
+      class="block text-brand-text-secondary/50 hover:text-brand-text-secondary transition-colors disabled:cursor-default disabled:pointer-events-none"
       title={i18n.t('rating.clearTooltip')}
       aria-label={i18n.t('rating.clearTooltip')}
     >
@@ -69,7 +69,7 @@
       onmousemove={(e) => {
         if (onRate) hoverValue = valueAt(star, e);
       }}
-      class="relative block {onRate ? 'cursor-pointer' : 'cursor-default'} disabled:pointer-events-none"
+      class="relative block {onRate ? '' : 'cursor-default'} disabled:pointer-events-none"
       title={onRate ? i18n.t('rating.setTooltip', { value: hoverValue ?? star }) : undefined}
       aria-label={i18n.t('rating.setTooltip', { value: star })}
     >

--- a/src/lib/components/Toast.svelte
+++ b/src/lib/components/Toast.svelte
@@ -50,7 +50,7 @@
         <button
           type="button"
           onclick={() => openExternalUrl(toast.url!)}
-          class="flex-1 text-left underline decoration-dotted underline-offset-2 hover:decoration-solid cursor-pointer"
+          class="flex-1 text-left underline decoration-dotted underline-offset-2 hover:decoration-solid"
         >
           {toast.text}
         </button>
@@ -59,7 +59,7 @@
       {/if}
       <button
         onclick={() => toastStore.dismiss(toast.id)}
-        class="shrink-0 opacity-60 hover:opacity-100 transition-opacity cursor-pointer"
+        class="shrink-0 opacity-60 hover:opacity-100 transition-opacity"
       >
         <X class="w-3.5 h-3.5" />
       </button>

--- a/src/lib/components/Toggle.svelte
+++ b/src/lib/components/Toggle.svelte
@@ -27,7 +27,7 @@
     aria-label={label}
     {disabled}
     onclick={() => onchange(!checked)}
-    class="relative inline-flex h-6 w-11 items-center rounded-full transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed {checked ? 'bg-brand-accent' : 'bg-brand-border'}"
+    class="relative inline-flex h-6 w-11 items-center rounded-full transition-colors disabled:opacity-50 disabled:cursor-not-allowed {checked ? 'bg-brand-accent' : 'bg-brand-border'}"
   >
     <span class="inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform {checked ? 'translate-x-6' : 'translate-x-1'}"></span>
   </button>

--- a/src/lib/components/TopNavigation.svelte
+++ b/src/lib/components/TopNavigation.svelte
@@ -234,7 +234,7 @@
   <div class="flex items-center gap-2">
     <button
       onclick={() => collectionStore.toggleSidebarCompact()}
-      class="p-2 rounded-lg text-brand-text-secondary hover:bg-brand-main hover:text-brand-text-primary transition-colors cursor-pointer"
+      class="p-2 rounded-lg text-brand-text-secondary hover:bg-brand-main hover:text-brand-text-primary transition-colors"
       title={i18n.t('topNav.toggleSidebarCompact', {}, 'Toggle sidebar (compact / expanded)')}
     >
       <Menu class="w-5 h-5" />
@@ -279,7 +279,7 @@
       <button
         type="button"
         onclick={() => playerStore.openFileDialog()}
-        class="p-1 text-brand-text-secondary hover:text-brand-accent-text transition-colors flex-shrink-0 cursor-pointer"
+        class="p-1 text-brand-text-secondary hover:text-brand-accent-text transition-colors flex-shrink-0"
         title={i18n.t('topNav.openFilesTooltip')}
       >
         <FolderOpen class="w-4 h-4" />
@@ -317,7 +317,7 @@
               collectionStore.openSmartBuilder(rules);
               isSearchFocused = false;
             }}
-            class="w-full flex items-center justify-between p-2.5 mb-2.5 rounded-xl bg-brand-accent/10 border border-brand-accent/40 hover:bg-brand-accent/20 transition-all cursor-pointer text-left group"
+            class="w-full flex items-center justify-between p-2.5 mb-2.5 rounded-xl bg-brand-accent/10 border border-brand-accent/40 hover:bg-brand-accent/20 transition-all text-left group"
           >
             <div class="flex items-center gap-2.5">
               <div class="p-1.5 rounded-lg bg-brand-accent text-brand-accent-contrast">
@@ -390,7 +390,7 @@
                       if (e.key === 'Enter' && artist.name) collectionStore.viewArtist(artist.name);
                       else handleSearchResultKeyDown(e);
                     }}
-                    class="search-result-item group flex items-center justify-between p-2 rounded-lg hover:bg-brand-main/80 transition-colors cursor-pointer focus:outline-none focus:ring-2 focus:ring-brand-accent"
+                    class="search-result-item group flex items-center justify-between p-2 rounded-lg hover:bg-brand-main/80 transition-colors focus:outline-none focus:ring-2 focus:ring-brand-accent"
                   >
                     <div class="flex items-center gap-3 min-w-0 flex-1">
                       <div class="w-8 h-8 rounded-full flex-shrink-0 flex items-center justify-center bg-brand-main/60 border border-brand-border/40 overflow-hidden">
@@ -430,7 +430,7 @@
                       if (e.key === 'Enter' && album.album) collectionStore.viewAlbum(album.album);
                       else handleSearchResultKeyDown(e);
                     }}
-                    class="search-result-item group flex items-center justify-between p-2 rounded-lg hover:bg-brand-main/80 transition-colors cursor-pointer focus:outline-none focus:ring-2 focus:ring-brand-accent"
+                    class="search-result-item group flex items-center justify-between p-2 rounded-lg hover:bg-brand-main/80 transition-colors focus:outline-none focus:ring-2 focus:ring-brand-accent"
                   >
                     <div class="flex items-center gap-3 min-w-0 flex-1">
                       <div class="relative shrink-0 overflow-hidden">
@@ -492,7 +492,7 @@
                         handleSearchResultKeyDown(e);
                       }
                     }}
-                    class="search-result-item group flex items-center justify-between p-2 rounded-lg hover:bg-brand-main/80 transition-colors cursor-pointer focus:outline-none focus:ring-2 focus:ring-brand-accent"
+                    class="search-result-item group flex items-center justify-between p-2 rounded-lg hover:bg-brand-main/80 transition-colors focus:outline-none focus:ring-2 focus:ring-brand-accent"
                   >
                     <div class="flex items-center gap-3 min-w-0 flex-1">
                       <div class="w-8 h-8 flex-shrink-0 flex items-center justify-center bg-brand-main/60 border border-brand-border/40 overflow-hidden">
@@ -541,7 +541,7 @@
                         handleSearchResultKeyDown(e);
                       }
                     }}
-                    class="search-result-item group flex items-center justify-between p-2 rounded-lg hover:bg-brand-main/80 transition-colors cursor-pointer focus:outline-none focus:ring-2 focus:ring-brand-accent"
+                    class="search-result-item group flex items-center justify-between p-2 rounded-lg hover:bg-brand-main/80 transition-colors focus:outline-none focus:ring-2 focus:ring-brand-accent"
                   >
                     <div class="flex items-center gap-3 min-w-0 flex-1">
                       <CoverArt
@@ -576,7 +576,7 @@
             <button
               type="button"
               onclick={(e) => { e.stopPropagation(); collectionStore.clearRecentSearches(); }}
-              class="text-xs text-brand-text-secondary hover:text-brand-accent-text transition-colors cursor-pointer"
+              class="text-xs text-brand-text-secondary hover:text-brand-accent-text transition-colors"
             >
               {i18n.t('topNav.clearRecentSearches', {}, 'Clear recent searches')}
             </button>
@@ -598,7 +598,7 @@
                   if (e.key === 'Enter') selectRecentSearch(item);
                   else handleSearchResultKeyDown(e);
                 }}
-                class="search-result-item group flex items-center justify-between p-2 rounded-lg hover:bg-brand-main/80 transition-colors cursor-pointer focus:outline-none focus:ring-2 focus:ring-brand-accent"
+                class="search-result-item group flex items-center justify-between p-2 rounded-lg hover:bg-brand-main/80 transition-colors focus:outline-none focus:ring-2 focus:ring-brand-accent"
               >
                 <div class="flex items-center gap-3 min-w-0 flex-1">
                   <!-- Avatar / Artwork / Icon -->
@@ -643,7 +643,7 @@
                     e.stopPropagation();
                     collectionStore.removeRecentSearch(item.id);
                   }}
-                  class="p-1.5 opacity-0 group-hover:opacity-100 hover:text-red-400 text-brand-text-secondary/60 transition-all cursor-pointer rounded"
+                  class="p-1.5 opacity-0 group-hover:opacity-100 hover:text-red-400 text-brand-text-secondary/60 transition-all rounded"
                   title={i18n.t('topNav.removeRecentSearchTooltip')}
                 >
                   <X class="w-3.5 h-3.5" />
@@ -660,21 +660,21 @@
   <div class="flex items-center gap-1.5 bg-brand-main/60 p-1 rounded-lg border border-brand-border/60 ml-auto flex-shrink-0 select-none">
     <button
       onclick={() => collectionStore.toggleSidebar()}
-      class="p-1.5 rounded-md transition-all cursor-pointer {collectionStore.sidebarOpen ? 'bg-brand-accent text-white shadow-sm' : 'text-brand-text-secondary hover:text-brand-accent-text-hover hover:bg-brand-accent/10'}"
+      class="p-1.5 rounded-md transition-all {collectionStore.sidebarOpen ? 'bg-brand-accent text-white shadow-sm' : 'text-brand-text-secondary hover:text-brand-accent-text-hover hover:bg-brand-accent/10'}"
       title={i18n.t('topNav.toggleSidebar')}
     >
       <PanelLeft class="w-4 h-4" />
     </button>
     <button
       onclick={() => collectionStore.toggleImmersiveMode()}
-      class="p-1.5 rounded-md transition-all cursor-pointer {collectionStore.immersiveMode ? 'bg-brand-accent text-white shadow-sm' : 'text-brand-text-secondary hover:text-brand-accent-text-hover hover:bg-brand-accent/10'}"
+      class="p-1.5 rounded-md transition-all {collectionStore.immersiveMode ? 'bg-brand-accent text-white shadow-sm' : 'text-brand-text-secondary hover:text-brand-accent-text-hover hover:bg-brand-accent/10'}"
       title={i18n.t('topNav.toggleImmersive')}
     >
       <PanelBottom class="w-4 h-4" />
     </button>
     <button
       onclick={() => collectionStore.toggleRightPanel()}
-      class="p-1.5 rounded-md transition-all cursor-pointer {collectionStore.rightPanelOpen ? 'bg-brand-accent text-white shadow-sm' : 'text-brand-text-secondary hover:text-brand-accent-text-hover hover:bg-brand-accent/10'}"
+      class="p-1.5 rounded-md transition-all {collectionStore.rightPanelOpen ? 'bg-brand-accent text-white shadow-sm' : 'text-brand-text-secondary hover:text-brand-accent-text-hover hover:bg-brand-accent/10'}"
       title={i18n.t('topNav.toggleRightPanel')}
     >
       <PanelRight class="w-4 h-4" />

--- a/src/lib/components/WaveformSeekBar.svelte
+++ b/src/lib/components/WaveformSeekBar.svelte
@@ -365,7 +365,7 @@
 <div
   bind:this={containerEl}
   onmousedown={handleMouseDown}
-  class="relative flex-1 h-7 overflow-hidden cursor-pointer flex items-center group select-none"
+  class="relative flex-1 h-7 overflow-hidden flex items-center group select-none"
   title={prefs.seekBarMode === 'bands'
     ? i18n.t('playerBar.bandsLegend', {}, 'Frequency bands — blue = low (bass), amber = mid (vocals/snares/leads), white = high (hi-hats/cymbals/transients); taller bands carry more energy')
     : undefined}

--- a/src/routes/dev/animations/+page.svelte
+++ b/src/routes/dev/animations/+page.svelte
@@ -101,7 +101,7 @@
         <p class="text-xs text-brand-text-secondary">
           Your OS has "reduce motion" on, so every card below is correctly collapsing to the spec's reduced-motion fallback (plain fade, or nothing for rings/glows) — that's intentional, not broken. Toggle below to preview full motion anyway.
         </p>
-        <label class="flex items-center gap-2 text-xs font-semibold shrink-0 cursor-pointer select-none">
+        <label class="flex items-center gap-2 text-xs font-semibold shrink-0 select-none">
           <input type="checkbox" bind:checked={forceFullMotion} class="accent-[var(--color-accent)]" />
           Preview full motion
         </label>
@@ -120,7 +120,7 @@
       <div class="h-16 flex items-center justify-center bg-brand-main rounded-lg">
         <HeartToggle favorite={favoriteDemo} onToggle={() => (favoriteDemo = !favoriteDemo)} sizeClass="w-6 h-6" />
       </div>
-      <button onclick={replayFavorite} class="text-xs font-semibold text-brand-accent-text border border-brand-accent/40 rounded-full px-3 py-1.5 self-start cursor-pointer hover:bg-brand-accent/10">▸ Replay</button>
+      <button onclick={replayFavorite} class="text-xs font-semibold text-brand-accent-text border border-brand-accent/40 rounded-full px-3 py-1.5 self-start hover:bg-brand-accent/10">▸ Replay</button>
     </div>
 
     <!-- 2. Import finished (real Toast component, mounted in +layout.svelte) -->
@@ -132,7 +132,7 @@
       <div class="h-16 flex items-center justify-center bg-brand-main rounded-lg text-xs text-brand-text-secondary text-center px-3">
         Watch the bottom of the screen
       </div>
-      <button onclick={replayToast} class="text-xs font-semibold text-brand-accent-text border border-brand-accent/40 rounded-full px-3 py-1.5 self-start cursor-pointer hover:bg-brand-accent/10">▸ Replay</button>
+      <button onclick={replayToast} class="text-xs font-semibold text-brand-accent-text border border-brand-accent/40 rounded-full px-3 py-1.5 self-start hover:bg-brand-accent/10">▸ Replay</button>
     </div>
 
     <!-- 3. Organizing complete -->
@@ -151,7 +151,7 @@
           {/each}
         {/key}
       </div>
-      <button onclick={() => replay('organizing')} class="text-xs font-semibold text-brand-accent-text border border-brand-accent/40 rounded-full px-3 py-1.5 self-start cursor-pointer hover:bg-brand-accent/10">▸ Replay</button>
+      <button onclick={() => replay('organizing')} class="text-xs font-semibold text-brand-accent-text border border-brand-accent/40 rounded-full px-3 py-1.5 self-start hover:bg-brand-accent/10">▸ Replay</button>
     </div>
 
     <!-- 4. First watched folder -->
@@ -168,7 +168,7 @@
           </div>
         {/key}
       </div>
-      <button onclick={() => replay('folder')} class="text-xs font-semibold text-brand-accent-text border border-brand-accent/40 rounded-full px-3 py-1.5 self-start cursor-pointer hover:bg-brand-accent/10">▸ Replay</button>
+      <button onclick={() => replay('folder')} class="text-xs font-semibold text-brand-accent-text border border-brand-accent/40 rounded-full px-3 py-1.5 self-start hover:bg-brand-accent/10">▸ Replay</button>
     </div>
 
     <!-- 5. Creating a new playlist -->
@@ -185,7 +185,7 @@
           </div>
         {/key}
       </div>
-      <button onclick={() => replay('playlist')} class="text-xs font-semibold text-brand-accent-text border border-brand-accent/40 rounded-full px-3 py-1.5 self-start cursor-pointer hover:bg-brand-accent/10">▸ Replay</button>
+      <button onclick={() => replay('playlist')} class="text-xs font-semibold text-brand-accent-text border border-brand-accent/40 rounded-full px-3 py-1.5 self-start hover:bg-brand-accent/10">▸ Replay</button>
     </div>
 
     <!-- 6. New auto-playlist appears -->
@@ -203,7 +203,7 @@
           </div>
         {/key}
       </div>
-      <button onclick={() => replay('autoPlaylist')} class="text-xs font-semibold text-brand-accent-text border border-brand-accent/40 rounded-full px-3 py-1.5 self-start cursor-pointer hover:bg-brand-accent/10">▸ Replay</button>
+      <button onclick={() => replay('autoPlaylist')} class="text-xs font-semibold text-brand-accent-text border border-brand-accent/40 rounded-full px-3 py-1.5 self-start hover:bg-brand-accent/10">▸ Replay</button>
     </div>
 
     <!-- 7. New release available — a new Luminous version, not a new song/album; shown in Settings → About -->
@@ -223,7 +223,7 @@
           </div>
         {/key}
       </div>
-      <button onclick={() => replay('release')} class="text-xs font-semibold text-brand-accent-text border border-brand-accent/40 rounded-full px-3 py-1.5 self-start cursor-pointer hover:bg-brand-accent/10">▸ Replay</button>
+      <button onclick={() => replay('release')} class="text-xs font-semibold text-brand-accent-text border border-brand-accent/40 rounded-full px-3 py-1.5 self-start hover:bg-brand-accent/10">▸ Replay</button>
     </div>
 
     <!-- 8. Reaching a milestone -->
@@ -238,7 +238,7 @@
           <span class="text-lg font-black text-brand-gold anim-milestone-bounce">1,000 songs</span>
         {/key}
       </div>
-      <button onclick={() => { replay('milestone'); replayMilestoneToast(); }} class="text-xs font-semibold text-brand-accent-text border border-brand-accent/40 rounded-full px-3 py-1.5 self-start cursor-pointer hover:bg-brand-accent/10">▸ Replay</button>
+      <button onclick={() => { replay('milestone'); replayMilestoneToast(); }} class="text-xs font-semibold text-brand-accent-text border border-brand-accent/40 rounded-full px-3 py-1.5 self-start hover:bg-brand-accent/10">▸ Replay</button>
     </div>
 
     <!-- 9. Completing a queue -->
@@ -255,7 +255,7 @@
           >Queue complete — nice listening</span>
         {/key}
       </div>
-      <button onclick={() => { replay('queue'); replayQueueToast(); }} class="text-xs font-semibold text-brand-accent-text border border-brand-accent/40 rounded-full px-3 py-1.5 self-start cursor-pointer hover:bg-brand-accent/10">▸ Replay</button>
+      <button onclick={() => { replay('queue'); replayQueueToast(); }} class="text-xs font-semibold text-brand-accent-text border border-brand-accent/40 rounded-full px-3 py-1.5 self-start hover:bg-brand-accent/10">▸ Replay</button>
     </div>
 
     <!-- 10. First launch -->
@@ -273,7 +273,7 @@
           </div>
         {/key}
       </div>
-      <button onclick={() => { replay('firstLaunch'); replayWelcomeToast(); }} class="text-xs font-semibold text-brand-accent-text border border-brand-accent/40 rounded-full px-3 py-1.5 self-start cursor-pointer hover:bg-brand-accent/10">▸ Replay</button>
+      <button onclick={() => { replay('firstLaunch'); replayWelcomeToast(); }} class="text-xs font-semibold text-brand-accent-text border border-brand-accent/40 rounded-full px-3 py-1.5 self-start hover:bg-brand-accent/10">▸ Replay</button>
     </div>
 
     <!-- 11. Import needs attention -->
@@ -290,7 +290,7 @@
           </div>
         {/key}
       </div>
-      <button onclick={() => { replay('warning'); replayWarningToast(); }} class="text-xs font-semibold text-brand-accent-text border border-brand-accent/40 rounded-full px-3 py-1.5 self-start cursor-pointer hover:bg-brand-accent/10">▸ Replay</button>
+      <button onclick={() => { replay('warning'); replayWarningToast(); }} class="text-xs font-semibold text-brand-accent-text border border-brand-accent/40 rounded-full px-3 py-1.5 self-start hover:bg-brand-accent/10">▸ Replay</button>
     </div>
 
   </div>

--- a/vite.config.js
+++ b/vite.config.js
@@ -87,8 +87,8 @@ export default defineConfig(async () => ({
         }
       : undefined,
     watch: {
-      // 3. tell Vite to ignore watching `src-tauri`
-      ignored: ["**/src-tauri/**"],
+      // 3. tell Vite to ignore watching `src-tauri` and `target` build outputs
+      ignored: ["**/src-tauri/**", "**/target/**"],
     },
   },
 }));


### PR DESCRIPTION
## 📋 Summary
Removes the browse/hand cursor (`cursor: pointer` / `cursor-pointer`) across the application so Luminous looks and behaves like a native desktop app (e.g., Spotify, Apple Music).

## 🔍 Implementation Notes
- **Global Base CSS (`src/app.css`)**:
  - Sets `cursor: default` as base styling for `*, ::before, ::after`, `button`, `a`, `select`, `input`, `label`, `summary`, and `[role="button"]`.
  - Configures `cursor: text` for editable text controls (`input[type="text"]`, `input[type="search"]`, `textarea`, `[contenteditable="true"]`).
  - Added `.cursor-pointer { cursor: default !important; }` override to prevent any residual pointer classes from showing a hand cursor.
  - Removed `cursor: pointer;` from `.themed-range` slider thumb rules.
- **Component Cleanups**: Removed `cursor-pointer` class assignments across 42 Svelte components in `src/lib/components/` and `src/routes/`.
- **Vite Watcher Configuration (`vite.config.js`)**: Added `"**/target/**"` to `server.watch.ignored` to prevent Vite file watcher lock errors (`EBUSY`) during `bun run tauri dev`.

## 🧪 Test Plan
- [x] `bun run check` (svelte-check passed with 0 errors, 0 warnings)
- [x] `bun run test -- --run` (35 test files passed, 321 tests passed)
- [x] Manually verified cursor behavior across controls, buttons, cards, list rows, sliders, and text fields.

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Desktop UX guidelines respected
