### PR TITLE
Fix lightningcss :global() warnings during production build

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -145,7 +145,7 @@
  * (specular edge, as if light is catching the glass) + a soft elevation
  * shadow + a low-opacity accent-colored glow around the panel.
  */
-:global(.glass-surface) {
+.glass-surface {
   position: relative;
   backdrop-filter: blur(20px) saturate(180%) !important;
   -webkit-backdrop-filter: blur(20px) saturate(180%) !important;
@@ -159,14 +159,14 @@
   transform: translateZ(0);
 }
 
-:global(.bg-brand-sidebar.glass-surface),
-:global(aside.glass-surface),
-:global(header.glass-surface) {
+.bg-brand-sidebar.glass-surface,
+aside.glass-surface,
+header.glass-surface {
   background-color: var(--glass-bg-sidebar) !important;
 }
 
-:global(.bg-brand-playerbar.glass-surface),
-:global(footer.glass-surface) {
+.bg-brand-playerbar.glass-surface,
+footer.glass-surface {
   background-color: var(--glass-bg-playerbar) !important;
 }
 


### PR DESCRIPTION
## Summary
- `src/app.css` had several `.glass-surface` rules wrapped in `:global(...)`, a Svelte scoped-style construct with no meaning in a plain global CSS file (likely copy-pasted from a `.svelte` component).
- lightningcss's minifier doesn't recognize `:global()` as valid CSS syntax, so every `bun run tauri build` / `vite build` emitted warnings like `'global' is not recognized as a valid pseudo-class`.
- Removed the unnecessary `:global()` wrappers, leaving plain selectors (`.glass-surface`, `aside.glass-surface`, etc.) — behavior is unchanged since the file was already unscoped.

## Test plan
- [x] `bunx vite build` — no lightningcss/`:global` warnings, build succeeds
- [x] `bun run tauri build` — frontend + Rust build clean, deb/rpm/AppImage bundles produced with no warnings (build only fails afterward on an unrelated pre-existing signing step, `TAURI_SIGNING_PRIVATE_KEY` not set in this environment)