### PR TITLE
fix(window): prevent blank app when restored from minimized state (#441)

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -5,6 +5,7 @@
   "windows": ["main"],
   "permissions": [
     "core:default",
+    "core:window:allow-show",
     "opener:default",
     "dialog:default",
     "window-state:default",

--- a/src-tauri/src/commands/window.rs
+++ b/src-tauri/src/commands/window.rs
@@ -170,6 +170,10 @@ pub async fn move_window_to_preset(window: WebviewWindow, position: String) -> R
 
 #[tauri::command]
 pub async fn get_window_geometry(window: WebviewWindow) -> Result<serde_json::Value, String> {
+    if window.is_minimized().unwrap_or(false) {
+        return Ok(serde_json::Value::Null);
+    }
+
     let size = window.inner_size().map_err(|e| e.to_string())?;
     let pos = window.outer_position().ok();
     let scale_factor = window.scale_factor().unwrap_or(1.0);
@@ -183,6 +187,15 @@ pub async fn get_window_geometry(window: WebviewWindow) -> Result<serde_json::Va
         ),
         None => (None, None),
     };
+
+    // Ignore placeholder minimized sizes (0x0) or Win32 offscreen minimized coordinates (-32000)
+    if width <= 0.0
+        || height <= 0.0
+        || x.map_or(false, |coord| coord <= -10000.0)
+        || y.map_or(false, |coord| coord <= -10000.0)
+    {
+        return Ok(serde_json::Value::Null);
+    }
 
     Ok(serde_json::json!({
         "width": width,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -113,6 +113,26 @@ pub fn run() {
     #[cfg(target_os = "linux")]
     std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
 
+    // On Windows, Chromium's CalculateNativeWinOcclusion feature puts the
+    // WebView2 rendering pipeline into a suspended/discarded state when the
+    // window is minimized or occluded for a period of time. Upon restore,
+    // WebView2 fails to resume/repaint, leaving a blank window. Disabling
+    // native window occlusion calculation keeps the rendering context intact.
+    #[cfg(target_os = "windows")]
+    {
+        let key = "WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS";
+        let flag = "--disable-features=CalculateNativeWinOcclusion";
+        let current = std::env::var(key).unwrap_or_default();
+        if !current.contains(flag) {
+            let new_val = if current.is_empty() {
+                flag.to_string()
+            } else {
+                format!("{} {}", current, flag)
+            };
+            std::env::set_var(key, new_val);
+        }
+    }
+
     tauri::Builder::default()
         .register_uri_scheme_protocol("luminous-art", move |ctx, request| {
             let app_handle = ctx.app_handle();
@@ -185,7 +205,14 @@ pub fn run() {
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_global_shortcut::Builder::new().build())
         .plugin(tauri_plugin_notification::init())
-        .plugin(tauri_plugin_window_state::Builder::default().build())
+        .plugin(
+            tauri_plugin_window_state::Builder::default()
+                .with_state_flags(
+                    tauri_plugin_window_state::StateFlags::all()
+                        & !tauri_plugin_window_state::StateFlags::VISIBLE,
+                )
+                .build(),
+        )
         .plugin(tauri_plugin_positioner::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_process::init())

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -18,6 +18,7 @@
   import { prefs } from '../lib/stores/prefs.svelte';
   import { updaterStore } from '../lib/stores/updater.svelte';
   import { onMount } from 'svelte';
+  import { getCurrentWindow } from '@tauri-apps/api/window';
   import {
     SIDEBAR_MIN_WIDTH_PX,
     SIDEBAR_MAX_WIDTH_PX,
@@ -36,6 +37,7 @@
     i18n.init();
     prefs.init();
     updaterStore.init();
+    void getCurrentWindow().show().catch(() => {});
 
     function handleGlobalHotkeys(e: KeyboardEvent) {
       if (!(e.ctrlKey || e.metaKey)) return;


### PR DESCRIPTION
## 📋 Summary
Fixes #441

Resolves an issue where restoring the application from a minimized state on Windows (especially after being left in the background for 30–60+ seconds) causes the window to render completely blank/white.

## 🔍 Implementation Notes
- **Chromium Occlusion Suspension**: Added `--disable-features=CalculateNativeWinOcclusion` to `WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS` on Windows in `src-tauri/src/lib.rs`. This stops Chromium/WebView2 from placing the rendering pipeline into a suspended/discarded state when minimized or occluded in the background.
- **Window-State Visibility Decoupling**: Configured `tauri-plugin-window-state` with `.with_state_flags(StateFlags::all() & !StateFlags::VISIBLE)` in `src-tauri/src/lib.rs` and added `getCurrentWindow().show()` in `src/routes/+layout.svelte` onMount so that window visibility is cleanly presented once SvelteKit mounts and is not persisted as `visible: false` on disk if closed while minimized.
- **Window Geometry Protection**: Added `is_minimized()` check and off-screen placeholder coordinate filtering (`x <= -10000`, `width <= 0`) to `get_window_geometry` in `src-tauri/src/commands/window.rs` to prevent Win32 placeholder minimized values (`-32000`) from being captured in local storage.

## 🧪 Test Plan
- [x] `bun run check` (svelte-check) - 0 errors, 0 warnings
- [x] `bun run test -- --run` (frontend) - 37 test files passed, 350 tests passed
- [x] `cargo test` (src-tauri) - 120 unit tests passed, 0 failed

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed
