### PR TITLE
Remove dead color/WCAG badge helpers and unused artist category label

### DIFF
--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -750,10 +750,6 @@ export const en = {
     albumsFilter: "Albums ({count})",
     epsFilter: "EPs ({count})",
     singlesFilter: "Singles ({count})",
-    singleEp: "Single/EP",
-    single: "Single",
-    ep: "EP",
-    album: "Album",
     discSet: "{count}-Disc Set",
     noReleasesFound: "No releases found.",
     playlistsFeaturing: "Playlists featuring {artist}"

--- a/src/lib/locales/fr.ts
+++ b/src/lib/locales/fr.ts
@@ -747,10 +747,6 @@ export const fr = {
     albumsFilter: "Albums ({count})",
     epsFilter: "EPs ({count})",
     singlesFilter: "Singles ({count})",
-    singleEp: "Single/EP",
-    single: "Single",
-    ep: "EP",
-    album: "Album",
     discSet: "Coffret {count} disques",
     noReleasesFound: "Aucune sortie trouvée.",
     playlistsFeaturing: "Listes de lecture avec {artist}"

--- a/src/lib/utils/artist.ts
+++ b/src/lib/utils/artist.ts
@@ -1,5 +1,4 @@
 import type { AlbumItem, Song } from "../types";
-import { i18n } from "../stores/i18n.svelte";
 
 /**
  * Matched case-insensitively: tag casing can drift across files/albums for the
@@ -69,24 +68,6 @@ export function classifyRelease(
   if (trackCount === 1) return "single";
   if ((totalDurationNanosec ?? 0) < EP_MAX_DURATION_NANOSEC) return "ep";
   return "album";
-}
-
-/** Single card-facing category label for an album, e.g. "{n}-Disc Set", "Single", "EP", "Album". */
-export function getAlbumCategoryLabel(
-  trackCount: number,
-  discCount: number | null | undefined,
-  totalDurationNanosec: number | null | undefined
-): string {
-  switch (classifyRelease(trackCount, discCount, totalDurationNanosec)) {
-    case "set":
-      return i18n.t("artistDetail.discSet", { count: discCount ?? 1 });
-    case "single":
-      return i18n.t("artistDetail.single");
-    case "ep":
-      return i18n.t("artistDetail.ep");
-    case "album":
-      return i18n.t("artistDetail.album");
-  }
 }
 
 const GRADIENTS = [

--- a/src/lib/utils/colorUtils.test.ts
+++ b/src/lib/utils/colorUtils.test.ts
@@ -6,11 +6,6 @@ import {
   isLightColor,
   calculateContrastRatio,
   checkWcagCompliance,
-  suggestTextColor,
-  getColorMetrics,
-  formatLuminance,
-  getWcagBadgeColor,
-  getWcagBadgeText,
   rgbToHsl,
   hslToRgb,
   scoreSwatch,
@@ -118,58 +113,6 @@ describe("checkWcagCompliance", () => {
     expect(result.level).toBe("AA");
     expect(result.wcagAA).toBe(true);
     expect(result.wcagAAA).toBe(false);
-  });
-});
-
-describe("suggestTextColor", () => {
-  it("suggests dark text on light backgrounds", () => {
-    expect(suggestTextColor("#ffffff")).toBe("#1a1a1a");
-  });
-
-  it("suggests light text on dark backgrounds", () => {
-    expect(suggestTextColor("#000000")).toBe("#ffffff");
-  });
-});
-
-describe("getColorMetrics", () => {
-  it("returns full metrics for white", () => {
-    const metrics = getColorMetrics("#ffffff");
-    expect(metrics.hex).toBe("#ffffff");
-    expect(metrics.rgb).toEqual({ r: 255, g: 255, b: 255 });
-    expect(metrics.luminance).toBeCloseTo(1, 5);
-    expect(metrics.isLight).toBe(true);
-    expect(metrics.linearRgb.r).toBeCloseTo(1, 5);
-  });
-
-  it("returns full metrics for black", () => {
-    const metrics = getColorMetrics("#000000");
-    expect(metrics.luminance).toBe(0);
-    expect(metrics.isLight).toBe(false);
-    expect(metrics.linearRgb).toEqual({ r: 0, g: 0, b: 0 });
-  });
-});
-
-describe("formatLuminance", () => {
-  it("formats luminance as a rounded percentage", () => {
-    expect(formatLuminance(1)).toBe("100%");
-    expect(formatLuminance(0)).toBe("0%");
-    expect(formatLuminance(0.5)).toBe("50%");
-  });
-});
-
-describe("getWcagBadgeColor", () => {
-  it("returns green for AAA, amber for AA, red for fail", () => {
-    expect(getWcagBadgeColor("AAA")).toBe("#10b981");
-    expect(getWcagBadgeColor("AA")).toBe("#f59e0b");
-    expect(getWcagBadgeColor("fail")).toBe("#ef4444");
-  });
-});
-
-describe("getWcagBadgeText", () => {
-  it("returns the expected label for each level", () => {
-    expect(getWcagBadgeText("AAA")).toBe("✓ WCAG AAA");
-    expect(getWcagBadgeText("AA")).toBe("✓ WCAG AA");
-    expect(getWcagBadgeText("fail")).toBe("✗ Below AA");
   });
 });
 

--- a/src/lib/utils/colorUtils.ts
+++ b/src/lib/utils/colorUtils.ts
@@ -6,14 +6,6 @@ import { LIGHTNESS_STEP } from "../constants";
 const MAX_CONTRAST_ADJUST_STEPS = 50;
 const MAX_PALETTE_TEXT_ADJUST_STEPS = 20;
 
-export interface ColorMetrics {
-  hex: string;
-  rgb: { r: number; g: number; b: number };
-  linearRgb: { r: number; g: number; b: number };
-  luminance: number;
-  isLight: boolean;
-}
-
 export interface ContrastResult {
   ratio: number;
   wcagAA: boolean;
@@ -66,16 +58,6 @@ function sRgbToLinearRgb(value: number): number {
     return normalized / 12.92;
   }
   return Math.pow((normalized + 0.055) / 1.055, 2.4);
-}
-
-/**
- * Convert Linear RGB to sRGB
- */
-function linearRgbToSRgb(value: number): number {
-  if (value <= 0.0031308) {
-    return value * 12.92 * 255;
-  }
-  return (1.055 * Math.pow(value, 1 / 2.4) - 0.055) * 255;
 }
 
 /**
@@ -144,14 +126,6 @@ export function checkWcagCompliance(foreground: string, background: string): Con
 }
 
 /**
- * Suggest appropriate text color (dark or light) based on background
- * Uses the 0.179 luminance threshold
- */
-export function suggestTextColor(backgroundColor: string): string {
-  return isLightColor(backgroundColor) ? '#1a1a1a' : '#ffffff';
-}
-
-/**
  * Picks white or black for text/icons rendered directly on top of a
  * background — e.g. a filled accent button — using perceived brightness
  * (YIQ), not the WCAG relative-luminance contrast ratio. Plain "whichever
@@ -204,61 +178,6 @@ export function clampForContrast(hex: string, backgroundHex: string, minRatio = 
   // minRatio — return the most extreme candidate reached rather than the
   // original, since it's strictly closer to compliant.
   return candidateHex;
-}
-
-/**
- * Get full color metrics for a hex color
- */
-export function getColorMetrics(hex: string): ColorMetrics {
-  const rgb = hexToRgb(hex);
-  const luminance = calculateLuminance(hex);
-
-  return {
-    hex,
-    rgb,
-    linearRgb: {
-      r: sRgbToLinearRgb(rgb.r),
-      g: sRgbToLinearRgb(rgb.g),
-      b: sRgbToLinearRgb(rgb.b)
-    },
-    luminance,
-    isLight: luminance > 0.179
-  };
-}
-
-/**
- * Format luminance as percentage for display
- */
-export function formatLuminance(luminance: number): string {
-  return `${Math.round(luminance * 100)}%`;
-}
-
-/**
- * Get WCAG level badge color
- */
-export function getWcagBadgeColor(level: 'fail' | 'AA' | 'AAA'): string {
-  switch (level) {
-    case 'AAA':
-      return '#10b981'; // green
-    case 'AA':
-      return '#f59e0b'; // amber
-    case 'fail':
-      return '#ef4444'; // red
-  }
-}
-
-/**
- * Get WCAG level badge text
- */
-export function getWcagBadgeText(level: 'fail' | 'AA' | 'AAA'): string {
-  switch (level) {
-    case 'AAA':
-      return '✓ WCAG AAA';
-    case 'AA':
-      return '✓ WCAG AA';
-    case 'fail':
-      return '✗ Below AA';
-  }
 }
 
 export interface HSL {


### PR DESCRIPTION
## Summary
- Removed five exported functions in `colorUtils.ts` (`getWcagBadgeColor`, `getWcagBadgeText`, `getColorMetrics`, `formatLuminance`, `suggestTextColor`) plus the `ColorMetrics` interface and an unexported helper (`linearRgbToSRgb`) — none had any callers outside their own unit tests, apparent leftovers from a removed WCAG/accessibility debug page.
- Removed `getAlbumCategoryLabel` from `artist.ts` — zero callers anywhere, including tests. `classifyRelease`, which it wrapped, is still actively used elsewhere and was left alone.
- Removed the now-orphaned `artistDetail.single`/`.ep`/`.album`/`.singleEp` translation strings from `en.ts`/`fr.ts` that only `getAlbumCategoryLabel` referenced.
- Deleted the matching dead tests in `colorUtils.test.ts`.

## Test plan
- [x] `bunx vitest run src/lib/utils/colorUtils.test.ts src/lib/utils/artist.test.ts` — 37/37 pass
- [x] `bunx tsc --noEmit -p tsconfig.json` — no errors
- [x] Full suite `bunx vitest run` — 332/333 pass; the one failure (`CollectionView.test.ts` date formatting) reproduces identically on `main` and is unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)