### PR TITLE
Full compilation (TCMP) support: read/write flag, UI toggle, Various Artists quick-fill

### DIFF
--- a/src-tauri/src/collection.rs
+++ b/src-tauri/src/collection.rs
@@ -898,6 +898,92 @@ impl CollectionScanner {
         Ok(songs)
     }
 
+    /// Compilation albums featuring `artist` on at least one track — the
+    /// mirror image of `get_songs_by_artist`'s effective-artist match: this
+    /// matches on the *raw per-track* `artist` column, since a Various
+    /// Artists compilation's effective (album-level) artist is never the
+    /// individual track artist, so it would otherwise never surface on that
+    /// artist's own detail page (#343). An album counts as a compilation if
+    /// any track has `compilation = 1`, its tracks disagree on `album_artist`,
+    /// or `album_artist` is literally "Various Artists". Returns the same
+    /// aggregated shape as `get_albums()`, but with `artist` always
+    /// "Various Artists" since these are compilations by definition.
+    pub fn get_compilations_by_artist(&self, artist: &str) -> Result<Vec<serde_json::Value>> {
+        let conn = self.db.pool.get()?;
+        let mut stmt = conn.prepare(
+            "SELECT
+                album,
+                MIN(year) AS year,
+                COUNT(*) AS track_count,
+                MAX(COALESCE(disc, 1)) AS disc_count,
+                MAX(CAST(art_embedded AS INTEGER)) AS art_embedded,
+                MAX(art_automatic) AS art_automatic,
+                MAX(art_manual) AS art_manual,
+                (
+                    SELECT genre
+                    FROM songs g
+                    WHERE g.album = songs.album AND g.source IN (1, 2) AND g.unavailable = 0
+                      AND g.genre IS NOT NULL AND g.genre != ''
+                    GROUP BY genre
+                    ORDER BY COUNT(*) DESC, genre ASC
+                    LIMIT 1
+                ) AS genre,
+                COALESCE(
+                    (SELECT rating FROM album_ratings ar WHERE ar.album_key = songs.album),
+                    -1
+                ) AS rating,
+                MAX(added) AS added,
+                COALESCE(SUM(length_nanosec), 0) AS total_duration_nanosec
+             FROM songs
+             WHERE source IN (1, 2) AND unavailable = 0 AND album IS NOT NULL
+               AND album IN (
+                 SELECT album FROM songs s2
+                 WHERE s2.source IN (1, 2) AND s2.unavailable = 0 AND s2.artist = ?1
+               )
+               AND album IN (
+                 SELECT album FROM songs s3
+                 WHERE s3.source IN (1, 2) AND s3.unavailable = 0
+                 GROUP BY album
+                 -- Mirrors get_albums()'s various-artists fallback: a compilation
+                 -- either has TCMP set, is explicitly credited to Various
+                 -- Artists, or fails to agree on a single effective album
+                 -- artist (the same condition that makes get_albums() emit
+                 -- NULL and the UI fall back to displaying Various Artists).
+                 HAVING MAX(s3.compilation) = 1
+                    OR MAX(CASE WHEN s3.album_artist = 'Various Artists' THEN 1 ELSE 0 END) = 1
+                    OR NOT (
+                         COUNT(DISTINCT NULLIF(s3.album_artist, '')) = 1
+                         OR (
+                           COUNT(DISTINCT NULLIF(s3.album_artist, '')) = 0
+                           AND COUNT(DISTINCT NULLIF(s3.artist, '')) = 1
+                         )
+                       )
+               )
+             GROUP BY album
+             ORDER BY album",
+        )?;
+        let albums: Vec<serde_json::Value> = stmt
+            .query_map(params![artist], |row| {
+                Ok(serde_json::json!({
+                    "artist": "Various Artists",
+                    "album": row.get::<_, Option<String>>(0)?,
+                    "year": row.get::<_, Option<i32>>(1)?,
+                    "track_count": row.get::<_, i32>(2)?,
+                    "disc_count": row.get::<_, i32>(3)?,
+                    "art_embedded": row.get::<_, bool>(4)?,
+                    "art_automatic": row.get::<_, Option<String>>(5)?,
+                    "art_manual": row.get::<_, Option<String>>(6)?,
+                    "genre": row.get::<_, Option<String>>(7)?,
+                    "rating": row.get::<_, f32>(8)?,
+                    "added": row.get::<_, Option<i64>>(9)?,
+                    "total_duration_nanosec": row.get::<_, i64>(10)?,
+                }))
+            })?
+            .filter_map(|r| r.ok())
+            .collect();
+        Ok(albums)
+    }
+
     /// Songs favourited via the 5-star/heart rating, for the "Favourites" auto-playlist.
     pub fn get_favourite_songs(&self) -> Result<Vec<Song>> {
         let conn = self.db.pool.get()?;
@@ -1831,6 +1917,13 @@ pub(crate) fn read_tags(path: &Path) -> Result<Song> {
         // Album artist (various tag formats store this differently)
         song.album_artist = tag.get_string(&ItemKey::AlbumArtist).map(|s| s.to_string());
 
+        // TCMP/cpil/COMPILATION "part of a compilation" flag — stored as text
+        // "1"/"0" across every format lofty supports (ID3v2, MP4, Vorbis/APE).
+        song.compilation = tag
+            .get_string(&ItemKey::FlagCompilation)
+            .map(|s| s.trim() == "1")
+            .unwrap_or(false);
+
         song.composer = tag.get_string(&ItemKey::Composer).map(|s| s.to_string());
 
         song.lyrics = tag.get_string(&ItemKey::Lyrics).map(|s| s.to_string());
@@ -1971,6 +2064,7 @@ pub(crate) fn upsert_song(conn: &rusqlite::Connection, song: &Song) -> Result<()
                     album=excluded.album, album_artist=excluded.album_artist,
                     track=excluded.track, disc=excluded.disc,
                     year=excluded.year, originalyear=excluded.originalyear, genre=excluded.genre,
+                    compilation=excluded.compilation,
                     composer=excluded.composer, lyrics=excluded.lyrics,
                     grouping=excluded.grouping, bpm=excluded.bpm, initial_key=excluded.initial_key,
                     comment=excluded.comment, length_nanosec=excluded.length_nanosec,
@@ -2003,6 +2097,7 @@ pub(crate) fn upsert_song(conn: &rusqlite::Connection, song: &Song) -> Result<()
             song.year,
             song.originalyear,
             song.genre,
+            song.compilation,
             song.grouping,
             song.bpm,
             song.initial_key,
@@ -2104,7 +2199,7 @@ const HOME_ITEM_SELECT_COLS: &str = "s.id, s.source, s.filetype, s.path, s.url, 
 
 const SONG_INSERT_COLS: &str = "
     source, filetype, path, title, artist, album, album_artist,
-    composer, lyrics, comment, track, disc, year, originalyear, genre,
+    composer, lyrics, comment, track, disc, year, originalyear, genre, compilation,
     grouping, bpm, initial_key,
     length_nanosec, bitrate, samplerate, channels, bitdepth,
     filesize, mtime, art_embedded, art_automatic, art_unset,
@@ -2112,7 +2207,7 @@ const SONG_INSERT_COLS: &str = "
 ";
 
 const SONG_INSERT_PLACEHOLDERS: &str =
-    "?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16,?17,?18,?19,?20,?21,?22,?23,?24,?25,?26,?27,?28,?29,?30,?31";
+    "?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16,?17,?18,?19,?20,?21,?22,?23,?24,?25,?26,?27,?28,?29,?30,?31,?32";
 
 pub(crate) fn row_to_song(row: &rusqlite::Row) -> rusqlite::Result<Song> {
     Ok(Song {
@@ -3080,6 +3175,148 @@ mod tests {
         let album_four = find_album("Album Four");
         assert_eq!(album_four["artist"].as_str(), None);
         assert_eq!(album_four["track_count"].as_i64(), Some(2));
+
+        let _ = std::fs::remove_dir_all(temp_dir);
+    }
+
+    #[test]
+    fn test_upsert_song_round_trips_compilation_flag() {
+        let temp_dir = std::env::temp_dir().join(format!(
+            "luminous_compilation_test_{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let db = Arc::new(Database::new(temp_dir.clone()).unwrap());
+        let conn = db.pool.get().unwrap();
+
+        let song = Song {
+            path: Some("path/comp.mp3".to_string()),
+            title: Some("Comp Track".to_string()),
+            artist: Some("Artist A".to_string()),
+            album: Some("Now That's What I Call Tests".to_string()),
+            source: SongSource::LocalFile,
+            filetype: FileType::Mp3,
+            unavailable: false,
+            compilation: true,
+            ..Default::default()
+        };
+        upsert_song(&conn, &song).unwrap();
+
+        let stored: bool = conn
+            .query_row(
+                "SELECT compilation FROM songs WHERE path = ?1",
+                params!["path/comp.mp3"],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert!(stored, "compilation flag should persist through upsert");
+
+        // Re-upserting the same path with compilation=false should clear it
+        // (SONG_INSERT_COLS previously omitted this column entirely, so it
+        // could only ever stay 0 — this guards against that regression).
+        let song_updated = Song {
+            compilation: false,
+            ..song
+        };
+        upsert_song(&conn, &song_updated).unwrap();
+        let stored: bool = conn
+            .query_row(
+                "SELECT compilation FROM songs WHERE path = ?1",
+                params!["path/comp.mp3"],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert!(!stored, "compilation flag should update on re-scan");
+
+        let _ = std::fs::remove_dir_all(temp_dir);
+    }
+
+    #[test]
+    fn test_get_compilations_by_artist() {
+        let temp_dir = std::env::temp_dir().join(format!(
+            "luminous_compilations_by_artist_test_{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let db = Arc::new(Database::new(temp_dir.clone()).unwrap());
+        let scanner = CollectionScanner::new(db.clone());
+        let conn = db.pool.get().unwrap();
+
+        let insert_song = |path: &str,
+                           artist: &str,
+                           album: &str,
+                           album_artist: Option<&str>,
+                           compilation: bool| {
+            let song = Song {
+                path: Some(path.to_string()),
+                title: Some(path.to_string()),
+                artist: Some(artist.to_string()),
+                album: Some(album.to_string()),
+                album_artist: album_artist.map(|s| s.to_string()),
+                source: SongSource::LocalFile,
+                filetype: FileType::Mp3,
+                unavailable: false,
+                compilation,
+                ..Default::default()
+            };
+            upsert_song(&conn, &song).unwrap();
+        };
+
+        // A properly tagged compilation: TCMP=1, shared "Various Artists" album_artist.
+        insert_song(
+            "path/comp1.mp3",
+            "Artist A",
+            "Compilation One",
+            Some("Various Artists"),
+            true,
+        );
+        insert_song(
+            "path/comp2.mp3",
+            "Artist B",
+            "Compilation One",
+            Some("Various Artists"),
+            true,
+        );
+
+        // A compilation identifiable only by disagreeing album_artist (no TCMP).
+        insert_song("path/comp3.mp3", "Artist A", "Compilation Two", None, false);
+        insert_song("path/comp4.mp3", "Artist C", "Compilation Two", None, false);
+
+        // Artist A's own solo album should NOT show up as a compilation.
+        insert_song(
+            "path/solo1.mp3",
+            "Artist A",
+            "Solo Album",
+            Some("Artist A"),
+            false,
+        );
+        insert_song(
+            "path/solo2.mp3",
+            "Artist A",
+            "Solo Album",
+            Some("Artist A"),
+            false,
+        );
+
+        let comps = scanner.get_compilations_by_artist("Artist A").unwrap();
+        let names: Vec<&str> = comps.iter().map(|a| a["album"].as_str().unwrap()).collect();
+        assert!(names.contains(&"Compilation One"));
+        assert!(names.contains(&"Compilation Two"));
+        assert!(!names.contains(&"Solo Album"));
+        assert_eq!(comps.len(), 2);
+
+        for comp in &comps {
+            assert_eq!(comp["artist"].as_str(), Some("Various Artists"));
+        }
+
+        // Artist B only appears on Compilation One.
+        let comps_b = scanner.get_compilations_by_artist("Artist B").unwrap();
+        assert_eq!(comps_b.len(), 1);
+        assert_eq!(comps_b[0]["album"].as_str(), Some("Compilation One"));
 
         let _ = std::fs::remove_dir_all(temp_dir);
     }

--- a/src-tauri/src/commands/collection.rs
+++ b/src-tauri/src/commands/collection.rs
@@ -145,6 +145,17 @@ pub async fn get_songs_by_artist(
 }
 
 #[tauri::command]
+pub async fn get_compilations_by_artist(
+    artist: String,
+    state: State<'_, AppState>,
+) -> Result<Vec<serde_json::Value>, String> {
+    let scanner = CollectionScanner::new(state.db.clone());
+    scanner
+        .get_compilations_by_artist(&artist)
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
 pub async fn get_favourite_songs(state: State<'_, AppState>) -> Result<Vec<Song>, String> {
     let scanner = CollectionScanner::new(state.db.clone());
     scanner.get_favourite_songs().map_err(|e| e.to_string())

--- a/src-tauri/src/commands/player.rs
+++ b/src-tauri/src/commands/player.rs
@@ -491,4 +491,3 @@ pub async fn add_songs_to_queue(
 
     Ok(())
 }
-

--- a/src-tauri/src/commands/tageditor.rs
+++ b/src-tauri/src/commands/tageditor.rs
@@ -21,6 +21,7 @@ pub struct SongDetails {
     pub bpm: Option<f32>,
     pub initial_key: String,
     pub rating: f32,
+    pub compilation: bool,
 }
 
 #[tauri::command]
@@ -31,7 +32,7 @@ pub async fn get_song_details(
     let conn = state.db.pool.get().map_err(|e| e.to_string())?;
     conn.query_row(
         "SELECT id, path, title, artist, album, album_artist, composer, genre, track, disc, year,
-                grouping, bpm, initial_key, rating
+                grouping, bpm, initial_key, rating, compilation
          FROM songs WHERE id = ?1",
         rusqlite::params![song_id],
         |row| {
@@ -51,6 +52,7 @@ pub async fn get_song_details(
                 bpm: row.get(12).ok(),
                 initial_key: row.get(13).unwrap_or_default(),
                 rating: row.get(14).unwrap_or(crate::stats::RATING_UNRATED),
+                compilation: row.get(15).unwrap_or(false),
             })
         },
     )
@@ -127,17 +129,20 @@ pub async fn save_song_tags(
     let _watcher_pause_guard = WatcherPauseGuard::new(Arc::clone(&state.watcher_paused));
 
     let conn = state.db.pool.get().map_err(|e| e.to_string())?;
-    let path_str: String = conn
+    let (path_str, compilation): (String, bool) = conn
         .query_row(
-            "SELECT path FROM songs WHERE id = ?1",
+            "SELECT path, compilation FROM songs WHERE id = ?1",
             rusqlite::params![song_id],
-            |row| row.get(0),
+            |row| Ok((row.get(0)?, row.get(1)?)),
         )
         .map_err(|_| "Song not found in library".to_string())?;
 
     let path = std::path::PathBuf::from(path_str);
 
     // 2. Write metadata back to disk (blocking lofty write in threadpool)
+    // The single-song tag editor has no compilation toggle (that's an
+    // album-level property owned by AlbumTagEditor.svelte), so preserve
+    // whatever's already in the DB rather than clobbering it.
     let path_clone = path.clone();
     let title_c = title.clone();
     let artist_c = artist.clone();
@@ -164,6 +169,7 @@ pub async fn save_song_tags(
             &grouping_c,
             bpm,
             &initial_key_c,
+            compilation,
         )
     })
     .await
@@ -208,6 +214,7 @@ pub async fn save_song_tags(
 }
 
 #[tauri::command]
+#[allow(clippy::too_many_arguments)]
 pub async fn save_album_tags(
     state: State<'_, AppState>,
     song_ids: Vec<i64>,
@@ -216,6 +223,7 @@ pub async fn save_album_tags(
     genre: Option<String>,
     year: Option<u32>,
     disc: Option<u32>,
+    compilation: bool,
 ) -> Result<u32, String> {
     if song_ids.is_empty() {
         return Ok(0);
@@ -286,6 +294,7 @@ pub async fn save_album_tags(
                 &item.grouping,
                 item.bpm,
                 &item.initial_key,
+                compilation,
             );
             if write_res.is_ok() {
                 count += 1;
@@ -304,9 +313,18 @@ pub async fn save_album_tags(
                 album_artist = ?2,
                 genre = ?3,
                 year = ?4,
-                disc = ?5
-             WHERE id = ?6",
-            rusqlite::params![album, album_artist, genre_str, year, disc, song_id],
+                disc = ?5,
+                compilation = ?6
+             WHERE id = ?7",
+            rusqlite::params![
+                album,
+                album_artist,
+                genre_str,
+                year,
+                disc,
+                compilation,
+                song_id
+            ],
         )
         .map_err(|e| e.to_string())?;
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -663,6 +663,7 @@ pub fn run() {
             commands::collection::finish_scan,
             commands::collection::get_songs_by_album,
             commands::collection::get_songs_by_artist,
+            commands::collection::get_compilations_by_artist,
             commands::collection::get_top_artists,
             commands::collection::get_favourite_songs,
             commands::collection::get_recently_added_songs,

--- a/src-tauri/src/player.rs
+++ b/src-tauri/src/player.rs
@@ -931,7 +931,8 @@ impl Player {
         if std::path::Path::new(&path).exists() {
             return true;
         }
-        let Some(healed) = crate::collection::resolve_case_insensitive_path(std::path::Path::new(&path))
+        let Some(healed) =
+            crate::collection::resolve_case_insensitive_path(std::path::Path::new(&path))
         else {
             return false;
         };
@@ -1941,8 +1942,12 @@ mod tests {
                 "SELECT {} FROM songs WHERE id = ?1",
                 crate::collection::SONG_SELECT_COLS
             );
-            conn.query_row(&sql, rusqlite::params![1i64], crate::collection::row_to_song)
-                .unwrap()
+            conn.query_row(
+                &sql,
+                rusqlite::params![1i64],
+                crate::collection::row_to_song,
+            )
+            .unwrap()
         };
         player
             .play_playlist(vec![PlaylistItem::new_song(0, 0, song)], 0, 0, None)
@@ -1950,7 +1955,10 @@ mod tests {
             .unwrap();
 
         let healed = player.try_heal_and_retry_current_track().await;
-        assert!(healed, "a case-only path mismatch should heal on the first error");
+        assert!(
+            healed,
+            "a case-only path mismatch should heal on the first error"
+        );
         let healed_path = player.current_song.as_ref().unwrap().path.clone().unwrap();
         assert!(
             std::path::Path::new(&healed_path).exists(),

--- a/src-tauri/src/playlist.rs
+++ b/src-tauri/src/playlist.rs
@@ -1395,8 +1395,7 @@ impl PlaylistManager {
             return Ok(Vec::new());
         }
 
-        let uuids_to_remove: Vec<String> =
-            tracks[..index].iter().map(|t| t.uuid.clone()).collect();
+        let uuids_to_remove: Vec<String> = tracks[..index].iter().map(|t| t.uuid.clone()).collect();
         self.remove_from_playlist(playlist_id, &uuids_to_remove)?;
         Ok(uuids_to_remove)
     }
@@ -2274,9 +2273,7 @@ mod tests {
         let tracks = manager.get_playlist_tracks(pl.id).unwrap();
         let uuid2 = tracks[2].uuid.clone();
 
-        let removed = manager
-            .trim_playlist_before_uuid(pl.id, &uuid2)
-            .unwrap();
+        let removed = manager.trim_playlist_before_uuid(pl.id, &uuid2).unwrap();
         assert_eq!(removed.len(), 2);
 
         let remaining = manager.get_playlist_tracks(pl.id).unwrap();

--- a/src-tauri/src/tageditor.rs
+++ b/src-tauri/src/tageditor.rs
@@ -107,6 +107,7 @@ pub fn write_tags(
     grouping: &str,
     bpm: Option<f32>,
     initial_key: &str,
+    compilation: bool,
 ) -> Result<()> {
     let mut tagged_file = Probe::open(path)
         .context("failed to open audio file for tag writing")?
@@ -138,6 +139,12 @@ pub fn write_tags(
     tag.insert_text(lofty::tag::ItemKey::Composer, composer.to_string());
     tag.insert_text(lofty::tag::ItemKey::ContentGroup, grouping.to_string());
     tag.insert_text(lofty::tag::ItemKey::InitialKey, initial_key.to_string());
+    // TCMP/cpil/COMPILATION "part of a compilation" flag — written as text
+    // "1"/"0" the same way lofty reads it back (see read_tags).
+    tag.insert_text(
+        lofty::tag::ItemKey::FlagCompilation,
+        if compilation { "1" } else { "0" }.to_string(),
+    );
 
     if let Some(b) = bpm {
         // ID3v2 (TBPM) and MP4 (tmpo) map from IntegerBpm; Vorbis/APE's freeform

--- a/src/lib/components/AlbumDetailView.svelte
+++ b/src/lib/components/AlbumDetailView.svelte
@@ -1129,6 +1129,7 @@
     initialGenre={songs[0].genre}
     initialYear={songs[0].year}
     initialDisc={songs[0].disc}
+    initialCompilation={songs[0].compilation}
     onClose={() => { showAlbumTagEditor = false; }}
     onSave={handleTagEditorSaved}
   />

--- a/src/lib/components/AlbumTagEditor.svelte
+++ b/src/lib/components/AlbumTagEditor.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { invoke } from "@tauri-apps/api/core";
-  import { Sliders, Save, X, LoaderCircle, Layers } from "lucide-svelte";
+  import { Sliders, Save, X, LoaderCircle, Layers, Lock } from "lucide-svelte";
   import { collectionStore } from "../stores/collection.svelte";
   import { i18n } from "../stores/i18n.svelte";
   import { toastStore } from "../stores/toast.svelte";
@@ -16,6 +16,7 @@
     initialGenre?: string | null;
     initialYear?: number | null;
     initialDisc?: number | null;
+    initialCompilation?: boolean;
     onClose: () => void;
     onSave?: () => void;
   }
@@ -27,6 +28,7 @@
     initialGenre = "",
     initialYear = null,
     initialDisc = null,
+    initialCompilation = false,
     onClose,
     onSave
   }: Props = $props();
@@ -41,6 +43,26 @@
   let year = $state<number | null>(initialYear);
   // svelte-ignore state_referenced_locally
   let disc = $state<number | null>(initialDisc);
+  // svelte-ignore state_referenced_locally
+  let compilation = $state(initialCompilation ?? false);
+
+  const VARIOUS_ARTISTS = "Various Artists";
+  // Remembers whatever was in Album Artist before the Compilation toggle
+  // overwrote it, so unchecking restores it instead of leaving "Various
+  // Artists" behind.
+  // svelte-ignore state_referenced_locally
+  let previousAlbumArtist = $state(initialAlbumArtist ?? "");
+
+  function handleCompilationToggle(e: Event) {
+    const next = (e.currentTarget as HTMLInputElement).checked;
+    if (next) {
+      previousAlbumArtist = albumArtist;
+      albumArtist = VARIOUS_ARTISTS;
+    } else {
+      albumArtist = previousAlbumArtist;
+    }
+    compilation = next;
+  }
 
   let isSaving = $state(false);
 
@@ -54,6 +76,7 @@
         genre: genre ?? "",
         year,
         disc,
+        compilation,
       });
 
       await collectionStore.refreshStats();
@@ -99,8 +122,29 @@
           </FormField>
 
           <FormField label={i18n.t('albumTagEditor.albumArtistField')} for="album-tag-albumartist" span2>
-            <Input id="album-tag-albumartist" bind:value={albumArtist} disabled={isSaving} size="sm" class="w-full" />
+            {#if compilation}
+              <div class="flex items-center h-9">
+                <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full border border-brand-border bg-brand-main text-xs font-semibold text-brand-text-primary">
+                  {VARIOUS_ARTISTS}
+                  <Lock class="w-3 h-3 text-brand-text-secondary shrink-0" />
+                </span>
+              </div>
+            {:else}
+              <Input id="album-tag-albumartist" bind:value={albumArtist} disabled={isSaving} size="sm" class="w-full" />
+            {/if}
           </FormField>
+
+          <label class="flex items-center gap-2 col-span-2 text-xs text-brand-text-primary select-none">
+            <input
+              type="checkbox"
+              id="album-tag-compilation"
+              checked={compilation}
+              onchange={handleCompilationToggle}
+              disabled={isSaving}
+              class="rounded accent-brand-accent"
+            />
+            {i18n.t('albumTagEditor.compilationField')}
+          </label>
 
           <FormField label={i18n.t('albumTagEditor.genreField')} for="album-tag-genre" span2>
             <Input id="album-tag-genre" bind:value={genre} disabled={isSaving} size="sm" class="w-full" />

--- a/src/lib/components/AlbumTagEditor.test.ts
+++ b/src/lib/components/AlbumTagEditor.test.ts
@@ -96,6 +96,7 @@ describe("AlbumTagEditor.svelte", () => {
         genre: "Rock",
         year: 2020,
         disc: 2,
+        compilation: false,
       });
       expect(onSave).toHaveBeenCalled();
       expect(onClose).toHaveBeenCalled();
@@ -130,6 +131,7 @@ describe("AlbumTagEditor.svelte", () => {
         genre: "",
         year: 2024,
         disc: null,
+        compilation: false,
       });
       expect(onSave).toHaveBeenCalled();
       expect(onClose).toHaveBeenCalled();
@@ -166,9 +168,72 @@ describe("AlbumTagEditor.svelte", () => {
         genre: "Pop",
         year: 2024,
         disc: null,
+        compilation: false,
       });
       expect(onSave).toHaveBeenCalled();
       expect(onClose).toHaveBeenCalled();
     });
+  });
+
+  it("toggling Compilation on replaces the Album Artist input with a Various Artists pill and saves both", async () => {
+    const onClose = vi.fn();
+    const onSave = vi.fn();
+    const { getByLabelText, getByRole, getByText, queryByLabelText } = render(AlbumTagEditor, {
+      songIds: [101],
+      initialAlbum: "Now That's What I Call Tests",
+      initialAlbumArtist: "Artist A",
+      initialGenre: "Pop",
+      initialYear: 2024,
+      initialDisc: 1,
+      initialCompilation: false,
+      onClose,
+      onSave,
+    });
+
+    expect(getByLabelText("Album Artist")).toBeInTheDocument();
+
+    const compilationCheckbox = getByLabelText(/compilation/i) as HTMLInputElement;
+    expect(compilationCheckbox.checked).toBe(false);
+    await fireEvent.click(compilationCheckbox);
+    expect(compilationCheckbox.checked).toBe(true);
+
+    // The editable input is gone; a static "Various Artists" pill takes its place.
+    expect(queryByLabelText("Album Artist")).not.toBeInTheDocument();
+    expect(getByText("Various Artists")).toBeInTheDocument();
+
+    const saveBtn = getByRole("button", { name: /save tags/i });
+    await fireEvent.click(saveBtn);
+
+    await waitFor(() => {
+      expect(invoke).toHaveBeenCalledWith("save_album_tags", {
+        songIds: [101],
+        album: "Now That's What I Call Tests",
+        albumArtist: "Various Artists",
+        genre: "Pop",
+        year: 2024,
+        disc: 1,
+        compilation: true,
+      });
+      expect(onSave).toHaveBeenCalled();
+      expect(onClose).toHaveBeenCalled();
+    });
+  });
+
+  it("unchecking Compilation restores the previous Album Artist value", async () => {
+    const onClose = vi.fn();
+    const { getByLabelText, queryByLabelText } = render(AlbumTagEditor, {
+      songIds: [101],
+      initialAlbum: "Test Album",
+      initialAlbumArtist: "Artist A",
+      onClose,
+    });
+
+    const compilationCheckbox = getByLabelText(/compilation/i) as HTMLInputElement;
+    await fireEvent.click(compilationCheckbox);
+    expect(queryByLabelText("Album Artist")).not.toBeInTheDocument();
+
+    await fireEvent.click(compilationCheckbox);
+    const artistInput = getByLabelText("Album Artist") as HTMLInputElement;
+    expect(artistInput.value).toBe("Artist A");
   });
 });

--- a/src/lib/components/ArtistDetailView.svelte
+++ b/src/lib/components/ArtistDetailView.svelte
@@ -34,6 +34,7 @@
 
   let songs = $state<Song[]>([]);
   let playlists = $state<Playlist[]>([]);
+  let compilations = $state<AlbumItem[]>([]);
   let loading = $state(true);
 
   let albumContextMenuState = $state<{ x: number; y: number; album: AlbumItem } | null>(null);
@@ -131,12 +132,14 @@
     loading = true;
     Promise.all([
       invoke<Song[]>("get_songs_by_artist", { artist: requested }),
-      invoke<Playlist[]>("get_playlists_by_artist", { artist: requested })
+      invoke<Playlist[]>("get_playlists_by_artist", { artist: requested }),
+      invoke<AlbumItem[]>("get_compilations_by_artist", { artist: requested })
     ])
-      .then(([fetchedSongs, fetchedPlaylists]) => {
+      .then(([fetchedSongs, fetchedPlaylists, fetchedCompilations]) => {
         if (requested !== artistName) return;
         songs = fetchedSongs;
         playlists = fetchedPlaylists.filter((p) => !p.is_queue);
+        compilations = fetchedCompilations;
       })
       .catch((err) => {
         console.error("Failed to load artist detail:", err);
@@ -879,6 +882,21 @@
       <p class="text-xs text-brand-text-secondary py-8 text-center">{i18n.t('artistDetail.noReleasesFound')}</p>
     {/if}
   </div>
+
+  {#if compilations.length > 0}
+    <div class="px-6 pt-10">
+      <HorizontalScrollRow title={i18n.t('artistDetail.compilationsFeaturing', { artist: artistName })}>
+        {#each compilations as album (album.album)}
+          <AlbumCard
+            {album}
+            widthClass="w-48 shrink-0"
+            onclick={() => openAlbum(album)}
+            oncontextmenu={(e) => handleAlbumContextMenu(e, album)}
+          />
+        {/each}
+      </HorizontalScrollRow>
+    </div>
+  {/if}
 
   {#if playlists.length > 0}
     <div class="px-6 pt-10 {playerStore.currentSong ? 'pb-28' : 'pb-6'}">

--- a/src/lib/components/SmartPlaylistBuilderModal.svelte
+++ b/src/lib/components/SmartPlaylistBuilderModal.svelte
@@ -145,12 +145,15 @@
     { key: "samplerate", label: i18n.t("smartPlaylistBuilder.fieldSampleRate", {}, "Sample Rate (Hz)"), type: "number" },
     { key: "bitdepth", label: i18n.t("smartPlaylistBuilder.fieldBitDepth", {}, "Bit Depth"), type: "number" },
     { key: "channels", label: i18n.t("smartPlaylistBuilder.fieldChannels", {}, "Channels"), type: "number" },
-    { key: "compilation", label: i18n.t("smartPlaylistBuilder.fieldCompilation", {}, "Compilation (1/0)"), type: "number" },
+    { key: "compilation", label: i18n.t("smartPlaylistBuilder.fieldCompilation", {}, "Compilation"), type: "boolean" },
     { key: "duration", label: i18n.t("smartPlaylistBuilder.fieldDuration", {}, "Duration (MM:SS or Sec)"), type: "text" },
   ];
 
   function getOperatorsForField(fieldKey: string) {
     const fieldObj = availableFields.find((f) => f.key === fieldKey);
+    if (fieldObj && fieldObj.type === "boolean") {
+      return [{ op: "=", label: i18n.t("smartPlaylistBuilder.opEquals", {}, "=") }];
+    }
     if (fieldObj && fieldObj.type === "number") {
       return [
         { op: "=", label: i18n.t("smartPlaylistBuilder.opEquals", {}, "=") },
@@ -295,6 +298,7 @@
 
         <div class="space-y-2.5">
           {#each rules as rule (rule.id)}
+            {@const fieldType = availableFields.find((f) => f.key === rule.field)?.type}
             <div class="flex items-center gap-2 bg-brand-main/60 p-2.5 rounded-xl border border-brand-border/40">
               <Select
                 value={rule.field}
@@ -302,6 +306,13 @@
                   rule.field = e.currentTarget.value;
                   const ops = getOperatorsForField(rule.field);
                   rule.op = ops[0].op;
+                  // A boolean field has no free-text value to type, so seed
+                  // it with a valid "1"/"0" right away — otherwise it'd read
+                  // as an empty rule and get dropped from the saved spec.
+                  const newFieldType = availableFields.find((f) => f.key === rule.field)?.type;
+                  if (newFieldType === "boolean" && rule.value.trim() === "") {
+                    rule.value = "1";
+                  }
                 }}
                 class="bg-brand-sidebar border border-brand-border text-brand-text-primary text-xs rounded-full pl-2.5 pr-8 py-1.5 focus:outline-none focus:border-brand-accent font-medium"
               >
@@ -310,24 +321,37 @@
                 {/each}
               </Select>
 
-              <Select
-                value={rule.op}
-                onchange={(e) => { rule.op = e.currentTarget.value; }}
-                class="bg-brand-sidebar border border-brand-border text-brand-text-primary text-xs rounded-full pl-2.5 pr-8 py-1.5 focus:outline-none focus:border-brand-accent font-medium"
-              >
-                {#each getOperatorsForField(rule.field) as opItem}
-                  <option value={opItem.op}>{opItem.label}</option>
-                {/each}
-              </Select>
+              {#if fieldType !== "boolean"}
+                <Select
+                  value={rule.op}
+                  onchange={(e) => { rule.op = e.currentTarget.value; }}
+                  class="bg-brand-sidebar border border-brand-border text-brand-text-primary text-xs rounded-full pl-2.5 pr-8 py-1.5 focus:outline-none focus:border-brand-accent font-medium"
+                >
+                  {#each getOperatorsForField(rule.field) as opItem}
+                    <option value={opItem.op}>{opItem.label}</option>
+                  {/each}
+                </Select>
+              {/if}
 
-              <Input
-                type="text"
-                bind:value={rule.value}
-                placeholder={i18n.t("smartPlaylistBuilder.valuePlaceholder")}
-                size="sm"
-                surface="sidebar"
-                class="flex-1 min-w-0"
-              />
+              {#if fieldType === "boolean"}
+                <div class="flex-1 min-w-0 flex items-center">
+                  <Toggle
+                    id="rule-toggle-{rule.id}"
+                    checked={rule.value.trim() === "1"}
+                    onchange={(checked) => { rule.value = checked ? "1" : "0"; }}
+                    label={i18n.t("smartPlaylistBuilder.fieldCompilation", {}, "Compilation")}
+                  />
+                </div>
+              {:else}
+                <Input
+                  type="text"
+                  bind:value={rule.value}
+                  placeholder={i18n.t("smartPlaylistBuilder.valuePlaceholder")}
+                  size="sm"
+                  surface="sidebar"
+                  class="flex-1 min-w-0"
+                />
+              {/if}
 
               {#if rules.length > 1}
                 <button

--- a/src/lib/components/TagEditor.svelte
+++ b/src/lib/components/TagEditor.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { invoke } from "@tauri-apps/api/core";
   import { onMount } from "svelte";
-  import { Sliders, Save, X, Sparkles, LoaderCircle, AlertTriangle, Check, SearchX } from "lucide-svelte";
+  import { Sliders, Save, X, Sparkles, LoaderCircle, AlertTriangle, Check, SearchX, Lock } from "lucide-svelte";
   import { fade } from "svelte/transition";
   import { collectionStore } from "../stores/collection.svelte";
   import { i18n } from "../stores/i18n.svelte";
@@ -37,6 +37,11 @@
   let initialKey = $state("");
   let path = $state("");
   let rating = $state(-1);
+  // Compilation is an album-level property edited via AlbumTagEditor, not
+  // here — this is read-only, just so a compilation's Album Artist shows
+  // the same "Various Artists" pill here as it does there instead of an
+  // editable field that would suggest a per-track override is meaningful.
+  let compilation = $state(false);
 
   let isLoading = $state(false);
   let isSaving = $state(false);
@@ -68,6 +73,7 @@
         bpm: number | null;
         initial_key: string;
         rating: number;
+        compilation: boolean;
       }>("get_song_details", { songId });
 
       title = details.title;
@@ -84,6 +90,7 @@
       initialKey = details.initial_key;
       path = details.path;
       rating = details.rating;
+      compilation = details.compilation;
     } catch (e: any) {
       console.error("Failed to load metadata:", e);
       errorMsg = e.toString();
@@ -319,7 +326,16 @@
             </FormField>
 
             <FormField label={i18n.t('tagEditor.albumArtistField')} for="tag-albumartist" tooltip={i18n.t('tagEditor.albumArtistTooltip')}>
-              <Input id="tag-albumartist" bind:value={albumArtist} disabled={isSaving} size="sm" class="w-full" />
+              {#if compilation}
+                <div class="flex items-center h-9">
+                  <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full border border-brand-border bg-brand-main text-xs font-semibold text-brand-text-primary">
+                    Various Artists
+                    <Lock class="w-3 h-3 text-brand-text-secondary shrink-0" />
+                  </span>
+                </div>
+              {:else}
+                <Input id="tag-albumartist" bind:value={albumArtist} disabled={isSaving} size="sm" class="w-full" />
+              {/if}
             </FormField>
 
             <FormField label={i18n.t('tagEditor.yearField')} for="tag-year">

--- a/src/lib/components/TagEditor.test.ts
+++ b/src/lib/components/TagEditor.test.ts
@@ -37,6 +37,7 @@ describe("TagEditor.svelte", () => {
     bpm: 120,
     initial_key: "Cmaj",
     rating: 3,
+    compilation: false,
   };
 
   beforeEach(() => {
@@ -73,6 +74,24 @@ describe("TagEditor.svelte", () => {
     expect(titleInput.value).toBe("Original Title");
     expect(artistInput.value).toBe("Original Artist");
     expect(albumInput.value).toBe("Original Album");
+  });
+
+  it("shows a read-only Various Artists pill instead of the Album Artist input when the song is part of a compilation", async () => {
+    vi.mocked(invoke).mockImplementation(async (cmd: string) => {
+      if (cmd === "get_song_details") {
+        return { ...mockSongDetails, album_artist: "Various Artists", compilation: true };
+      }
+      if (cmd === "get_library_snapshot") return { songs: [], albums: [], artists: [] };
+      return null;
+    });
+
+    const onClose = vi.fn();
+    const { getByText, queryByLabelText } = render(TagEditor, { songId: 10, onClose });
+
+    await waitFor(() => {
+      expect(getByText("Various Artists")).toBeInTheDocument();
+    });
+    expect(queryByLabelText("Album Artist")).not.toBeInTheDocument();
   });
 
   it("calls onClose when cancel button is clicked", async () => {

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -662,6 +662,7 @@ export const en = {
     albumField: "Album Title",
     albumArtistField: "Album Artist",
     genreField: "Genre",
+    compilationField: "Compilation (mark as Various Artists)",
     yearField: "Release Year",
     discField: "Disc #",
     tracksAffected: "Applies to {count} songs",
@@ -753,7 +754,8 @@ export const en = {
     singlesFilter: "Singles ({count})",
     discSet: "{count}-Disc Set",
     noReleasesFound: "No releases found.",
-    playlistsFeaturing: "Playlists featuring {artist}"
+    playlistsFeaturing: "Playlists featuring {artist}",
+    compilationsFeaturing: "Compilations featuring {artist}"
   },
   albumDetail: {
     backToAlbums: "Back to Albums",
@@ -868,7 +870,7 @@ export const en = {
     fieldChannels: "Channels",
     fieldAdded: "Date Added (Unix Timestamp)",
     fieldOriginalYear: "Original Year",
-    fieldCompilation: "Compilation (1/0)",
+    fieldCompilation: "Compilation",
     opEquals: "=",
     opNotEquals: "!=",
     opGte: ">=",

--- a/src/lib/locales/fr.ts
+++ b/src/lib/locales/fr.ts
@@ -659,6 +659,7 @@ export const fr = {
     albumField: "Titre de l'album",
     albumArtistField: "Artiste de l'album",
     genreField: "Genre",
+    compilationField: "Compilation (marquer comme Artistes divers)",
     yearField: "Année de sortie",
     discField: "N° de disque",
     tracksAffected: "S'applique à {count} chansons",
@@ -750,7 +751,8 @@ export const fr = {
     singlesFilter: "Singles ({count})",
     discSet: "Coffret {count} disques",
     noReleasesFound: "Aucune sortie trouvée.",
-    playlistsFeaturing: "Listes de lecture avec {artist}"
+    playlistsFeaturing: "Listes de lecture avec {artist}",
+    compilationsFeaturing: "Compilations avec {artist}"
   },
   albumDetail: {
     backToAlbums: "Retour aux albums",
@@ -865,7 +867,7 @@ export const fr = {
     fieldChannels: "Canaux",
     fieldAdded: "Date d'ajout (horodatage Unix)",
     fieldOriginalYear: "Année d'origine",
-    fieldCompilation: "Compilation (1/0)",
+    fieldCompilation: "Compilation",
     opEquals: "=",
     opNotEquals: "!=",
     opGte: ">=",


### PR DESCRIPTION
## Summary

Closes #343. Compilation support (the ID3 `TCMP` "part of a compilation" flag) had partial plumbing — stored in the DB, exposed as a Smart Playlist filter field — but was never actually read from files on import, never written back on edit, never surfaced in any editing UI, and an artist's own tracks on a Various Artists compilation were invisible on that artist's detail page.

- **Read on import/rescan**: `extract_metadata` now maps lofty's `ItemKey::FlagCompilation` (`TCMP`/`cpil`/`COMPILATION`) into `song.compilation`, and `compilation` was added to `SONG_INSERT_COLS` — previously omitted, so every scanned track's flag could only ever persist as `0`.
- **Write on edit**: `write_tags()` now writes the flag back to disk; `save_album_tags` takes a `compilation` param and persists it (compilation is treated as an album-level property). `save_song_tags` preserves the existing DB value rather than clobbering it, since the single-song editor has no toggle of its own.
- **UI**:
  - `AlbumTagEditor` gets a Compilation toggle. Checking it replaces the editable Album Artist field with a locked "Various Artists" pill (and restores whatever was there before if unchecked) — following the standard `TPE2=Various Artists` + `TCMP=1` convention for maximum player compatibility (MusicBee, iTunes, Foobar2000, Plex).
  - `TagEditor` (single-song editor) shows the same read-only "Various Artists" pill for songs belonging to a compilation, since that's edited at the album level.
  - Smart Playlist builder's Compilation filter field is now a proper on/off `Toggle` instead of a numeric "1/0" text entry with nonsensical `>`/`<` operators.
- **New "Compilations featuring {artist}" row** on `ArtistDetailView` via a new `get_compilations_by_artist` backend query — matches on the *raw per-track* artist (not the effective/album-level artist), since a Various Artists compilation's effective artist is never the individual track artist and was previously never surfacing there at all.
- Verified `compilation:1`/`compilation:=0` Smart Playlist filtering now actually returns results.

## Test plan

- [x] `cargo test --lib` — all pass except one pre-existing, unrelated failure (`test_resolve_case_insensitive_path_finds_real_casing`, reproduces identically on unmodified `main` — a Windows temp-dir case-folding quirk in this environment)
- [x] New Rust tests: `test_upsert_song_round_trips_compilation_flag`, `test_get_compilations_by_artist`
- [x] `cargo clippy --lib --no-deps` clean (aside from one pre-existing unrelated warning)
- [x] `bun run test` — 336/336 pass, including new/updated coverage in `AlbumTagEditor.test.ts` and `TagEditor.test.ts`
- [x] `bun run check` (svelte-check) — 0 errors, 0 warnings
- [ ] Manual verification in a running dev build (checkbox/toggle/pill behavior, artist compilations row) — not run here per this repo's convention that the sandboxed browser preview can't drive Luminous's Tauri IPC bridge

🤖 Generated with [Claude Code](https://claude.com/claude-code)