### PR TITLE
Fix Tauri AppImage builds on rolling-release distros (Arch/CachyOS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,14 +100,20 @@ luminous/
 
 Luminous is a cross-platform application that can be built and run on both Linux and Windows.
 
-### Linux (Ubuntu/Debian)
+### Linux (Ubuntu/Debian, Arch/CachyOS)
 
 #### 1. Install System Dependencies
 Ensure the required build tools, GTK, WebKit, ALSA, and SSL development headers are installed:
-```bash
-sudo apt update
-sudo apt install -y build-essential curl wget file libssl-dev libgtk-3-dev libwebkit2gtk-4.1-dev libsoup-3.0-dev libayatanaloop-dev libayatana-appindicator3-dev librsvg2-dev libasound2-dev pkg-config
-```
+
+*   **Ubuntu/Debian**:
+    ```bash
+    sudo apt update
+    sudo apt install -y build-essential curl wget file libssl-dev libgtk-3-dev libwebkit2gtk-4.1-dev libsoup-3.0-dev libayatanaloop-dev libayatana-appindicator3-dev librsvg2-dev libasound2-dev pkg-config
+    ```
+*   **Arch/CachyOS**:
+    ```bash
+    sudo pacman -S --needed base-devel curl wget file openssl gtk3 webkit2gtk-4.1 libappindicator-gtk3 librsvg pkg-config
+    ```
 
 #### 2. Install Bun & Rust
 *   **Bun**: Install the JavaScript runtime & package manager:
@@ -131,6 +137,7 @@ Production bundles include updater artifacts, which must be signed. If you haven
 ```bash
 bun run tauri build
 ```
+> On rolling-release distros (Arch/CachyOS), the AppImage step bundles `strip` binaries too old to handle the RELR relocations in current system libraries. `bun run tauri build` sets `NO_STRIP=true` for this automatically, so no extra steps are needed here — it only skips stripping debug symbols from vendored libraries, slightly increasing AppImage size.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "install:git-hooks": "git config core.hooksPath .githooks",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --tsgo",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --tsgo --watch",
-    "tauri": "tauri",
+    "tauri": "NO_STRIP=true tauri",
     "icon": "tauri icon app-icon.svg",
     "test": "vitest",
     "test:run": "vitest run",


### PR DESCRIPTION
## 📋 Summary
Fixes `bun run tauri build` failing on a fresh CachyOS install during the AppImage bundling step.

## 🔍 Implementation Notes
Tauri's bundled `linuxdeploy` tool ships an old `strip` binary that can't parse the `.relr.dyn` RELR relocation sections emitted by current glibc/binutils on rolling-release distros like Arch/CachyOS. It fails to strip vendored system libraries (webkit2gtk, gtk, etc.) copied into the AppDir, which aborts the whole bundle step.

- `package.json`: the `tauri` script now sets `NO_STRIP=true`, which tells `linuxdeploy` to skip stripping debug symbols from vendored libraries. This only affects the AppImage bundling step (irrelevant to `.deb`/`.rpm`/`nsis` targets and to Windows/macOS), and the only side effect elsewhere is a slightly larger AppImage — no functional difference. Bun executes `package.json` scripts through its own cross-platform shell, so the `VAR=value cmd` syntax works on Windows too.
- `README.md`: documented the Arch/CachyOS `pacman` package list alongside the existing Ubuntu/Debian `apt` list (package names differ: e.g. `webkit2gtk-4.1` vs `libwebkit2gtk-4.1-dev`, `libappindicator-gtk3` vs `libayatana-appindicator3-dev`), plus a short note on the `NO_STRIP` behavior next to the build command.
- CI (`.github/workflows/release.yml`) is untouched — it invokes `tauri-apps/tauri-action` directly (not this npm script) and runs on `ubuntu-22.04`, which isn't affected by this issue.

## 🧪 Test Plan
- [ ] `bun run check` (svelte-check)
- [ ] `bun run test -- --run` (frontend)
- [ ] `cargo test` (src-tauri, if Rust changed)
- [x] Manually verified: `bun run tauri build` previously failed at the `javascriptcore-rs-sys` pkg-config step (missing `webkit2gtk-4.1`/`libappindicator-gtk3` packages) and then at the AppImage strip step on a fresh CachyOS install. After installing the pacman prerequisites and adding `NO_STRIP=true`, `bun run tauri build` produced working `.deb`, `.rpm`, and `.AppImage` bundles.

## 📸 Screenshots
N/A — build tooling/docs only.

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs updated (README Arch/CachyOS section)