### PR TITLE
Self-heal stale-cased song paths on playback failure (Linux)

### DIFF
--- a/src-tauri/src/collection.rs
+++ b/src-tauri/src/collection.rs
@@ -20,7 +20,7 @@ use rayon::prelude::*;
 use rusqlite::{params, ToSql};
 use std::{
     collections::HashMap,
-    path::{Path, PathBuf},
+    path::{Component, Path, PathBuf},
     sync::{
         atomic::{AtomicU32, AtomicU64, Ordering},
         Arc,
@@ -1701,7 +1701,7 @@ fn is_audio_file(path: &Path) -> bool {
         .unwrap_or(false)
 }
 
-fn get_mtime(path: &Path) -> Option<i64> {
+pub(crate) fn get_mtime(path: &Path) -> Option<i64> {
     std::fs::metadata(path)
         .ok()?
         .modified()
@@ -2148,6 +2148,37 @@ pub(crate) fn row_to_song(row: &rusqlite::Row) -> rusqlite::Result<Song> {
 // ---------------------------------------------------------------------------
 // File Watcher & Deletion Sync
 // ---------------------------------------------------------------------------
+
+/// Resolves `path` to its real on-disk path when it differs only in case from
+/// what's stored — e.g. a tag-driven rename shifted an album folder's casing.
+/// `Path::exists()` treats a stale-cased path as a hit on a case-insensitive-
+/// but-case-preserving filesystem (Windows, macOS), which is why this drift
+/// only ever surfaces as a real playback failure on Linux/ext4. Returns
+/// `None` if some component genuinely doesn't exist on disk under any case.
+pub(crate) fn resolve_case_insensitive_path(path: &Path) -> Option<PathBuf> {
+    let mut current = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::Normal(name) => {
+                if current.join(name).exists() {
+                    current.push(name);
+                    continue;
+                }
+                if !current.is_dir() {
+                    return None;
+                }
+                let target = name.to_string_lossy().to_lowercase();
+                let entry = std::fs::read_dir(&current)
+                    .ok()?
+                    .filter_map(|e| e.ok())
+                    .find(|e| e.file_name().to_string_lossy().to_lowercase() == target)?;
+                current.push(entry.file_name());
+            }
+            _ => current.push(component),
+        }
+    }
+    Some(current)
+}
 
 /// Matches DB rows whose file has vanished from its recorded path ("orphans")
 /// against freshly discovered files that have no DB row yet ("candidates"),
@@ -3912,6 +3943,47 @@ mod tests {
             .unwrap();
         assert_eq!(id, original_id, "repath must preserve the song's id");
         assert_eq!(path, real_path.to_string_lossy().to_string());
+
+        let _ = std::fs::remove_dir_all(temp_dir);
+    }
+
+    #[test]
+    fn test_resolve_case_insensitive_path_finds_real_casing() {
+        let temp_dir = std::env::temp_dir().join(format!(
+            "luminous_resolve_case_test_{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let album_dir = temp_dir.join("HERO");
+        std::fs::create_dir_all(&album_dir).unwrap();
+        let real_path = album_dir.join("Track.mp3");
+        std::fs::write(&real_path, b"pretend audio bytes").unwrap();
+
+        // Same path but with the stale casing a stored DB row might have.
+        let stale_path = temp_dir.join("Hero").join("track.mp3");
+
+        let resolved = resolve_case_insensitive_path(&stale_path)
+            .expect("a case-only mismatch should still resolve to the real file");
+        assert_eq!(resolved, real_path);
+
+        let _ = std::fs::remove_dir_all(temp_dir);
+    }
+
+    #[test]
+    fn test_resolve_case_insensitive_path_none_when_truly_missing() {
+        let temp_dir = std::env::temp_dir().join(format!(
+            "luminous_resolve_case_missing_test_{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&temp_dir).unwrap();
+
+        let missing_path = temp_dir.join("Nonexistent").join("track.mp3");
+        assert!(resolve_case_insensitive_path(&missing_path).is_none());
 
         let _ = std::fs::remove_dir_all(temp_dir);
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -440,31 +440,39 @@ pub fn run() {
                                         "[Luminous Backend] ERROR from audio engine: {}",
                                         message
                                     );
-                                    let outcome = p.note_playback_error();
 
-                                    if let Some(song) = &outcome.failed_song {
-                                        let _ = app.emit(
-                                            "playback-error",
-                                            serde_json::json!({
-                                                "songId": song.id,
-                                                "title": song.title,
-                                                "path": song.path,
-                                            }),
-                                        );
-                                    }
-                                    if outcome.flagged_unavailable {
+                                    if p.try_heal_and_retry_current_track().await {
+                                        // Stale-cased path (Linux/case-sensitive
+                                        // filesystem quirk) — repointed and retried
+                                        // in place, nothing to surface to the user.
                                         let _ = app.emit("library-changed", ());
-                                    }
-
-                                    if outcome.should_stop {
-                                        log::error!(
-                                            "Stopping playback after {} consecutive audio errors \
-                                             — likely a disconnected drive or dead playlist",
-                                            crate::player::MAX_CONSECUTIVE_PLAYBACK_ERRORS
-                                        );
-                                        let _ = p.stop().await;
                                     } else {
-                                        let _ = p.next_track().await;
+                                        let outcome = p.note_playback_error();
+
+                                        if let Some(song) = &outcome.failed_song {
+                                            let _ = app.emit(
+                                                "playback-error",
+                                                serde_json::json!({
+                                                    "songId": song.id,
+                                                    "title": song.title,
+                                                    "path": song.path,
+                                                }),
+                                            );
+                                        }
+                                        if outcome.flagged_unavailable {
+                                            let _ = app.emit("library-changed", ());
+                                        }
+
+                                        if outcome.should_stop {
+                                            log::error!(
+                                                "Stopping playback after {} consecutive audio errors \
+                                                 — likely a disconnected drive or dead playlist",
+                                                crate::player::MAX_CONSECUTIVE_PLAYBACK_ERRORS
+                                            );
+                                            let _ = p.stop().await;
+                                        } else {
+                                            let _ = p.next_track().await;
+                                        }
                                     }
                                     let state = p.get_state().await;
                                     let _ = app.emit("playback-state", state);

--- a/src-tauri/src/player.rs
+++ b/src-tauri/src/player.rs
@@ -885,6 +885,63 @@ impl Player {
         }
     }
 
+    /// Called by the audio-event loop before treating a playback failure as a
+    /// real skip. If the current song's path is only stale-cased (see
+    /// `collection::resolve_case_insensitive_path`), repoints it to the real
+    /// on-disk path in the DB and retries the same track in place, so the
+    /// user never sees a toast for what's really just a Linux/case-sensitive-
+    /// filesystem quirk. Returns `true` if a heal+retry was attempted.
+    pub async fn try_heal_and_retry_current_track(&mut self) -> bool {
+        let Some(path) = self.current_song.as_ref().and_then(|s| s.path.clone()) else {
+            return false;
+        };
+        if std::path::Path::new(&path).exists() {
+            return false;
+        }
+        let Some(healed) = crate::collection::resolve_case_insensitive_path(std::path::Path::new(&path))
+        else {
+            return false;
+        };
+        let healed_str = healed.to_string_lossy().to_string();
+        if healed_str == path {
+            return false;
+        }
+
+        let Some(song_id) = self.current_song.as_ref().map(|s| s.id) else {
+            return false;
+        };
+        let mtime = crate::collection::get_mtime(&healed).unwrap_or(0);
+        let updated = match self._db.pool.get() {
+            Ok(conn) => conn
+                .execute(
+                    "UPDATE songs SET path = ?1, mtime = ?2 WHERE id = ?3",
+                    rusqlite::params![healed_str, mtime, song_id],
+                )
+                .map(|n| n > 0)
+                .unwrap_or(false),
+            Err(_) => false,
+        };
+        if !updated {
+            return false;
+        }
+
+        if let Some(song) = self.current_song.as_mut() {
+            song.path = Some(healed_str.clone());
+        }
+        if let Some(uuid) = self.current_item_uuid.clone() {
+            if let Some(item) = self.playlist_items.iter_mut().find(|i| i.uuid == uuid) {
+                if let Some(song) = item.song.as_mut() {
+                    song.path = Some(healed_str.clone());
+                }
+            }
+        }
+
+        if let Some(idx) = self.current_index {
+            let _ = self.play_at_index(idx).await;
+        }
+        true
+    }
+
     /// Called by the audio-event loop when the engine reports it couldn't
     /// open/decode the current track. Flags the failed song `unavailable` if
     /// its file is confirmed gone right now (a live single-file check, not


### PR DESCRIPTION
## 📋 Summary
Fixes an album-playback bug reported on Linux: playing an album fails and skips the first song with `Couldn't play "{title}" — file not found. Skipped.`, followed by a couple of "song updated" toasts.

Root cause: `Path::exists()` treats a stale-cased DB path as valid on case-insensitive-but-case-preserving filesystems (Windows/macOS) — so if a song's path drifted only in case (e.g. a tag-driven rename shifted an album folder from `Hero` to `HERO`), it kept working silently there. On Linux's case-sensitive filesystems (ext4/btrfs), the same stale-cased path hard-fails with ENOENT, which flags the song `unavailable`, surfaces the misleading "file not found" toast, and then gets silently repointed by the next background scan — producing the trailing "song updated" toast(s).

## 🔍 Implementation Notes
- `resolve_case_insensitive_path()` ([collection.rs](src-tauri/src/collection.rs)) walks a path's components against real directory entries to find the actual on-disk casing — mirrors the logic the scanner's `reconcile_moved_songs` already uses to detect case-only renames during a rescan.
- `Player::try_heal_and_retry_current_track()` ([player.rs](src-tauri/src/player.rs)) runs on a playback failure: if the failure is just a case mismatch, it repoints `songs.path` in the DB (self-healing — no repeated lookups on future plays) and retries the same track in place.
- Wired into the audio-error handler in [lib.rs](src-tauri/src/lib.rs) ahead of the existing skip/unavailable/toast flow, so a case-drifted track now plays transparently instead of erroring and skipping.
- Also flagged that the frontend's playback-error toast text is hardcoded to say "file not found" regardless of the actual underlying error — left as-is/out of scope here since it didn't affect this fix, but worth noting for reviewers.
- Couldn't fully confirm from static analysis why the report was consistently the *first* track of the album rather than a random one; this fix addresses the underlying mechanism regardless.

## 🧪 Test Plan
- [x] `cargo test` (src-tauri) — full suite passes (112 passed, 1 pre-existing ignored)
- [x] Added `test_resolve_case_insensitive_path_finds_real_casing` and `test_resolve_case_insensitive_path_none_when_truly_missing` unit tests
- [ ] `bun run check` (svelte-check) — no frontend changes in this PR
- [ ] `bun run test -- --run` (frontend) — no frontend changes in this PR
- [ ] Manually verified in the app — not verified against a real Linux case-mismatch reproduction; recommend confirming against the reporter's actual library if the issue persists

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed — n/a, this fixes a silent backend recovery path with no new UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)