### PR TITLE
feat: system tray icon with minimize-to-tray toggle and playback controls

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,7 +37,7 @@ jobs:
       if: matrix.language == 'rust' && runner.os == 'Linux'
       run: |
         sudo apt-get update
-        sudo apt-get install -y libasound2-dev libssl-dev pkg-config libglib2.0-dev libgtk-3-dev libwebkit2gtk-4.1-dev
+        sudo apt-get install -y libasound2-dev libssl-dev pkg-config libglib2.0-dev libgtk-3-dev libwebkit2gtk-4.1-dev libayatana-appindicator3-dev
 
     - name: Pre-build Rust dependencies & generated code
       if: matrix.language == 'rust'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,11 +67,12 @@ into Picard's territory; it's a different, complementary axis Picard was never m
 Required before `cargo check` / `bun run tauri dev`:
 
 ```bash
-pkexec apt-get install -y libasound2-dev libssl-dev pkg-config
+pkexec apt-get install -y libasound2-dev libssl-dev pkg-config libayatana-appindicator3-dev
 ```
 
 - `libasound2-dev` — ALSA headers needed by the `cpal` audio crate
 - `libssl-dev` — OpenSSL headers (needed by some Tauri transitive deps)
+- `libayatana-appindicator3-dev` — links the system tray icon (`tray-icon` Cargo feature)
 - `pkg-config` — used by build scripts to locate system libraries
 
 ## Quick Start Commands

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -584,6 +584,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
 name = "bytes"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2532,6 +2538,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "moxcms",
+ "num-traits",
+ "png 0.18.1",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3152,6 +3171,16 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
 ]
 
 [[package]]
@@ -4076,6 +4105,12 @@ checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "pxfm"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea"
 
 [[package]]
 name = "quick-xml"
@@ -5669,6 +5704,7 @@ dependencies = [
  "gtk",
  "heck 0.5.0",
  "http",
+ "image",
  "jni 0.21.1",
  "libc",
  "log",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -20,7 +20,9 @@ tauri-build = { version = "2", features = [] }
 # --- Tauri ---
 # "unstable" gates `Manager::get_window`, needed to reach the lower-level
 # `Window::start_resize_dragging` from a `WebviewWindow` command handler.
-tauri = { version = "2", features = ["unstable"] }
+# "tray-icon" is off by default; "image-png" lets tray.rs build the tray
+# icon from an embedded PNG via `Image::from_bytes`.
+tauri = { version = "2", features = ["unstable", "tray-icon", "image-png"] }
 tauri-runtime = "2"
 tauri-plugin-opener = "2"
 tauri-plugin-dialog = "2"

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -156,6 +156,39 @@ pub async fn get_all_app_settings(
     Ok(settings)
 }
 
+/// Reads the in-memory flag `tray.rs` already keeps in sync with the
+/// `app_state` row of the same name — no DB round-trip needed for the read.
+#[tauri::command]
+pub fn get_minimize_to_tray_enabled(state: State<'_, AppState>) -> bool {
+    state
+        .minimize_to_tray
+        .load(std::sync::atomic::Ordering::Relaxed)
+}
+
+/// Persists the setting and updates the in-memory flag `tray.rs`'s
+/// `CloseRequested` handler reads, so the new value takes effect on the
+/// very next window close — not just after a restart.
+#[tauri::command]
+pub async fn set_minimize_to_tray_enabled(
+    state: State<'_, AppState>,
+    enabled: bool,
+) -> Result<(), String> {
+    state
+        .minimize_to_tray
+        .store(enabled, std::sync::atomic::Ordering::Relaxed);
+    let Ok(conn) = state.db.pool.get() else {
+        log::error!("Failed to persist minimize_to_tray setting: no DB connection");
+        return Ok(());
+    };
+    if let Err(e) = conn.execute(
+        "INSERT OR REPLACE INTO app_state (key, value) VALUES ('minimize_to_tray', ?1)",
+        rusqlite::params![enabled.to_string()],
+    ) {
+        log::error!("Failed to persist minimize_to_tray setting: {e}");
+    }
+    Ok(())
+}
+
 #[tauri::command]
 pub fn get_commit_hash() -> String {
     option_env!("BUILD_COMMIT_HASH").unwrap_or("").to_string()

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -29,6 +29,7 @@ pub mod playlist;
 pub mod playlist_parsers;
 pub mod stats;
 pub mod tageditor;
+pub mod tray;
 pub mod waveform;
 
 use std::sync::Arc;
@@ -191,11 +192,7 @@ pub fn run() {
         .plugin(tauri_plugin_process::init())
         .plugin(build_prevent_default_plugin())
         .plugin(tauri_plugin_single_instance::init(|app, args, _cwd| {
-            if let Some(window) = app.get_webview_window("main") {
-                let _ = window.show();
-                let _ = window.unminimize();
-                let _ = window.set_focus();
-            }
+            tray::restore_main_window(app);
 
             // A file association (or `luminous <file>` invocation) launched a
             // second instance; forward the opened paths to the running app.
@@ -555,6 +552,10 @@ pub fn run() {
             crate::loudness::spawn_background_analyzer(app.handle().clone(), Arc::clone(&state.db));
 
             app.manage(state);
+
+            if let Err(e) = tray::init(app) {
+                log::warn!("Failed to initialize system tray: {e}");
+            }
 
             let media_shortcuts = [
                 "MediaPlayPause",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -63,6 +63,12 @@ pub struct AppState {
     /// integration failed to initialize (unsupported desktop, no session
     /// bus, etc), in which case Luminous simply runs without it.
     pub media_session: Option<media_session::MediaSessionHandle>,
+    /// Whether closing the main window hides it to the tray instead of
+    /// quitting (off by default — see `tray.rs`). An atomic rather than a DB
+    /// read on every close event, since `tray.rs`'s `CloseRequested` handler
+    /// needs this synchronously; kept in sync with the `app_state` row of
+    /// the same name by `commands::settings::set_minimize_to_tray_enabled`.
+    pub minimize_to_tray: Arc<std::sync::atomic::AtomicBool>,
 }
 
 /// Suppresses stock webview browser chrome — reload/find/print keybindings and
@@ -273,6 +279,18 @@ pub fn run() {
             }
 
             let audio = Arc::new(Mutex::new(audio_engine));
+
+            let minimize_to_tray = Arc::new(std::sync::atomic::AtomicBool::new(false));
+            if let Ok(conn) = db.pool.get() {
+                if let Ok(value) = conn.query_row(
+                    "SELECT value FROM app_state WHERE key = 'minimize_to_tray'",
+                    [],
+                    |row| row.get::<_, String>(0),
+                ) {
+                    minimize_to_tray
+                        .store(value == "true", std::sync::atomic::Ordering::Relaxed);
+                }
+            }
 
             let player = Arc::new(Mutex::new(Player::new(Arc::clone(&db), Arc::clone(&audio))));
             let volume_before_mute = Arc::new(Mutex::new(1.0));
@@ -544,6 +562,7 @@ pub fn run() {
                 watcher_paused,
                 startup_file: Mutex::new(startup_path),
                 media_session,
+                minimize_to_tray,
             };
 
             crate::collection::start_watcher(app.handle().clone(), &state);
@@ -766,6 +785,8 @@ pub fn run() {
             commands::settings::get_db_schema_status,
             commands::settings::get_fade_settings,
             commands::settings::set_fade_settings,
+            commands::settings::get_minimize_to_tray_enabled,
+            commands::settings::set_minimize_to_tray_enabled,
             install_format::get_install_format,
             // Stats commands
             commands::stats::set_song_rating,

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -1,10 +1,11 @@
 //! System tray icon: left-click toggles the main window, right-click shows a
-//! menu with playback controls, and closing the main window hides it instead
-//! of quitting (#tray). The close-to-tray hook is only registered once the
-//! tray itself has been built successfully, so a failed tray init (e.g. no
-//! notification host on a minimal Linux desktop) can't strand the window
-//! with no way to bring it back — the OS close button still quits normally
-//! in that case.
+//! menu with playback controls, and — when the "Minimize to tray" setting is
+//! on (off by default) — closing the main window hides it instead of
+//! quitting. The close-to-tray hook is only registered once the tray itself
+//! has been built successfully, so a failed tray init (e.g. no notification
+//! host on a minimal Linux desktop) can't strand the window with no way to
+//! bring it back — the OS close button always quits normally in that case,
+//! and also quits normally whenever the setting is off.
 //!
 //! Platform note: on Linux, `tray-icon`'s `TrayIconEvent` (including left
 //! click) is not emitted at all — a libappindicator limitation, not
@@ -69,8 +70,14 @@ pub fn init(app: &tauri::App) -> tauri::Result<()> {
         let app_handle = app.handle().clone();
         window.on_window_event(move |event| {
             if let tauri::WindowEvent::CloseRequested { api, .. } = event {
-                api.prevent_close();
-                hide_main_window(&app_handle);
+                let minimize_to_tray = app_handle
+                    .state::<AppState>()
+                    .minimize_to_tray
+                    .load(std::sync::atomic::Ordering::Relaxed);
+                if minimize_to_tray {
+                    api.prevent_close();
+                    hide_main_window(&app_handle);
+                }
             }
         });
     }

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -1,0 +1,222 @@
+//! System tray icon: left-click toggles the main window, right-click shows a
+//! menu with playback controls, and closing the main window hides it instead
+//! of quitting (#tray). The close-to-tray hook is only registered once the
+//! tray itself has been built successfully, so a failed tray init (e.g. no
+//! notification host on a minimal Linux desktop) can't strand the window
+//! with no way to bring it back — the OS close button still quits normally
+//! in that case.
+//!
+//! Platform note: on Linux, `tray-icon`'s `TrayIconEvent` (including left
+//! click) is not emitted at all — a libappindicator limitation, not
+//! something we can work around here. Any click on Linux falls through to
+//! the native context menu, where "Show/Hide Luminous" covers the same
+//! toggle. Left-click-to-toggle only fires on Windows/macOS.
+
+use crate::models::{PlayState, PlaybackState};
+use crate::AppState;
+use tauri::image::Image;
+use tauri::menu::{Menu, MenuItem, PredefinedMenuItem};
+use tauri::tray::{MouseButton, MouseButtonState, TrayIcon, TrayIconBuilder, TrayIconEvent};
+use tauri::{AppHandle, Emitter, Listener, Manager};
+
+const TRAY_ICON_BYTES: &[u8] = include_bytes!("../icons/32x32.png");
+
+pub fn init(app: &tauri::App) -> tauri::Result<()> {
+    let play_pause = MenuItem::with_id(app, "tray-play-pause", "Play/Pause", true, None::<&str>)?;
+    let next = MenuItem::with_id(app, "tray-next", "Next", true, None::<&str>)?;
+    let previous = MenuItem::with_id(app, "tray-previous", "Previous", true, None::<&str>)?;
+    let toggle_window = MenuItem::with_id(
+        app,
+        "tray-toggle-window",
+        "Show/Hide Luminous",
+        true,
+        None::<&str>,
+    )?;
+    let quit = MenuItem::with_id(app, "tray-quit", "Quit", true, None::<&str>)?;
+
+    let menu = Menu::with_items(
+        app,
+        &[
+            &play_pause,
+            &next,
+            &previous,
+            &PredefinedMenuItem::separator(app)?,
+            &toggle_window,
+            &PredefinedMenuItem::separator(app)?,
+            &quit,
+        ],
+    )?;
+
+    let tray = TrayIconBuilder::with_id("main-tray")
+        .icon(Image::from_bytes(TRAY_ICON_BYTES)?)
+        .tooltip("Luminous")
+        .menu(&menu)
+        .show_menu_on_left_click(false)
+        .on_menu_event(handle_menu_event)
+        .on_tray_icon_event(|tray, event| {
+            if let TrayIconEvent::Click {
+                button: MouseButton::Left,
+                button_state: MouseButtonState::Up,
+                ..
+            } = event
+            {
+                toggle_main_window(tray.app_handle());
+            }
+        })
+        .build(app)?;
+
+    if let Some(window) = app.get_webview_window("main") {
+        let app_handle = app.handle().clone();
+        window.on_window_event(move |event| {
+            if let tauri::WindowEvent::CloseRequested { api, .. } = event {
+                api.prevent_close();
+                hide_main_window(&app_handle);
+            }
+        });
+    }
+
+    seed_tooltip(app.handle().clone(), tray.clone());
+
+    app.listen("playback-state", move |event| {
+        if let Ok(state) = serde_json::from_str::<PlaybackState>(event.payload()) {
+            let _ = tray.set_tooltip(Some(&tooltip_text(&state)));
+        }
+    });
+
+    Ok(())
+}
+
+/// Shows, unminimizes, and focuses the main window. The single place every
+/// "bring Luminous back" path (tray left-click, tray menu, single-instance
+/// relaunch) routes through, so they all restore the macOS Dock icon the
+/// same way instead of only some of them remembering to.
+pub fn restore_main_window(app: &AppHandle) {
+    if let Some(window) = app.get_webview_window("main") {
+        let _ = window.show();
+        let _ = window.unminimize();
+        let _ = window.set_focus();
+    }
+    #[cfg(target_os = "macos")]
+    let _ = app.set_activation_policy(tauri::ActivationPolicy::Regular);
+}
+
+fn hide_main_window(app: &AppHandle) {
+    if let Some(window) = app.get_webview_window("main") {
+        let _ = window.hide();
+    }
+    #[cfg(target_os = "macos")]
+    let _ = app.set_activation_policy(tauri::ActivationPolicy::Accessory);
+}
+
+fn toggle_main_window(app: &AppHandle) {
+    let visible = app
+        .get_webview_window("main")
+        .and_then(|w| w.is_visible().ok())
+        .unwrap_or(false);
+    if visible {
+        hide_main_window(app);
+    } else {
+        restore_main_window(app);
+    }
+}
+
+/// Dispatches tray menu clicks. Play/Pause/Next/Previous go straight through
+/// `state.player`, mirroring the existing global media-key shortcut handler
+/// in `lib.rs` and `media_session::handle_event` — no IPC round-trip needed.
+fn handle_menu_event(app: &AppHandle, event: tauri::menu::MenuEvent) {
+    match event.id().as_ref() {
+        "tray-toggle-window" => return toggle_main_window(app),
+        "tray-quit" => return app.exit(0),
+        _ => {}
+    }
+
+    let app = app.clone();
+    let action = event.id().as_ref().to_string();
+    tauri::async_runtime::spawn(async move {
+        let state = app.state::<AppState>();
+        let mut player = state.player.lock().await;
+
+        let result = match action.as_str() {
+            "tray-play-pause" => {
+                if player.get_state().await.state == PlayState::Playing {
+                    player.pause().await
+                } else {
+                    player.resume().await
+                }
+            }
+            "tray-next" => {
+                if let Some(stats) = player.note_manual_skip() {
+                    let _ = app.emit("song-stats-changed", stats);
+                }
+                player.next_track().await
+            }
+            "tray-previous" => player.previous_track().await,
+            _ => Ok(()),
+        };
+
+        if result.is_ok() {
+            let playback_state = player.get_state().await;
+            crate::media_session::mirror_state(&app, &playback_state).await;
+            let _ = app.emit("playback-state", playback_state);
+        }
+    });
+}
+
+/// The tray tooltip only updates on `"playback-state"`, which fires on
+/// *changes* — so a track restored from a prior session at launch (loaded
+/// but not yet touched) wouldn't otherwise show up until the next
+/// play/pause/seek. Seed it once, right after the tray is built.
+fn seed_tooltip(app: AppHandle, tray: TrayIcon) {
+    tauri::async_runtime::spawn(async move {
+        let state = app.state::<AppState>();
+        let snapshot = state.player.lock().await.get_state().await;
+        let _ = tray.set_tooltip(Some(&tooltip_text(&snapshot)));
+    });
+}
+
+fn tooltip_text(state: &PlaybackState) -> String {
+    match &state.current_song {
+        Some(song) => match &song.artist {
+            Some(artist) => format!("{} — {}", song.display_title(), artist),
+            None => song.display_title().to_string(),
+        },
+        None => "Luminous".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::Song;
+
+    #[test]
+    fn tooltip_shows_title_and_artist() {
+        let state = PlaybackState {
+            current_song: Some(Song {
+                title: Some("Money".to_string()),
+                artist: Some("Pink Floyd".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        assert_eq!(tooltip_text(&state), "Money — Pink Floyd");
+    }
+
+    #[test]
+    fn tooltip_falls_back_to_title_only_without_artist() {
+        let state = PlaybackState {
+            current_song: Some(Song {
+                title: Some("Money".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        assert_eq!(tooltip_text(&state), "Money");
+    }
+
+    #[test]
+    fn tooltip_falls_back_to_app_name_when_idle() {
+        let state = PlaybackState::default();
+        assert_eq!(tooltip_text(&state), "Luminous");
+    }
+}

--- a/src/lib/components/FoldersView.svelte
+++ b/src/lib/components/FoldersView.svelte
@@ -431,6 +431,18 @@
             <option value="stars">{i18n.t('settings.ratingStyleStars')}</option>
           </Select>
         </div>
+
+        <div class="flex items-center justify-between gap-4 pt-4 border-t border-brand-border/50">
+          <div class="flex flex-col gap-0.5 min-w-0">
+            <span class="text-sm font-medium text-brand-text-primary">{i18n.t('settings.minimizeToTrayLabel')}</span>
+            <p class="text-xs text-brand-text-secondary">{i18n.t('settings.minimizeToTrayHint')}</p>
+          </div>
+          <Toggle
+            checked={prefs.minimizeToTray}
+            onchange={(v) => prefs.setMinimizeToTray(v)}
+            label={i18n.t('settings.minimizeToTrayLabel')}
+          />
+        </div>
       </div>
 
       {#if !updaterStore.isStoreManaged}

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -219,6 +219,8 @@ export const en = {
     ratingStyleHeart: "Heart (favourite)",
     ratingStyleStars: "5-star",
     ratingStyleHint: "Choose Heart to mark songs as favourites, or 5-star for half-step ratings — both save to the same rating.",
+    minimizeToTrayLabel: "Minimize to tray",
+    minimizeToTrayHint: "Closing the window hides Luminous to the system tray instead of quitting.",
     appAndUpdatesTitle: "Application & Updates",
     updateCheckNowBtn: "Check for Updates",
     updateChecking: "Checking...",

--- a/src/lib/locales/fr.ts
+++ b/src/lib/locales/fr.ts
@@ -219,6 +219,8 @@ export const fr = {
     ratingStyleHeart: "Cœur (favori)",
     ratingStyleStars: "5 étoiles",
     ratingStyleHint: "Choisissez Cœur pour marquer les chansons comme favorites, ou 5 étoiles pour des notes par demi-étoile — les deux utilisent la même note.",
+    minimizeToTrayLabel: "Réduire dans la barre système",
+    minimizeToTrayHint: "Fermer la fenêtre masque Luminous dans la barre système au lieu de quitter l'application.",
     appAndUpdatesTitle: "Application & Mises à jour",
     updateCheckNowBtn: "Rechercher des mises à jour",
     updateChecking: "Vérification...",

--- a/src/lib/stores/prefs.svelte.ts
+++ b/src/lib/stores/prefs.svelte.ts
@@ -24,6 +24,8 @@ class PrefsStore {
   artistsViewMode = $state<CollectionViewMode>("cards");
   playlistsAutoViewMode = $state<CollectionViewMode>("cards");
   playlistsCustomViewMode = $state<CollectionViewMode>("cards");
+  /** Off by default — closing the window quits unless explicitly opted in. */
+  minimizeToTray = $state<boolean>(false);
 
   async init() {
     const prefs = await invoke<UiPreferences>("get_ui_preferences");
@@ -34,6 +36,7 @@ class PrefsStore {
     this.artistsViewMode = prefs.artists_view_mode;
     this.playlistsAutoViewMode = prefs.playlists_auto_view_mode;
     this.playlistsCustomViewMode = prefs.playlists_custom_view_mode;
+    this.minimizeToTray = await invoke<boolean>("get_minimize_to_tray_enabled");
   }
 
   /** Persist the whole current state — fire-and-forget on the backend. */
@@ -83,6 +86,13 @@ class PrefsStore {
   setPlaylistsCustomViewMode(mode: CollectionViewMode) {
     this.playlistsCustomViewMode = mode;
     this.save();
+  }
+
+  /** Not part of `save()` — persisted via its own dedicated command so the
+   * backend's `tray.rs` close handler picks up the change immediately. */
+  setMinimizeToTray(enabled: boolean) {
+    this.minimizeToTray = enabled;
+    invoke("set_minimize_to_tray_enabled", { enabled });
   }
 }
 


### PR DESCRIPTION
## 📋 Summary
Fixes #438.

Adds a system tray icon: left-click toggles the main window (Windows/macOS), right-click shows a menu (Play/Pause, Next, Previous, Show/Hide Luminous, Quit), the tooltip shows the current track, and — when the new "Minimize to tray" toggle in Settings > General is on (**off by default**) — closing the main window hides it to the tray instead of quitting the app.

## 🔍 Implementation Notes
- New `src-tauri/src/tray.rs`. Menu actions (Play/Pause, Next, Previous) call straight into `state.player`, the same paths already used by the global media-key shortcuts (`lib.rs`) and OS media-session events (`media_session::handle_event`) — no new IPC round-trip, no capability/ACL changes, since the frontend never talks to the tray.
- Tooltip listens to the existing `"playback-state"` event (already emitted on every state change) rather than adding new plumbing, plus an explicit seed right after tray init so a track restored from a prior session shows up immediately.
- **Minimize-to-tray is a Settings > General toggle, off by default.** Closing the window quits normally unless a user opts in. The setting lives as an `AtomicBool` on `AppState` (`minimize_to_tray`) so `tray.rs`'s `CloseRequested` handler can read it synchronously with no DB round-trip; `set_minimize_to_tray_enabled` keeps it in sync with its `app_state` row so a toggle flip takes effect on the very next window close, not just after a restart. When the toggle is off (or tray init failed), the OS close button quits normally.
- `tauri-plugin-single-instance`'s relaunch callback now calls the same `tray::restore_main_window()` helper the tray itself uses, so both paths restore the macOS Dock icon consistently.
- Enabled Tauri's `tray-icon` (off by default) and `image-png` Cargo features; ships with the existing `icons/32x32.png` as the tray icon rather than a new asset.
- **Known platform limitation:** on Linux, `tray-icon`'s click events aren't emitted at all (an upstream `libappindicator` constraint) — left-click-to-toggle only works on Windows/macOS. Any click on Linux opens the context menu, where "Show/Hide Luminous" covers the same action.
- New Linux build dependency: `libayatana-appindicator3-dev` (already present in `release.yml`; added to `AGENTS.md` and `codeql.yml`, which were both missing it).

## 🧪 Test Plan
- [x] `cargo check` / `cargo clippy --lib` (src-tauri) — clean, after installing `libayatana-appindicator3-dev` locally
- [x] `cargo test --lib` — 127 passed, 1 pre-existing ignore, including 3 new unit tests for the tooltip fallback logic (title+artist / title-only / idle)
- [x] `bun run check` (svelte-check) — 0 errors
- [x] `bun run test -- --run` (frontend) — 352 passed
- [x] Manually verified in the app — not possible in this sandbox (no `$DISPLAY`/tray host); needs a pass on a real Windows/macOS/Linux desktop (see platform limitation note above for what to expect on Linux)

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs updated (`AGENTS.md`, `codeql.yml` system-dependency lists)