### PR TITLE
Add milestone check to PR-creation workflow in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -203,6 +203,13 @@ P2–P4). Don't default new issues to P2/P3 — assign a label using the same cr
   4. Write the issue or PR body to a temporary scratch file in the workspace or the artifacts scratch directory.
   5. Create the issue using the GitHub CLI: `gh issue create --title "<Title>" --body-file "<PathToScratchFile>" --label "<Label>" --milestone "<Milestone>"`.
   6. Verify the created issue by running `gh issue view <id>`.
+  7. Before opening a PR that closes/fixes an issue, check that issue's Milestone
+     (`gh issue view <id> --json milestone`): if it's "2.0", branch from and target the PR at
+     `next`, not `main` (see Branching Model above). Everything else targets `main`. Do this even
+     when a branch name was already assigned for the task — the assigned branch name doesn't
+     imply a base branch, and defaulting to `main` for 2.0 work is a real regression risk (it
+     ships unfinished 2.0 work early). If the issue's milestone changes after the PR is opened,
+     re-check whether the base branch still matches and retarget the PR if not.
 - **Releases & Tagging**: When tagging a new release, only create and push a single semantic version tag matching the repository's convention (e.g., `vX.Y.Z` where X.Y.Z matches the project version in `package.json`/`Cargo.toml`) to avoid triggering duplicate build workflows in GitHub Actions.
 
 ## Git Hooks


### PR DESCRIPTION
## 📋 Summary
On #411 (originally Milestone "2.0"), I opened the fix PR against `main` instead of `next`. AGENTS.md's Branching Model section already says 2.0-Milestone issues should target `next`, but the actual step-by-step "Creating Issues & Pull Requests" workflow never told an agent to check an issue's milestone before picking a base branch — so it silently defaulted to `main`.

This adds an explicit step 7 to that workflow: check the issue's milestone with `gh issue view <id> --json milestone` before opening the PR, and use `next` as the base (and branch-from point) when it's "2.0", `main` otherwise. It also calls out that an assigned branch *name* for a task doesn't imply a base branch — those are independent, and re-check should the issue's milestone change mid-PR.

## 🔍 Implementation Notes
- Docs-only change, `AGENTS.md` only.
- No code touched, so no test/build implications.

## 🧪 Test Plan
- N/A — documentation change only.

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed — not applicable, this only affects internal agent workflow docs

---
_Generated by [Claude Code](https://claude.ai/code/session_01HGSBLo81gJbtR8P1QNmpeo)_