### PR TITLE
fix: album year lost for ID3v2-tagged files after lofty 0.25 bump

### DIFF
--- a/src-tauri/src/collection.rs
+++ b/src-tauri/src/collection.rs
@@ -1910,9 +1910,10 @@ pub(crate) fn read_tags(path: &Path) -> Result<Song> {
         song.album = tag.album().map(|a| a.to_string());
         song.genre = tag.genre().map(|g| g.to_string());
         song.comment = tag.comment().map(|c| c.to_string());
-        song.year = tag
-            .get_string(ItemKey::Year)
-            .and_then(|s| s.trim().parse::<i32>().ok());
+        // `date()` checks ItemKey::RecordingDate (ID3v2 TDRC, MP4, Vorbis DATE)
+        // before falling back to ItemKey::Year (ID3v1 only) — using Year alone
+        // silently drops the year for every ID3v2-tagged file (#428).
+        song.year = tag.date().map(|d| d.year as i32);
         song.track = tag.track().map(|t| t as i32);
         song.disc = tag.disk().map(|d| d as i32);
 

--- a/src-tauri/src/collection.rs
+++ b/src-tauri/src/collection.rs
@@ -10,10 +10,11 @@ use crate::{
 };
 use anyhow::{Context, Result};
 use lofty::{
+    config::ParsingMode,
     file::TaggedFileExt,
     prelude::*,
     probe::Probe,
-    tag::{Accessor, ItemKey, Tag},
+    tag::{items::Timestamp, Accessor, ItemKey, Tag},
 };
 use notify::Watcher;
 use rayon::prelude::*;
@@ -1914,6 +1915,18 @@ pub(crate) fn read_tags(path: &Path) -> Result<Song> {
         // before falling back to ItemKey::Year (ID3v1 only) — using Year alone
         // silently drops the year for every ID3v2-tagged file (#428).
         song.year = tag.date().map(|d| d.year as i32);
+        // Original release date (ID3v2 TDOR, MP4/Vorbis equivalents) — used by
+        // decade auto-playlists as a fallback when `year` (the pressing's own
+        // date, e.g. a reissue) isn't set. Parsed the same relaxed way `date()`
+        // parses ItemKey::RecordingDate, since lofty has no Accessor helper for it.
+        song.originalyear = tag
+            .get_string(ItemKey::OriginalReleaseDate)
+            .and_then(|s| {
+                Timestamp::parse(&mut s.as_bytes(), ParsingMode::Relaxed)
+                    .ok()
+                    .flatten()
+            })
+            .map(|d| d.year as i32);
         song.track = tag.track().map(|t| t as i32);
         song.disc = tag.disk().map(|d| d as i32);
 

--- a/src-tauri/src/tageditor.rs
+++ b/src-tauri/src/tageditor.rs
@@ -174,8 +174,19 @@ pub fn write_tags(
     }
 
     if let Some(y) = year {
-        tag.insert_text(lofty::tag::ItemKey::Year, y.to_string());
+        // set_date() writes ItemKey::RecordingDate (ID3v2 TDRC, MP4, Vorbis
+        // DATE) — writing ItemKey::Year directly has no ID3v2 mapping and
+        // silently fails to produce a frame most players/taggers read (#428).
+        tag.set_date(lofty::tag::items::Timestamp {
+            year: y as u16,
+            month: None,
+            day: None,
+            hour: None,
+            minute: None,
+            second: None,
+        });
     } else {
+        tag.remove_date();
         tag.remove_key(lofty::tag::ItemKey::Year);
     }
 


### PR DESCRIPTION
## Summary
- The lofty 0.21→0.25 bump in #404 rewrote year-tag reading to use `ItemKey::Year` directly, but that key is only mapped for legacy ID3v1 tags — ID3v2 (nearly all MP3s) stores the year in `TDRC`, which lofty exposes as `ItemKey::RecordingDate`.
- Reads silently returned no year for ID3v2-tagged files. A subsequent library rescan then overwrote the DB's `year` column with those nulls (`upsert_song`'s unconditional `year=excluded.year`), wiping the year for most of a real library (~91% of songs in the reporting user's DB). Files on disk were never touched — the year tag is still there.
- The tag-editor write path had the mirror bug: `insert_text(ItemKey::Year, ...)` has no ID3v2 frame mapping, so manually re-entering a year through the app's tag editor didn't produce a standard, portable tag either.

## Fix
Both directions now go through lofty's `Accessor::date()` / `set_date()`, which already check `RecordingDate` before falling back to `Year` — matching the behavior of the pre-regression `Tag::year()` convenience method that #404 replaced.

## Test plan
- [x] `cargo check` / `cargo build` clean
- [x] Verified against a real affected library: confirmed via `exiftool` that a file reading `year = NULL` in the DB still has an intact `RecordingTime: 2024` ID3v2.4 tag on disk
- [ ] After merge: rescan a library with ID3v2-tagged files and confirm years repopulate
- [ ] Edit a year via the in-app tag editor and confirm a standard `TDRC` frame is written (verifiable with `exiftool`/Mp3tag)