### PR TITLE
ci: silence known-unfixable informational advisories in security audit

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -24,3 +24,31 @@ jobs:
         uses: rustsec/audit-check@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          # These are informational "unmaintained"/"unsound" advisories, not
+          # vulnerabilities, all coming from transitive deps we don't control
+          # directly: Tauri's Linux webview stack (webkit2gtk/tray-icon still
+          # pull the archived gtk-rs 0.18 GTK3 bindings) and souvlaki's MPRIS
+          # backend (zbus 3.x, itself pulling `derivative`/`instant`).
+          # Re-check and prune this list whenever those upstreams move off
+          # the flagged crates.
+          ignore: >-
+            RUSTSEC-2024-0413,
+            RUSTSEC-2024-0416,
+            RUSTSEC-2024-0388,
+            RUSTSEC-2024-0412,
+            RUSTSEC-2024-0418,
+            RUSTSEC-2024-0411,
+            RUSTSEC-2024-0417,
+            RUSTSEC-2024-0414,
+            RUSTSEC-2024-0415,
+            RUSTSEC-2024-0420,
+            RUSTSEC-2024-0419,
+            RUSTSEC-2024-0384,
+            RUSTSEC-2024-0436,
+            RUSTSEC-2024-0370,
+            RUSTSEC-2025-0081,
+            RUSTSEC-2025-0075,
+            RUSTSEC-2025-0080,
+            RUSTSEC-2025-0100,
+            RUSTSEC-2025-0098,
+            RUSTSEC-2024-0429


### PR DESCRIPTION
## 📋 Summary
The [Security Audit workflow](https://github.com/esoltys/luminous/actions/runs/31919292155/job/95096388828#step:3:1) was flagging **20 warnings** on every run. `cargo-audit` found **0 actual vulnerabilities** — all 20 are informational `unmaintained`/`unsound` advisories on transitive dependencies we don't control directly:

- **Tauri's Linux webview stack** (`webkit2gtk`/`tray-icon`) still pulls the archived `gtk-rs` 0.18 GTK3 bindings (`gtk`, `gdk`, `atk`, `gdkx11`, `unic-*`, `glib` unsoundness, etc.) — 18 of the 20.
- **`souvlaki`** (our direct MPRIS dependency) pins `zbus` 3.x, which pulls `derivative` and `instant` — the other 2.

Neither is something we can resolve by bumping our own `Cargo.toml` pins today (both `souvlaki` and `lofty` are already at their latest published versions); the fix has to land upstream in `tauri`/`souvlaki`. This PR ignores those specific 20 `RUSTSEC-*` IDs in the audit workflow so CI stops re-flagging known, unfixable, non-vulnerability noise while still catching anything new.

## 🔍 Implementation Notes
- Only `.github/workflows/audit.yml` changed — added an `ignore:` list to the `rustsec/audit-check@v2` step with the exact 20 advisory IDs from the flagged run, plus a comment explaining why and a note to prune the list once upstream moves off the flagged crates.
- No dependency or application code changed.

## 🧪 Test Plan
- [x] Verified the 20 `RUSTSEC-*` IDs in `ignore:` match exactly the 20 warnings from the failing run's `cargo audit --json` output.
- [x] Validated `.github/workflows/audit.yml` parses as valid YAML and the `ignore` field resolves to the expected comma-separated list.
- [ ] `bun run check` (svelte-check) — not applicable, no frontend changes
- [ ] `bun run test -- --run` (frontend) — not applicable
- [ ] `cargo test` (src-tauri) — not applicable, no Rust code changed
- [x] Will confirm the `Security Audit` workflow run on this PR comes back green with the informational warnings suppressed

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed — not applicable, CI-only change


---
_Generated by [Claude Code](https://claude.ai/code/session_01Xv8mPJTwPNZSk8W8tNt5vm)_