### PR TITLE
Fix untagged songs breaking artist navigation and freezing cover art

### DIFF
--- a/src-tauri/src/collection.rs
+++ b/src-tauri/src/collection.rs
@@ -884,7 +884,7 @@ impl CollectionScanner {
         let conn = self.db.pool.get()?;
         let sql = format!(
             "SELECT {} FROM songs
-             WHERE COALESCE(NULLIF(album_artist, ''), artist) = ?1
+             WHERE COALESCE(NULLIF(album_artist, ''), artist, '') = ?1
                AND source IN (1, 2)
                AND unavailable = 0
              ORDER BY album, disc, track",
@@ -1159,7 +1159,7 @@ impl CollectionScanner {
                 GROUP BY album
              ),
              base AS (
-                SELECT s.id, s.album, COALESCE(NULLIF(s.album_artist, ''), s.artist) AS effective_artist
+                SELECT s.id, s.album, COALESCE(NULLIF(s.album_artist, ''), s.artist, '') AS effective_artist
                 FROM songs s
                 WHERE s.source IN (1, 2) AND s.unavailable = 0
              ),
@@ -1180,7 +1180,7 @@ impl CollectionScanner {
                 (
                     SELECT genre
                     FROM songs sg
-                    WHERE COALESCE(NULLIF(sg.album_artist, ''), sg.artist) = g.effective_artist COLLATE NOCASE
+                    WHERE COALESCE(NULLIF(sg.album_artist, ''), sg.artist, '') = g.effective_artist COLLATE NOCASE
                       AND sg.source IN (1, 2) AND sg.unavailable = 0 AND sg.genre IS NOT NULL AND sg.genre != ''
                     GROUP BY sg.genre
                     ORDER BY COUNT(*) DESC, sg.genre ASC
@@ -1219,7 +1219,7 @@ impl CollectionScanner {
              ),
              base AS (
                 SELECT s.id, s.album, s.playcount,
-                       COALESCE(NULLIF(s.album_artist, ''), s.artist) AS effective_artist
+                       COALESCE(NULLIF(s.album_artist, ''), s.artist, '') AS effective_artist
                 FROM songs s
                 WHERE s.source IN (1, 2) AND s.unavailable = 0
              ),
@@ -1245,7 +1245,7 @@ impl CollectionScanner {
                 (
                     SELECT genre
                     FROM songs sg
-                    WHERE COALESCE(NULLIF(sg.album_artist, ''), sg.artist) = g.effective_artist COLLATE NOCASE
+                    WHERE COALESCE(NULLIF(sg.album_artist, ''), sg.artist, '') = g.effective_artist COLLATE NOCASE
                       AND sg.source IN (1, 2) AND sg.unavailable = 0 AND sg.genre IS NOT NULL AND sg.genre != ''
                     GROUP BY sg.genre
                     ORDER BY COUNT(*) DESC, sg.genre ASC
@@ -3238,6 +3238,57 @@ mod tests {
             artists
         );
         assert_eq!(matches[0]["song_count"].as_i64(), Some(2));
+
+        let _ = std::fs::remove_dir_all(temp_dir);
+    }
+
+    /// Regression test for #362: a song with no artist/album_artist tags at
+    /// all (both NULL) must still be reachable via the same "effective
+    /// artist" value that get_artists() groups it under — previously
+    /// get_artists() grouped NULL artists together as SQL NULL while
+    /// get_songs_by_artist() only matched against `''`, so NULL never
+    /// equaled `''` and the click-through returned zero songs.
+    #[test]
+    fn test_untagged_song_reachable_via_get_artists_grouping() {
+        let temp_dir = std::env::temp_dir().join(format!(
+            "luminous_untagged_artist_test_{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let db = Arc::new(Database::new(temp_dir.clone()).unwrap());
+        let conn = db.pool.get().unwrap();
+
+        upsert_song(
+            &conn,
+            &Song {
+                artist: None,
+                album_artist: None,
+                album: None,
+                title: None,
+                source: SongSource::LocalFile,
+                path: Some(r"C:\Music\untagged.ogg".to_string()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let scanner = CollectionScanner::new(db.clone());
+        let artists = scanner.get_artists().unwrap();
+
+        let untagged = artists
+            .iter()
+            .find(|a| a["name"].as_str() == Some(""))
+            .expect("untagged song should surface as an empty-string artist entry");
+        assert_eq!(untagged["song_count"].as_i64(), Some(1));
+
+        let songs = scanner.get_songs_by_artist("").unwrap();
+        assert_eq!(
+            songs.len(),
+            1,
+            "get_songs_by_artist(\"\") must return the song grouped under the empty-string artist"
+        );
 
         let _ = std::fs::remove_dir_all(temp_dir);
     }

--- a/src-tauri/src/covermanager.rs
+++ b/src-tauri/src/covermanager.rs
@@ -188,25 +188,49 @@ impl CoverManager {
     /// the top result's 600x600 artwork. Returns `Ok(None)` — not an error —
     /// both when the song lacks artist/album metadata to search with and
     /// when the API returns no match; either way, the song's `art_unset`
-    /// flag is set on a miss so future scans don't keep re-querying it.
+    /// flag is set on a miss so future scans (and the frontend's per-row
+    /// retry-on-mount) don't keep re-querying it.
+    ///
+    /// Deliberately never holds a pooled DB connection across the network
+    /// `.await`s below — the pool only has a handful of connections (see
+    /// `Database::new`), and a stalled/slow request holding one would
+    /// starve every other DB-backed command in the app (#362 follow-up).
     pub async fn fetch_remote_cover(&self, song_id: i64) -> Result<Option<String>> {
-        let conn = self.db.pool.get()?;
-        let (artist, album, album_artist) = conn.query_row(
-            "SELECT artist, album, album_artist FROM songs WHERE id = ?1",
-            params![song_id],
-            |row| {
-                Ok((
-                    row.get::<_, Option<String>>(0)?,
-                    row.get::<_, Option<String>>(1)?,
-                    row.get::<_, Option<String>>(2)?,
-                ))
-            },
-        )?;
+        let (artist, album, album_artist, art_unset) = {
+            let conn = self.db.pool.get()?;
+            conn.query_row(
+                "SELECT artist, album, album_artist, art_unset FROM songs WHERE id = ?1",
+                params![song_id],
+                |row| {
+                    Ok((
+                        row.get::<_, Option<String>>(0)?,
+                        row.get::<_, Option<String>>(1)?,
+                        row.get::<_, Option<String>>(2)?,
+                        row.get::<_, bool>(3)?,
+                    ))
+                },
+            )?
+        };
+
+        // Already tried and failed (no metadata or no API match) — don't
+        // re-hit the network every time a row remounts.
+        if art_unset {
+            return Ok(None);
+        }
 
         let artist_query = album_artist.as_ref().or(artist.as_ref());
         let (query_artist, query_album) = match (artist_query, album.as_ref()) {
             (Some(art), Some(alb)) => (art, alb),
-            _ => return Ok(None),
+            _ => {
+                // No artist/album to search with — mark unset immediately so
+                // untagged songs don't get re-queried on every remount.
+                let conn = self.db.pool.get()?;
+                conn.execute(
+                    "UPDATE songs SET art_unset = 1 WHERE id = ?1",
+                    params![song_id],
+                )?;
+                return Ok(None);
+            }
         };
 
         log::info!(
@@ -214,7 +238,9 @@ impl CoverManager {
             query_artist,
             query_album
         );
-        let client = reqwest::Client::new();
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(10))
+            .build()?;
         let search_url = format!(
             "https://itunes.apple.com/search?term={}&entity=album&limit=1",
             percent_encoding::utf8_percent_encode(
@@ -247,6 +273,7 @@ impl CoverManager {
                     std::fs::write(&dest_path, cleaned_bytes)?;
                     log::info!("Saved remote cover art to: {}", dest_path.display());
 
+                    let conn = self.db.pool.get()?;
                     conn.execute(
                         "UPDATE songs SET art_automatic = ?1, art_unset = 0 WHERE id = ?2",
                         params![filename, song_id],
@@ -258,6 +285,7 @@ impl CoverManager {
         }
 
         // If no artwork found, mark it as unset so we don't spam requests
+        let conn = self.db.pool.get()?;
         conn.execute(
             "UPDATE songs SET art_unset = 1 WHERE id = ?1",
             params![song_id],
@@ -371,6 +399,76 @@ mod tests {
             hash_a,
             manager.get_album_hash("Eric Soltys", "You Wreck Me")
         );
+
+        let _ = std::fs::remove_dir_all(&temp_dir);
+    }
+
+    /// Regression test for the #362 follow-up: a song with no artist/album
+    /// tags must be marked `art_unset` on the very first remote-fetch
+    /// attempt (not left perpetually "not yet tried"), so `CoverArt.svelte`
+    /// remounting the row on every navigation doesn't re-trigger this call
+    /// forever — and, separately, once `art_unset` is set, a second call
+    /// must short-circuit before doing any network I/O.
+    #[tokio::test]
+    async fn test_fetch_remote_cover_marks_untagged_song_unset_without_network() {
+        let temp_dir = std::env::temp_dir().join(format!(
+            "luminous_covermanager_untagged_test_{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let db = Arc::new(Database::new(temp_dir.clone()).unwrap());
+        {
+            let conn = db.pool.get().unwrap();
+            crate::collection::upsert_song(
+                &conn,
+                &crate::models::Song {
+                    artist: None,
+                    album: None,
+                    album_artist: None,
+                    title: None,
+                    source: crate::models::SongSource::LocalFile,
+                    path: Some(r"C:\Music\untagged.ogg".to_string()),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        }
+        let song_id: i64 = {
+            let conn = db.pool.get().unwrap();
+            conn.query_row(
+                "SELECT id FROM songs WHERE path = ?1",
+                params![r"C:\Music\untagged.ogg"],
+                |r| r.get(0),
+            )
+            .unwrap()
+        };
+
+        let manager = CoverManager::new(db.clone(), temp_dir.clone());
+
+        let result = manager.fetch_remote_cover(song_id).await.unwrap();
+        assert_eq!(result, None);
+
+        let art_unset: bool = {
+            let conn = db.pool.get().unwrap();
+            conn.query_row(
+                "SELECT art_unset FROM songs WHERE id = ?1",
+                params![song_id],
+                |r| r.get(0),
+            )
+            .unwrap()
+        };
+        assert!(
+            art_unset,
+            "untagged song should be marked art_unset after the first fetch attempt"
+        );
+
+        // Second call must short-circuit on the art_unset check before ever
+        // touching the network — if it didn't, this would hang/fail in a
+        // sandboxed test environment with no network access.
+        let result2 = manager.fetch_remote_cover(song_id).await.unwrap();
+        assert_eq!(result2, None);
 
         let _ = std::fs::remove_dir_all(&temp_dir);
     }

--- a/src-tauri/src/playlist.rs
+++ b/src-tauri/src/playlist.rs
@@ -339,7 +339,7 @@ impl PlaylistManager {
                  SELECT 1 FROM playlist_items pi
                  JOIN songs s ON s.id = pi.song_id
                  WHERE pi.playlist_id = p.id
-                   AND COALESCE(NULLIF(s.album_artist, ''), s.artist) = ?1
+                   AND COALESCE(NULLIF(s.album_artist, ''), s.artist, '') = ?1
                    AND s.unavailable = 0
              )
              ORDER BY p.created",

--- a/src/lib/components/CollectionView.svelte
+++ b/src/lib/components/CollectionView.svelte
@@ -357,8 +357,13 @@
     }
   }
 
-  function handlePlaySong(song: Song) {
-    playerStore.playSong(song.id);
+  async function handlePlaySong(song: Song) {
+    try {
+      await playerStore.playSong(song.id);
+    } catch (err) {
+      console.error("Failed to play song:", err);
+      toastStore.show(i18n.t("playerBar.playSongFailed", {}, "Couldn't play this track."), "error");
+    }
   }
 
   async function handlePlayAlbum(albumName: string) {

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -612,7 +612,8 @@ export const en = {
     lyricsNone: "Not downloaded",
     trackSkippedToast: 'Couldn\'t play "{title}" — file not found. Skipped.',
     tracksSkippedToast: "Skipped {count} unavailable tracks.",
-    openNothingPlayable: "No supported audio files found to play."
+    openNothingPlayable: "No supported audio files found to play.",
+    playSongFailed: "Couldn't play this track."
   },
   miniplayer: {
     title: "Miniplayer",

--- a/src/lib/locales/fr.ts
+++ b/src/lib/locales/fr.ts
@@ -610,7 +610,8 @@ export const fr = {
     lyricsNone: "Non téléchargées",
     trackSkippedToast: 'Impossible de lire « {title} » — fichier introuvable. Morceau ignoré.',
     tracksSkippedToast: "{count} morceaux indisponibles ignorés.",
-    openNothingPlayable: "Aucun fichier audio pris en charge à lire."
+    openNothingPlayable: "Aucun fichier audio pris en charge à lire.",
+    playSongFailed: "Impossible de lire ce morceau."
   },
   miniplayer: {
     title: "Mini-lecteur",


### PR DESCRIPTION
## 📋 Summary
Fixes #362. Songs with no embedded metadata (NULL artist/album/title) broke artist navigation, and testing that fix surfaced a second, more severe bug where enough untagged songs remounting at once could freeze the whole app.

- `get_artists()` grouped untagged songs under SQL `NULL` while `get_songs_by_artist()` only matched against `''` — `NULL = ''` is never true in SQLite, so clicking through to the artist page for an untagged song always came back empty. Normalized the "no artist" sentinel to `''` consistently across `get_artists`, `get_top_artists`, `get_songs_by_artist`, and `get_playlists_by_artist`.
- `handlePlaySong()` fired-and-forgot `playerStore.playSong()`, so a failed play silently did nothing. It now awaits and shows an error toast, matching the other play handlers.
- `fetch_remote_cover()` held a pooled DB connection across the iTunes Search API network calls, with no request timeout, and never marked untagged songs `art_unset` — so `CoverArt.svelte` retried the fetch on every remount. Enough of them mounting simultaneously (e.g. navigating back to Songs) could exhaust the 8-connection pool and hang every other DB-backed command in the app.

## 🔍 Implementation Notes
- `src-tauri/src/collection.rs`, `src-tauri/src/playlist.rs`: added a third `COALESCE(..., '')` arg everywhere an "effective artist" is grouped or matched against, so NULL and `''` agree.
- `src-tauri/src/covermanager.rs`: `fetch_remote_cover` no longer holds a connection across `.await`s, added a 10s `reqwest` client timeout, sets `art_unset` immediately on the no-metadata early return, and short-circuits entirely once `art_unset` is already set (also benefits tagged-but-unmatched songs, which weren't gated before either).
- `src/lib/components/CollectionView.svelte`: `handlePlaySong` is now async with a try/catch + toast. Added `playerBar.playSongFailed` to `en.ts`/`fr.ts`.

## 🧪 Test Plan
- [x] `bun run check` (svelte-check) — clean
- [ ] `bun run test -- --run` (frontend) — not run this pass, no frontend logic tests added
- [x] `cargo test` (src-tauri) — 119/119 lib tests pass, including two new regression tests:
  - `test_untagged_song_reachable_via_get_artists_grouping`
  - `test_fetch_remote_cover_marks_untagged_song_unset_without_network`
- [x] Manually verified in the app: reporter confirmed songs without metadata now play from Home and Songs, and the ArtistDetailView shows them. The cover-art freeze fix (connection-hold + no timeout) still needs a live re-test against the same repro (Songs → click untagged artist → back to Songs).

## ✅ Checklist
- [x] No unrelated changes bundled in
- [ ] Docs/screenshots updated if user-facing behavior changed — no user-facing UI changed beyond a new error toast; skipped