### PR TITLE
Fix Linux acrylic/transparent regression in Miniplayer and PlayerBar

### DIFF
--- a/src/lib/components/Miniplayer.svelte
+++ b/src/lib/components/Miniplayer.svelte
@@ -218,7 +218,7 @@
   onpointerleave={hideHover}
   onmouseleave={hideHover}
   tabindex="0"
-  class="group relative w-full h-full flex flex-col justify-between overflow-hidden bg-brand-main select-none p-3 shadow-2xl {themeStore.isGlassTheme ? 'glass-surface' : ''}"
+  class="group relative w-full h-full flex flex-col justify-between overflow-hidden bg-brand-main select-none p-3 shadow-2xl {themeStore.isGlassTheme || isLinux ? 'glass-surface' : ''} {isLinux ? 'opaque-linux' : ''}"
 >
   <!-- Edge and Corner Resize Handles for Frameless Window (non-Linux platforms) -->
   {#if !isLinux}
@@ -429,6 +429,15 @@
   :global(.glass-surface) {
     backdrop-filter: blur(20px) saturate(180%);
     -webkit-backdrop-filter: blur(20px) saturate(180%);
+  }
+
+  /* backdrop-filter doesn't composite reliably in WebKitGTK, rendering the
+     panel see-through instead of frosted — same issue and same fix as
+     PlayerBar's footer.opaque-linux (PlayerBar.svelte). */
+  :global(.glass-surface.opaque-linux) {
+    background-color: var(--bg-main, #08090c) !important;
+    backdrop-filter: none !important;
+    -webkit-backdrop-filter: none !important;
   }
 
   /* Grabber texture: a repeating dot pattern spanning the full drag region,

--- a/src/lib/components/PlayerBar.svelte
+++ b/src/lib/components/PlayerBar.svelte
@@ -396,7 +396,7 @@
     box-shadow: var(--glass-shadow, none), var(--glass-glow, none);
   }
 
-  :global(footer.opaque-linux) {
+  :global(footer.glass-surface.opaque-linux) {
     background-color: var(--bg-playerbar, #191b23) !important;
     backdrop-filter: none !important;
     -webkit-backdrop-filter: none !important;


### PR DESCRIPTION
## 📋 Summary
- `PlayerBar` already forces an opaque background on Linux (`opaque-linux`) because `backdrop-filter` doesn't composite reliably in WebKitGTK, leaving the panel see-through instead of frosted. `Miniplayer`'s outer container never got the equivalent treatment — since `themeStore.isGlassTheme` became unconditionally `true`, it always carried `glass-surface` with no Linux gate, making the miniplayer completely transparent on Linux.
- Applied the same `opaque-linux` pattern to Miniplayer's outer container: forces a solid `--bg-main` background and disables `backdrop-filter` on Linux.
- Also bumped PlayerBar's `opaque-linux` selector to `footer.glass-surface.opaque-linux` for higher specificity — it was only winning by accident of stylesheet order after #355 activated a previously-dead `app.css` rule at the same specificity, which made the outcome fragile against future build changes.

## 🔍 Implementation Notes
- `src/lib/components/Miniplayer.svelte`: outer container class list now mirrors PlayerBar's `{isGlassTheme || isLinux ? 'glass-surface' : ''} {isLinux ? 'opaque-linux' : ''}`, plus a new `.glass-surface.opaque-linux` style rule.
- `src/lib/components/PlayerBar.svelte`: `:global(footer.opaque-linux)` → `:global(footer.glass-surface.opaque-linux)` (specificity fix only, no behavior change intended for non-Linux platforms).

## 🧪 Test Plan
- [x] `bun run test -- --run` for `Miniplayer.test.ts` and `PlayerBar.test.ts` (19 passed)
- [x] Built the app (`bun run build`) and verified computed styles against the actual shipped CSS: both `footer.glass-surface.opaque-linux` and `.glass-surface.opaque-linux` resolve to solid backgrounds with `backdrop-filter: none`, independent of stylesheet order
- [ ] `bun run check` (svelte-check) — not run this session
- [ ] Manually verified on a real Linux/WebKitGTK Tauri build (only verified via computed CSS in a Chromium-based preview, since WebKitGTK isn't available in this environment)

## ✅ Checklist
- [x] No unrelated changes bundled in
- [ ] Docs/screenshots updated — not applicable (bugfix, no user-facing UI change beyond restoring intended opacity)