### PR TITLE
docs: document main/next branching model for 2.0 development

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -2,9 +2,9 @@ name: Security Audit
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "next" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "next" ]
   schedule:
     - cron: '0 0 * * 0' # Every Sunday at midnight
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,9 @@ name: "CodeQL Advanced"
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "next" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "next" ]
   schedule:
     - cron: '43 21 * * 6'
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,6 +158,20 @@ pkexec apt-get install -y libasound2-dev libssl-dev pkg-config
 - Database access uses indices, FTS5 for track/album search, and prepared statements.
 - Band waveform/FFT analysis runs on a background thread and must not block playback.
 
+## Branching Model
+
+- **`main`** is the rolling 1.x release line. Milestone-1 fixes (and any 1.x feature work) land
+  here and ship as rolling releases (1.1, 1.25, 1.44, etc.) per `docs/RELEASE_CHECKLIST.md`.
+- **`next`** is the long-lived 2.0 feature-integration branch. New stories tracked under the
+  "2.0" GitHub Milestone (see Issue Priority Labels below) target PRs at `next`, not `main`.
+  `next` is a branch name — don't confuse it with the "2.0" Milestone used for issue triage;
+  they're two different things that happen to be about the same release.
+- Keep `next` current by periodically merging `main` into it (`git merge origin/main`, no
+  automated sync) — at minimum before starting a new round of 2.0 work, and always right before
+  eventually merging `next` back into `main`.
+- When the "2.0" Milestone's issues are done, `next` merges into `main` via PR and becomes the
+  new baseline. A fresh `next` (or renamed successor) gets cut for whatever comes after that.
+
 ## Issue Priority Labels
 
 Open issues in the "2.0" milestone carry a `P1`–`P4` label indicating priority for work after


### PR DESCRIPTION
## 📋 Summary
Sets up the branching strategy for parallel 1.x maintenance and 2.0 development, as discussed:
`main` keeps rolling forward with milestone-1 fixes/releases (1.1, 1.25, 1.44, …), while a new
long-lived `next` branch (already created and pushed) holds 2.0 feature work and periodically
merges in `main`'s fixes.

## 🔍 Implementation Notes
- Created and pushed `next` off `main`'s current tip — the 2.0 feature-integration branch.
- Named it `next` rather than `milestone-2`/`2.0` because AGENTS.md already documents an
  existing GitHub Milestone called **"2.0"** used for issue triage (P1–P4 labels). A same-named
  branch would collide with that in PR/issue references, so the branch and the Milestone stay
  clearly distinct.
- Added a `## Branching Model` section to `AGENTS.md` (just above `## Issue Priority Labels`,
  since that section already talks about the "2.0" Milestone) documenting: what `main` vs `next`
  are for, that new 2.0 stories PR into `next`, and the manual `git merge origin/main` sync
  cadence.
- Extended `.github/workflows/audit.yml` and `.github/workflows/codeql.yml` `push`/
  `pull_request` branch triggers to include `next`, so 2.0 PRs get the same security/dependency
  scanning `main` gets. `release.yml` is untouched — it triggers on `v*` tags regardless of
  branch, which is unaffected by this.
- Not done (no tool access to repo settings): mirroring `main`'s branch-protection rule
  (required PR review) onto `next`. That needs to be set up manually in Settings → Branches.

## 🧪 Test Plan
Docs/CI-config only, no app code changed.
- [x] Visually reviewed the `audit.yml`/`codeql.yml` diffs for YAML correctness
- [ ] `bun run check` (svelte-check) — N/A, no frontend changes
- [ ] `bun run test -- --run` (frontend) — N/A
- [ ] `cargo test` (src-tauri) — N/A
- [x] Confirmed `next` exists on origin and matches `main`'s tip at creation time

## 📸 Screenshots
N/A — no UI changes.

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs updated (this PR *is* the docs update)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FD6qvbGkMDtmU4dQaZHaww)_