### PR TITLE
docs: reference PR #405 in v0.99.4 release notes

### DIFF
--- a/docs/release-notes/v0.99.4.md
+++ b/docs/release-notes/v0.99.4.md
@@ -10,7 +10,7 @@ no user-facing changes.
   and reserved display name (`Luminous Music Player`) assigned to this app. The Windows
   build now uses the correct identity, and the display name override that stripped the
   space has been removed (it was unnecessary — the binary filename is already pinned via
-  `mainBinaryName`).
+  `mainBinaryName`) (#405).
 
 This release exists to unblock the pending Microsoft Store submission. There are no
 changes to the app itself.


### PR DESCRIPTION
## 📋 Summary
Small follow-up to #406 — adds a `(#405)` reference to `docs/release-notes/v0.99.4.md`, matching the convention used in every prior release-notes file (e.g. `(#387)` in v0.99.3's notes).

## 🔍 Implementation Notes
Docs-only change, no code touched.

## 🧪 Test Plan
- [x] N/A — markdown-only change

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs updated (this PR *is* the docs update)


---
_Generated by [Claude Code](https://claude.ai/code/session_01EmaFuXMX4LCcQd4nmR9i9A)_