### PR TITLE
chore(release): bump version to 0.99.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2984,7 +2984,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "luminous"
-version = "0.99.3"
+version = "0.99.4"
 dependencies = [
  "anyhow",
  "bs1770",

--- a/docs/release-notes/v0.99.4.md
+++ b/docs/release-notes/v0.99.4.md
@@ -1,0 +1,16 @@
+# Release Notes - Luminous v0.99.4
+
+Infrastructure-only patch release fixing the Microsoft Store (MSIX) package identity;
+no user-facing changes.
+
+### 🛠️ Other Improvements
+- **MSIX Package Identity Fixed**: v0.99.3's MSIX build used `org.luminous.music` as the
+  package identity and a space-free `LuminousMusicPlayer` display name, which Partner
+  Center rejected — it didn't match the identity (`39231EricJamesSoltys.LuminousMusicPlayer`)
+  and reserved display name (`Luminous Music Player`) assigned to this app. The Windows
+  build now uses the correct identity, and the display name override that stripped the
+  space has been removed (it was unnecessary — the binary filename is already pinned via
+  `mainBinaryName`).
+
+This release exists to unblock the pending Microsoft Store submission. There are no
+changes to the app itself.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "luminous",
-  "version": "0.99.3",
+  "version": "0.99.4",
   "description": "A high-performance home for the music you already own",
   "author": "Eric James Soltys <ericjamessoltys@outlook.com>",
   "license": "MIT",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "luminous"
-version = "0.99.3"
+version = "0.99.4"
 description = "A high-performance home for the music you already own"
 authors = ["Eric James Soltys <ericjamessoltys@outlook.com>"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Luminous Music Player",
   "mainBinaryName": "LuminousMusicPlayer",
-  "version": "0.99.3",
+  "version": "0.99.4",
   "identifier": "org.luminous.music",
   "build": {
     "beforeDevCommand": "bun run dev",


### PR DESCRIPTION
## 📋 Summary
`v0.99.3`'s MSIX build was published with the broken package identity (`org.luminous.music` / no-space display name), which #405 fixed on `main` — but only after the `v0.99.3` tag/release was already published with the broken artifacts. Rather than force-moving the already-published `v0.99.3` tag (blocked in this session anyway — no permission to force-push tags, and no GitHub API tool for updating refs), this cuts a real `0.99.4` patch release so the tag accurately reflects what's in the build.

## 🔍 Implementation Notes
- Ran `bun run scripts/bump-version.ts 0.99.4` (updates `package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`) and `cargo update -p luminous --precise 0.99.4` to sync `Cargo.lock`.
- Added `docs/release-notes/v0.99.4.md` following the existing release-notes convention, describing the MSIX identity fix.
- No app code changed — this is purely a version bump to get a clean tag/release for the Store submission.

## 🧪 Test Plan
- [x] Verified only version fields changed (`git diff`), no other files reference `0.99.3`
- [ ] `bun run check` (svelte-check) — n/a, no code changed
- [ ] `bun run test -- --run` (frontend) — n/a, no code changed
- [ ] `cargo test` (src-tauri) — n/a, no code changed
- [ ] Full verification requires the release workflow to actually build and publish `v0.99.4`, which isn't possible in this session

## ✅ Checklist
- [x] No unrelated changes bundled in
- [ ] Docs/screenshots updated if user-facing behavior changed — n/a, no user-facing behavior change


---
_Generated by [Claude Code](https://claude.ai/code/session_01EmaFuXMX4LCcQd4nmR9i9A)_