### PR TITLE
fix: don't treat Microsoft Store (MSIX) installs as self-updatable

### DIFF
--- a/src-tauri/src/install_format.rs
+++ b/src-tauri/src/install_format.rs
@@ -99,6 +99,20 @@ pub fn detect_install_format() -> InstallFormatInfo {
     {
         if let Ok(exe_path) = env::current_exe() {
             let path_lower = exe_path.to_string_lossy().to_lowercase();
+            // MSIX/Store installs live under `...\WindowsApps\<PackageFamilyName>_...\`,
+            // a system-protected, read-only directory the in-app updater can't write to.
+            // The Store owns updates for these installs, so the downloaded installer can
+            // never actually take effect — without this check the app would keep seeing
+            // itself as out-of-date and re-download/re-"install" the same build on every
+            // launch.
+            if path_lower.contains("\\windowsapps\\") {
+                return InstallFormatInfo {
+                    format: "msix".to_string(),
+                    human_name: "Microsoft Store".to_string(),
+                    supports_self_update: false,
+                };
+            }
+
             if path_lower.contains("appdata\\local\\programs")
                 || path_lower.contains("program files")
             {

--- a/src/lib/components/FoldersView.svelte
+++ b/src/lib/components/FoldersView.svelte
@@ -128,6 +128,7 @@
   function getFormatName(fmt: string, fallback: string): string {
     switch (fmt) {
       case "windows_setup": return i18n.t('settings.formatWindowsSetup', {}, fallback);
+      case "msix": return i18n.t('settings.formatMsix', {}, fallback);
       case "appimage": return i18n.t('settings.formatAppImage', {}, fallback);
       case "deb": return i18n.t('settings.formatDeb', {}, fallback);
       case "rpm": return i18n.t('settings.formatRpm', {}, fallback);

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -238,6 +238,7 @@ export const en = {
     updateInstallError: "Update failed.",
     updateRetryBtn: "Retry",
     formatWindowsSetup: "Windows Installer (.exe / .msi)",
+    formatMsix: "Microsoft Store",
     formatAppImage: "Linux AppImage",
     formatDeb: "Debian Package (.deb)",
     formatRpm: "RPM Package (.rpm)",

--- a/src/lib/locales/fr.ts
+++ b/src/lib/locales/fr.ts
@@ -238,6 +238,7 @@ export const fr = {
     updateInstallError: "Échec de la mise à jour.",
     updateRetryBtn: "Réessayer",
     formatWindowsSetup: "Installeur Windows (.exe / .msi)",
+    formatMsix: "Microsoft Store",
     formatAppImage: "AppImage Linux",
     formatDeb: "Paquet Debian (.deb)",
     formatRpm: "Paquet RPM (.rpm)",


### PR DESCRIPTION
## 📋 Summary
`get_install_format()` on Windows only ever returned `windows_setup` with `supports_self_update: true` — even for Microsoft Store/MSIX installs living under `...\WindowsApps\`. That directory is read-only and Store-managed, so the in-app updater's downloaded installer can never actually replace the running build; the app would keep seeing itself as out of date and try to re-"install" the same version on every launch. Same category of bug as #411 (AppImage), just for MSIX.

## 🔍 Implementation Notes
- Detects the `\WindowsApps\` path segment and reports `format: "msix"` / `supports_self_update: false`, matching how Flatpak/Snap are already handled on Linux.
- Added the `msix` case to `FoldersView.svelte`'s format label switch and `en.ts`/`fr.ts` locale strings ("Microsoft Store").

## 🧪 Test Plan
- [x] `bun run test -- --run` (frontend) — 347 passed
- [ ] `cargo test` (src-tauri) — couldn't run in this sandbox (missing system GTK/WebKit dev packages unrelated to this change); the touched code is `#[cfg(target_os = "windows")]`-gated and unreachable on this Linux box regardless
- [ ] Manually verified in the app

## ✅ Checklist
- [x] No unrelated changes bundled in


---
_Generated by [Claude Code](https://claude.ai/code/session_011aHWBt3ERFLARJG6Qcirab)_