### PR TITLE
Fix playlist undo restoring items to the wrong position

### DIFF
--- a/src-tauri/src/collection.rs
+++ b/src-tauri/src/collection.rs
@@ -610,10 +610,11 @@ impl CollectionScanner {
             );
         }
 
-        let mut updating_scanned = 0u64;
         let mut remote_fetch_count = 0;
-        for (song_id, path_str, effective_artist, album, art_embedded) in albums_to_resolve {
-            updating_scanned += 1;
+        for (idx, (song_id, path_str, effective_artist, album, art_embedded)) in
+            albums_to_resolve.into_iter().enumerate()
+        {
+            let updating_scanned = idx as u64 + 1;
             let display_desc = if !effective_artist.trim().is_empty() && !album.trim().is_empty() {
                 format!("Cover art: {effective_artist} - {album}")
             } else if !album.trim().is_empty() {
@@ -2761,6 +2762,28 @@ pub fn start_watcher(app: AppHandle, state: &crate::AppState) {
         .expect("failed to spawn watcher thread");
 }
 
+pub fn parse_decade_range(decade: &str) -> Option<(i32, i32)> {
+    let clean = decade.trim().trim_end_matches(['s', 'S']);
+    let year: i32 = clean.parse().ok()?;
+    let start = (year / 10) * 10;
+    let end = start + 9;
+    Some((start, end))
+}
+
+/// Parses a `bpmrange:` dynamic-spec suffix (e.g. `"60-90"` or the
+/// open-ended `"150-"`) into a `(min, max)` pair for
+/// [`CollectionScanner::get_songs_by_bpm_range`].
+pub fn parse_bpm_range_spec(spec: &str) -> Option<(f64, Option<f64>)> {
+    let (min_str, max_str) = spec.split_once('-')?;
+    let min: f64 = min_str.trim().parse().ok()?;
+    let max = if max_str.trim().is_empty() {
+        None
+    } else {
+        Some(max_str.trim().parse().ok()?)
+    };
+    Some((min, max))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -3813,7 +3836,7 @@ mod tests {
         )
         .unwrap();
 
-        let reconciled = reconcile_moved_songs(&conn, &[new_path.clone()]).unwrap();
+        let reconciled = reconcile_moved_songs(&conn, std::slice::from_ref(&new_path)).unwrap();
         assert_eq!(reconciled, 1);
 
         let (id, path, playcount): (i64, String, i32) = conn
@@ -4042,26 +4065,4 @@ mod tests {
 
         let _ = std::fs::remove_dir_all(temp_dir);
     }
-}
-
-pub fn parse_decade_range(decade: &str) -> Option<(i32, i32)> {
-    let clean = decade.trim().trim_end_matches(['s', 'S']);
-    let year: i32 = clean.parse().ok()?;
-    let start = (year / 10) * 10;
-    let end = start + 9;
-    Some((start, end))
-}
-
-/// Parses a `bpmrange:` dynamic-spec suffix (e.g. `"60-90"` or the
-/// open-ended `"150-"`) into a `(min, max)` pair for
-/// [`CollectionScanner::get_songs_by_bpm_range`].
-pub fn parse_bpm_range_spec(spec: &str) -> Option<(f64, Option<f64>)> {
-    let (min_str, max_str) = spec.split_once('-')?;
-    let min: f64 = min_str.trim().parse().ok()?;
-    let max = if max_str.trim().is_empty() {
-        None
-    } else {
-        Some(max_str.trim().parse().ok()?)
-    };
-    Some((min, max))
 }

--- a/src-tauri/src/filter_parser.rs
+++ b/src-tauri/src/filter_parser.rs
@@ -174,19 +174,19 @@ fn parse_field_filter(token: &str) -> Option<FieldFilter> {
     })
 }
 
-fn parse_op_and_value<'a>(val_str: &'a str, is_numeric: bool) -> (Op, &'a str) {
-    if val_str.starts_with(">=") {
-        (Op::Gte, &val_str[2..])
-    } else if val_str.starts_with("<=") {
-        (Op::Lte, &val_str[2..])
-    } else if val_str.starts_with("!=") {
-        (Op::Neq, &val_str[2..])
-    } else if val_str.starts_with('>') {
-        (Op::Gt, &val_str[1..])
-    } else if val_str.starts_with('<') {
-        (Op::Lt, &val_str[1..])
-    } else if val_str.starts_with('=') {
-        (Op::Eq, &val_str[1..])
+fn parse_op_and_value(val_str: &str, is_numeric: bool) -> (Op, &str) {
+    if let Some(rest) = val_str.strip_prefix(">=") {
+        (Op::Gte, rest)
+    } else if let Some(rest) = val_str.strip_prefix("<=") {
+        (Op::Lte, rest)
+    } else if let Some(rest) = val_str.strip_prefix("!=") {
+        (Op::Neq, rest)
+    } else if let Some(rest) = val_str.strip_prefix('>') {
+        (Op::Gt, rest)
+    } else if let Some(rest) = val_str.strip_prefix('<') {
+        (Op::Lt, rest)
+    } else if let Some(rest) = val_str.strip_prefix('=') {
+        (Op::Eq, rest)
     } else if is_numeric {
         (Op::Eq, val_str)
     } else {
@@ -271,7 +271,7 @@ mod tests {
     #[test]
     fn test_parse_duration() {
         assert_eq!(parse_duration_ns("3:45"), Some(225_000_000_000));
-        assert_eq!(parse_duration_ns("1:02:03"), Some(3723_000_000_000));
+        assert_eq!(parse_duration_ns("1:02:03"), Some(3_723_000_000_000));
         assert_eq!(parse_duration_ns("180"), Some(180_000_000_000));
     }
 }

--- a/src-tauri/src/install_format.rs
+++ b/src-tauri/src/install_format.rs
@@ -66,11 +66,11 @@ pub fn detect_install_format() -> InstallFormatInfo {
             }
         }
 
-        return InstallFormatInfo {
+        InstallFormatInfo {
             format: "linux_generic".to_string(),
             human_name: "Linux Executable".to_string(),
             supports_self_update: false,
-        };
+        }
     }
 
     #[cfg(target_os = "windows")]
@@ -88,11 +88,11 @@ pub fn detect_install_format() -> InstallFormatInfo {
             }
         }
 
-        return InstallFormatInfo {
+        InstallFormatInfo {
             format: "windows_setup".to_string(),
             human_name: "Windows Installer (.exe / .msi)".to_string(),
             supports_self_update: true,
-        };
+        }
     }
 
     #[cfg(not(any(target_os = "linux", target_os = "windows")))]

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -725,30 +725,40 @@ mod tests {
 
     #[test]
     fn test_is_same_album_or_cue_sibling() {
-        let mut s1 = Song::default();
-        s1.album = Some("The Dark Side of the Moon".to_string());
-        s1.artist = Some("Pink Floyd".to_string());
+        let s1 = Song {
+            album: Some("The Dark Side of the Moon".to_string()),
+            artist: Some("Pink Floyd".to_string()),
+            ..Default::default()
+        };
 
-        let mut s2 = Song::default();
-        s2.album = Some("The Dark Side of the Moon".to_string());
-        s2.artist = Some("Pink Floyd".to_string());
+        let s2 = Song {
+            album: Some("The Dark Side of the Moon".to_string()),
+            artist: Some("Pink Floyd".to_string()),
+            ..Default::default()
+        };
 
         assert!(s1.is_same_album_or_cue_sibling(&s2));
 
-        let mut s3 = Song::default();
-        s3.album = Some("Abbey Road".to_string());
-        s3.artist = Some("The Beatles".to_string());
+        let s3 = Song {
+            album: Some("Abbey Road".to_string()),
+            artist: Some("The Beatles".to_string()),
+            ..Default::default()
+        };
 
         assert!(!s1.is_same_album_or_cue_sibling(&s3));
     }
 
     #[test]
     fn test_cue_sibling_match() {
-        let mut s1 = Song::default();
-        s1.cue_path = Some("/music/album.cue".to_string());
+        let s1 = Song {
+            cue_path: Some("/music/album.cue".to_string()),
+            ..Default::default()
+        };
 
-        let mut s2 = Song::default();
-        s2.cue_path = Some("/music/album.cue".to_string());
+        let s2 = Song {
+            cue_path: Some("/music/album.cue".to_string()),
+            ..Default::default()
+        };
 
         assert!(s1.is_same_album_or_cue_sibling(&s2));
     }

--- a/src-tauri/src/organizer.rs
+++ b/src-tauri/src/organizer.rs
@@ -1105,11 +1105,26 @@ pub fn execute_apply(
     })
 }
 
+/// Clears the readonly bit so a stray junk/leftover file can be deleted.
+/// `Permissions::set_readonly(false)` ORs in `0o222` on Unix, which grants
+/// write access to *everyone*, not just the owner — grant owner-write only
+/// instead to avoid briefly making the file world-writable.
+#[cfg(unix)]
+fn clear_readonly(perms: &mut fs::Permissions) {
+    use std::os::unix::fs::PermissionsExt;
+    perms.set_mode(perms.mode() | 0o200);
+}
+
+#[cfg(not(unix))]
+fn clear_readonly(perms: &mut fs::Permissions) {
+    perms.set_readonly(false);
+}
+
 fn force_remove_file(path: &Path) -> std::io::Result<()> {
     if let Ok(metadata) = fs::metadata(path) {
         let mut perms = metadata.permissions();
         if perms.readonly() {
-            perms.set_readonly(false);
+            clear_readonly(&mut perms);
             let _ = fs::set_permissions(path, perms);
         }
     }
@@ -1120,7 +1135,7 @@ fn force_remove_dir(path: &Path) -> std::io::Result<()> {
     if let Ok(metadata) = fs::metadata(path) {
         let mut perms = metadata.permissions();
         if perms.readonly() {
-            perms.set_readonly(false);
+            clear_readonly(&mut perms);
             let _ = fs::set_permissions(path, perms);
         }
     }
@@ -1210,10 +1225,8 @@ pub(crate) fn remove_empty_dirs_under_root(root: &Path) -> usize {
             continue;
         }
         let dir = entry.path();
-        if clean_if_effectively_empty(dir).unwrap_or(false) {
-            if force_remove_dir(dir).is_ok() {
-                removed += 1;
-            }
+        if clean_if_effectively_empty(dir).unwrap_or(false) && force_remove_dir(dir).is_ok() {
+            removed += 1;
         }
     }
     removed

--- a/src-tauri/src/playlist.rs
+++ b/src-tauri/src/playlist.rs
@@ -813,16 +813,15 @@ impl PlaylistManager {
             )?;
         }
 
-        let mut next_pos: i32 = current.iter().map(|(_, _, p)| *p).max().unwrap_or(-1) + 1;
+        let start_pos: i32 = current.iter().map(|(_, _, p)| *p).max().unwrap_or(-1) + 1;
         let mut added_uuids = std::collections::HashSet::new();
-        for song in &to_add {
+        for (next_pos, song) in (start_pos..).zip(to_add.iter()) {
             let uuid = Uuid::new_v4().to_string();
             conn.execute(
                 "INSERT INTO playlist_items (playlist_id, song_id, position, uuid, type) VALUES (?1, ?2, ?3, ?4, 0)",
                 params![playlist_id, song.id, next_pos, uuid],
             )?;
             added_uuids.insert(uuid);
-            next_pos += 1;
         }
         self.renumber_positions(&conn, playlist_id)?;
         drop(conn);
@@ -1047,10 +1046,8 @@ impl PlaylistManager {
                 if let Some(ref song) = item.song {
                     let p = if let Some(ref path) = song.path {
                         std::path::Path::new(path)
-                    } else if let Some(ref url) = item.url {
-                        std::path::Path::new(url)
                     } else {
-                        return None;
+                        std::path::Path::new(item.url.as_ref()?)
                     };
                     let dur_sec = song.length_nanosec.map(|ns| ns / 1_000_000_000);
                     Some(ExportTrack {

--- a/src-tauri/src/playlist.rs
+++ b/src-tauri/src/playlist.rs
@@ -1577,7 +1577,18 @@ impl PlaylistManager {
             }
             PlaylistOp::Remove { playlist_id, items } => {
                 let conn = self.db.pool.get()?;
-                for item in items {
+                // Restore items in ascending original-position order, opening a
+                // gap for each one before inserting it. Relying on
+                // renumber_positions' `ORDER BY position` tiebreak instead would
+                // be nondeterministic: SQLite doesn't guarantee tie order, so a
+                // reinserted row can land one slot off from the row it displaces.
+                let mut items_by_position: Vec<&ClearedItem> = items.iter().collect();
+                items_by_position.sort_by_key(|item| item.position);
+                for item in items_by_position {
+                    conn.execute(
+                        "UPDATE playlist_items SET position = position + 1 WHERE playlist_id = ?1 AND position >= ?2",
+                        params![playlist_id, item.position],
+                    )?;
                     conn.execute(
                         "INSERT INTO playlist_items (playlist_id, song_id, position, uuid, type, url, stream_url, additional_metadata)
                          VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
@@ -1961,6 +1972,66 @@ mod tests {
         manager.redo().unwrap();
         let tracks_after_redo = manager.get_playlist_tracks(pl.id).unwrap();
         assert_eq!(tracks_after_redo.len(), 0);
+
+        let _ = std::fs::remove_dir_all(temp_dir);
+    }
+
+    #[test]
+    fn test_remove_middle_item_undo_restores_exact_position() {
+        let (db, temp_dir) = setup_test_db();
+        let db_arc = std::sync::Arc::new(db);
+
+        {
+            let conn = db_arc.pool.get().unwrap();
+            for i in 1..=5 {
+                conn.execute(
+                    "INSERT INTO songs (id, title) VALUES (?1, ?2)",
+                    params![i, format!("Song {i}")],
+                )
+                .unwrap();
+            }
+        }
+
+        let mut manager = PlaylistManager::new(db_arc.clone()).unwrap();
+        let pl = manager.create_playlist("Middle Remove Test").unwrap();
+        manager
+            .add_songs_to_playlist(pl.id, &[1, 2, 3, 4, 5])
+            .unwrap();
+
+        let original_tracks = manager.get_playlist_tracks(pl.id).unwrap();
+        assert_eq!(original_tracks.len(), 5);
+        let original_uuids: Vec<String> = original_tracks.iter().map(|t| t.uuid.clone()).collect();
+        // Song 3 sits at index 2, flanked by items that will shift when it's removed.
+        let middle_uuid = original_tracks[2].uuid.clone();
+        assert_eq!(
+            original_tracks[2].song.as_ref().unwrap().title.as_deref(),
+            Some("Song 3")
+        );
+
+        manager
+            .remove_from_playlist(pl.id, std::slice::from_ref(&middle_uuid))
+            .unwrap();
+        let after_remove = manager.get_playlist_tracks(pl.id).unwrap();
+        assert_eq!(after_remove.len(), 4);
+        assert!(after_remove.iter().all(|t| t.uuid != middle_uuid));
+
+        manager.undo().unwrap();
+        let after_undo = manager.get_playlist_tracks(pl.id).unwrap();
+        assert_eq!(after_undo.len(), 5);
+
+        // The restored item must land back at its exact original index, not
+        // merely somewhere in the list — and every other item's position must
+        // be untouched too.
+        let restored_uuids: Vec<String> = after_undo.iter().map(|t| t.uuid.clone()).collect();
+        assert_eq!(restored_uuids, original_uuids);
+        assert_eq!(after_undo[2].uuid, middle_uuid);
+        assert_eq!(
+            after_undo[2].song.as_ref().unwrap().title.as_deref(),
+            Some("Song 3")
+        );
+        for (idx, track) in after_undo.iter().enumerate() {
+            assert_eq!(track.position, idx as i32);
+        }
 
         let _ = std::fs::remove_dir_all(temp_dir);
     }

--- a/src-tauri/src/tageditor.rs
+++ b/src-tauri/src/tageditor.rs
@@ -72,7 +72,6 @@ struct AcoustIdResponse {
 // ---------------------------------------------------------------------------
 
 #[allow(clippy::too_many_arguments)]
-#[allow(clippy::too_many_arguments)]
 pub fn write_tags(
     path: &Path,
     title: &str,


### PR DESCRIPTION
## Summary
- Fixes a real undo bug: removing a track from the middle of a (non-Queue) playlist and then undoing could restore it to the wrong slot. `remove_from_playlist` recorded the removed item's original `position` on the undo stack, but `renumber_positions` closes the gap by shifting every later item down. On undo, re-inserting at the recorded position collided with the item that had shifted into that slot, and SQLite gives no tie-break guarantee for `ORDER BY position` — so the restored item could land one slot off, nondeterministically.
- Fix: before each reinsertion, shift positions `>= target` up by one (processing multi-item removals in ascending original-position order), so undo no longer depends on SQLite's tie-break behavior.
- Added `test_remove_middle_item_undo_restores_exact_position`, which reliably fails against the old code and passes against the fix (verified both ways locally).
- Also cleaned up every pre-existing `cargo clippy --lib --tests -p luminous` warning across the touched crate (separate commit), including a minor security nit in `organizer.rs` where `set_readonly(false)` briefly made files world-writable on Unix instead of owner-writable only.

Found via manual testing while verifying an unrelated PR (Queue live-playback-queue sync IPC changes) — not related to that work, it's a pre-existing bug in the position-renumbering logic.

## Test plan
- [x] `cargo test --lib playlist::` — all 18 playlist tests pass, including the new regression test
- [x] Verified the new test fails deterministically against the pre-fix code and passes against the fix
- [x] `cargo clippy --lib --tests -p luminous` — zero warnings
- [x] `cargo test --lib` — 108 passed, 1 ignored; 2 pre-existing `organizer::tests` failures reproduce identically on the unmodified base commit (case-only rename tests, environment/filesystem-specific, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)