### PR TITLE
fix: restore Windows PlayBar acrylic glass transparency (#370)

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -151,12 +151,6 @@
   -webkit-backdrop-filter: blur(20px) saturate(180%) !important;
   border-color: var(--glass-border-color, var(--color-border));
   box-shadow: var(--glass-shadow, none);
-  /* Pin this panel's backdrop-filter output to its own GPU layer so it's
-     cached instead of re-rasterized on every composite frame triggered
-     elsewhere in the window (see AlbumDetailView's backdrop <img> fix for
-     the same underlying flicker). */
-  will-change: backdrop-filter;
-  transform: translateZ(0);
 }
 
 .bg-brand-sidebar.glass-surface,


### PR DESCRIPTION
## 📋 Summary

Fixes #370.

Restores the frosted acrylic/glass visual effect on the floating PlayBar dock (`PlayerBar.svelte`) on Windows platforms where it previously rendered completely see-through without backdrop blur or background tint.

## 🔍 Implementation Notes

- Removed `will-change: backdrop-filter;` and `transform: translateZ(0);` from `.glass-surface` in `src/app.css`. Promoting the `.glass-surface` container to an isolated GPU compositing layer in WebKit/WebView2 on Windows detached the element from the DOM composite tree, preventing `backdrop-filter` from sampling the underlying backdrop.
- Kept all Linux `opaque-linux` exclusions and themed `var(--bg-playerbar)` fallback rules in `PlayerBar.svelte` and `Miniplayer.svelte` completely intact for WebKitGTK.

## 🧪 Test Plan

- [x] `bun run check` (svelte-check found 0 errors and 0 warnings)
- [x] `bun run test -- --run` (frontend unit tests: 36 test files, 336 tests passed)
- [x] Manually verified in the app on Windows

## ✅ Checklist

- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed
