### PR TITLE
fix: hide the update-check settings pane for Microsoft Store installs

### DIFF
--- a/src/lib/components/FoldersView.svelte
+++ b/src/lib/components/FoldersView.svelte
@@ -433,6 +433,7 @@
         </div>
       </div>
 
+      {#if !updaterStore.isStoreManaged}
       <div class="bg-brand-sidebar border border-brand-border rounded-xl p-6 space-y-5">
         <div class="pb-4 border-b border-brand-border/50 flex items-center justify-between gap-4">
           <div class="flex items-center gap-3 min-w-0">
@@ -580,6 +581,7 @@
           </button>
         </div>
       </div>
+      {/if}
     {:else if settingsTab === "folders"}
       <div class="bg-brand-sidebar border border-brand-border rounded-xl p-6 space-y-4">
         <div class="pb-3 flex justify-between items-center">

--- a/src/lib/stores/updater.svelte.ts
+++ b/src/lib/stores/updater.svelte.ts
@@ -49,6 +49,14 @@ class UpdaterStore {
     return this.updateAutoInstall ? "auto" : "notify";
   }
 
+  // Microsoft Store (MSIX) installs are updated by the Store, not by us —
+  // GitHub releases aren't even the same artifact stream. The whole
+  // check/notify/auto-install UI is meaningless there, so callers use this
+  // to hide it rather than rendering a control panel with nothing it can do.
+  get isStoreManaged(): boolean {
+    return this.installFormat.format === "msix";
+  }
+
   installStatus = $state<InstallStatus>("idle");
   downloadProgress = $state<DownloadProgress | null>(null);
 
@@ -61,7 +69,24 @@ class UpdaterStore {
     this.initialized = true;
 
     try {
-      // 1. Load preferences
+      // 1. Fetch install format from backend
+      try {
+        const fmt = await invoke<InstallFormatInfo>("get_install_format");
+        if (fmt) {
+          this.installFormat = fmt;
+        }
+      } catch (err) {
+        console.error("Failed to detect install format:", err);
+      }
+
+      // Store-managed installs never check or install updates themselves —
+      // stored preferences are irrelevant, and there's nothing to poll for.
+      if (this.isStoreManaged) {
+        this.updateCheckEnabled = false;
+        return;
+      }
+
+      // 2. Load preferences
       const settings = await invoke<Record<string, string>>("get_all_app_settings");
       if (settings?.update_check_enabled === "false") {
         this.updateCheckEnabled = false;
@@ -70,16 +95,6 @@ class UpdaterStore {
       }
       if (settings?.update_auto_install === "true") {
         this.updateAutoInstall = true;
-      }
-
-      // 2. Fetch install format from backend
-      try {
-        const fmt = await invoke<InstallFormatInfo>("get_install_format");
-        if (fmt) {
-          this.installFormat = fmt;
-        }
-      } catch (err) {
-        console.error("Failed to detect install format:", err);
       }
 
       // 3. Perform check & setup interval if enabled
@@ -148,6 +163,8 @@ class UpdaterStore {
   }
 
   async checkForUpdates() {
+    if (this.isStoreManaged) return;
+
     this.checkStatus = "checking";
     this.errorMessage = null;
     this.installStatus = "idle";

--- a/src/lib/stores/updater.test.ts
+++ b/src/lib/stores/updater.test.ts
@@ -161,6 +161,43 @@ describe("UpdaterStore", () => {
     expect(updaterStore.lastCheckedAt).toBe(null);
   });
 
+  describe("isStoreManaged", () => {
+    it("is true only for msix installs", () => {
+      updaterStore.installFormat = { format: "msix", human_name: "Microsoft Store", supports_self_update: false };
+      expect(updaterStore.isStoreManaged).toBe(true);
+
+      updaterStore.installFormat = { format: "windows_setup", human_name: "Windows Installer (.exe / .msi)", supports_self_update: true };
+      expect(updaterStore.isStoreManaged).toBe(false);
+    });
+
+    it("init() disables checking and never calls the updater plugin for msix", async () => {
+      const { invoke } = await import("@tauri-apps/api/core");
+      vi.mocked(invoke).mockImplementation((cmd: string) => {
+        if (cmd === "get_install_format") {
+          return Promise.resolve({ format: "msix", human_name: "Microsoft Store", supports_self_update: false });
+        }
+        return Promise.resolve({});
+      });
+
+      await updaterStore.init();
+      await Promise.resolve();
+
+      expect(updaterStore.updateCheckEnabled).toBe(false);
+      expect(updaterStore.isStoreManaged).toBe(true);
+      expect(check).not.toHaveBeenCalled();
+    });
+
+    it("checkForUpdates() is a no-op for msix even if called directly", async () => {
+      updaterStore.installFormat = { format: "msix", human_name: "Microsoft Store", supports_self_update: false };
+      vi.mocked(check).mockResolvedValueOnce(fakeUpdate());
+
+      await updaterStore.checkForUpdates();
+
+      expect(check).not.toHaveBeenCalled();
+      expect(updaterStore.checkStatus).toBe("idle");
+    });
+  });
+
   describe("updatePolicy", () => {
     it("derives never/notify/auto from the underlying toggles", () => {
       updaterStore.updateCheckEnabled = false;


### PR DESCRIPTION
## 📋 Summary
Follow-up to #416. The Never/Notify/Auto-install card in Settings → Application checks GitHub releases and offers a "Download from GitHub" fallback — neither makes sense for a Microsoft Store (MSIX) install:

- The Store manages updates on its own schedule, independent of GitHub releases.
- The GitHub-download fallback would let a Store user run the NSIS/MSI installer and end up with a duplicate side-by-side install — exactly the bug this branch started from (productName rename orphaning the NSIS upgrade path), just self-inflicted via our own UI this time.
- We can't link out to the Store listing yet since it isn't published.

So for `format === "msix"`, hide the whole card rather than showing controls that do nothing useful.

## 🔍 Implementation Notes
- `updater.svelte.ts`: added `UpdaterStore.isStoreManaged` (`installFormat.format === "msix"`). `init()` now fetches the install format first; for store-managed installs it forces `updateCheckEnabled = false` and returns before ever loading/touching the `update_check_enabled`/`update_auto_install` preferences or calling the updater plugin. `checkForUpdates()` also bails immediately if store-managed, as a defensive guard in case it's ever called directly.
- `FoldersView.svelte`: wrapped the update card in `{#if !updaterStore.isStoreManaged}`.
- The separate "Updated to Luminous" celebration toast (shown after any version bump, Store-driven or not) is untouched — that's expected to still fire for Store updates.

## 🧪 Test Plan
- [x] `bun run test -- --run` (frontend) — 350 passed, added 3 new cases covering `isStoreManaged`, that `init()` never calls the updater plugin for msix, and that `checkForUpdates()` is a no-op for msix
- [ ] `cargo test` (src-tauri) — no Rust changes in this PR
- [ ] Manually verified in the app

## ✅ Checklist
- [x] No unrelated changes bundled in


---
_Generated by [Claude Code](https://claude.ai/code/session_011aHWBt3ERFLARJG6Qcirab)_