### PR TITLE
fix: address AppImage blank window from bundled WebKitGTK mismatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ubuntu-22.04, windows-latest]
+        platform: [ubuntu-24.04, windows-latest]
 
     runs-on: ${{ matrix.platform }}
     steps:
@@ -28,7 +28,7 @@ jobs:
         run: bun install
 
       - name: Install system dependencies (Linux)
-        if: matrix.platform == 'ubuntu-22.04'
+        if: matrix.platform == 'ubuntu-24.04'
         run: |
           sudo apt-get update
           sudo apt-get install -y libwebkit2gtk-4.1-dev libasound2-dev libssl-dev pkg-config libayatana-appindicator3-dev librsvg2-dev

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -102,6 +102,14 @@ fn build_prevent_default_plugin<R: tauri::Runtime>() -> tauri::plugin::TauriPlug
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    // The AppImage bundles its own WebKitGTK (built on the CI runner), which
+    // can be substantially older than the host's system WebKitGTK. Older
+    // WebKitGTK builds' accelerated compositing path is known to render a
+    // blank window against newer Mesa/Wayland stacks; disabling compositing
+    // mode avoids that without touching DMA-BUF handling, which the line
+    // below already covers separately (#370).
+    #[cfg(target_os = "linux")]
+    std::env::set_var("WEBKIT_DISABLE_COMPOSITING_MODE", "1");
     #[cfg(target_os = "linux")]
     std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
 


### PR DESCRIPTION
## Summary
- The v0.99.1 release AppImage loads with a blank window on repeated launches (not just first-run integration) on at least one Linux system, while a locally-built AppImage on the same machine renders fine every time.
- Root cause, confirmed by extracting the downloaded AppImage: it bundles its own `libwebkit2gtk-4.1.so.0`, built on the GitHub Actions `ubuntu-22.04` runner via `linuxdeploy`. That bundled WebKitGTK is significantly older than the host's system webkit2gtk (`2.52.5-2` on the reporter's machine), and older WebKitGTK's accelerated compositing path is a known cause of blank rendering against newer Mesa/Wayland driver stacks. A locally built AppImage bundles the host's own (current) WebKitGTK instead, so it doesn't hit this.
- Fixes: disable `WEBKIT_DISABLE_COMPOSITING_MODE` on Linux alongside the existing `WEBKIT_DISABLE_DMABUF_RENDERER` workaround (#370), and bump the release Linux runner to `ubuntu-24.04` so future AppImages bundle a newer WebKitGTK.

Closes the issue filed alongside this PR.

## Test plan
- [ ] `cargo check` passes (done locally)
- [ ] Cut a new tag (e.g. v0.99.2) and confirm the resulting AppImage renders on the reporter's system, both first launch and subsequent launches
- [ ] Spot-check that disabling compositing mode doesn't regress transparency/backdrop-filter effects (#370, #ad3c8a) on Linux