### PR TITLE
fix: keep release draft when uploading MSIX assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,6 +124,9 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ needs.create-release.outputs.tag }}
+          # softprops/action-gh-release publishes the release if `draft` is
+          # omitted - it doesn't preserve the existing draft state.
+          draft: true
           files: |
             target/msix/*.msix
             target/msix/*.msixbundle


### PR DESCRIPTION
## Summary
The "Upload MSIX to Release Assets" step (softprops/action-gh-release, windows-only)
didn't set \`draft: true\`, and that action publishes the release if \`draft\` is omitted
- it doesn't preserve whatever draft state the release already had. This ran right
after tauri-action correctly kept v0.99.3 as a draft, un-publishing it moments later.

Confirmed live: v0.99.3 was published prematurely by exactly this step. GitHub doesn't
allow re-drafting an already-published release via the API, so that one's stuck
published (harmless - assets are correct), but this fix prevents it going forward.

## Test plan
- [x] Reproduced live on v0.99.3's real tag-push release run
- [ ] Next tagged release stays a draft through both matrix legs