### PR TITLE
Publish to Winget and Microsoft Store

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,15 +39,17 @@ jobs:
       # manifests — this bit us in v0.99.2).
       - name: Create or reuse draft release
         id: release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ steps.tag.outputs.tag }}
-          name: 'Luminous ${{ steps.tag.outputs.tag }}'
-          body: 'Release of Luminous ${{ steps.tag.outputs.tag }}.'
-          draft: true
-          prerelease: false
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ steps.tag.outputs.tag }}"
+          if ID=$(gh release view "$TAG" --json id -q .id 2>/dev/null); then
+            echo "Found existing release $ID for $TAG"
+          else
+            gh release create "$TAG" --draft --title "Luminous $TAG" --notes "Release of Luminous $TAG."
+            ID=$(gh release view "$TAG" --json id -q .id)
+          fi
+          echo "id=${ID}" >> "$GITHUB_OUTPUT"
 
   release:
     needs: create-release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,7 +153,7 @@ jobs:
       - name: Submit package update using wingetcreate
         run: |
           $ver = "${{ steps.get_version.outputs.version }}"
-          $url = "https://github.com/esoltys/luminous/releases/download/v$ver/Luminous_${ver}_x64-setup.exe"
+          $url = "https://github.com/esoltys/luminous/releases/download/v$ver/LuminousMusicPlayer_${ver}_x64-setup.exe"
           wingetcreate update EricSoltys.Luminous --version $ver --urls $url --token ${{ secrets.WINGET_PAT }}
 
   microsoft-store:
@@ -169,6 +169,9 @@ jobs:
         run: |
           VERSION="${TAG_NAME#v}"
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          # tauri-windows-bundle pads to a four-part version (X.Y.Z -> X.Y.Z.0)
+          # for the MSIX filename.
+          echo "msix_version=${VERSION}.0" >> $GITHUB_OUTPUT
         env:
           TAG_NAME: ${{ github.event.release.tag_name || github.ref_name }}
 
@@ -179,7 +182,7 @@ jobs:
           client-id: ${{ secrets.STORE_CLIENT_ID }}
           client-secret: ${{ secrets.STORE_CLIENT_SECRET }}
           app-id: ${{ secrets.STORE_APP_ID }}
-          package-path: "https://github.com/esoltys/luminous/releases/download/v${{ steps.get_version.outputs.version }}/Luminous_${{ steps.get_version.outputs.version }}_x64.msix"
+          package-path: "https://github.com/esoltys/luminous/releases/download/v${{ steps.get_version.outputs.version }}/LuminousMusicPlayer_${{ steps.get_version.outputs.msix_version }}_x64.msix"
 
 
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,6 +105,7 @@ jobs:
           with: |
             releaseId: ${{ needs.create-release.outputs.release_id }}
             tagName: ${{ needs.create-release.outputs.tag }}
+            releaseDraft: true
             prerelease: false
 
       - name: Build MSIX Package (Windows)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,6 +86,11 @@ jobs:
 
       - name: Build MSIX Package (Windows)
         if: matrix.platform == 'windows-latest'
+        # src-tauri is a workspace member (see root Cargo.toml), so Cargo's
+        # shared target dir lives at the workspace root, not src-tauri/target.
+        # tauri-windows-bundle assumes the latter unless told otherwise.
+        env:
+          CARGO_TARGET_DIR: ${{ github.workspace }}/target
         run: |
           cargo install tauri-cli
           bun run tauri:windows:build
@@ -96,8 +101,8 @@ jobs:
         with:
           tag_name: ${{ steps.tag.outputs.tag }}
           files: |
-            src-tauri/target/msix/*.msix
-            src-tauri/target/msix/*.msixbundle
+            target/msix/*.msix
+            target/msix/*.msixbundle
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,7 +153,7 @@ jobs:
       - name: Submit package update using wingetcreate
         run: |
           $ver = "${{ steps.get_version.outputs.version }}"
-          $url = "https://github.com/esoltys/luminous/releases/download/v$ver/LuminousMusicPlayer_${ver}_x64-setup.exe"
+          $url = "https://github.com/esoltys/luminous/releases/download/v$ver/Luminous_${ver}_x64-setup.exe"
           wingetcreate update EricSoltys.Luminous --version $ver --urls $url --token ${{ secrets.WINGET_PAT }}
 
   microsoft-store:
@@ -169,9 +169,6 @@ jobs:
         run: |
           VERSION="${TAG_NAME#v}"
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
-          # tauri-windows-bundle pads to a four-part version (X.Y.Z -> X.Y.Z.0)
-          # for the MSIX filename.
-          echo "msix_version=${VERSION}.0" >> $GITHUB_OUTPUT
         env:
           TAG_NAME: ${{ github.event.release.tag_name || github.ref_name }}
 
@@ -182,7 +179,7 @@ jobs:
           client-id: ${{ secrets.STORE_CLIENT_ID }}
           client-secret: ${{ secrets.STORE_CLIENT_SECRET }}
           app-id: ${{ secrets.STORE_APP_ID }}
-          package-path: "https://github.com/esoltys/luminous/releases/download/v${{ steps.get_version.outputs.version }}/LuminousMusicPlayer_${{ steps.get_version.outputs.msix_version }}_x64.msix"
+          package-path: "https://github.com/esoltys/luminous/releases/download/v${{ steps.get_version.outputs.version }}/Luminous_${{ steps.get_version.outputs.version }}_x64.msix"
 
 
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,18 +55,34 @@ jobs:
           fi
           echo "tag=${TAG}" >> $GITHUB_OUTPUT
 
-      - name: Build and Release
-        uses: tauri-apps/tauri-action@v0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
-          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+      - name: Cache Tauri bundler tools (NSIS/WiX)
+        if: matrix.platform == 'windows-latest'
+        uses: actions/cache@v4
         with:
-          tagName: ${{ steps.tag.outputs.tag }}
-          releaseName: 'Luminous ${{ steps.tag.outputs.tag }}'
-          releaseBody: 'Release of Luminous ${{ steps.tag.outputs.tag }}.'
-          releaseDraft: true
-          prerelease: false
+          path: |
+            ~/AppData/Local/tauri/NSIS
+            ~/AppData/Local/tauri/WixTools*
+          key: tauri-bundler-tools-windows
+
+      # tauri-apps/binary-releases (source of the NSIS toolchain) occasionally
+      # returns transient 503s, which fails the whole matrix leg. Retry a
+      # couple of times before giving up.
+      - name: Build and Release
+        uses: Wandalen/wretry.action@v3
+        with:
+          action: tauri-apps/tauri-action@v0
+          attempt_limit: 3
+          attempt_delay: 15000
+          env: |
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+            TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          with: |
+            tagName: ${{ steps.tag.outputs.tag }}
+            releaseName: 'Luminous ${{ steps.tag.outputs.tag }}'
+            releaseBody: 'Release of Luminous ${{ steps.tag.outputs.tag }}.'
+            releaseDraft: true
+            prerelease: false
 
       - name: Build MSIX Package (Windows)
         if: matrix.platform == 'windows-latest'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,7 +152,7 @@ jobs:
       - name: Submit package update using wingetcreate
         run: |
           $ver = "${{ steps.get_version.outputs.version }}"
-          $url = "https://github.com/esoltys/luminous/releases/download/v$ver/Luminous_${ver}_x64-setup.exe"
+          $url = "https://github.com/esoltys/luminous/releases/download/v$ver/LuminousMusicPlayer_${ver}_x64-setup.exe"
           wingetcreate update EricSoltys.Luminous --version $ver --urls $url --token ${{ secrets.WINGET_PAT }}
 
   microsoft-store:
@@ -168,6 +168,9 @@ jobs:
         run: |
           VERSION="${TAG_NAME#v}"
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          # tauri-windows-bundle pads to a four-part version (X.Y.Z -> X.Y.Z.0)
+          # for the MSIX filename.
+          echo "msix_version=${VERSION}.0" >> $GITHUB_OUTPUT
         env:
           TAG_NAME: ${{ github.event.release.tag_name || github.ref_name }}
 
@@ -178,7 +181,7 @@ jobs:
           client-id: ${{ secrets.STORE_CLIENT_ID }}
           client-secret: ${{ secrets.STORE_CLIENT_SECRET }}
           app-id: ${{ secrets.STORE_APP_ID }}
-          package-path: "https://github.com/esoltys/luminous/releases/download/v${{ steps.get_version.outputs.version }}/Luminous_${{ steps.get_version.outputs.version }}_x64.msix"
+          package-path: "https://github.com/esoltys/luminous/releases/download/v${{ steps.get_version.outputs.version }}/LuminousMusicPlayer_${{ steps.get_version.outputs.msix_version }}_x64.msix"
 
 
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,14 +69,14 @@ jobs:
       # couple of times before giving up.
       - name: Build and Release
         uses: Wandalen/wretry.action@v3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
           action: tauri-apps/tauri-action@v0
           attempt_limit: 3
           attempt_delay: 15000
-          env: |
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-            TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
-            TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
           with: |
             tagName: ${{ steps.tag.outputs.tag }}
             releaseName: 'Luminous ${{ steps.tag.outputs.tag }}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,18 +9,53 @@ on:
   workflow_dispatch:
 
 jobs:
+  create-release:
+    if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) || github.event_name == 'workflow_dispatch'
+    permissions:
+      contents: write
+    runs-on: ubuntu-24.04
+    outputs:
+      tag: ${{ steps.tag.outputs.tag }}
+      release_id: ${{ steps.release.outputs.id }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Determine Release Tag
+        id: tag
+        shell: bash
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            TAG="${GITHUB_REF#refs/tags/}"
+          else
+            VERSION=$(node -p "require('./package.json').version")
+            TAG="v${VERSION}"
+          fi
+          echo "tag=${TAG}" >> $GITHUB_OUTPUT
+
+      # Create the draft release once, up front, so both matrix legs below
+      # can run in parallel and upload into the same release instead of each
+      # racing to create their own draft (split assets, incompatible updater
+      # manifests — this bit us in v0.99.2).
+      - name: Create or reuse draft release
+        id: release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.tag.outputs.tag }}
+          name: 'Luminous ${{ steps.tag.outputs.tag }}'
+          body: 'Release of Luminous ${{ steps.tag.outputs.tag }}.'
+          draft: true
+          prerelease: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   release:
+    needs: create-release
     if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) || github.event_name == 'workflow_dispatch'
     permissions:
       contents: write
     strategy:
       fail-fast: false
-      # Serialized (not parallel): tauri-action creates the draft release if
-      # it doesn't exist yet, and both platforms running at once raced to
-      # create two separate drafts with split assets and incompatible
-      # updater manifests (v0.99.2). Running one platform at a time means
-      # the second always finds and reuses the first's draft.
-      max-parallel: 1
       matrix:
         platform: [ubuntu-24.04, windows-latest]
 
@@ -42,18 +77,6 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y libwebkit2gtk-4.1-dev libasound2-dev libssl-dev pkg-config libayatana-appindicator3-dev librsvg2-dev
-
-      - name: Determine Release Tag
-        id: tag
-        shell: bash
-        run: |
-          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
-            TAG="${GITHUB_REF#refs/tags/}"
-          else
-            VERSION=$(node -p "require('./package.json').version")
-            TAG="v${VERSION}"
-          fi
-          echo "tag=${TAG}" >> $GITHUB_OUTPUT
 
       - name: Cache Tauri bundler tools (NSIS/WiX)
         if: matrix.platform == 'windows-latest'
@@ -78,10 +101,8 @@ jobs:
           attempt_limit: 3
           attempt_delay: 15000
           with: |
-            tagName: ${{ steps.tag.outputs.tag }}
-            releaseName: 'Luminous ${{ steps.tag.outputs.tag }}'
-            releaseBody: 'Release of Luminous ${{ steps.tag.outputs.tag }}.'
-            releaseDraft: true
+            releaseId: ${{ needs.create-release.outputs.release_id }}
+            tagName: ${{ needs.create-release.outputs.tag }}
             prerelease: false
 
       - name: Build MSIX Package (Windows)
@@ -99,7 +120,7 @@ jobs:
         if: matrix.platform == 'windows-latest'
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ steps.tag.outputs.tag }}
+          tag_name: ${{ needs.create-release.outputs.tag }}
           files: |
             target/msix/*.msix
             target/msix/*.msixbundle

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2984,7 +2984,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "luminous"
-version = "0.99.2"
+version = "0.99.3"
 dependencies = [
  "anyhow",
  "bs1770",

--- a/docs/release-notes/v0.99.3.md
+++ b/docs/release-notes/v0.99.3.md
@@ -1,0 +1,21 @@
+# Release Notes - Luminous v0.99.3
+
+Infrastructure-only patch release fixing the Windows release build; no user-facing
+changes.
+
+### 🛠️ Other Improvements
+- **Windows Release Build Fixed**: The Windows NSIS installer build was failing on
+  transient `503`s from the upstream NSIS toolchain download on GitHub, and the
+  separate MSIX (Microsoft Store) build was failing to find its compiled binary
+  because the bundler assumed the Rust `target/` directory lived under `src-tauri/`,
+  when this repo's Cargo workspace actually places it at the repo root. Both are now
+  fixed: the NSIS download step retries and caches the extracted toolchain, and the
+  MSIX build points `CARGO_TARGET_DIR` at the correct location.
+- **Linux and Windows Builds Run in Parallel Again**: The release matrix had been
+  serialized (one platform at a time) to avoid both platforms racing to create
+  separate draft GitHub releases, which split assets across two releases in v0.99.2.
+  The draft release is now created once, up front, in its own job, and both
+  platforms upload into it — restoring parallel builds.
+
+This release exists to validate the fixed pipeline and unblock the pending Winget and
+Microsoft Store submissions. There are no changes to the app itself.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "luminous",
-  "version": "0.99.2",
+  "version": "0.99.3",
   "description": "A high-performance home for the music you already own",
   "author": "Eric James Soltys <ericjamessoltys@outlook.com>",
   "license": "MIT",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "luminous"
-version = "0.99.2"
+version = "0.99.3"
 description = "A high-performance home for the music you already own"
 authors = ["Eric James Soltys <ericjamessoltys@outlook.com>"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Luminous Music Player",
   "mainBinaryName": "LuminousMusicPlayer",
-  "version": "0.99.2",
+  "version": "0.99.3",
   "identifier": "org.luminous.music",
   "build": {
     "beforeDevCommand": "bun run dev",


### PR DESCRIPTION
## Summary
Re-adds the winget and Microsoft Store publishing jobs (split out of #387) with their asset URLs fixed to match the LuminousMusicPlayer_* naming the build now actually produces (was still Luminous_*, and the MSIX path was also missing the four-part version padding tauri-windows-bundle applies).

## Status
**Draft - holding until:**
- The winget submission (EricSoltys.Luminous) is approved
- The Microsoft Store submission is approved and STORE_TENANT_ID / STORE_CLIENT_ID /  STORE_CLIENT_SECRET / STORE_APP_ID secrets are populated

Until then these jobs are absent from release.yml (removed in #387) so failing/missing secrets don't turn every release run red.