### PR TITLE
fix: declare broadFileSystemAccess in MSIX manifest

### DIFF
--- a/src-tauri/gen/windows/bundle.config.json
+++ b/src-tauri/gen/windows/bundle.config.json
@@ -4,6 +4,9 @@
   "capabilities": {
     "general": [
       "internetClient"
+    ],
+    "restricted": [
+      "broadFileSystemAccess"
     ]
   },
   "extensions": {


### PR DESCRIPTION
## 📋 Summary
Declares the `broadFileSystemAccess` restricted capability in the MSIX manifest config (`src-tauri/gen/windows/bundle.config.json`), which is read by `@choochmeque/tauri-windows-bundle` at build time via `bun run tauri:windows:build`.

Without it, library folders outside the well-known Music/Documents/Pictures/Videos/Downloads folders (e.g. `D:\MusicLibrary`, a NAS share mapped to a drive letter) only get filesystem access for the app session in which they were picked via the native folder dialog. On the next app restart, Luminous's background directory watcher (`notify`, started unconditionally in `src-tauri/src/lib.rs` on startup) and its rescans (`walkdir` in `src-tauri/src/collection.rs`) reopen those paths as plain filesystem calls with no re-acquired access token. Under the MSIX sandbox that fails silently — the errors are swallowed (`let _ = watcher.watch(...)`) — so the library just quietly stops picking up changes in those folders with no error shown to the user.

## 🔍 Implementation Notes
- Single-line addition to the `capabilities` block in `src-tauri/gen/windows/bundle.config.json`; the `tauri-windows-bundle` template renders this straight into `<rescap:Capability Name="broadFileSystemAccess">` in the generated `AppxManifest.xml`.
- No Rust or frontend code changes — this capability makes the existing plain `std::fs`/`walkdir`/`notify` calls work for arbitrary local and drive-mapped paths without needing a `StorageApplicationPermissions.FutureAccessList` token round-trip.
- `runFullTrust` is auto-added by the bundler regardless; this only adds the restricted capability.
- Declaring a restricted capability requires a written justification in Microsoft Partner Center at submission time and typically adds review scrutiny. Suggested justification text, included here for reuse when submitting/resubmitting:

  > Luminous is a local music player where the core feature is letting the user point the app at any folder on their system (internal drives, external drives, or network shares mapped as a drive letter) to build their music library. The app persistently rescans and watches these user-selected folders for changes across app restarts. Because these folders are frequently outside the OS's well-known media locations (Music, Documents, Pictures, Videos, Downloads), the app requires broad file system access to reliably read the user's chosen library folders and detect file changes (adds, removes, edits, tag updates) after every launch, not just in the session where the folder was originally selected via the picker.

- This repo's current Store submission is in Partner Center certification with this gap already present; this fix targets the next point release so it's ready ahead of/after that cert result rather than requiring a from-scratch resubmission.

## 🧪 Test Plan
- [ ] `bun run check` (svelte-check) — not applicable, no frontend/type changes
- [ ] `bun run test -- --run` (frontend) — not applicable, no frontend changes
- [ ] `cargo test` (src-tauri, if Rust changed) — not applicable, no Rust changes
- [x] Verified by extracting `@choochmeque/tauri-windows-bundle@0.1.28` from npm and tracing `generateManifest()`/`generateCapabilities()` in `dist/index.js` to confirm `bundle.config.json`'s `capabilities.restricted` array is validated against `RESTRICTED_CAPABILITIES` (which includes `broadFileSystemAccess`) and rendered into the `AppxManifest.xml` template's `{{CAPABILITIES}}` placeholder as `<rescap:Capability Name="broadFileSystemAccess" />`.
- [ ] Full MSIX build + install verification on Windows (not possible from this environment) — recommend a maintainer runs the "Build MSIX Package (Windows)" CI job or a local `tauri-windows-bundle build` and inspects the generated `AppxManifest.xml` before the next Store submission.

## ✅ Checklist
- [x] No unrelated changes bundled in
- [ ] Docs/screenshots updated if user-facing behavior changed — n/a, no user-facing UI change; only a packaging capability

---
_Generated by [Claude Code](https://claude.ai/code/session_012duUa1opWqSsT1qdFZ4khz)_