### PR TITLE
fix: make tsconfig's node type dependency explicit

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,8 @@
     "skipLibCheck": true,
     "sourceMap": true,
     "strict": true,
-    "moduleResolution": "bundler"
+    "moduleResolution": "bundler",
+    "types": ["node"]
   }
   // Path aliases are handled by https://svelte.dev/docs/kit/configuration#alias
   // except $lib which is handled by https://svelte.dev/docs/kit/configuration#files


### PR DESCRIPTION
## Summary
- `vite.config.js` uses `process.env.TAURI_DEV_HOST` and is included in svelte-check's checked files, but `tsconfig.json` never set `types` explicitly — it relied on TypeScript's old default of auto-including every installed `@types` package.
- TypeScript 6.0 (landed via #326) flips that default to an empty array, so this was silently depending on legacy behavior. Declares `"types": ["node"]` explicitly instead.

Follow-up from the TypeScript 7 migration (#326) — noticed while checking whether the repo relied on any defaults that version bump changed.

## Test plan
- [x] `bun run check` (svelte-check --tsgo) — 0 errors
- [x] `bun run build` — succeeds
- [x] `bun run test:run` — 336/336 tests pass