### PR TITLE
fix: grant checks:write so Security Audit can report on push

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: read
+  checks: write
 
 jobs:
   security_audit:


### PR DESCRIPTION
## Summary
- Every `push`-triggered run of the Security Audit workflow on `main` has been failing with `Resource not accessible by integration` right after a clean audit (e.g. https://github.com/esoltys/luminous/actions/runs/31230347897) — the vulnerability scan itself succeeds, but `rustsec/audit-check@v2` can't publish its results as a GitHub Check because the workflow only grants `contents: read`.
- `pull_request`-triggered runs happen to work around this, which is why it went unnoticed until a batch of merges to `main` today made the push failures visible.
- Adds `checks: write` to the workflow's `permissions` block.

## Test plan
- [x] Not locally testable (GitHub Actions permissions only take effect in Actions) — verify the next push to `main` triggers a passing Security Audit check