### PR TITLE
Remove redundant comments across Rust, Svelte, and TS

### DIFF
--- a/src-tauri/src/analyzer.rs
+++ b/src-tauri/src/analyzer.rs
@@ -44,7 +44,6 @@ impl AudioVisualizerBuffer {
             result.push(buf[i]);
         }
 
-        // Zero-pad if needed
         while result.len() < size {
             result.push(0.0);
         }

--- a/src-tauri/src/audio.rs
+++ b/src-tauri/src/audio.rs
@@ -537,7 +537,6 @@ fn build_output(
     let target_sample_rate = config.sample_rate;
     let target_channels = config.channels;
 
-    // Update equalizer sample rate and channels format using target device values
     if let Ok(mut eq) = equalizer.lock() {
         eq.update_format(target_sample_rate, target_channels as usize);
     }
@@ -904,7 +903,6 @@ fn decode_thread(
         let mut transition: Option<PendingTransition> = None;
         let mut last_device_check = std::time::Instant::now();
 
-        // Decode loop
         'decode: loop {
             // Periodic default output device change / error check (~500ms throttle)
             let now = std::time::Instant::now();
@@ -1003,7 +1001,6 @@ fn decode_thread(
 
             let out = output.as_mut().unwrap();
 
-            // Non-blocking command check
             match cmd_rx.try_recv() {
                 Ok(AudioCommand::Pause) => {
                     let _ = out.stream.pause();
@@ -1170,7 +1167,7 @@ fn decode_thread(
                         current.about_to_finish_sent = false;
                     }
                 }
-                Err(mpsc::TryRecvError::Empty) => {} // no pending command
+                Err(mpsc::TryRecvError::Empty) => {}
                 Err(mpsc::TryRecvError::Disconnected) => break 'decode,
                 Ok(AudioCommand::Resume) | Ok(AudioCommand::ResumeWithFade(_)) => {} // already playing
                 Ok(AudioCommand::Cue(_)) => {} // already playing
@@ -1223,7 +1220,6 @@ fn decode_thread(
                 }
             }
 
-            // If the decoder exhausted the current file:
             if current.eof {
                 if transition.is_some() {
                     // Waiting for the boundary to be consumed before the
@@ -1268,7 +1264,6 @@ fn decode_thread(
                 continue 'decode;
             }
 
-            // Decode one packet
             match current.format.next_packet() {
                 Ok(Some(packet)) => {
                     if packet.track_id != current.track_id {
@@ -1309,7 +1304,6 @@ fn decode_thread(
                             );
                             let resampled = current.resampler.resample(&channel_converted);
 
-                            // Push samples into the shared playback buffer
                             let mut pushed = 0;
                             while pushed < resampled.len() {
                                 let written = out.producer.push_slice(&resampled[pushed..]);

--- a/src-tauri/src/collection.rs
+++ b/src-tauri/src/collection.rs
@@ -672,7 +672,6 @@ impl CollectionScanner {
             // 3. Try remote fetch (limit to 50 to avoid long scans / rate limits)
             if !resolved && remote_fetch_count < 50 {
                 remote_fetch_count += 1;
-                // Add a small delay between requests
                 std::thread::sleep(std::time::Duration::from_millis(150));
 
                 if let Ok(Some(filename)) = cover_manager.fetch_remote_cover(song_id).await {
@@ -1827,7 +1826,6 @@ pub(crate) fn read_tags(path: &Path) -> Result<Song> {
             .get_string(&ItemKey::ReplayGainAlbumGain)
             .and_then(parse_replaygain_db);
 
-        // Check for embedded art
         song.art_embedded = !tag.pictures().is_empty();
     }
 
@@ -2427,10 +2425,8 @@ pub fn start_watcher(app: AppHandle, state: &crate::AppState) {
     let db = Arc::clone(&state.db);
     let app_clone = app.clone();
 
-    // Create a channel to receive events
     let (tx, rx) = std::sync::mpsc::channel::<WatcherMsg>();
 
-    // Create recommended watcher
     let watcher = notify::recommended_watcher(move |res: Result<notify::Event, notify::Error>| {
         match res {
             Ok(event) => {
@@ -2836,7 +2832,6 @@ mod tests {
         let scanner = CollectionScanner::new(db.clone());
         let conn = db.pool.get().unwrap();
 
-        // Helper to insert a song
         let insert_song = |path: &str,
                            title: &str,
                            artist: Option<&str>,
@@ -2922,7 +2917,6 @@ mod tests {
 
         let albums = scanner.get_albums().unwrap();
 
-        // Helper to find album by name
         let find_album = |name: &str| -> &serde_json::Value {
             albums
                 .iter()
@@ -2951,7 +2945,6 @@ mod tests {
         assert_eq!(album_four["artist"].as_str(), None);
         assert_eq!(album_four["track_count"].as_i64(), Some(2));
 
-        // Cleanup
         let _ = std::fs::remove_dir_all(temp_dir);
     }
 

--- a/src-tauri/src/commands/lyrics.rs
+++ b/src-tauri/src/commands/lyrics.rs
@@ -96,7 +96,6 @@ pub async fn get_lyrics(state: State<'_, AppState>, song_id: i64) -> Result<Stri
                 "[Luminous Backend] Successfully fetched online lyrics (len: {}, synced: {is_synced}). Caching in SQLite...",
                 final_lyrics.len()
             );
-            // Cache back in SQLite
             conn.execute(
                 "UPDATE songs SET lyrics = ?1 WHERE id = ?2",
                 rusqlite::params![final_lyrics, song_id],
@@ -106,7 +105,6 @@ pub async fn get_lyrics(state: State<'_, AppState>, song_id: i64) -> Result<Stri
         }
         Err(e) => {
             eprintln!("[Luminous Backend] Online search failed: {e}");
-            // Online search failed, fall back to cached local lyrics if available
             if let Some(lyrics) = cached_lyrics {
                 if !lyrics.trim().is_empty() {
                     // Mark as checked to prevent future online lookup spamming

--- a/src-tauri/src/commands/tageditor.rs
+++ b/src-tauri/src/commands/tageditor.rs
@@ -67,7 +67,6 @@ pub async fn lookup_acoustid_tags(
     state: State<'_, AppState>,
     song_id: i64,
 ) -> Result<SuggestedTags, String> {
-    // 1. Fetch file path from database
     let conn = state.db.pool.get().map_err(|e| e.to_string())?;
     let path_str: String = conn
         .query_row(
@@ -127,7 +126,6 @@ pub async fn save_song_tags(
     // whatever feedback the tag editor itself shows (#233).
     let _watcher_pause_guard = WatcherPauseGuard::new(Arc::clone(&state.watcher_paused));
 
-    // 1. Fetch file path from database
     let conn = state.db.pool.get().map_err(|e| e.to_string())?;
     let path_str: String = conn
         .query_row(

--- a/src-tauri/src/commands/visualizer.rs
+++ b/src-tauri/src/commands/visualizer.rs
@@ -7,12 +7,10 @@ pub async fn get_waveform_data(
     state: State<'_, AppState>,
     song_id: i64,
 ) -> Result<Option<Vec<u8>>, String> {
-    // 1. Check cache in SQLite
     if let Ok(Some(cached)) = crate::waveform::get_cached_waveform(&state.db, song_id) {
         return Ok(Some(cached));
     }
 
-    // 2. Fetch song path from SQLite
     let conn = state.db.pool.get().map_err(|e| e.to_string())?;
     let path_str: Option<String> = conn
         .query_row(
@@ -44,12 +42,10 @@ pub async fn get_band_waveform_data(
     state: State<'_, AppState>,
     song_id: i64,
 ) -> Result<Option<Vec<u8>>, String> {
-    // 1. Check cache in SQLite
     if let Ok(Some(cached)) = crate::band_waveform::get_cached_band_waveform(&state.db, song_id) {
         return Ok(Some(cached));
     }
 
-    // 2. Fetch song path from SQLite
     let conn = state.db.pool.get().map_err(|e| e.to_string())?;
     let path_str: Option<String> = conn
         .query_row(

--- a/src-tauri/src/covermanager.rs
+++ b/src-tauri/src/covermanager.rs
@@ -104,7 +104,6 @@ impl CoverManager {
         let filename = format!("{}.{}", hash_name, ext);
         let dest_path = self.covers_dir.join(&filename);
 
-        // Write the picture data to the covers directory
         std::fs::write(&dest_path, cleaned_data)
             .context("failed to write cover art file to cache")?;
 
@@ -220,7 +219,6 @@ impl CoverManager {
                     std::fs::write(&dest_path, cleaned_bytes)?;
                     log::info!("Saved remote cover art to: {}", dest_path.display());
 
-                    // Update song database row
                     conn.execute(
                         "UPDATE songs SET art_automatic = ?1, art_unset = 0 WHERE id = ?2",
                         params![filename, song_id],

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -73,7 +73,6 @@ impl Database {
     fn run_migrations(&self) -> Result<i32> {
         let conn = self.pool.get().context("failed to get db connection")?;
 
-        // Create schema_version table if it doesn't exist
         conn.execute_batch(
             "CREATE TABLE IF NOT EXISTS schema_version (version INTEGER PRIMARY KEY);",
         )?;
@@ -588,7 +587,6 @@ mod tests {
 
     #[test]
     fn test_database_initialization() {
-        // Use a unique temp path for testing
         let temp_dir = std::env::temp_dir().join(format!(
             "luminous_test_{}",
             std::time::SystemTime::now()
@@ -606,7 +604,6 @@ mod tests {
         ).unwrap();
         assert_eq!(tables_count, 3);
 
-        // Cleanup
         let _ = std::fs::remove_dir_all(temp_dir);
     }
 
@@ -643,7 +640,6 @@ mod tests {
         assert_eq!(db.schema_version, CURRENT_SCHEMA_VERSION + 1);
         assert!(db.is_newer_than_app());
 
-        // Cleanup
         let _ = std::fs::remove_dir_all(temp_dir);
     }
 }

--- a/src-tauri/src/equalizer.rs
+++ b/src-tauri/src/equalizer.rs
@@ -5,7 +5,6 @@ pub const EQ_BANDS: [f32; 10] = [
     31.25, 62.5, 125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0, 8000.0, 16000.0,
 ];
 
-/// Number of bands in the parametric equalizer mode.
 pub const PARAMETRIC_BAND_COUNT: usize = 20;
 
 /// Default Q for graphic-mode bands. The 10 bands are spaced 1 octave apart
@@ -110,7 +109,6 @@ impl BiquadFilter {
 
         let cos_w0 = w0.cos();
 
-        // Peaking EQ coefficients
         let b0 = 1.0 + alpha * a;
         let b1 = -2.0 * cos_w0;
         let b2 = 1.0 - alpha * a;
@@ -515,7 +513,6 @@ impl Equalizer {
                 }
             }
 
-            // Clip prevention/limiting
             *sample = out.clamp(-1.0, 1.0);
         }
     }
@@ -546,7 +543,6 @@ mod tests {
         assert_eq!(bands.len(), PARAMETRIC_BAND_COUNT);
         assert!((bands[0].freq - 31.0).abs() < 2.0);
         assert!((bands[19].freq - 16000.0).abs() < 50.0);
-        // Strictly ascending
         for pair in bands.windows(2) {
             assert!(pair[1].freq > pair[0].freq);
         }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -110,7 +110,6 @@ pub fn run() {
             let app_handle = ctx.app_handle();
             let covers_dir = app_handle.path().app_data_dir().unwrap().join("covers");
 
-            // Extract the resource path directly from the full URI string
             let uri_str = request.uri().to_string();
             let mut trimmed = &uri_str[..];
             if let Some(t) = uri_str.strip_prefix("http://luminous-art.localhost/") {
@@ -216,13 +215,11 @@ pub fn run() {
             }
         }))
         .setup(|app| {
-            // Initialize database (creates file + runs migrations)
             let db = Arc::new(
                 Database::new(app.path().app_data_dir().expect("no app data dir"))
                     .expect("failed to initialize database"),
             );
 
-            // Initialize audio engine
             let audio_engine = AudioEngine::new();
 
             // Load and restore equalizer settings on startup
@@ -272,11 +269,9 @@ pub fn run() {
 
             let audio = Arc::new(Mutex::new(audio_engine));
 
-            // Initialize player (needs db + audio refs)
             let player = Arc::new(Mutex::new(Player::new(Arc::clone(&db), Arc::clone(&audio))));
             let volume_before_mute = Arc::new(Mutex::new(1.0));
 
-            // Initialize playlist manager
             let manager = PlaylistManager::new(Arc::clone(&db)).expect("failed to init playlists");
             // Bootstrap the built-in Queue before the window loads, so the
             // frontend can treat its existence as a guarantee rather than a
@@ -286,7 +281,6 @@ pub fn run() {
             }
             let playlists = Arc::new(Mutex::new(manager));
 
-            // Initialize cover manager
             let cover_manager = Arc::new(CoverManager::new(
                 Arc::clone(&db),
                 app.path().app_data_dir().expect("no app data dir"),
@@ -539,7 +533,6 @@ pub fn run() {
                 media_session,
             };
 
-            // Start background directory watcher
             crate::collection::start_watcher(app.handle().clone(), &state);
 
             // Start background EBU R128 loudness analyzer (#77)

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -275,7 +275,6 @@ impl Song {
 // Playlist models
 // ---------------------------------------------------------------------------
 
-/// Item type within a playlist.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum PlaylistItemType {
@@ -449,7 +448,6 @@ impl Playlist {
 // Playback state models
 // ---------------------------------------------------------------------------
 
-/// Shuffle mode.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum ShuffleMode {
@@ -461,7 +459,6 @@ pub enum ShuffleMode {
     Artists,
 }
 
-/// Repeat mode.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum RepeatMode {

--- a/src-tauri/src/organizer.rs
+++ b/src-tauri/src/organizer.rs
@@ -254,7 +254,6 @@ fn build_target_path_parts(
         .and_then(|e| e.to_str())
         .unwrap_or("flac");
 
-    // Determine root destination directory
     let root_dir: PathBuf = if let Some(ref dest) = options.destination_dir {
         PathBuf::from(dest)
     } else {
@@ -706,7 +705,6 @@ pub fn compute_preview(
                 }
             }
 
-            // External collision!
             let dest_folder: PathBuf = if let Some(ref dest) = options.destination_dir {
                 PathBuf::from(dest)
             } else {

--- a/src-tauri/src/player.rs
+++ b/src-tauri/src/player.rs
@@ -125,7 +125,6 @@ impl Player {
             ) {
                 if let Ok(v) = v_str.parse::<f32>() {
                     volume = v.clamp(0.0, 1.0);
-                    // Apply to audio engine
                     if let Ok(engine) = audio.try_lock() {
                         let _ = engine.set_volume(volume);
                     }
@@ -370,11 +369,9 @@ impl Player {
 
         self.persist_adhoc_queue();
 
-        // Build shuffle order if needed
         self.rebuild_shuffle_order();
 
         let play_index = if self.shuffle_mode != ShuffleMode::Off {
-            // Find the position of start_index in the shuffle order
             self.shuffle_order
                 .iter()
                 .position(|&i| i == start_index)
@@ -588,7 +585,6 @@ impl Player {
         let mut attempts = 0;
         loop {
             if attempts >= total {
-                // Every item in the playlist is unavailable — stop.
                 log::warn!("Entire playlist contains only unavailable tracks — stopping.");
                 return self.stop().await;
             }
@@ -969,7 +965,6 @@ impl Player {
     }
 
     pub async fn next_track(&mut self) -> Result<()> {
-        // Drain unavailable items from the front of the queue before playing
         while let Some(front) = self.queue.front() {
             if Self::is_item_playable(front) {
                 break;
@@ -978,7 +973,6 @@ impl Player {
             self.queue.pop_front();
         }
 
-        // Check queue first
         if let Some(queued) = self.queue.pop_front() {
             let song = queued
                 .song
@@ -998,10 +992,7 @@ impl Player {
         let next_index = self.get_next_index();
         match next_index {
             Some(idx) => self.play_at_index(idx).await,
-            None => {
-                // End of playlist — stop
-                self.stop().await
-            }
+            None => self.stop().await,
         }
     }
 
@@ -1269,7 +1260,6 @@ impl Player {
 
         match self.repeat_mode {
             RepeatMode::Track => {
-                // Replay current track
                 if let Some(idx) = self.current_index {
                     return self.play_at_index(idx).await;
                 }
@@ -1410,7 +1400,6 @@ impl Player {
                         .push(i);
                 }
 
-                // Shuffle within each album group
                 for group_tracks in groups.values_mut() {
                     group_tracks.shuffle(&mut rng);
                 }
@@ -1452,7 +1441,6 @@ impl Player {
                         .push(i);
                 }
 
-                // Shuffle the order of other albums
                 other_keys.shuffle(&mut rng);
 
                 // Add current album's remaining tracks first (keeps their original order)
@@ -1492,7 +1480,6 @@ impl Player {
                         .push(i);
                 }
 
-                // Shuffle the order of other artists
                 other_keys.shuffle(&mut rng);
 
                 // Add current artist's remaining tracks first (keeps their original order)
@@ -1715,7 +1702,6 @@ mod tests {
         let (db, temp_dir) = setup_test_db();
         let db_arc = Arc::new(db);
 
-        // Insert a dummy song into DB
         {
             let conn = db_arc.pool.get().unwrap();
             conn.execute(
@@ -1749,7 +1735,6 @@ mod tests {
         assert_eq!(state.state, crate::models::PlayState::Paused);
         assert_eq!(state.position_nanosec, 45_000_000_000);
 
-        // Test updating persistence
         player.current_song = None;
         player.persist_current_song();
         player.persist_position(0);

--- a/src-tauri/src/playlist.rs
+++ b/src-tauri/src/playlist.rs
@@ -454,7 +454,6 @@ impl PlaylistManager {
         let conn = self.db.pool.get()?;
         let now = chrono::Utc::now().timestamp();
 
-        // Prune decade auto-playlists for decades no longer in the library.
         let mut stmt =
             conn.prepare("SELECT id, dynamic_spec FROM playlists WHERE dynamic_enabled = 1 AND dynamic_spec LIKE 'decade:%'")?;
         let existing: Vec<(i64, String)> = stmt
@@ -1203,7 +1202,6 @@ impl PlaylistManager {
     pub fn add_songs_to_playlist(&mut self, playlist_id: i64, song_ids: &[i64]) -> Result<()> {
         let conn = self.db.pool.get()?;
 
-        // Get current max position
         let max_pos: i32 = conn
             .query_row(
                 "SELECT COALESCE(MAX(position), -1) FROM playlist_items WHERE playlist_id = ?1",
@@ -1261,7 +1259,6 @@ impl PlaylistManager {
             }
         }
 
-        // Re-number positions to be contiguous
         self.renumber_positions(&conn, playlist_id)?;
         self.touch_updated(&conn, playlist_id)?;
 
@@ -1844,27 +1841,22 @@ mod tests {
         let db_arc = std::sync::Arc::new(db);
         let manager = PlaylistManager::new(db_arc.clone()).unwrap();
 
-        // Create playlist
         let pl = manager.create_playlist("Chill Mix").unwrap();
         let pl_id = pl.id;
         assert!(pl_id > 0);
 
-        // Get playlists
         let playlists = manager.get_playlists().unwrap();
         assert_eq!(playlists.len(), 1);
         assert_eq!(playlists[0].name, "Chill Mix");
 
-        // Rename playlist
         manager.rename_playlist(pl_id, "Chill Beats").unwrap();
         let playlists = manager.get_playlists().unwrap();
         assert_eq!(playlists[0].name, "Chill Beats");
 
-        // Delete playlist
         manager.delete_playlist(pl_id).unwrap();
         let playlists = manager.get_playlists().unwrap();
         assert_eq!(playlists.len(), 0);
 
-        // Cleanup
         let _ = std::fs::remove_dir_all(temp_dir);
     }
 
@@ -1873,7 +1865,6 @@ mod tests {
         let (db, temp_dir) = setup_test_db();
         let db_arc = std::sync::Arc::new(db);
 
-        // Insert dummy song into DB
         {
             let conn = db_arc.pool.get().unwrap();
             conn.execute(
@@ -1889,12 +1880,10 @@ mod tests {
         let tracks = manager.get_playlist_tracks(pl.id).unwrap();
         assert_eq!(tracks.len(), 1);
 
-        // Clear playlist
         manager.clear_playlist(pl.id).unwrap();
         let tracks_after_clear = manager.get_playlist_tracks(pl.id).unwrap();
         assert_eq!(tracks_after_clear.len(), 0);
 
-        // Undo clear
         manager.undo().unwrap();
         let tracks_after_undo = manager.get_playlist_tracks(pl.id).unwrap();
         assert_eq!(tracks_after_undo.len(), 1);
@@ -1903,7 +1892,6 @@ mod tests {
             Some("Test Song")
         );
 
-        // Redo clear
         manager.redo().unwrap();
         let tracks_after_redo = manager.get_playlist_tracks(pl.id).unwrap();
         assert_eq!(tracks_after_redo.len(), 0);
@@ -2022,7 +2010,6 @@ mod tests {
             .collect();
         assert_eq!(titles, vec!["Song 3", "Song 4", "Song 1", "Song 2"]);
 
-        // Test Undo
         manager.undo().unwrap();
         let tracks_undo = manager.get_playlist_tracks(pl.id).unwrap();
         let titles_undo: Vec<&str> = tracks_undo
@@ -2368,7 +2355,6 @@ mod tests {
             .unwrap();
         manager.populate_dynamic_playlist(rock_pl.id).unwrap();
 
-        // Trigger sync pass again
         manager.sync_genre_auto_playlists().unwrap();
 
         let playlists_after = manager.get_playlists().unwrap();

--- a/src-tauri/tests/design_tools_bdd.rs
+++ b/src-tauri/tests/design_tools_bdd.rs
@@ -104,7 +104,6 @@ fn click_save_custom_theme(w: &mut DesignToolsWorld) {
     w.custom_themes.push(theme);
     w.active_theme_id = new_id;
 
-    // Persist in DB app_state table
     let conn = w.db.pool.get().expect("db conn failed");
     conn.execute(
         "INSERT OR REPLACE INTO app_state (key, value) VALUES ('active_theme_id', ?1)",

--- a/src/lib/components/AlbumDetailView.svelte
+++ b/src/lib/components/AlbumDetailView.svelte
@@ -269,7 +269,6 @@
       .then((fetchedSongs) => {
         if (requested !== albumName) return;
         let filtered = [...fetchedSongs];
-        // Sort by disc, then by track
         filtered.sort((a, b) => {
           if (a.disc !== b.disc) {
             return (a.disc ?? 1) - (b.disc ?? 1);
@@ -420,7 +419,6 @@
 
   function handleTagEditorSaved() {
     collectionStore.refreshLibrary();
-    // Reload songs
     loading = true;
     invoke<Song[]>("get_songs_by_album", { album: albumName })
       .then((fetchedSongs) => {
@@ -506,10 +504,8 @@
     </div>
   {/if}
 
-  <!-- Album Hero & Summary Banner Header -->
   <div class="relative z-30 w-full border-b border-brand-border/60 bg-brand-main/60 backdrop-blur-md px-6 pt-6 pb-6">
     <div class="flex items-start justify-between gap-6 relative z-10">
-      <!-- Left Title & Summary Metadata -->
       <div class="flex flex-col justify-end gap-1.5 min-w-0 max-w-xl">
         <h1 class="text-3xl sm:text-4xl font-heading font-bold text-brand-text-primary leading-snug truncate py-0.5" title={albumName}>
           {albumName}
@@ -554,7 +550,6 @@
           {/if}
         </div>
 
-        <!-- Control Buttons -->
         <div class="flex items-center gap-3 mt-3 select-none">
           <PlayShuffleButtons
             onPlayAll={handlePlayAll}
@@ -588,7 +583,6 @@
         </div>
       </div>
 
-      <!-- Right: Full Album Cover Art -->
       <div class="relative w-40 h-40 hidden sm:block shrink-0">
         <div class="absolute inset-0 overflow-hidden border border-brand-border/60 shadow-2xl">
           <CoverArt
@@ -609,10 +603,8 @@
     </div>
   </div>
 
-  <!-- Songs Table Section -->
   <div class="relative z-10 px-6 py-6" class:pb-28={!!playerStore.currentSong}>
     <div class="border border-brand-border rounded-lg bg-brand-sidebar/50 backdrop-blur-xl shadow-2xl overflow-hidden">
-      <!-- Table Header -->
       <div class="sticky top-0 z-10 flex flex-col rounded-t-lg bg-brand-sidebar/80 backdrop-blur-md border-b border-brand-border text-[10px] text-brand-text-primary uppercase tracking-wider font-semibold select-none">
         <div class="grid items-center py-2.5 px-4" style={gridColsStyle}>
           <div class="text-center w-9"></div>
@@ -910,7 +902,6 @@
         </div>
       </div>
 
-      <!-- Table Body -->
       <div class="divide-y divide-brand-border/40 rounded-b-lg overflow-hidden">
         {#if loading}
           <div class="flex items-center justify-center py-16">

--- a/src/lib/components/AlbumTagEditor.svelte
+++ b/src/lib/components/AlbumTagEditor.svelte
@@ -81,7 +81,6 @@
 </script>
 
 <Modal onClose={onClose} onKeydown={handleKeydown}>
-    <!-- Header -->
     <div class="h-14 flex items-center justify-between px-6 border-b border-brand-border shrink-0 bg-brand-main">
       <div class="flex items-center gap-2">
         <Sliders class="w-4 h-4 text-brand-accent-text" />
@@ -92,27 +91,21 @@
       </button>
     </div>
 
-    <!-- Body -->
     <div class="flex-1 overflow-y-auto p-6 max-h-[calc(100vh-200px)]">
       <div class="flex flex-col gap-4">
-        <!-- Form fields -->
         <div class="grid grid-cols-2 gap-4">
-          <!-- Album Title -->
           <FormField label={i18n.t('albumTagEditor.albumField')} for="album-tag-album" span2>
             <Input id="album-tag-album" bind:value={album} disabled={isSaving} size="sm" class="w-full" />
           </FormField>
 
-          <!-- Album Artist -->
           <FormField label={i18n.t('albumTagEditor.albumArtistField')} for="album-tag-albumartist" span2>
             <Input id="album-tag-albumartist" bind:value={albumArtist} disabled={isSaving} size="sm" class="w-full" />
           </FormField>
 
-          <!-- Genre -->
           <FormField label={i18n.t('albumTagEditor.genreField')} for="album-tag-genre" span2>
             <Input id="album-tag-genre" bind:value={genre} disabled={isSaving} size="sm" class="w-full" />
           </FormField>
 
-          <!-- Year -->
           <FormField label={i18n.t('albumTagEditor.yearField')} for="album-tag-year">
             <Input
               id="album-tag-year"
@@ -128,7 +121,6 @@
             />
           </FormField>
 
-          <!-- Disc -->
           <FormField label={i18n.t('albumTagEditor.discField')} for="album-tag-disc">
             <Input
               id="album-tag-disc"
@@ -147,7 +139,6 @@
       </div>
     </div>
 
-    <!-- Footer -->
     <div class="h-16 flex items-center justify-between px-6 border-t border-brand-border bg-brand-main shrink-0">
       <div class="flex items-center gap-2 text-xs font-medium text-brand-text-secondary">
         <Layers class="w-3.5 h-3.5 text-brand-accent-text shrink-0" />

--- a/src/lib/components/ArtistDetailView.svelte
+++ b/src/lib/components/ArtistDetailView.svelte
@@ -308,19 +308,15 @@
 </script>
 
 <div class="flex-1 flex flex-col overflow-y-auto bg-brand-main text-brand-text-secondary h-full carousel-scroll" use:rememberScroll={`artist-detail:${artistName}`}>
-  <!-- Stacked Cover Art Hero & Summary Banner Header -->
   <div class="relative z-30 w-full border-b border-brand-border/60 bg-brand-main/60 backdrop-blur-md px-6 pt-6 pb-6">
     <div class="flex items-start justify-between gap-6 relative z-10">
-      <!-- Left Title & Summary Metadata -->
       <div class="flex flex-col justify-end gap-1.5 max-w-xl">
         <h1 class="text-3xl sm:text-4xl font-heading font-bold text-brand-text-primary leading-snug truncate py-0.5">{artistName}</h1>
 
-        <!-- Summary Metadata Line -->
         <div class="flex items-center gap-3 text-xs text-brand-text-secondary font-medium">
           <span>{i18n.t('artistDetail.statsLine', { genre: genreLabel, songs: songsText, duration: totalDurationLabel })}</span>
         </div>
 
-        <!-- Action Buttons: Play All & Shuffle Play -->
         <div class="flex items-center gap-3 mt-3">
           <PlayShuffleButtons
             onPlayAll={handlePlayAll}
@@ -333,7 +329,6 @@
         </div>
       </div>
 
-      <!-- Right: 3D Stacked Album Cover Preview Header -->
       {#if headerCovers.length > 0}
         <div class="relative w-48 h-36 hidden sm:block shrink-0 flex items-center justify-end">
           <CoverStack covers={headerCovers} direction="left" sizeClass="w-28 h-28" />
@@ -342,7 +337,6 @@
     </div>
   </div>
 
-  <!-- Release Categories (Sets, Albums, EPs, Singles) -->
   <div class="px-6 pt-6 flex flex-col gap-8">
     {#if sets.length > 0}
       <HorizontalScrollRow title={i18n.t('artistDetail.setsFilter', { count: sets.length })}>
@@ -387,7 +381,6 @@
       <div class="flex flex-col gap-3">
         <h2 class="text-xl font-semibold text-brand-text-primary">{i18n.t('artistDetail.singlesFilter', { count: singleSongs.length })}</h2>
         <div class="border border-brand-border rounded-lg bg-brand-sidebar/50 backdrop-blur-xl shadow-2xl overflow-hidden">
-          <!-- Table Header -->
           <div class="sticky top-0 z-10 flex flex-col rounded-t-lg bg-brand-sidebar/80 backdrop-blur-md border-b border-brand-border text-[10px] text-brand-text-primary uppercase tracking-wider font-semibold select-none">
             <div class="grid items-center py-2.5 px-4" style={gridColsStyle}>
               <div class="text-center w-9"></div>
@@ -685,7 +678,6 @@
             </div>
           </div>
 
-          <!-- Table Body -->
           <div class="divide-y divide-brand-border/40 rounded-b-lg overflow-hidden">
             {#each sortedSingleSongs as song, index (song.id)}
               {@const disconnected = !song.unavailable && collectionStore.isPathOnDisconnectedDrive(song.path)}
@@ -888,7 +880,6 @@
     {/if}
   </div>
 
-  <!-- Playlists featuring this artist -->
   {#if playlists.length > 0}
     <div class="px-6 pt-10 {playerStore.currentSong ? 'pb-28' : 'pb-6'}">
       <HorizontalScrollRow title={i18n.t('artistDetail.playlistsFeaturing', { artist: artistName })}>

--- a/src/lib/components/AutoPlaylistDetailView.svelte
+++ b/src/lib/components/AutoPlaylistDetailView.svelte
@@ -74,7 +74,6 @@ import { shuffleArray } from "../utils/shuffle";
   let editingSongId = $state<number | null>(null);
   let contextMenuState = $state<{ x: number; y: number; song: Song } | null>(null);
 
-  // Save auto-playlist as custom playlist modal state
   let showSaveModal = $state(false);
   let savePlaylistName = $state("");
 
@@ -503,10 +502,8 @@ import { shuffleArray } from "../utils/shuffle";
   class="flex-1 flex flex-col overflow-y-auto carousel-scroll bg-brand-main text-brand-text-secondary h-full"
   use:rememberScroll={`autoplaylist:${view.kind}:${view.genre ?? view.decade ?? view.bpm ?? ""}`}
 >
-  <!-- Auto-Playlist Hero & Summary Banner Header -->
   <div class="relative z-30 w-full border-b border-brand-border/60 bg-brand-main/60 backdrop-blur-md px-6 pt-6 pb-6 shrink-0">
     <div class="flex items-stretch justify-between gap-6 relative z-10">
-      <!-- Left Title & Summary Metadata -->
       <div class="flex flex-col justify-end gap-1.5 min-w-0 flex-1">
         <h1 class="text-3xl sm:text-4xl font-heading font-bold text-brand-text-primary leading-snug truncate py-0.5" title={displayName}>
           {displayName}
@@ -522,7 +519,6 @@ import { shuffleArray } from "../utils/shuffle";
           {/if}
         </div>
 
-        <!-- Primary Control Buttons Row -->
         <div class="flex flex-wrap items-center gap-3 mt-3 select-none">
           <PlayShuffleButtons
             onPlayAll={handlePlayAll}
@@ -533,9 +529,7 @@ import { shuffleArray } from "../utils/shuffle";
           <ColumnSelector align="left" iconOnly />
         </div>
 
-        <!-- Secondary Control Buttons Row: Search Filter Bar, Undo, Redo, More -->
         <div class="flex flex-wrap items-center gap-2.5 mt-2.5 select-none relative z-40">
-          <!-- Search Filter Bar -->
           <div class="relative w-full max-w-xs">
             <Search class="w-3.5 h-3.5 absolute left-3.5 top-1/2 -translate-y-1/2 text-brand-text-secondary/60 pointer-events-none" />
             <Input
@@ -575,7 +569,6 @@ import { shuffleArray } from "../utils/shuffle";
           </div>
         </div>
 
-        <!-- Additional controls for genre/decade playlists: population-mode -->
         {#if (kind === "genre" || kind === "decade" || kind === "bpm") && playlistId !== undefined}
           <div class="flex flex-wrap items-center gap-2.5 mt-2.5 select-none relative z-40">
             <!-- Queue population mode tabs (#120): what bias to (re)populate this auto-playlist with -->
@@ -588,7 +581,6 @@ import { shuffleArray } from "../utils/shuffle";
         {/if}
       </div>
 
-      <!-- Right: Cover Stack -->
       <div class="relative w-40 h-40 hidden sm:block shrink-0">
         {#if (kind === "genre" || kind === "decade" || kind === "bpm") && topCovers.length > 0}
           <div class="w-full h-full bg-brand-main bg-gradient-to-br {kind === 'decade' ? 'from-[#2563EB]/25 to-[#38BDF8]/15 border-[#38BDF8]/30 shadow-[0_0_28px_3px_rgba(56,189,248,0.4)]' : kind === 'bpm' ? 'from-[#C026D3]/25 to-[#E879F9]/15 border-[#E879F9]/30 shadow-[0_0_28px_3px_rgba(232,121,249,0.4)]' : 'from-[#059669]/25 to-[#34D399]/15 border-[#34D399]/30 shadow-[0_0_28px_3px_rgba(52,211,153,0.4)]'} flex items-center justify-center overflow-hidden border relative">
@@ -625,7 +617,6 @@ import { shuffleArray } from "../utils/shuffle";
 
   <div class="px-6 py-6 flex flex-col" class:pb-28={!!playerStore.currentSong}>
     <div class="border border-brand-border/60 rounded-xl bg-brand-sidebar/30 backdrop-blur-md relative overflow-hidden">
-      <!-- Header -->
       <div class="sticky top-0 z-20 flex flex-col bg-brand-sidebar border-b border-brand-border text-xs text-brand-text-primary uppercase tracking-wider font-semibold select-none">
         <div role="row" class="grid items-center py-3 px-4" style={gridColsStyle}>
           <SortableHeader
@@ -919,7 +910,6 @@ import { shuffleArray } from "../utils/shuffle";
         </div>
       </div>
 
-      <!-- Rows -->
       <div class="divide-y divide-brand-border/40">
         {#if loading}
           <div class="py-16 text-center text-brand-text-primary text-sm">

--- a/src/lib/components/CollectionView.svelte
+++ b/src/lib/components/CollectionView.svelte
@@ -176,16 +176,13 @@
     SONG_TABLE_COLUMNS.filter((col) => col.field && collectionStore.visibleColumns[col.key])
   );
 
-  // Trigger search on collectionStore when query changes
   $effect(() => {
     collectionStore.search(collectionStore.searchQuery);
   });
 
-  // Computed songs list with filtering and sorting
   let filteredSongs = $derived.by(() => {
     let result = collectionStore.filteredSongs;
 
-    // Apply sort
     return [...result].sort((a, b) => {
       let valA = a[sortField];
       let valB = b[sortField];
@@ -241,7 +238,6 @@
     typeof window !== "undefined" ? localStorage.getItem("sort_artist_asc") !== "false" : true
   );
 
-  // Save sorting states to localStorage when they change
   $effect(() => {
     if (typeof window !== "undefined") {
       localStorage.setItem("sort_song_field", sortField);
@@ -253,7 +249,6 @@
     }
   });
 
-  // Computed sorted albums list
   let sortedAlbums = $derived.by(() => {
     const list = [...collectionStore.filteredAlbums];
     const field = albumSortField;
@@ -276,7 +271,6 @@
     });
   });
 
-  // Computed sorted artists list
   let sortedArtists = $derived.by(() => {
     const list = [...collectionStore.filteredArtists];
     const field = artistSortField;
@@ -417,15 +411,12 @@
 {:else}
 <div class="flex-1 flex flex-col overflow-hidden bg-brand-main text-brand-text-secondary h-full">
   {#if collectionStore.activeSubTab === "songs"}
-    <!-- Top bar for Songs View -->
     <div class="px-6 pt-4 pb-2 flex-shrink-0">
       <div class="h-9 flex items-center justify-between">
-        <!-- Showing Count (Left) -->
         <div class="text-xs text-brand-text-secondary font-medium">
           {filteredSongs.length === 1 ? i18n.t('collection.showingOneSong') : i18n.t('collection.showingSongs', { count: filteredSongs.length })}
         </div>
 
-        <!-- Columns + Sort Dropdown (Right) -->
         <div class="flex items-center gap-2">
           <ColumnSelector align="right" iconOnly />
           <div class="relative">
@@ -448,9 +439,7 @@
       </div>
     </div>
 
-    <!-- Main View Songs Container -->
     <div class="flex-1 px-6 pt-2 overflow-hidden flex flex-col {playerStore.currentSong ? 'pb-28' : 'pb-6'}">
-      <!-- Songs Table View -->
       <div bind:this={songsTableContainer} class="flex-1 overflow-hidden border border-brand-border rounded-lg bg-brand-sidebar/40 flex flex-col min-h-0">
         <div class="sticky top-0 z-20 flex flex-col bg-brand-sidebar border-b border-brand-border text-xs text-brand-text-secondary uppercase tracking-wider font-semibold select-none">
           <div class="grid items-center py-3 px-4" style="{gridColsStyle}; padding-right: calc(1rem + {scrollbarWidth}px)">
@@ -980,12 +969,9 @@
     </div>
 
   {:else}
-    <!-- Scrollable Container for Albums / Artists Views -->
     <div class="flex-1 px-6 overflow-y-auto {playerStore.currentSong ? 'pb-28' : 'pb-6'}" use:rememberScroll={`collection:${collectionStore.activeSubTab}`}>
-      <!-- Sticky header: Filter Info / View Mode Toggle / Sort controls -->
       <div class="sticky top-0 z-20 bg-brand-main pt-3">
         <div class="h-12 flex items-center justify-between">
-          <!-- Showing Count (Left) -->
           <div class="text-xs text-brand-text-secondary font-medium">
             {#if collectionStore.activeSubTab === "albums"}
               {sortedAlbums.length === 1 ? i18n.t('collection.showingOneAlbum') : i18n.t('collection.showingAlbums', { count: sortedAlbums.length })}
@@ -994,7 +980,6 @@
             {/if}
           </div>
 
-          <!-- View Mode Toggle + Sort Dropdown (Right) -->
           <div class="flex items-center gap-2">
             <div class="inline-flex items-center gap-0.5 bg-brand-sidebar border border-brand-border rounded-full p-1">
               <button
@@ -1102,7 +1087,6 @@
       <div class="pt-2">
         {#if collectionStore.activeSubTab === "albums"}
         {#if activeViewMode === "rows"}
-          <!-- Albums Row List View -->
           <div class="grid grid-cols-[repeat(auto-fill,minmax(280px,1fr))] gap-2">
             {#each sortedAlbums as album}
               <AlbumRowCard
@@ -1113,7 +1097,6 @@
             {@render albumEmptyState()}
           </div>
         {:else}
-          <!-- Albums Card Grid View -->
           <div class="grid grid-cols-[repeat(auto-fill,minmax(180px,1fr))] gap-6">
             {#each sortedAlbums as album}
               <AlbumCard
@@ -1127,7 +1110,6 @@
         {/if}
         {:else if collectionStore.activeSubTab === "artists"}
         {#if activeViewMode === "rows"}
-          <!-- Artists Row List View -->
           <div class="grid grid-cols-[repeat(auto-fill,minmax(280px,1fr))] gap-2">
             {#each sortedArtists as artist}
               {@const artistAlbums = getArtistAlbumsFor(artist.name)}
@@ -1142,7 +1124,6 @@
             {@render artistEmptyState()}
           </div>
         {:else}
-          <!-- Artists List Grid View -->
           <div class="grid grid-cols-[repeat(auto-fill,minmax(180px,1fr))] gap-6">
             {#each sortedArtists as artist}
               {@const artistAlbums = getArtistAlbumsFor(artist.name)}

--- a/src/lib/components/ColumnSelector.svelte
+++ b/src/lib/components/ColumnSelector.svelte
@@ -98,7 +98,6 @@
     { key: "skipcount", label: "collection.columnSkipCount" },
   ];
 
-  // Currently-visible columns in table order
   let visibleInOrder = $derived(
     TABLE_ORDER.filter(col => collectionStore.visibleColumns[col.key])
   );
@@ -126,7 +125,6 @@
       class="column-selector-menu fixed bg-brand-sidebar border border-brand-border rounded-xl shadow-2xl p-3 z-50 w-64 overflow-y-auto flex flex-col gap-0.5 select-none custom-scrollbar"
       style="top: {menuTop}px; left: {menuLeft}px; max-height: {menuMaxHeight}px"
     >
-      <!-- Visible: currently-on columns in table order -->
       <div class="text-[10px] font-extrabold text-brand-accent-text uppercase tracking-wider px-2 pt-1 pb-0.5">
         Visible
       </div>
@@ -141,7 +139,6 @@
         {/each}
       {/if}
 
-      <!-- Metatags: all metatag columns alphabetically -->
       <div class="text-[10px] font-extrabold text-brand-accent-text uppercase tracking-wider px-2 pt-2 pb-0.5 mt-1 border-t border-brand-border/30">
         Metatags
       </div>
@@ -152,7 +149,6 @@
         </label>
       {/each}
 
-      <!-- Luminous: derived values alphabetically -->
       <div class="text-[10px] font-extrabold text-brand-accent-text uppercase tracking-wider px-2 pt-2 pb-0.5 mt-1 border-t border-brand-border/30">
         Luminous
       </div>

--- a/src/lib/components/CoverArt.svelte
+++ b/src/lib/components/CoverArt.svelte
@@ -26,7 +26,6 @@
   let isLoading = $state(false);
   let hasFailed = $state(false);
 
-  // Function to load the cover art URI
   async function loadCoverArt() {
     if (artManual) {
       if (artManual.startsWith("http://") || artManual.startsWith("https://") || artManual.startsWith("/")) {
@@ -85,9 +84,7 @@
     }
   }
 
-  // React to changes in songId, artAutomatic, etc. using Svelte 5 $effect
   $effect(() => {
-    // Svelte 5 will re-run this function if any of these referenced variables change
     const _id = songId;
     const _auto = artAutomatic;
     const _manual = artManual;

--- a/src/lib/components/Equalizer.svelte
+++ b/src/lib/components/Equalizer.svelte
@@ -340,7 +340,6 @@
 </script>
 
 <div class="flex flex-col gap-6 text-brand-text-primary">
-  <!-- EQ Card -->
   <div class="bg-brand-sidebar border border-brand-border rounded-xl p-6 flex flex-col gap-6">
     <div class="flex flex-col gap-4">
     <div class="flex items-start justify-between">
@@ -367,10 +366,8 @@
         />
       </div>
     </div>
-    <!-- Mode, Presets & Preamp controls -->
     <div class="flex items-center gap-4 flex-wrap">
 
-      <!-- Mode segmented control -->
       <div class="flex items-center bg-brand-main border border-brand-border rounded-[2rem] p-0.5" role="group" aria-label={i18n.t('equalizer.modeLabel')}>
         <button
           class="text-xs font-semibold px-4 py-1.5 rounded-full transition-colors {mode === 'graphic10' ? 'bg-brand-accent text-brand-accent-contrast shadow-sm' : 'text-brand-text-secondary hover:text-brand-text-primary'}"
@@ -465,16 +462,13 @@
     {/if}
 
     {#if mode === "graphic10"}
-      <!-- Graphic Sliders Rack -->
       <div class="grid grid-cols-5 md:grid-cols-10 gap-3 md:gap-5 h-64 md:h-72 items-center bg-brand-main/50 border border-brand-border/50 rounded-xl p-4 md:p-6">
         {#each gains as gain, idx}
           <div class="flex flex-col items-center justify-between h-full group">
-            <!-- Gain display -->
             <span class="text-[10px] font-bold w-full text-center transition-colors {gain > 0 ? 'text-green-400/80' : gain < 0 ? 'text-red-400/80' : 'text-brand-text-secondary/70'}">
               {gain > 0 ? "+" : ""}{gain.toFixed(1)}
             </span>
 
-            <!-- Slider track -->
             <div class="h-40 md:h-48 flex items-center justify-center relative">
               <input
                 type="range"
@@ -489,7 +483,6 @@
               />
             </div>
 
-            <!-- Label -->
             <span class="text-[10px] md:text-[11px] font-medium text-brand-text-secondary text-center truncate w-full">
               {bandLabels[idx]}
             </span>
@@ -497,7 +490,6 @@
         {/each}
       </div>
     {:else}
-      <!-- Parametric Sliders Rack -->
       <div class="grid grid-cols-10 md:grid-cols-[repeat(20,minmax(0,1fr))] gap-1 md:gap-1.5 h-64 md:h-72 items-center bg-brand-main/50 border border-brand-border/50 rounded-xl p-3 md:p-4">
         {#each parametric as band, idx}
           <div
@@ -508,12 +500,10 @@
             onkeydown={(e) => { if (e.key === "Enter" || e.key === " ") selectedBand = idx; }}
             aria-label={`${i18n.t('equalizer.bandLabel')} ${idx + 1}`}
           >
-            <!-- Gain display -->
             <span class="text-[9px] font-bold w-full text-center transition-colors {band.gain_db > 0 ? 'text-green-400/80' : band.gain_db < 0 ? 'text-red-400/80' : 'text-brand-text-secondary/70'}">
               {band.gain_db > 0 ? "+" : ""}{band.gain_db.toFixed(1)}
             </span>
 
-            <!-- Slider track -->
             <div class="h-40 md:h-48 flex items-center justify-center relative">
               <input
                 type="range"
@@ -528,7 +518,6 @@
               />
             </div>
 
-            <!-- Frequency label -->
             <span class="text-[9px] font-medium text-center truncate w-full {selectedBand === idx ? 'text-brand-accent-text' : 'text-brand-text-secondary'}">
               {formatFreq(band.freq)}
             </span>
@@ -658,7 +647,6 @@
         </div>
       </div>
 
-      <!-- Fade on Pause/Stop -->
       <div class="flex flex-col gap-1.5 pt-1">
         <div class="flex items-center justify-between mb-4">
           <span class="text-sm font-bold text-brand-text-primary">{i18n.t('fades.fadePause')}</span>
@@ -696,7 +684,6 @@
         {/if}
       </div>
 
-      <!-- Automatic Crossfade -->
       <div class="flex flex-col gap-1.5 border-t border-brand-border pt-6">
         <div class="flex items-center justify-between mb-4">
           <span class="text-sm font-bold text-brand-text-primary">{i18n.t('fades.crossfadeAuto')}</span>

--- a/src/lib/components/FoldersView.svelte
+++ b/src/lib/components/FoldersView.svelte
@@ -161,7 +161,6 @@
     }
   }
 
-  // Custom Theme state
   let newThemeName = $state("");
   let customColors = $state<ThemeColors>({
     "bg-main": "#0d0b18",
@@ -282,14 +281,12 @@
 </script>
 
 <div class="flex-1 flex flex-col overflow-hidden bg-brand-main text-brand-text-secondary h-full">
-  <!-- Top Header bar -->
   <div class="h-16 pl-6 pr-8 border-b border-brand-border flex items-center justify-between shrink-0">
     <div class="flex items-center gap-3">
       <Settings class="w-5 h-5 text-brand-accent-text" />
       <h2 class="text-base font-bold text-brand-text-primary">{i18n.t('settings.title')}</h2>
     </div>
 
-    <!-- Sleek Tab Control -->
     <div class="flex bg-brand-sidebar border border-brand-border rounded-xl p-0.5 text-xs shadow-sm">
       <button
         onclick={() => { settingsTab = "general"; }}
@@ -330,10 +327,8 @@
     </div>
   </div>
 
-  <!-- Content Area -->
   <div bind:this={contentEl} class="flex-1 overflow-y-scroll p-6 space-y-6" class:pb-28={!!playerStore.currentSong} use:rememberScroll={`settings:${settingsTab}`}>
     {#if settingsTab === "general"}
-      <!-- General Settings Section -->
       <div class="bg-brand-sidebar border border-brand-border rounded-xl p-6">
         <div class="pb-3 flex items-center justify-between">
           <div class="flex items-center gap-3">
@@ -347,7 +342,6 @@
           </div>
         </div>
 
-        <!-- Language row -->
         <div class="flex items-center justify-between gap-4 py-4 border-b border-brand-border/50">
           <label for="language-select" class="text-sm font-medium text-brand-text-primary">{i18n.t('settings.selectLanguage')}</label>
           <Select
@@ -361,7 +355,6 @@
           </Select>
         </div>
 
-        <!-- Rating style row -->
         <div class="flex items-center justify-between gap-4 pt-4">
           <div class="flex flex-col gap-0.5 min-w-0">
             <label for="rating-style-select" class="text-sm font-medium text-brand-text-primary">{i18n.t('settings.ratingStyle')}</label>
@@ -379,7 +372,6 @@
         </div>
       </div>
 
-      <!-- Application & Updates Section -->
       <div class="bg-brand-sidebar border border-brand-border rounded-xl p-6 space-y-4">
         <div class="pb-3 grid grid-cols-1 md:grid-cols-2 gap-4 items-start">
           <div class="flex items-center gap-3">
@@ -414,7 +406,6 @@
           </div>
         </div>
 
-        <!-- Version & Format Info Row -->
         <div class="grid grid-cols-1 md:grid-cols-2 gap-4 pt-1">
           <div class="bg-brand-main/50 border border-brand-border/60 rounded-xl p-4 flex items-center justify-between">
             <div class="space-y-0.5">
@@ -446,7 +437,6 @@
           </div>
         </div>
 
-        <!-- Update Available Alert Banner (if available) -->
         {#if updaterStore.updateAvailable || updaterStore.installStatus !== 'idle'}
           <div class="bg-brand-accent/10 border border-brand-accent/30 rounded-xl p-4 flex items-center justify-between gap-4 anim-card-materialize">
             <div class="flex items-center gap-3 min-w-0">
@@ -513,7 +503,6 @@
           </div>
         {/if}
 
-        <!-- Toggle Controls -->
         <div class="space-y-4 pt-2 border-t border-brand-border/50">
           <div class="flex items-center justify-between gap-4">
             <div class="flex flex-col gap-0.5 min-w-0">
@@ -544,7 +533,6 @@
         </div>
       </div>
     {:else if settingsTab === "folders"}
-      <!-- Watched Folders Section -->
       <div class="bg-brand-sidebar border border-brand-border rounded-xl p-6 space-y-4">
         <div class="pb-3 flex justify-between items-center">
           <div class="flex items-center gap-3">
@@ -568,7 +556,6 @@
           </div>
         {/if}
 
-        <!-- Folders List -->
         <div class="space-y-2">
           {#each collectionStore.directories as dir}
             <div class="flex items-center justify-between bg-brand-main/50 border border-brand-border/60 rounded-xl p-4 hover:border-brand-border transition-colors">
@@ -609,7 +596,6 @@
         </div>
       </div>
 
-      <!-- Library Scanning & Maintenance Section -->
       <div class="bg-brand-sidebar border border-brand-border rounded-xl p-6 space-y-5">
         <div class="pb-3 flex items-center justify-between">
           <div class="flex items-center gap-3">
@@ -623,7 +609,6 @@
           </div>
         </div>
 
-        <!-- Scan Status & Progress Bar (when scanning) -->
         {#if collectionStore.isScanning}
           <div class="bg-brand-main/60 border border-brand-accent/30 rounded-xl p-4 space-y-2">
             <div class="flex justify-between items-center text-xs font-semibold text-brand-text-primary">
@@ -643,7 +628,6 @@
           </div>
         {/if}
 
-        <!-- Manual Action Buttons -->
         <div class="flex flex-wrap items-center gap-3">
           <Button
             onclick={() => collectionStore.startScan(false)}
@@ -668,9 +652,7 @@
           </Button>
         </div>
 
-        <!-- Configuration Toggles -->
         <div class="pt-3 space-y-4">
-          <!-- Real-time Folder Watching -->
           <div class="flex items-center justify-between gap-4">
             <div class="flex flex-col gap-0.5 min-w-0">
               <span class="text-sm font-medium text-brand-text-primary">{i18n.t('settings.watchRealtimeLabel')}</span>
@@ -683,7 +665,6 @@
             />
           </div>
 
-          <!-- Rescan on Startup -->
           <div class="flex items-center justify-between gap-4">
             <div class="flex flex-col gap-0.5 min-w-0">
               <span class="text-sm font-medium text-brand-text-primary">{i18n.t('settings.scanOnStartupLabel')}</span>
@@ -697,7 +678,6 @@
           </div>
         </div>
 
-        <!-- Library Stats & Last Scan Summary -->
         <div class="pt-3 border-t border-brand-border/50 space-y-3">
           {#if collectionStore.lastScanTime}
             <div class="text-xs text-brand-text-secondary flex items-center justify-between font-medium">
@@ -729,7 +709,6 @@
       </div>
       </div>
     {:else if settingsTab === "tools"}
-      <!-- Tools Section -->
       <OrganizeFiles embedded songIds={[]} initialScope="library" refreshKey={organizeRefreshKey} />
 
       <div class="bg-brand-sidebar border border-brand-border rounded-xl p-6 space-y-5">
@@ -746,7 +725,6 @@
         </div>
       </div>
 
-      <!-- AcoustID Integration Section -->
       <div class="bg-brand-sidebar border border-brand-border rounded-xl p-6 space-y-4">
         <div class="pb-3 flex justify-between items-center">
           <div class="flex items-center gap-3">
@@ -798,7 +776,6 @@
         </div>
       </div>
     {:else if settingsTab === "themes"}
-      <!-- UI Themes Section -->
       <div class="space-y-6">
         <div class="bg-brand-sidebar border border-brand-border rounded-xl p-6 space-y-6">
         <div class="pb-1 flex justify-between items-center">
@@ -813,7 +790,6 @@
           </div>
         </div>
 
-        <!-- Dynamic Themes Section -->
         <div>
           <h4 class="text-xs text-brand-text-secondary font-bold tracking-wider uppercase mb-3">{i18n.t('settings.dynamicThemes', {}, 'Dynamic Themes')}</h4>
           <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
@@ -856,7 +832,6 @@
           </div>
         </div>
 
-        <!-- Predefined Themes Section -->
         <div>
           <h4 class="text-xs text-brand-text-secondary font-bold tracking-wider uppercase mb-3">{i18n.t('settings.predefinedThemes', {}, 'Predefined Themes')}</h4>
           <div class="grid grid-cols-1 md:grid-cols-3 lg:grid-cols-5 gap-4">
@@ -933,7 +908,6 @@
         {/if}
         </div>
 
-        <!-- Custom Theme Builder Form -->
         <div class="bg-brand-sidebar border border-brand-border rounded-xl p-6 space-y-5">
           <div class="flex items-center justify-between border-b border-brand-border pb-3">
             <div class="flex items-center gap-3">
@@ -1052,12 +1026,9 @@
         </div>
       </div>
     {:else if settingsTab === "equalizer"}
-      <!-- Equalizer Section -->
       <Equalizer />
     {:else if settingsTab === "about"}
-      <!-- About & Credits Section -->
       <div class="space-y-6 max-w-4xl">
-        <!-- Hero Header -->
         <div class="bg-brand-sidebar border border-brand-border rounded-2xl p-6 flex flex-col md:flex-row items-center gap-6 shadow-md">
           <img src="/app-icon.svg" alt="Luminous Logo" class="w-20 h-20 shrink-0 drop-shadow-md" />
           <div class="space-y-2 text-center md:text-left flex-1 min-w-0">
@@ -1079,7 +1050,6 @@
           </div>
         </div>
 
-        <!-- External Links / Quick Actions -->
         <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
           <button
             onclick={() => openExternalUrl("https://esoltys.dev/luminous")}
@@ -1162,7 +1132,6 @@
           </button>
         </div>
 
-        <!-- Tech Stack Breakdown -->
         <div class="bg-brand-sidebar border border-brand-border rounded-2xl p-6 space-y-4">
           <h4 class="text-xs text-brand-text-secondary font-bold tracking-wider uppercase border-b border-brand-border pb-2">
             {i18n.t('settings.aboutCoreTech')}

--- a/src/lib/components/HomeView.svelte
+++ b/src/lib/components/HomeView.svelte
@@ -49,9 +49,7 @@
 </script>
 
 <div class="flex flex-col h-full w-full bg-brand-main overflow-hidden">
-  <!-- Content Area -->
   <div class="flex-1 overflow-y-auto {playerStore.currentSong ? 'pb-28' : 'pb-6'}" use:rememberScroll={"home"}>
-    <!-- Header -->
     <div class="px-6 pt-8">
       <h1 class="text-3xl font-heading font-bold text-brand-text-primary">
         {getTimeOfDayGreeting()}
@@ -67,7 +65,6 @@
         <div class="text-brand-text-secondary">{i18n.t('home.loading')}</div>
       </div>
     {:else}
-      <!-- Top Artists Section -->
       {#if topArtists.length > 0}
         <HorizontalScrollRow title={i18n.t('home.topArtists')}>
           {#each topArtists as artist (artist.name)}
@@ -83,7 +80,6 @@
         </HorizontalScrollRow>
       {/if}
 
-      <!-- Most Played / Recently Added Row Columns -->
       {#if frequentlyPlayed.length > 0 || recentlyAdded.length > 0}
         <div class="grid grid-cols-1 lg:grid-cols-2 gap-8">
           {#if frequentlyPlayed.length > 0}
@@ -95,7 +91,6 @@
         </div>
       {/if}
 
-      <!-- Empty State -->
       {#if topArtists.length === 0 && frequentlyPlayed.length === 0 && recentlyAdded.length === 0}
         <div class="flex items-center justify-center py-16">
           <LibraryWelcome />

--- a/src/lib/components/KeyboardShortcutsModal.svelte
+++ b/src/lib/components/KeyboardShortcutsModal.svelte
@@ -46,7 +46,6 @@
 </script>
 
 <Modal {onClose} closeOnBackdropClick ariaLabelledby="shortcuts-modal-title" class="max-h-[85vh]">
-  <!-- Header -->
   <div class="flex items-center justify-between px-6 py-4 border-b border-brand-border/60 bg-brand-main/50 shrink-0">
     <div class="flex items-center gap-2.5">
       <div class="p-2 rounded-xl bg-brand-accent/20 text-brand-accent-text">
@@ -62,7 +61,6 @@
     </button>
   </div>
 
-  <!-- Groups -->
   <div class="flex-1 overflow-y-auto p-6 flex flex-col gap-6">
     {#each groups as group (group.title)}
       <div>

--- a/src/lib/components/Knob.svelte
+++ b/src/lib/components/Knob.svelte
@@ -38,10 +38,8 @@
 
   function updateValueFromPointer(e: PointerEvent) {
     if (disabled) return;
-    // Calculate angle from center of the knob
     let a = Math.atan2(e.clientY - cy, e.clientX - cx) * 180 / Math.PI;
     
-    // Normalize to 0..360
     if (a < 0) a += 360;
     
     // Our track goes from 135 to 405 (which wraps to 45).
@@ -50,7 +48,6 @@
     
     // Dead zone handling (between 90 and 135 degrees)
     if (a > 90 && a < 135) {
-      // Snap to nearest end
       if (a < 112.5) a = 405;
       else a = 135;
     }
@@ -81,7 +78,6 @@
       cy = rect.top + rect.height / 2;
     }
     
-    // Update immediately on click
     updateValueFromPointer(e);
   }
 

--- a/src/lib/components/LyricsView.svelte
+++ b/src/lib/components/LyricsView.svelte
@@ -27,7 +27,6 @@
       return [];
     }
     
-    // Clean marker if present
     let cleanText = lyricsText;
     if (cleanText.startsWith("[synced:false]\n")) {
       cleanText = cleanText.substring("[synced:false]\n".length);
@@ -69,7 +68,6 @@
 
   let isSynced = $derived(parsedLines.length > 0);
 
-  // Find active line index based on current playback position
   let activeLineIndex = $derived.by(() => {
     if (!isSynced || parsedLines.length === 0) return -1;
     const currentMs = playerStore.positionNanosec / 1_000_000;
@@ -200,7 +198,6 @@
     isEditing = true;
   }
 
-  // Load lyrics when song changes
   $effect(() => {
     console.log("[LyricsView] Song changed. Reloading lyrics for song ID:", playerStore.currentSong?.id);
     loadLyrics(playerStore.currentSong?.id);
@@ -239,7 +236,6 @@
 </script>
 
 <div class="flex-1 flex flex-col h-full bg-brand-main text-brand-text-primary select-none overflow-hidden relative">
-  <!-- Top Panel Toolbar -->
   <div class="h-16 flex items-center justify-between px-8 border-b border-brand-border bg-brand-main/40 backdrop-blur-md shrink-0">
     <div class="flex items-center gap-3">
       <FileText class="w-6 h-6 text-brand-accent-text" />
@@ -253,7 +249,6 @@
       </div>
     </div>
 
-    <!-- Actions -->
     {#if playerStore.currentSong}
       <div class="flex items-center gap-2">
         {#if playerStore.currentSong.is_instrumental}
@@ -279,14 +274,12 @@
     {/if}
   </div>
 
-  <!-- Lyrics Container Viewport -->
   <div class="flex-1 overflow-y-auto px-6 py-12" class:pb-28={!!playerStore.currentSong} bind:this={containerEl} use:rememberScroll={"lyrics"}>
     {#if isLoading}
       <div class="w-full h-full flex flex-col items-center justify-center gap-3">
         <LoadingSpinner label={i18n.t('lyrics.fetching', {}, "Fetching lyrics...")} />
       </div>
     {:else if playerStore.currentSong?.is_instrumental}
-      <!-- Instrumental View -->
       <div class="w-full h-full flex flex-col items-center justify-center gap-4 p-8 text-center">
         <div class="p-4 rounded-full bg-brand-sidebar border border-brand-border text-brand-accent shadow-inner">
           <Music2 class="w-12 h-12 stroke-[1.5]" />
@@ -304,7 +297,6 @@
         </Button>
       </div>
     {:else if isEditing}
-      <!-- Editor Mode -->
       <div class="max-w-2xl mx-auto h-full flex flex-col gap-3">
         <label for="lyrics-editor" class="text-xs font-bold text-brand-text-secondary/65 uppercase tracking-wider">{i18n.t('lyrics.editorLabel', {}, "Lyrics Text (plain or LRC synced format)")}</label>
         <textarea
@@ -317,7 +309,6 @@
     {:else if lyricsText}
       <div class="max-w-3xl mx-auto text-center">
         {#if isSynced}
-          <!-- Synced View -->
           <div class="flex flex-col gap-6 md:gap-8 pb-32">
             {#each parsedLines as line, idx}
               {@const isActive = idx === activeLineIndex}
@@ -333,7 +324,6 @@
             {/each}
           </div>
         {:else}
-          <!-- Plain Text View -->
           <div class="mb-8 inline-flex items-center gap-2 px-3 py-1.5 rounded-full border border-brand-border bg-brand-sidebar text-[11px] font-semibold text-brand-text-secondary/60 select-none shadow-sm">
             <span class="w-1.5 h-1.5 rounded-full bg-amber-500 animate-pulse"></span>
             {i18n.t('lyrics.plainTextNotice', {}, "Synced lyrics not available. Showing plain text.")}

--- a/src/lib/components/Miniplayer.svelte
+++ b/src/lib/components/Miniplayer.svelte
@@ -239,7 +239,6 @@
     <!-- svelte-ignore a11y_no_static_element_interactions -->
     <div class="absolute bottom-0 right-0 w-4 h-4 cursor-se-resize z-50" onpointerdown={(e) => handleStartResize("south-east", e)}></div>
   {/if}
-  <!-- Ambient Tint / Cover Art Glow Background -->
   {#if playerStore.currentSong}
     <div
       class="absolute inset-0 z-0 opacity-25 blur-2xl pointer-events-none"
@@ -257,7 +256,6 @@
 
   <!-- IDLE STATIC LAYOUT -->
   <div class="relative z-10 w-full h-full flex flex-col items-center justify-between pointer-events-auto">
-    <!-- Centered Sharp Active Album Art Card -->
     <div class="flex-1 w-full flex items-center justify-center min-h-0 py-2">
       <div class="relative aspect-square h-full max-h-full max-w-[90%] rounded-none overflow-hidden border border-brand-border/30 bg-brand-sidebar flex items-center justify-center {isHovered ? 'scale-[0.98]' : ''} transition-transform duration-300">
         <CoverArt
@@ -270,7 +268,6 @@
       </div>
     </div>
 
-    <!-- Lower Text Description Card tracking active Title / Artist -->
     <div class="w-full text-center px-2 py-1 flex flex-col items-center justify-center flex-shrink-0">
       <span class="text-sm font-bold text-brand-text-primary truncate w-full" title={playerStore.currentSong?.title}>
         {playerStore.currentSong?.title || i18n.t('playerBar.notPlaying')}
@@ -289,7 +286,6 @@
     onpointerleave={hideHover}
     class="absolute inset-0 z-30 flex flex-col justify-between p-3 transition-opacity duration-200 {isHovered ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'} {isLinux ? 'bg-brand-main' : 'bg-brand-main/85 backdrop-blur-md'}"
   >
-    <!-- Full-width Window Drag Region spanning the top edge, textured with a grabber dot pattern -->
     <div
       data-tauri-drag-region
       onpointerdown={handleStartDrag}
@@ -300,7 +296,6 @@
       title={i18n.t('miniplayer.dragHint', {}, 'Drag window')}
     ></div>
 
-    <!-- Song Metadata Info in Hover Mask -->
     <div class="w-full text-center px-1 py-0.5 flex flex-col items-center justify-center flex-shrink-0 mt-auto">
       <span class="text-sm font-bold text-brand-text-primary truncate w-full" title={playerStore.currentSong?.title}>
         {playerStore.currentSong?.title || i18n.t('playerBar.notPlaying')}
@@ -319,11 +314,8 @@
       {/if}
     </div>
 
-    <!-- CENTER PLAYBACK CONTROLS & WAVEFORM PROGRESS (Grouped together with tight spacing) -->
     <div class="flex flex-col items-center justify-center w-full gap-2 my-auto flex-shrink-0">
-      <!-- Transport Control Ring -->
       <div class="flex items-center justify-center gap-4 w-full">
-        <!-- Shuffle Mode -->
         <button
           onclick={cycleShuffle}
           class="p-1.5 transition-colors hover:text-brand-text-primary flex items-center gap-1 {playerStore.shuffleMode !== 'off' ? 'text-brand-accent-text font-bold' : 'text-brand-text-secondary/60'}"
@@ -336,7 +328,6 @@
           <Shuffle class="w-4.5 h-4.5" />
         </button>
 
-        <!-- Skip Previous -->
         <button
           onclick={() => playerStore.previous()}
           class="p-1.5 text-brand-text-secondary hover:text-brand-text-primary transition-colors"
@@ -345,7 +336,6 @@
           <SkipBack class="w-5 h-5 fill-current" />
         </button>
 
-        <!-- Play / Pause prominent ring button -->
         {#if playerStore.state === 'playing'}
           <button
             onclick={() => playerStore.pause()}
@@ -364,7 +354,6 @@
           </button>
         {/if}
 
-        <!-- Skip Next -->
         <button
           onclick={() => playerStore.next()}
           class="p-1.5 text-brand-text-secondary hover:text-brand-text-primary transition-colors"
@@ -373,7 +362,6 @@
           <SkipForward class="w-5 h-5 fill-current" />
         </button>
 
-        <!-- Repeat Mode -->
         <button
           onclick={cycleRepeat}
           class="p-1.5 transition-colors hover:text-brand-text-primary flex items-center gap-1 {playerStore.repeatMode !== 'off' ? 'text-brand-accent-text font-bold' : 'text-brand-text-secondary/60'}"
@@ -387,7 +375,6 @@
         </button>
       </div>
 
-      <!-- Waveform Progress Timeline positioned directly under play controls -->
       <div class="flex flex-col gap-1 w-full text-[10px] text-brand-text-secondary/70 px-1">
         <WaveformSeekBar />
         <div class="flex items-center justify-between w-full px-0.5 font-mono text-[9px] opacity-80">
@@ -397,9 +384,7 @@
       </div>
     </div>
 
-    <!-- Bottom-aligned Volume (left) & Restore (right) Controls -->
     <div class="flex items-center justify-between w-full flex-shrink-0 z-50">
-      <!-- Volume Control -->
       <div class="flex items-center gap-1.5">
         <button
           onclick={toggleMute}
@@ -429,7 +414,6 @@
         />
       </div>
 
-      <!-- Restore -->
       <button
         onclick={() => collectionStore.exitMiniplayerMode()}
         class="p-1 text-brand-text-secondary hover:text-brand-text-primary hover:bg-brand-border/40 rounded transition-colors"

--- a/src/lib/components/OrganizeFiles.svelte
+++ b/src/lib/components/OrganizeFiles.svelte
@@ -351,7 +351,6 @@
 
 {#snippet body()}
         {#if songIds.length > 0}
-          <!-- Scope selector -->
           <div class="flex items-center justify-between bg-brand-sidebar/40 p-3 rounded-xl border border-brand-border/30">
             <span class="font-semibold text-brand-text-primary">{i18n.t("organizer.scopeLabel")}</span>
             <div class="flex items-center gap-1.5 bg-brand-sidebar p-1 rounded-lg border border-brand-border/50">
@@ -371,7 +370,6 @@
           </div>
         {/if}
 
-        <!-- Template Pattern Input -->
         <div>
           <div class="flex items-center justify-between mb-1.5">
             <label for="template-input" class="font-semibold text-brand-text-primary">
@@ -394,7 +392,6 @@
             spellcheck="false"
           />
 
-          <!-- Variable chips -->
           <div class="flex flex-wrap items-center gap-1.5 pt-1">
             <span class="text-[11px] text-brand-text-secondary mr-1">{i18n.t("organizer.placeholders")}:</span>
             {#each VARIABLE_CHIPS as chip}
@@ -410,9 +407,7 @@
           </div>
         </div>
 
-        <!-- Options row -->
         <div class="grid grid-cols-1 md:grid-cols-2 gap-3 pt-2">
-          <!-- Destination folder -->
           <div class="md:col-span-2">
             <label for="dest-dir-input" class="block font-semibold text-brand-text-primary mb-1.5">
               {i18n.t("organizer.destinationDirLabel")}
@@ -434,7 +429,6 @@
             </div>
           </div>
 
-          <!-- Toggles Column -->
           <div class="flex flex-col gap-3">
             <div class="flex items-center justify-between gap-2 text-brand-text-secondary">
               <span>{i18n.t("organizer.replaceSpaces")}</span>
@@ -465,7 +459,6 @@
           </div>
         </div>
 
-        <!-- Preview Table Section -->
         <div class="space-y-2 pt-2">
           <div class="flex flex-col gap-1.5">
             <div class="flex items-center justify-between">
@@ -485,7 +478,6 @@
               </Button>
             </div>
 
-            <!-- Summary badges & filter toggle -->
             <div class="flex flex-col gap-2 text-xs">
               <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
                 <div class="flex items-center justify-between gap-2 text-brand-text-secondary">
@@ -523,7 +515,6 @@
             </div>
           </div>
 
-          <!-- Virtualized table -->
           <div class="h-64 border border-brand-border/60 rounded-xl overflow-hidden bg-brand-sidebar/40 flex flex-col">
             {#if items.length === 0}
               <div class="h-full flex items-center justify-center text-brand-text-secondary">
@@ -538,7 +529,6 @@
                 <span>{i18n.t("organizer.noChangingFilesMatch")}</span>
               </div>
             {:else}
-              <!-- Common Base Path Bar -->
               {#if commonPrefix}
                 <div class="px-3 py-1 bg-brand-sidebar/80 border-b border-brand-border/40 text-[10px] text-brand-text-secondary font-mono flex items-center gap-1.5 shrink-0" title={commonPrefix}>
                   <span class="font-semibold text-brand-accent-text shrink-0">{i18n.t("organizer.commonBasePath")}</span>
@@ -546,14 +536,11 @@
                 </div>
               {/if}
 
-              <!-- Horizontally scrollable viewport wrapper -->
               <div class="flex-1 min-h-0 overflow-x-auto overflow-y-hidden">
                 <div style="min-width: {96 + fromColWidth + 24 + toColWidth + 20}px;" class="h-full flex flex-col">
-                  <!-- Table Column Header with Draggable Splitters -->
                   <div class="h-7 px-3 flex items-center bg-brand-sidebar/95 border-b border-brand-border/60 text-[10px] font-semibold text-brand-text-secondary uppercase tracking-wider select-none shrink-0 font-mono">
                     <div class="w-24 shrink-0">{i18n.t("organizer.colStatus")}</div>
 
-                    <!-- Original Path Header -->
                     <div class="flex items-center shrink-0 pr-1" style="width: {fromColWidth}px;">
                       <span class="truncate flex-1">{i18n.t("organizer.colSource")}</span>
                       <button
@@ -570,7 +557,6 @@
 
                     <div class="w-6 text-center shrink-0 text-brand-text-secondary">→</div>
 
-                    <!-- Target Path Header -->
                     <div class="flex items-center shrink-0 pl-1" style="width: {toColWidth}px;">
                       <span class="truncate flex-1">{i18n.t("organizer.colDestination")}</span>
                       <button
@@ -586,7 +572,6 @@
                     </div>
                   </div>
 
-                  <!-- Virtualized rows -->
                   <div class="flex-1 min-h-0">
                     <VirtualList items={displayedItems} height="100%" itemHeight={36}>
                       {#snippet children(rawRow: any)}
@@ -597,7 +582,6 @@
                         <div
                           class="h-9 px-3 flex items-center border-b border-brand-border/20 text-[11px] font-mono hover:bg-brand-accent/10 transition-colors whitespace-nowrap"
                         >
-                          <!-- Status badge -->
                           <div class="w-24 shrink-0">
                             {#if st === "ok"}
                               <span class="px-2 py-0.5 rounded bg-brand-accent/15 text-brand-accent-text border border-brand-accent/30">
@@ -622,7 +606,6 @@
                             {/if}
                           </div>
 
-                          <!-- Original path cell -->
                           <div
                             class="px-2 overflow-x-auto scrollbar-none shrink-0 {item.from_path ? 'text-brand-text-secondary' : 'text-rose-400 font-medium'}"
                             style="width: {fromColWidth}px;"
@@ -631,10 +614,8 @@
                             {@html highlightPathHtml(displayFrom || i18n.t("organizer.noPathRecorded"))}
                           </div>
 
-                          <!-- Arrow separator -->
                           <div class="w-6 text-center text-brand-text-secondary shrink-0">→</div>
 
-                          <!-- Target path cell -->
                           <div
                             class="px-2 overflow-x-auto scrollbar-none shrink-0 {st === 'ok' ? 'text-brand-text-primary font-medium' : st === 'collision' || st === 'error' ? 'text-rose-400 font-semibold' : 'text-brand-text-primary'}"
                             style="width: {toColWidth}px;"
@@ -736,7 +717,6 @@
       <div
         class="w-full max-w-4xl max-h-[90vh] bg-brand-sidebar border border-brand-border/80 rounded-2xl shadow-2xl flex flex-col overflow-hidden animate-in zoom-in-95 duration-200 text-brand-text-primary"
       >
-        <!-- Header -->
         <div class="px-6 py-4 border-b border-brand-border/40 flex items-center justify-between shrink-0">
           <div class="flex items-center gap-3">
             <div class="p-2 rounded-xl bg-brand-accent/15 text-brand-accent-text">
@@ -761,12 +741,10 @@
           </button>
         </div>
 
-        <!-- Content area -->
         <div class="p-6 space-y-4 overflow-y-auto flex-1 text-xs">
           {@render body()}
         </div>
 
-        <!-- Footer -->
         <div class="px-6 py-4 border-t border-brand-border/40 flex items-center justify-between shrink-0 bg-brand-sidebar/50">
           <div class="text-xs text-brand-text-secondary">
             {@render collisionWarning()}

--- a/src/lib/components/PlayerBar.svelte
+++ b/src/lib/components/PlayerBar.svelte
@@ -38,7 +38,6 @@
 
 
 
-  // Helper to format nanoseconds to M:SS
   function formatTime(nanosec: number | undefined): string {
     if (nanosec === undefined) return "0:00";
     const sec = Math.floor(nanosec / 1_000_000_000);
@@ -47,20 +46,17 @@
     return `${m}:${s < 10 ? "0" : ""}${s}`;
   }
 
-  // Volume slider gradient style
   let volumePercent = $derived(playerStore.volume * 100);
   let volumeSliderStyle = $derived(
     `background: linear-gradient(to right, var(--color-accent) 0%, var(--color-accent) ${volumePercent}%, var(--color-border) ${volumePercent}%, var(--color-border) 100%)`
   );
 
-  // Handle seek progress bar click
   function handleSeek(e: Event) {
     const input = e.target as HTMLInputElement;
     const targetNs = parseFloat(input.value);
     playerStore.seek(targetNs);
   }
 
-  // Handle volume bar click
   function handleVolumeChange(e: Event) {
     const input = e.target as HTMLInputElement;
     const vol = parseFloat(input.value);
@@ -180,7 +176,6 @@
 </script>
 
 <footer transition:fly={{ y: 40, duration: 300, easing: cubicOut }} class="h-20 max-w-[1200px] mx-auto bg-brand-playerbar border border-brand-border rounded-[2rem] flex items-center justify-between px-8 text-brand-text-secondary select-none {themeStore.isGlassTheme || isLinux ? 'glass-surface' : ''} {isLinux ? 'opaque-linux' : ''}">
-  <!-- Track Metadata & Art -->
   <div class="flex items-center gap-3 w-1/3 min-w-[200px] max-w-xs">
     <button
       onclick={handleCoverClick}
@@ -238,7 +233,6 @@
     </div>
   </div>
 
-  <!-- Player controls / Playback engine controller -->
   <div class="flex flex-col items-center gap-1.5 w-1/3 max-w-[600px]">
     <div class="flex items-center gap-5">
       <div class="relative">
@@ -315,7 +309,6 @@
 
     </div>
 
-    <!-- Scrubber -->
     <div class="flex items-center gap-2.5 w-full text-[10px] text-brand-text-secondary/60">
       <!-- Invisible spacer matching the mode-toggle button's footprint, so the
            waveform + timers stay centered instead of skewing left toward it. -->
@@ -341,7 +334,6 @@
     </div>
   </div>
 
-  <!-- Auxiliary (Volume & Visualizers) -->
   <div class="flex items-center justify-end gap-3 w-1/3 min-w-[200px] max-w-xs">
     <div class="w-24 h-7 mr-2 hidden md:block">
       <SpectrumVisualizer />

--- a/src/lib/components/PlaylistView.svelte
+++ b/src/lib/components/PlaylistView.svelte
@@ -97,18 +97,14 @@
 
   let editingSongId = $state<number | null>(null);
 
-  // Inline title rename state
   let isEditingTitle = $state(false);
   let editTitleValue = $state("");
 
-  // In-playlist real-time search filter state
   let filterQuery = $state("");
 
-  // Multi-selection state
   let selectedUuids = $state<Set<string>>(new Set());
   let lastSelectedIndex = $state<number | null>(null);
 
-  // Right-click context menu state
   let contextMenuState = $state<{ x: number; y: number; item: PlaylistItem } | null>(null);
 
   // Overflow ("more actions") menu state — houses the lower-frequency playlist
@@ -118,7 +114,6 @@
   let overflowMenuPos = $state<{ x: number; y: number } | null>(null);
   let overflowButtonEl = $state<HTMLButtonElement | undefined>(undefined);
 
-  // Save Queue as Custom Playlist modal state
   let showSaveQueueModal = $state(false);
   let saveQueueName = $state("Queue Playlist");
 
@@ -166,7 +161,6 @@
     isEditingTitle = false;
   }
 
-  // Import / Export handlers
   async function handleImportPlaylist() {
     try {
       const selected = await open({
@@ -217,7 +211,6 @@
     }
   }
 
-  // Selected playlist from the store
   let activePlaylist = $derived(
     playlistsStore.playlists.find((p) => p.id === playlistsStore.activePlaylistId)
   );
@@ -303,7 +296,6 @@
       .map((v) => String(v).toLowerCase());
   }
 
-  // Derived filtered tracks based on filterQuery and sort selection
   let filteredTracks = $derived.by(() => {
     const q = filterQuery.trim().toLowerCase();
     let result = playlistsStore.activePlaylistTracks;
@@ -355,7 +347,6 @@
     return list;
   });
 
-  // Summary stats
   let totalRuntimeLabel = $derived.by(() => {
     const totalNs = playlistsStore.activePlaylistTracks.reduce(
       (sum, item) => sum + (item.song?.length_nanosec ?? 0),
@@ -383,7 +374,6 @@
     return top.slice(0, 2).join(" / ");
   });
 
-  // Duplicate track detection
   let duplicateUuids = $derived.by(() => {
     const seen = new Set<string>();
     const dupes: string[] = [];
@@ -474,7 +464,6 @@
     });
   }
 
-  // Row selection handlers
   function handleRowClick(event: MouseEvent, item: PlaylistItem) {
     const actualIndex = playlistsStore.activePlaylistTracks.findIndex((t) => t.uuid === item.uuid);
 
@@ -571,7 +560,6 @@
     }
   }
 
-  // Drag and drop state and handlers
   let draggedIndex = $state<number | null>(null);
   let dragOverIndex = $state<number | null>(null);
 
@@ -773,10 +761,8 @@
       class="flex-1 flex flex-col min-h-0 relative z-10 overflow-y-auto carousel-scroll"
       use:rememberScroll={`playlist:${playlistsStore.activePlaylistId}`}
     >
-    <!-- Stacked Cover Art Hero & Summary Banner Header -->
     <div class="relative z-30 w-full overflow-hidden border-b border-brand-border/60 bg-brand-main/60 backdrop-blur-md px-6 pt-6 pb-6 shrink-0">
       <div class="flex items-stretch justify-between gap-6 relative z-10">
-        <!-- Left Title & Summary Metadata -->
         <div class="flex flex-col justify-end gap-1.5 min-w-0 flex-1">
           {#if isEditingTitle}
             <div class="flex items-center gap-2">
@@ -812,7 +798,6 @@
             </div>
           {/if}
 
-          <!-- Summary Metadata Line -->
           <div class="flex items-center gap-3 text-xs text-brand-text-secondary font-medium">
             <span>
               {#if isSpecialPlaylist}
@@ -832,7 +817,6 @@
             </span>
           </div>
 
-          <!-- Action Buttons: Play All & Shuffle Play -->
           <div class="flex items-center gap-3 mt-3">
             <Button
               onclick={handlePlayAll}
@@ -877,9 +861,7 @@
             <ColumnSelector align="left" iconOnly />
           </div>
 
-          <!-- Secondary Control Buttons Row -->
           <div class="flex flex-wrap items-center gap-2.5 mt-2.5 select-none">
-            <!-- Search Filter Bar -->
             <div class="relative w-full max-w-xs">
               <Search class="w-3.5 h-3.5 absolute left-3.5 top-1/2 -translate-y-1/2 text-brand-text-secondary/60 pointer-events-none" />
               <Input
@@ -921,7 +903,6 @@
           </div>
         </div>
 
-        <!-- Right: 3D Stacked Album Cover Preview Header or Special Queue/Smart Banner -->
         {#if isQueue}
           <div class="w-40 h-40 hidden sm:flex shrink-0 bg-brand-main bg-gradient-to-br from-brand-accent/25 to-brand-accent/15 items-center justify-center overflow-hidden border border-brand-accent/30 shadow-[0_0_28px_3px] shadow-brand-accent/40">
             {#key playerStore.currentSong?.id}
@@ -971,10 +952,8 @@
       </div>
     </div>
 
-    <!-- Tracks List Container -->
     <div class="p-6 flex flex-col" class:pb-28={!!playerStore.currentSong}>
       <div class="border border-brand-border/60 rounded-xl bg-brand-sidebar/30 backdrop-blur-md relative overflow-hidden">
-      <!-- Header -->
       <div class="sticky top-0 z-20 flex flex-col bg-brand-sidebar border-b border-brand-border text-xs text-brand-text-primary uppercase tracking-wider font-semibold select-none">
         <div role="row" class="grid items-center py-3 px-4" style={gridColsStyle}>
           <SortableHeader
@@ -1268,7 +1247,6 @@
         </div>
       </div>
 
-      <!-- Rows -->
       <div class="divide-y divide-brand-border/40">
         {#each filteredTracks as item, index (item.uuid)}
           {@const trueUnavailable = isItemUnavailable(item)}
@@ -1551,7 +1529,6 @@
   </div>
   </div>
 
-    <!-- Floating Multi-Select Batch Toolbar -->
     {#if selectedUuids.size > 0}
       <div data-floating-toolbar="true" class="absolute left-1/2 -translate-x-1/2 z-40 bg-brand-sidebar/95 border border-brand-border/80 shadow-2xl rounded-full px-5 py-2.5 flex items-center gap-4 text-xs font-semibold backdrop-blur-xl animate-in fade-in slide-in-from-bottom-4 duration-200" class:bottom-6={!playerStore.currentSong} class:bottom-28={!!playerStore.currentSong}>
         <span class="text-brand-accent-text font-bold">
@@ -1582,7 +1559,6 @@
       </div>
     {/if}
   {:else}
-    <!-- No playlist selected -->
     <div class="flex-1 flex flex-col items-center justify-center text-brand-text-primary/60">
       <ListMusic class="w-16 h-16 mb-4 text-brand-text-primary/30" />
       <h2 class="text-lg font-bold text-brand-text-primary/80 mb-1">{i18n.t("playlists.noPlaylistsTitle")}</h2>

--- a/src/lib/components/PlaylistsCollectionView.svelte
+++ b/src/lib/components/PlaylistsCollectionView.svelte
@@ -309,10 +309,8 @@
 {:else}
   <div class="flex-1 flex flex-col overflow-hidden bg-brand-main text-brand-text-secondary h-full">
     <div class="flex-1 px-6 overflow-y-auto {playerStore.currentSong ? 'pb-28' : 'pb-6'}" use:rememberScroll={`playlists:${collectionStore.playlistsSubTab}`}>
-      <!-- Top bar with Filter Info / Sort controls (sticky) -->
       <div class="sticky top-0 z-20 bg-brand-main pt-3">
         {#if collectionStore.playlistsSubTab === "custom"}
-          <!-- Actions (Left) -->
           <div class="h-10 flex items-center gap-2 mb-2">
             <Button onclick={handleCreateBlankPlaylist} variant="primary" title={i18n.t('playlists.newPlaylistBtn')}>
               <Plus class="w-4 h-4" />
@@ -330,7 +328,6 @@
         {/if}
 
         <div class="h-9 flex items-center justify-between">
-          <!-- Showing Count (Left) -->
           <div class="text-xs text-brand-text-secondary font-medium">
             {#if collectionStore.playlistsSubTab === "auto"}
               {sortedAutoDefs.length === 1 ? i18n.t('playlists.showingOnePlaylist') : i18n.t('playlists.showingPlaylists', { count: sortedAutoDefs.length })}
@@ -339,7 +336,6 @@
             {/if}
           </div>
 
-          <!-- View Mode Toggle + Sort Dropdown (Right) -->
           <div class="flex items-center gap-2">
             <button
               onclick={handleRefreshAll}

--- a/src/lib/components/ReactiveLogoBrand.svelte
+++ b/src/lib/components/ReactiveLogoBrand.svelte
@@ -13,7 +13,6 @@
 
   let { size = "md", className = "" }: Props = $props();
 
-  // Map size to dimensions
   const sizeMap = {
     sm: "w-8 h-8",
     md: "w-12 h-12",
@@ -21,7 +20,6 @@
     xl: "w-20 h-20"
   };
 
-  // State variables for pulsing
   let isPulsingEnabled = $state(true);
   let bassIntensity = $state(0);
   let midIntensity = $state(0);
@@ -52,7 +50,6 @@
       );
     }
 
-    // Listen to real-time audio spectrum
     try {
       unlisten = await listen<number[]>("spectrum-data", (event) => {
         if (!isPulsingEnabled) {
@@ -165,7 +162,6 @@
       </filter>
     </defs>
 
-    <!-- Base container with dynamic saturation pulse -->
     <g
       style="filter: saturate({saturationVal}); transition: filter 0.05s ease-out;"
     >

--- a/src/lib/components/RightPanel.svelte
+++ b/src/lib/components/RightPanel.svelte
@@ -57,9 +57,7 @@
   style="width: {width}px;"
   class="relative bg-brand-sidebar flex flex-col h-full text-brand-text-secondary select-none flex-shrink-0 overflow-hidden {themeStore.isGlassTheme ? 'glass-surface' : ''}"
 >
-  <!-- Content -->
   <div class="flex-1 overflow-y-auto px-6 pt-6 pb-6 space-y-6">
-    <!-- Current Song -->
     {#if currentSong}
       <div class="space-y-3">
         <div class="space-y-1">
@@ -88,7 +86,6 @@
         </div>
       </div>
 
-      <!-- Playback Info -->
       <div class="space-y-2">
         {#if currentSong.filetype}
           <div class="flex items-start justify-between gap-3 text-xs">
@@ -126,7 +123,6 @@
         </div>
       </div>
 
-      <!-- Additional Metadata -->
       <div class="space-y-2 text-xs">
         {#if currentSong.year}
           <div class="flex items-start justify-between gap-3">

--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -61,7 +61,6 @@
 </script>
 
 <aside style="width: {width}px;" class="bg-brand-sidebar flex flex-col h-full text-brand-text-secondary select-none flex-shrink-0 overflow-hidden {themeStore.isGlassTheme ? 'glass-surface' : ''}">
-  <!-- Navigation -->
   <nav class="{isCollapsed ? 'p-2' : 'p-4'} space-y-1 flex flex-col items-center">
     <button
       onclick={() => { collectionStore.activeTab = "home"; }}

--- a/src/lib/components/SmartPlaylistBuilderModal.svelte
+++ b/src/lib/components/SmartPlaylistBuilderModal.svelte
@@ -243,7 +243,6 @@
     class="bg-brand-sidebar border border-brand-border rounded-2xl w-full max-w-xl shadow-2xl overflow-hidden flex flex-col animate-in fade-in zoom-in-95 duration-150"
     style="max-height: min(90vh, calc(100vh - {dockClearance + 32}px))"
   >
-    <!-- Header -->
     <div class="flex items-center justify-between px-6 py-4 border-b border-brand-border/60 bg-brand-main/50">
       <div class="flex items-center gap-2.5">
         <div class="p-2 rounded-xl bg-brand-accent/20 text-brand-accent-text">
@@ -262,9 +261,7 @@
       </button>
     </div>
 
-    <!-- Form Content -->
     <form onsubmit={handleSubmit} class="p-6 flex-1 overflow-y-auto flex flex-col gap-5">
-      <!-- Playlist Name -->
       <div>
         <label for="smart-playlist-name-input" class="block text-xs font-semibold text-brand-text-secondary uppercase tracking-wider mb-1.5">
           {i18n.t("smartPlaylistBuilder.nameLabel")}
@@ -280,7 +277,6 @@
         />
       </div>
 
-      <!-- Rules Section -->
       <div>
         <div class="flex items-center justify-between mb-2">
           <span class="text-xs font-semibold text-brand-text-secondary uppercase tracking-wider flex items-center gap-1.5">
@@ -300,7 +296,6 @@
         <div class="space-y-2.5">
           {#each rules as rule (rule.id)}
             <div class="flex items-center gap-2 bg-brand-main/60 p-2.5 rounded-xl border border-brand-border/40">
-              <!-- Field Selector -->
               <Select
                 value={rule.field}
                 onchange={(e) => {
@@ -315,7 +310,6 @@
                 {/each}
               </Select>
 
-              <!-- Operator Selector -->
               <Select
                 value={rule.op}
                 onchange={(e) => { rule.op = e.currentTarget.value; }}
@@ -326,7 +320,6 @@
                 {/each}
               </Select>
 
-              <!-- Value Input -->
               <Input
                 type="text"
                 bind:value={rule.value}
@@ -336,7 +329,6 @@
                 class="flex-1 min-w-0"
               />
 
-              <!-- Delete Rule -->
               {#if rules.length > 1}
                 <button
                   type="button"
@@ -358,7 +350,6 @@
         <PopulationModeTabs mode={populationMode} onChange={(m) => (populationMode = m)} />
       </div>
 
-      <!-- Footer Buttons -->
       <div class="flex items-center justify-end gap-3 pt-4 border-t border-brand-border/60">
         <Button type="button" onclick={onClose} variant="secondary" size="sm">
           {i18n.t("smartPlaylistBuilder.cancel")}

--- a/src/lib/components/SpectrumVisualizer.svelte
+++ b/src/lib/components/SpectrumVisualizer.svelte
@@ -26,7 +26,6 @@
     const ctx = canvas.getContext("2d");
     if (!ctx) return;
 
-    // Handle high DPI screens
     const dpr = window.devicePixelRatio || 1;
     const width = canvas.clientWidth;
     const height = canvas.clientHeight;
@@ -43,18 +42,16 @@
     const barGap = 2.5;
     const barWidth = (width - (numBars - 1) * barGap) / numBars;
 
-    // Dynamically read active theme colors from themeStore
     const colors = themeStore.resolvedColors;
     const accentColor = colors["color-accent"] || '#8b5cf6';
     const hoverColor = colors["color-accent-hover"] || '#a78bfa';
 
     const rgb = hexToRgb(accentColor) || { r: 139, g: 92, b: 246 };
 
-    // Premium gradient: custom or themed accent to hover
     const grad = ctx.createLinearGradient(0, height, 0, 0);
-    grad.addColorStop(0, `rgba(${rgb.r}, ${rgb.g}, ${rgb.b}, 0.2)`); // faint accent color at bottom
-    grad.addColorStop(0.5, `rgba(${rgb.r}, ${rgb.g}, ${rgb.b}, 0.8)`); // strong accent color
-    grad.addColorStop(1, hoverColor); // accent hover color
+    grad.addColorStop(0, `rgba(${rgb.r}, ${rgb.g}, ${rgb.b}, 0.2)`);
+    grad.addColorStop(0.5, `rgba(${rgb.r}, ${rgb.g}, ${rgb.b}, 0.8)`);
+    grad.addColorStop(1, hoverColor);
 
     ctx.fillStyle = grad;
 
@@ -69,7 +66,6 @@
       const x = i * (barWidth + barGap);
       const y = height - barHeight;
 
-      // Draw rounded rectangle for bar
       ctx.beginPath();
       ctx.roundRect(x, y, barWidth, barHeight, [1.5, 1.5, 0, 0]);
       ctx.fill();
@@ -77,7 +73,6 @@
   }
 
   $effect(() => {
-    // Redraw when theme or artwork colors change
     const _theme = themeStore.activeThemeId;
     const _art = themeStore.artworkColors;
     draw();

--- a/src/lib/components/TagEditor.svelte
+++ b/src/lib/components/TagEditor.svelte
@@ -167,11 +167,9 @@
         initialKey,
       });
 
-      // Refresh the database views and collection store stats
       await collectionStore.refreshStats();
       await collectionStore.refreshLibrary();
 
-      // Trigger UI updates for playlists and playback queue
       if (playlistsStore.activePlaylistId !== null && playlistsStore.activePlaylistId !== undefined) {
         await playlistsStore.selectPlaylist(playlistsStore.activePlaylistId);
       }
@@ -211,7 +209,6 @@
 </script>
 
 <Modal onClose={onClose} onKeydown={handleKeydown}>
-    <!-- Header -->
     <div class="h-14 flex items-center justify-between px-6 border-b border-brand-border shrink-0 bg-brand-main">
       <div class="flex items-center gap-2">
         <Sliders class="w-4 h-4 text-brand-accent-text" />
@@ -222,7 +219,6 @@
       </button>
     </div>
 
-    <!-- Body -->
     <div class="flex-1 overflow-y-auto p-6 max-h-[calc(100vh-200px)]">
       {#if isLoading}
         <div class="w-full py-16 flex flex-col items-center justify-center gap-3">
@@ -236,13 +232,11 @@
         </div>
       {:else}
         <div class="flex flex-col gap-4">
-          <!-- File Path (read-only) -->
           <div class="flex flex-col gap-1 bg-brand-main border border-brand-border rounded-lg p-2.5">
             <span class="text-[9px] font-bold text-brand-text-secondary/60 uppercase font-mono">{i18n.t('tagEditor.locationField')}</span>
             <span class="text-[10px] text-brand-text-secondary break-all select-text font-mono">{path}</span>
           </div>
 
-          <!-- AcoustID lookup error info -->
           {#if lookupErrorMsg}
             <div class="flex items-start gap-2.5 bg-brand-main border border-red-500/40 rounded-xl p-3 text-red-500 text-xs">
               <AlertTriangle class="w-4 h-4 shrink-0 mt-0.5" />
@@ -254,7 +248,6 @@
                album, composer, album artist, year, genre, grouping, bpm, initial key), with Disc paired
                alongside Track (Disc first) since it has no column of its own in the table. -->
           <div class="grid grid-cols-2 gap-4">
-            <!-- Disc Number -->
             <FormField label={i18n.t('tagEditor.discField')} for="tag-disc">
               <Input
                 id="tag-disc"
@@ -270,7 +263,6 @@
               />
             </FormField>
 
-            <!-- Track Number -->
             <FormField label={i18n.t('tagEditor.trackField')} for="tag-track">
               <Input
                 id="tag-track"
@@ -286,7 +278,6 @@
               />
             </FormField>
 
-            <!-- Title -->
             <FormField label={i18n.t('tagEditor.titleField')} for="tag-title" span2>
               <Input
                 id="tag-title"
@@ -299,7 +290,6 @@
               />
             </FormField>
 
-            <!-- Artist -->
             <FormField label={i18n.t('tagEditor.artistField')} for="tag-artist">
               <Input
                 id="tag-artist"
@@ -312,7 +302,6 @@
               />
             </FormField>
 
-            <!-- Album -->
             <FormField label={i18n.t('tagEditor.albumField')} for="tag-album">
               <Input
                 id="tag-album"
@@ -325,17 +314,14 @@
               />
             </FormField>
 
-            <!-- Composer -->
             <FormField label={i18n.t('tagEditor.composerField')} for="tag-composer">
               <Input id="tag-composer" bind:value={composer} disabled={isSaving} size="sm" class="w-full" />
             </FormField>
 
-            <!-- Album Artist -->
             <FormField label={i18n.t('tagEditor.albumArtistField')} for="tag-albumartist" tooltip={i18n.t('tagEditor.albumArtistTooltip')}>
               <Input id="tag-albumartist" bind:value={albumArtist} disabled={isSaving} size="sm" class="w-full" />
             </FormField>
 
-            <!-- Year -->
             <FormField label={i18n.t('tagEditor.yearField')} for="tag-year">
               <Input
                 id="tag-year"
@@ -353,17 +339,14 @@
               />
             </FormField>
 
-            <!-- Genre -->
             <FormField label={i18n.t('tagEditor.genreField')} for="tag-genre">
               <Input id="tag-genre" bind:value={genre} disabled={isSaving} size="sm" class="w-full" />
             </FormField>
 
-            <!-- Grouping -->
             <FormField label={i18n.t('tagEditor.groupingField')} for="tag-grouping" tooltip={i18n.t('tagEditor.groupingTooltip')}>
               <Input id="tag-grouping" bind:value={grouping} disabled={isSaving} size="sm" class="w-full" />
             </FormField>
 
-            <!-- BPM -->
             <FormField label={i18n.t('tagEditor.bpmField')} for="tag-bpm" tooltip={i18n.t('tagEditor.bpmTooltip')}>
               <Input
                 id="tag-bpm"
@@ -379,7 +362,6 @@
               />
             </FormField>
 
-            <!-- Initial Key -->
             <FormField label={i18n.t('tagEditor.initialKeyField')} for="tag-initialkey" tooltip={i18n.t('tagEditor.initialKeyTooltip')}>
               <Input id="tag-initialkey" bind:value={initialKey} disabled={isSaving} size="sm" class="w-full" />
             </FormField>
@@ -394,7 +376,6 @@
       {/if}
     </div>
 
-    <!-- Footer -->
     <div class="h-16 flex items-center justify-between px-6 border-t border-brand-border shrink-0 bg-brand-main">
       {#if !isLoading && !errorMsg}
         <div class="flex items-center gap-3">

--- a/src/lib/components/TopNavigation.svelte
+++ b/src/lib/components/TopNavigation.svelte
@@ -20,7 +20,6 @@
   let searchDropdownRef: HTMLDivElement | undefined = $state();
   let isSearchFocused = $state(false);
 
-  // Move focus into the dropdown's result list, roving with the arrow keys
   function focusFirstSearchResult() {
     const first = searchDropdownRef?.querySelector<HTMLElement>(".search-result-item");
     first?.focus();
@@ -63,7 +62,6 @@
       | { type: "custom"; id: number; label: string; subtitle: string }
     > = [];
 
-    // Favourites auto-playlist
     const favLabel = i18n.t("playlists.autoFavourites", {}, "Favourite Songs");
     if (favLabel.toLowerCase().includes(query) || "favourites".includes(query) || "favorites".includes(query)) {
       results.push({
@@ -75,7 +73,6 @@
       });
     }
 
-    // Recently Added auto-playlist
     const recLabel = i18n.t("playlists.autoRecentlyAdded", {}, "Recently Added");
     if (recLabel.toLowerCase().includes(query) || "recently added".includes(query) || "recent".includes(query)) {
       results.push({
@@ -87,7 +84,6 @@
       });
     }
 
-    // History auto-playlist
     const histLabel = i18n.t("playlists.autoHistory", {}, "History");
     if (histLabel.toLowerCase().includes(query) || "history".includes(query)) {
       results.push({
@@ -140,7 +136,6 @@
     return results;
   });
 
-  // Handle Ctrl+L to focus search & Escape to close search dropdown
   function handleKeyDown(e: KeyboardEvent) {
     if ((e.ctrlKey || e.metaKey) && e.key === "l") {
       e.preventDefault();
@@ -150,7 +145,6 @@
       isSearchFocused = false;
     }
 
-    // Dedicated keyboard "Browser Back"/"Browser Forward" keys
     if (e.key === "BrowserBack") {
       e.preventDefault();
       collectionStore.goBack();
@@ -171,14 +165,12 @@
     }
   }
 
-  // Close dropdown on click outside
   function handleWindowMouseDown(e: MouseEvent) {
     if (searchContainerRef && !searchContainerRef.contains(e.target as Node)) {
       isSearchFocused = false;
     }
   }
 
-  // Search handler (prevent reload & record query to recent searches)
   function handleSearch(e: Event) {
     e.preventDefault();
     const q = collectionStore.searchQuery.trim();
@@ -218,7 +210,6 @@
     isSearchFocused = false;
   }
 
-  // Clear search query
   function clearSearch() {
     collectionStore.searchQuery = "";
     collectionStore.search("");
@@ -230,7 +221,6 @@
 <svelte:window on:keydown={handleKeyDown} on:mouseup={handleMouseUp} on:mousedown={handleWindowMouseDown} />
 
 <header in:fade={{ duration: 600 }} class="w-full h-20 bg-brand-sidebar flex items-center px-6 gap-6 z-50 overflow-visible {themeStore.isGlassTheme ? 'glass-surface' : ''}">
-  <!-- History Navigation Controls -->
   <div class="flex items-center gap-2">
     <button
       onclick={() => collectionStore.toggleSidebarCompact()}
@@ -257,7 +247,6 @@
     </button>
   </div>
 
-  <!-- Universal Search Bar Container -->
   <div bind:this={searchContainerRef} class="relative flex-1 max-w-2xl">
     <form onsubmit={handleSearch} class="w-full flex items-center gap-3 bg-brand-main rounded-lg px-4 py-2 border border-brand-border focus-within:border-brand-accent transition-colors">
       <Search class="w-4 h-4 text-brand-text-secondary flex-shrink-0" />
@@ -275,7 +264,6 @@
         class="flex-1 bg-transparent text-brand-text-primary text-sm focus:outline-none placeholder-brand-text-secondary/50"
       />
 
-      <!-- Open Files/Playlists button -->
       <button
         type="button"
         onclick={() => playerStore.openFileDialog()}
@@ -285,7 +273,6 @@
         <FolderOpen class="w-4 h-4" />
       </button>
 
-      <!-- Search feedback / progress -->
       {#if collectionStore.searchLoading}
         <div class="animate-spin rounded-full h-4 w-4 border-2 border-brand-accent border-t-transparent flex-shrink-0" title={i18n.t('topNav.searching')}></div>
       {:else if collectionStore.searchQuery}
@@ -303,7 +290,6 @@
       {/if}
     </form>
 
-    <!-- Search Dropdown Popover -->
     {#if isSearchFocused}
       <div
         bind:this={searchDropdownRef}
@@ -349,7 +335,6 @@
           </div>
         {/if}
 
-        <!-- Auto-suggestions (Shown when typing a non-empty search query) -->
         {#if collectionStore.searchQuery.trim() !== ""}
           <div class="mb-3">
             <div class="flex items-center justify-between px-2 py-1 mb-1 border-b border-brand-border/40 select-none">
@@ -369,7 +354,6 @@
               </div>
             {:else}
               <div class="flex flex-col gap-1">
-                <!-- Matching Artists (Top 3) -->
                 {#each collectionStore.filteredArtists.slice(0, MAX_SEARCH_SUGGESTIONS_PER_CATEGORY) as artist (artist.name)}
                   <div
                     role="button"
@@ -408,7 +392,6 @@
                   </div>
                 {/each}
 
-                <!-- Matching Albums (Top 3) -->
                 {#each collectionStore.filteredAlbums.slice(0, MAX_SEARCH_SUGGESTIONS_PER_CATEGORY) as album (album.album)}
                   <div
                     role="button"
@@ -457,7 +440,6 @@
                   </div>
                 {/each}
 
-                <!-- Matching Playlists & Auto-playlists (Top 3) -->
                 {#each matchingPlaylists.slice(0, MAX_SEARCH_SUGGESTIONS_PER_CATEGORY) as item (item.id)}
                   <div
                     role="button"
@@ -510,7 +492,6 @@
                   </div>
                 {/each}
 
-                <!-- Matching Songs (Top 3) -->
                 {#each collectionStore.searchResults.slice(0, MAX_SEARCH_SUGGESTIONS_PER_CATEGORY) as song (song.id)}
                   <div
                     role="button"
@@ -567,7 +548,6 @@
           </div>
         {/if}
 
-        <!-- Recent Searches Section (Below Auto-suggestions) -->
         <div class="flex items-center justify-between px-2 py-1 mb-2 border-b border-brand-border/40 select-none">
           <span class="text-xs font-semibold text-brand-text-secondary uppercase tracking-wider">
             {i18n.t('topNav.recentSearches', {}, 'Recent searches')}
@@ -601,7 +581,6 @@
                 class="search-result-item group flex items-center justify-between p-2 rounded-lg hover:bg-brand-main/80 transition-colors focus:outline-none focus:ring-2 focus:ring-brand-accent"
               >
                 <div class="flex items-center gap-3 min-w-0 flex-1">
-                  <!-- Avatar / Artwork / Icon -->
                   {#if item.artUrl}
                     <CoverArt
                       songId={typeof item.entityId === 'number' ? item.entityId : undefined}
@@ -625,7 +604,6 @@
                     </div>
                   {/if}
 
-                  <!-- Title & Subtitle -->
                   <div class="flex flex-col min-w-0 flex-1">
                     <span class="text-sm font-medium text-brand-text-primary truncate group-hover:text-brand-accent-text transition-colors">
                       {item.title}
@@ -636,7 +614,6 @@
                   </div>
                 </div>
 
-                <!-- Delete Single Item Button -->
                 <button
                   type="button"
                   onclick={(e) => {
@@ -656,7 +633,6 @@
     {/if}
   </div>
 
-  <!-- Layout Panel Toggles Group -->
   <div class="flex items-center gap-1.5 bg-brand-main/60 p-1 rounded-lg border border-brand-border/60 ml-auto flex-shrink-0 select-none">
     <button
       onclick={() => collectionStore.toggleSidebar()}
@@ -681,7 +657,6 @@
     </button>
   </div>
 
-  <!-- Reactive Logo Brand -->
   <!-- overflow-hidden + isolate scoped to just this wrapper (not the header,
        which needs overflow-visible for the search dropdown popover) so the
        logo's SVG glow filter can never bleed into the sidebar/header layers -->

--- a/src/lib/components/WaveformSeekBar.svelte
+++ b/src/lib/components/WaveformSeekBar.svelte
@@ -115,7 +115,6 @@
     }
   }
 
-  // Draw waveform or bands, depending on prefs.seekBarMode
   function draw() {
     if (!canvas || !containerEl) return;
     const ctx = canvas.getContext("2d");
@@ -137,7 +136,6 @@
     const songLength = playerStore.currentSong?.length_nanosec || 1;
     const progressPct = playerStore.positionNanosec / songLength;
 
-    // Dynamically read active theme colors from themeStore
     const colors = themeStore.resolvedColors;
     const accentColor = colors["color-accent"] || '#8b5cf6';
     const hoverColor = colors["color-accent-hover"] || '#a78bfa';
@@ -166,7 +164,6 @@
     const barGap = width < NARROW_WIDTH_BREAKPOINT_PX ? 0.5 : 1.0;
     const barWidth = Math.max(1, (width - (numBars - 1) * barGap) / numBars);
 
-    // Premium gradients for played part
     const gradPlayed = ctx.createLinearGradient(0, height, 0, 0);
     gradPlayed.addColorStop(0, accentColor);
     gradPlayed.addColorStop(1, hoverColor);
@@ -193,7 +190,6 @@
         }
       }
 
-      // Center the bars vertically
       const barHeight = Math.max(2, val * height * 0.85);
       const x = i * (barWidth + barGap);
       const y = (height - barHeight) / 2;
@@ -302,7 +298,6 @@
   let loadedSongId: number | undefined = undefined;
   let loadedMode: string | undefined = undefined;
 
-  // Fetch waveform or bands when song or mode actually changes.
   $effect(() => {
     const songId = playerStore.currentSong?.id;
     const mode = prefs.seekBarMode;

--- a/src/lib/stores/collection.svelte.ts
+++ b/src/lib/stores/collection.svelte.ts
@@ -593,7 +593,6 @@ class CollectionStore {
         }
       }
 
-      // Listen to library scan progress events
       await listen<ScanProgress>("scan-progress", (event) => {
         this.scanProgress = event.payload;
         this.isScanning = event.payload.phase !== "done";

--- a/src/lib/stores/player.svelte.ts
+++ b/src/lib/stores/player.svelte.ts
@@ -9,7 +9,6 @@ import { playlistsStore } from "./playlists.svelte";
 import { i18n } from "./i18n.svelte";
 
 export class PlayerStore {
-  // Reactive state using Svelte 5 Runes
   state = $state<PlayState>("stopped");
   currentSong = $state<Song | undefined>(undefined);
   playlistId = $state<number | undefined>(undefined);
@@ -44,7 +43,6 @@ export class PlayerStore {
 
   private async init() {
     try {
-      // Get initial playback state from backend
       const initialState: PlaybackState = await invoke("get_playback_state");
       this.updateState(initialState);
       themeStore.updateArtworkColors(this.currentSong);
@@ -54,7 +52,6 @@ export class PlayerStore {
         this.positionNanosec = event.payload.position_nanosec;
       });
 
-      // Listen for playback state changes
       await listen<PlaybackState>("playback-state", async (event) => {
         const oldSongId = this.currentSong?.id;
         const oldItemUuid = this.playlistItemUuid;
@@ -82,7 +79,6 @@ export class PlayerStore {
         }
       });
 
-      // Listen for track changes
       await listen<{ song: Song | null }>("track-changed", async (event) => {
         this.currentSong = event.payload.song || undefined;
         themeStore.updateArtworkColors(this.currentSong);
@@ -120,7 +116,6 @@ export class PlayerStore {
         this.openAndPlay(event.payload);
       });
 
-      // Check for startup file argument
       const startupFile = await invoke<string | null>("get_startup_file");
       if (startupFile) {
         await this.openAndPlay([startupFile]);

--- a/src/lib/utils/colorUtils.ts
+++ b/src/lib/utils/colorUtils.ts
@@ -68,9 +68,6 @@ function sRgbToLinearRgb(value: number): number {
   return Math.pow((normalized + 0.055) / 1.055, 2.4);
 }
 
-/**
- * Convert Linear RGB to sRGB
- */
 function linearRgbToSRgb(value: number): number {
   if (value <= 0.0031308) {
     return value * 12.92 * 255;
@@ -206,9 +203,6 @@ export function clampForContrast(hex: string, backgroundHex: string, minRatio = 
   return candidateHex;
 }
 
-/**
- * Get full color metrics for a hex color
- */
 export function getColorMetrics(hex: string): ColorMetrics {
   const rgb = hexToRgb(hex);
   const luminance = calculateLuminance(hex);
@@ -226,16 +220,10 @@ export function getColorMetrics(hex: string): ColorMetrics {
   };
 }
 
-/**
- * Format luminance as percentage for display
- */
 export function formatLuminance(luminance: number): string {
   return `${Math.round(luminance * 100)}%`;
 }
 
-/**
- * Get WCAG level badge color
- */
 export function getWcagBadgeColor(level: 'fail' | 'AA' | 'AAA'): string {
   switch (level) {
     case 'AAA':
@@ -247,9 +235,6 @@ export function getWcagBadgeColor(level: 'fail' | 'AA' | 'AAA'): string {
   }
 }
 
-/**
- * Get WCAG level badge text
- */
 export function getWcagBadgeText(level: 'fail' | 'AA' | 'AAA'): string {
   switch (level) {
     case 'AAA':

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -41,7 +41,6 @@ if (typeof window !== "undefined" && typeof (window as any).ResizeObserver === "
   (window as any).ResizeObserver = globalThis.ResizeObserver;
 }
 
-// Mock Tauri core API
 vi.mock("@tauri-apps/api/core", () => {
   return {
     invoke: vi.fn().mockImplementation(async (cmd, args) => {
@@ -92,7 +91,6 @@ vi.mock("@tauri-apps/api/core", () => {
   };
 });
 
-// Mock Tauri event API
 vi.mock("@tauri-apps/api/event", () => {
   return {
     listen: vi.fn().mockImplementation(async (event, callback) => {


### PR DESCRIPTION
## 📋 Summary
Sunday cleanup pass over comments repo-wide, guided by "comments should describe what is not obvious": strip comments that merely restate the code directly below them, keep everything that explains WHY.

## 🔍 Implementation Notes
Split across three scoped passes (comment-only diffs, no logic changes):
- **Rust backend** (`src-tauri/src/**`, `src-tauri/tests/**`) — 15 files, e.g. `// Cleanup` above `remove_dir_all`, `// Create a channel to receive events` above `channel()`.
- **Svelte components** (`src/lib/components/*.svelte`) — 26 files, mostly markup section labels like `<!-- Header -->` / `<!-- Footer -->` / `<!-- Genre -->` sitting directly above self-explanatory elements, plus a few one-line JS comments restating the call below.
- **TS stores/utils/scripts** (`src/lib/stores`, `src/lib/utils`, `vitest.setup.ts`) — 4 files, mostly bare JSDoc blocks on `colorUtils.ts` helpers that just repeated the function name, and event-listener comments in `player.svelte.ts` / `collection.svelte.ts` restating the `listen(...)` call below.

Left untouched: bug-history notes and issue references (`#77`, `#79`, `#120`, `#233`), Tauri/browser/Wayland quirk explanations, `unsafe` safety rationale, WCAG/color-science math comments, reactive-ordering gotchas, and all `<!-- svelte-ignore -->` directives. `*.test.ts`/`*.benchmark.ts` files were left out of scope entirely — no dead-code or test changes here (a separate dead-code pass, e.g. `getWcagBadgeText`, is planned as its own PR).

## 🧪 Test Plan
- [x] `bun run check` (svelte-check) — 0 errors, 0 warnings across 75 files
- [ ] `bun run test -- --run` (frontend)
- [x] `cargo check --tests` (src-tauri) — compiles clean
- [ ] Manually verified in the app (comment-only change, not applicable)

## 📸 Screenshots
Not applicable — no UI/behavior changes.

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed — not applicable, no user-facing behavior changed