### PR TITLE
Fix ENOENT when an ancestor case-only rename relocates a file first

### DIFF
--- a/src-tauri/src/organizer.rs
+++ b/src-tauri/src/organizer.rs
@@ -958,12 +958,6 @@ pub fn execute_apply(
         let src = Path::new(&item.from_path);
         let dst = Path::new(&item.to_path);
 
-        if !src.exists() {
-            errors.push(format!("Source file missing: {}", item.from_path));
-            skipped_count += 1;
-            continue;
-        }
-
         if let (Some(src_parent), Some(dst_parent)) = (src.parent(), dst.parent()) {
             source_parents_to_clean.insert(src_parent.to_path_buf());
             moved_dir_pairs.insert(src_parent.to_path_buf(), dst_parent.to_path_buf());
@@ -981,8 +975,28 @@ pub fn execute_apply(
             }
         }
 
-        let move_res =
-            fs::rename(src, dst).or_else(|_| fs::copy(src, dst).and_then(|_| fs::remove_file(src)));
+        // Fixing an ancestor directory's casing above renames that directory in place,
+        // which carries its contents with it (this can also happen from an earlier item
+        // in this same batch that shares the ancestor). When that ancestor was the only
+        // difference between `src` and `dst`, the file is no longer at the literal `src`
+        // path but instead sitting under the now-corrected ancestor with its old filename.
+        let relocated_src = dst
+            .parent()
+            .and_then(|p| src.file_name().map(|name| p.join(name)));
+        let effective_src = match (src.exists(), &relocated_src) {
+            (true, _) => src,
+            (false, Some(candidate)) if candidate.exists() => candidate.as_path(),
+            _ => src,
+        };
+
+        if !effective_src.exists() {
+            errors.push(format!("Source file missing: {}", item.from_path));
+            skipped_count += 1;
+            continue;
+        }
+
+        let move_res = fs::rename(effective_src, dst)
+            .or_else(|_| fs::copy(effective_src, dst).and_then(|_| fs::remove_file(effective_src)));
 
         let move_res = move_res.and_then(|_| match verify_case_on_disk(dst) {
             Ok(true) => Ok(()),


### PR DESCRIPTION
## 📋 Summary
Fixes a real, deterministic bug (not a sandbox/filesystem quirk) in the case-only ancestor directory rename path added for #295, uncovered by the regression test `test_execute_apply_fixes_case_only_ancestor_directory` failing on Linux with `No such file or directory (os error 2)`.

`execute_apply()` fixes an ancestor directory's on-disk casing (e.g. `Hero` -> `HERO`) by renaming the directory in place, which carries its contents along with it. The subsequent per-file `fs::rename()` still targeted the pre-fix `src` path, which no longer existed on case-sensitive filesystems (Linux/most CI), failing every time. This was masked on Windows/NTFS because a case-insensitive-but-preserving lookup still resolves the stale path to the same file.

This also broke batches where multiple tracks share an ancestor: fixing the casing for the first track invalidated the literal `src` path for every other queued item pointing at that same ancestor, surfacing as spurious "Source file missing" errors.

## 🔍 Implementation Notes
- [`src-tauri/src/organizer.rs`](src-tauri/src/organizer.rs): after `create_dir_all_case_correct(dst_parent)` runs, compute `effective_src` — falling back to `dst_parent.join(src.file_name())` when the literal `src` path no longer exists — and use that for both the existence check and the actual move/copy.
- No other call sites use this case-correction pattern; it's private to `organizer.rs`.
- Verified the two other `Hero`/`HERO` tests in `collection.rs` are unaffected: one is correctly `#[cfg(any(windows, target_os = "macos"))]`-gated (tests case-insensitive-filesystem behavior specifically), the other only manipulates DB path strings with no filesystem interaction.

## 🧪 Test Plan
- [x] `cargo test` (src-tauri) — full suite: 109 passed, 1 ignored (unrelated), 0 failed
- [x] Specifically reproduced and fixed `organizer::tests::test_execute_apply_fixes_case_only_ancestor_directory` and `organizer::tests::test_compute_preview_and_apply_converge_on_majority_artist_and_album_casing`
- [ ] `bun run check` (svelte-check) — not applicable, no frontend changes
- [ ] `bun run test -- --run` (frontend) — not applicable, no frontend changes

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed — not applicable, no user-facing behavior change