### PR TITLE
chore: bump next branch version to 2.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2984,7 +2984,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "luminous"
-version = "0.99.5"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bs1770",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "luminous",
-  "version": "0.99.5",
+  "version": "2.0.0",
   "description": "A high-performance home for the music you already own",
   "author": "Eric James Soltys <ericjamessoltys@outlook.com>",
   "license": "MIT",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "luminous"
-version = "0.99.5"
+version = "2.0.0"
 description = "A high-performance home for the music you already own"
 authors = ["Eric James Soltys <ericjamessoltys@outlook.com>"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Luminous Music Player",
   "mainBinaryName": "LuminousMusicPlayer",
-  "version": "0.99.5",
+  "version": "2.0.0",
   "identifier": "org.luminous.music",
   "build": {
     "beforeDevCommand": "bun run dev",


### PR DESCRIPTION
## 📋 Summary
Bumps the version on `next` (the 2.0 feature-integration branch) to `2.0.0`, so 2.0 dev builds
are versioned ahead of the rolling 1.x line staying on `main`.

## 🔍 Implementation Notes
- Ran `bun run bump-version 2.0.0`, which updates `package.json`, `src-tauri/tauri.conf.json`,
  and `src-tauri/Cargo.toml` in one shot (per the script's own doc comment, "so a release
  doesn't miss one of them").
- Also regenerated the `luminous` package entry in `Cargo.lock` to match (via `cargo check`;
  only that one entry changed).
- Checked for any other static version references (MSIX/AppX manifest, README) — the only other
  hit is `src-tauri/gen/windows/AppxManifest.xml.template`, which uses a `{{VERSION}}` build-time
  placeholder sourced from `tauri.conf.json`, so nothing to edit there.

## 🧪 Test Plan
- [x] `bun run scripts/bump-version.ts 2.0.0` — ran clean, all three files updated
- [x] `cd src-tauri && cargo check` — attempted; failed on missing system deps
      (`gdk-3.0`/GTK) unrelated to this change, but not before Cargo resolved and rewrote
      `Cargo.lock`'s `luminous` entry to `2.0.0`
- [x] `grep` swept the repo for the old `0.99.5` version string — only remaining hits are
      historical files under `docs/release-notes/`, which shouldn't change
- [ ] `bun run check` / `bun run test -- --run` / smoke test — not run, no code changes beyond
      version strings

## 📸 Screenshots
N/A — no UI changes.

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots — N/A, version bump only

---
_Generated by [Claude Code](https://claude.ai/code/session_01FD6qvbGkMDtmU4dQaZHaww)_