### PR TITLE
Fix song table columns rendered in monospace font

### DIFF
--- a/src/lib/components/AlbumDetailView.svelte
+++ b/src/lib/components/AlbumDetailView.svelte
@@ -1011,27 +1011,27 @@
                 </div>
               {/if}
               {#if collectionStore.visibleColumns.bpm}
-                <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-mono">
+                <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium">
                   {song.bpm || "—"}
                 </div>
               {/if}
               {#if collectionStore.visibleColumns.initial_key}
-                <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-mono">
+                <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium">
                   {song.initial_key || "—"}
                 </div>
               {/if}
               {#if collectionStore.visibleColumns.bitrate}
-                <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-mono">
+                <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium">
                   {song.bitrate ? `${song.bitrate}k` : "—"}
                 </div>
               {/if}
               {#if collectionStore.visibleColumns.samplerate}
-                <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-mono">
+                <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium">
                   {formatSampleRate(song.samplerate)}
                 </div>
               {/if}
               {#if collectionStore.visibleColumns.bitdepth}
-                <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-mono">
+                <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium">
                   {formatBitDepth(song.bitdepth)}
                 </div>
               {/if}
@@ -1041,7 +1041,7 @@
                 </div>
               {/if}
               {#if collectionStore.visibleColumns.filesize}
-                <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-mono">
+                <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium">
                   {formatFileSize(song.filesize)}
                 </div>
               {/if}
@@ -1058,7 +1058,7 @@
                 </div>
               {/if}
               {#if collectionStore.visibleColumns.skipcount}
-                <div class="text-center text-brand-text-primary font-mono text-xs">
+                <div class="text-center text-brand-text-primary font-medium text-xs">
                   {song.skipcount ?? 0}
                 </div>
               {/if}
@@ -1080,7 +1080,7 @@
               {/if}
 
               {#if collectionStore.visibleColumns.path}
-                <div class="text-brand-text-primary truncate pr-4 min-w-0 text-xs font-mono" title={song.path}>
+                <div class="text-brand-text-primary truncate pr-4 min-w-0 text-xs font-medium" title={song.path}>
                   {song.path || "—"}
                 </div>
               {/if}

--- a/src/lib/components/ArtistDetailView.svelte
+++ b/src/lib/components/ArtistDetailView.svelte
@@ -774,27 +774,27 @@
                   </div>
                 {/if}
                 {#if collectionStore.visibleColumns.bpm}
-                  <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-mono">
+                  <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium">
                     {song.bpm || "—"}
                   </div>
                 {/if}
                 {#if collectionStore.visibleColumns.initial_key}
-                  <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-mono">
+                  <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium">
                     {song.initial_key || "—"}
                   </div>
                 {/if}
                 {#if collectionStore.visibleColumns.bitrate}
-                  <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-mono">
+                  <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium">
                     {song.bitrate ? `${song.bitrate}k` : "—"}
                   </div>
                 {/if}
                 {#if collectionStore.visibleColumns.samplerate}
-                  <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-mono">
+                  <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium">
                     {formatSampleRate(song.samplerate)}
                   </div>
                 {/if}
                 {#if collectionStore.visibleColumns.bitdepth}
-                  <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-mono">
+                  <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium">
                     {formatBitDepth(song.bitdepth)}
                   </div>
                 {/if}
@@ -804,7 +804,7 @@
                   </div>
                 {/if}
                 {#if collectionStore.visibleColumns.filesize}
-                  <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-mono">
+                  <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium">
                     {formatFileSize(song.filesize)}
                   </div>
                 {/if}
@@ -821,7 +821,7 @@
                   </div>
                 {/if}
                 {#if collectionStore.visibleColumns.skipcount}
-                  <div class="text-center text-brand-text-primary font-mono text-xs">
+                  <div class="text-center text-brand-text-primary font-medium text-xs">
                     {song.skipcount ?? 0}
                   </div>
                 {/if}
@@ -843,7 +843,7 @@
                 {/if}
 
                 {#if collectionStore.visibleColumns.path}
-                  <div class="text-brand-text-primary truncate pr-4 min-w-0 text-xs font-mono" title={song.path}>
+                  <div class="text-brand-text-primary truncate pr-4 min-w-0 text-xs font-medium" title={song.path}>
                     {song.path || "—"}
                   </div>
                 {/if}

--- a/src/lib/components/AutoPlaylistDetailView.svelte
+++ b/src/lib/components/AutoPlaylistDetailView.svelte
@@ -1027,27 +1027,27 @@ import { shuffleArray } from "../utils/shuffle";
                 </div>
               {/if}
               {#if collectionStore.visibleColumns.bpm}
-                <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-mono">
+                <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium">
                   {song.bpm || "—"}
                 </div>
               {/if}
               {#if collectionStore.visibleColumns.initial_key}
-                <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-mono">
+                <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium">
                   {song.initial_key || "—"}
                 </div>
               {/if}
               {#if collectionStore.visibleColumns.bitrate}
-                <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-mono">
+                <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium">
                   {song.bitrate ? `${song.bitrate}k` : "—"}
                 </div>
               {/if}
               {#if collectionStore.visibleColumns.samplerate}
-                <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-mono">
+                <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium">
                   {formatSampleRate(song.samplerate)}
                 </div>
               {/if}
               {#if collectionStore.visibleColumns.bitdepth}
-                <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-mono">
+                <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium">
                   {formatBitDepth(song.bitdepth)}
                 </div>
               {/if}
@@ -1057,7 +1057,7 @@ import { shuffleArray } from "../utils/shuffle";
                 </div>
               {/if}
               {#if collectionStore.visibleColumns.filesize}
-                <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-mono">
+                <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium">
                   {formatFileSize(song.filesize)}
                 </div>
               {/if}
@@ -1092,7 +1092,7 @@ import { shuffleArray } from "../utils/shuffle";
                 </div>
               {/if}
               {#if collectionStore.visibleColumns.path}
-                <div class="text-brand-text-primary truncate pr-4 min-w-0 text-xs font-mono" title={song.path}>
+                <div class="text-brand-text-primary truncate pr-4 min-w-0 text-xs font-medium" title={song.path}>
                   {song.path || "—"}
                 </div>
               {/if}

--- a/src/lib/components/CollectionView.svelte
+++ b/src/lib/components/CollectionView.svelte
@@ -877,27 +877,27 @@
                   </div>
                 {/if}
                 {#if collectionStore.visibleColumns.bpm}
-                  <div class="text-brand-text-secondary truncate pr-2 min-w-0 text-xs font-mono">
+                  <div class="text-brand-text-secondary truncate pr-2 min-w-0 text-xs font-medium">
                     {song.bpm || "—"}
                   </div>
                 {/if}
                 {#if collectionStore.visibleColumns.initial_key}
-                  <div class="text-brand-text-secondary truncate pr-2 min-w-0 text-xs font-mono">
+                  <div class="text-brand-text-secondary truncate pr-2 min-w-0 text-xs font-medium">
                     {song.initial_key || "—"}
                   </div>
                 {/if}
                 {#if collectionStore.visibleColumns.bitrate}
-                  <div class="text-brand-text-secondary truncate pr-2 min-w-0 text-xs font-mono">
+                  <div class="text-brand-text-secondary truncate pr-2 min-w-0 text-xs font-medium">
                     {song.bitrate ? `${song.bitrate}k` : "—"}
                   </div>
                 {/if}
                 {#if collectionStore.visibleColumns.samplerate}
-                  <div class="text-brand-text-secondary truncate pr-2 min-w-0 text-xs font-mono">
+                  <div class="text-brand-text-secondary truncate pr-2 min-w-0 text-xs font-medium">
                     {formatSampleRate(song.samplerate)}
                   </div>
                 {/if}
                 {#if collectionStore.visibleColumns.bitdepth}
-                  <div class="text-brand-text-secondary truncate pr-2 min-w-0 text-xs font-mono">
+                  <div class="text-brand-text-secondary truncate pr-2 min-w-0 text-xs font-medium">
                     {formatBitDepth(song.bitdepth)}
                   </div>
                 {/if}
@@ -907,7 +907,7 @@
                   </div>
                 {/if}
                 {#if collectionStore.visibleColumns.filesize}
-                  <div class="text-brand-text-secondary truncate pr-2 min-w-0 text-xs font-mono">
+                  <div class="text-brand-text-secondary truncate pr-2 min-w-0 text-xs font-medium">
                     {formatFileSize(song.filesize)}
                   </div>
                 {/if}
@@ -917,12 +917,12 @@
                   </div>
                 {/if}
                 {#if collectionStore.visibleColumns.playcount}
-                  <div class="text-center text-brand-text-secondary font-mono text-xs">
+                  <div class="text-center text-brand-text-secondary font-medium text-xs">
                     {song.playcount ?? 0}
                   </div>
                 {/if}
                 {#if collectionStore.visibleColumns.skipcount}
-                  <div class="text-center text-brand-text-secondary font-mono text-xs">
+                  <div class="text-center text-brand-text-secondary font-medium text-xs">
                     {song.skipcount ?? 0}
                   </div>
                 {/if}
@@ -937,10 +937,10 @@
                   </div>
                 {/if}
                 {#if collectionStore.visibleColumns.duration}
-                  <div class="text-center text-brand-text-secondary font-mono text-xs">{formatDuration(song.length_nanosec)}</div>
+                  <div class="text-center text-brand-text-secondary font-medium text-xs">{formatDuration(song.length_nanosec)}</div>
                 {/if}
                 {#if collectionStore.visibleColumns.path}
-                  <div class="text-brand-text-secondary truncate pr-4 min-w-0 text-xs font-mono" title={song.path}>
+                  <div class="text-brand-text-secondary truncate pr-4 min-w-0 text-xs font-medium" title={song.path}>
                     {song.path || "—"}
                   </div>
                 {/if}

--- a/src/lib/components/PlaylistView.svelte
+++ b/src/lib/components/PlaylistView.svelte
@@ -1416,27 +1416,27 @@
               </div>
             {/if}
             {#if collectionStore.visibleColumns.bpm}
-              <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-mono">
+              <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium">
                 {item.song?.bpm || "—"}
               </div>
             {/if}
             {#if collectionStore.visibleColumns.initial_key}
-              <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-mono">
+              <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium">
                 {item.song?.initial_key || "—"}
               </div>
             {/if}
             {#if collectionStore.visibleColumns.bitrate}
-              <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-mono">
+              <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium">
                 {item.song?.bitrate ? `${item.song.bitrate}k` : "—"}
               </div>
             {/if}
             {#if collectionStore.visibleColumns.samplerate}
-              <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-mono">
+              <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium">
                 {formatSampleRate(item.song?.samplerate)}
               </div>
             {/if}
             {#if collectionStore.visibleColumns.bitdepth}
-              <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-mono">
+              <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium">
                 {formatBitDepth(item.song?.bitdepth)}
               </div>
             {/if}
@@ -1446,7 +1446,7 @@
               </div>
             {/if}
             {#if collectionStore.visibleColumns.filesize}
-              <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-mono">
+              <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium">
                 {formatFileSize(item.song?.filesize)}
               </div>
             {/if}
@@ -1483,7 +1483,7 @@
               </div>
             {/if}
             {#if collectionStore.visibleColumns.path}
-              <div class="text-brand-text-primary truncate pr-4 min-w-0 text-xs font-mono" title={item.song?.path}>
+              <div class="text-brand-text-primary truncate pr-4 min-w-0 text-xs font-medium" title={item.song?.path}>
                 {item.song?.path || "—"}
               </div>
             {/if}


### PR DESCRIPTION
## Summary
- BPM was rendered with `font-mono` while the neighboring Duration column used the default (non-mono) font — inconsistent and unintentional.
- Auditing further turned up the same mistake on several other numeric/technical columns: Initial Key, Bitrate, Sample Rate, Bit Depth, File Size, Path, Play Count, Skip Count, and (in the main Library view only) Duration itself.
- Switched all of the above from `font-mono` to `font-medium` across the five views that render the song table: Library ([CollectionView.svelte](src/lib/components/CollectionView.svelte)), Playlist ([PlaylistView.svelte](src/lib/components/PlaylistView.svelte)), Album detail ([AlbumDetailView.svelte](src/lib/components/AlbumDetailView.svelte)), Artist detail ([ArtistDetailView.svelte](src/lib/components/ArtistDetailView.svelte)), and Auto-Playlist detail ([AutoPlaylistDetailView.svelte](src/lib/components/AutoPlaylistDetailView.svelte)).

## Test plan
- [ ] Visually confirm no column in the Library/Playlist/Album/Artist/Auto-Playlist song tables uses monospace font, and text weight/alignment looks consistent with the rest of the row.