### PR TITLE
fix: use Partner Center package identity for MSIX Windows build

### DIFF
--- a/src-tauri/tauri.windows.conf.json
+++ b/src-tauri/tauri.windows.conf.json
@@ -1,3 +1,3 @@
 {
-  "productName": "LuminousMusicPlayer"
+  "identifier": "39231EricJamesSoltys.LuminousMusicPlayer"
 }


### PR DESCRIPTION
## 📋 Summary
Fixes the Partner Center MSIX validation errors on submission:
- `Invalid package identity name: org.luminous.music (expected: 39231EricJamesSoltys.LuminousMusicPlayer)`
- `Invalid package family name: org.luminous.music_3cwpgnyg4f1v8 (expected: 39231EricJamesSoltys.LuminousMusicPlayer_3cwpgnyg4f1v8)`
- `This package's manifest (Package/Properties/DisplayName) uses a display name that you have not reserved: LuminousMusicPlayer`

## 🔍 Implementation Notes
`tauri-windows-bundle` maps `tauri.conf.json`'s `identifier` straight into the MSIX manifest's `Package/Identity/Name`, and `productName` straight into `Package/Properties/DisplayName`.

`src-tauri/tauri.windows.conf.json` previously overrode `productName` to `LuminousMusicPlayer` (no space) purely to avoid spaces in the compiled binary's filename. That's unnecessary — `mainBinaryName` (base `tauri.conf.json`) and the Cargo `[[bin]] name` already pin the binary filename to `LuminousMusicPlayer` independently of `productName`. Dropping the override lets `DisplayName` fall back to the base config's `Luminous Music Player`, which matches the name reserved in Partner Center (reservations are on the *display* name — package identity is a separate, always-space-free internal identifier).

Also added an `identifier` override (Windows-only, via JSON merge patch) set to `39231EricJamesSoltys.LuminousMusicPlayer` — the exact package identity name Partner Center assigned for this app (visible on the app's "App identity" page). The base `identifier` (`org.luminous.music`) stays reverse-DNS style for Linux packaging (desktop file id, AppStream metainfo), since that value doesn't need to match a Store-assigned identity.

## 🧪 Test Plan
- [ ] `bun run check` (svelte-check) — no Rust/JS logic changed, config-only
- [ ] `bun run test -- --run` (frontend) — n/a, config-only
- [ ] `cargo test` (src-tauri) — n/a, config-only
- [x] Verified via `tauri-windows-bundle` source (upstream repo) that `PACKAGE_NAME` ← `identifier` and `DISPLAY_NAME` ← `productName`, and confirmed via `git blame` that the `productName` override was added only to avoid binary-path spaces (already handled by `mainBinaryName`/`[[bin]] name`)
- [ ] Full verification requires an actual Windows CI MSIX build + Partner Center submission, which isn't possible in this session

## ✅ Checklist
- [x] No unrelated changes bundled in
- [ ] Docs/screenshots updated if user-facing behavior changed — n/a, no user-facing behavior change


---
_Generated by [Claude Code](https://claude.ai/code/session_01EmaFuXMX4LCcQd4nmR9i9A)_