### PR TITLE
Fix Now Playing badge border contrast in immersive view

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -396,7 +396,7 @@
             <div class="flex flex-col text-center md:text-left space-y-4 max-w-md">
               {#if playerStore.currentSong}
                 <div>
-                  <span class="px-3 py-1 text-xs font-semibold uppercase tracking-wider bg-brand-accent/15 text-brand-accent-text border border-brand-accent/25 rounded-full select-none">
+                  <span class="px-3 py-1 text-xs font-semibold uppercase tracking-wider bg-brand-accent/15 text-brand-accent-text border border-brand-border rounded-full select-none">
                     {i18n.t('playerBar.nowPlaying')}
                   </span>
                 </div>


### PR DESCRIPTION
## 📋 Summary
Fixes #412. The "NOW PLAYING" pill badge in the immersive album artwork view used `border-brand-accent/25`, which washes out against dark, vibrant, or tinted album art backgrounds. Switched to the standard `border-brand-border` theme token, which is already used consistently elsewhere in the app for clear border definition.

## 🔍 Implementation Notes
- Single class change in `src/routes/+layout.svelte` (badge on the immersive/flip-card back face, above the track title).
- `bg-brand-accent/15` and `text-brand-accent-text` are left as-is — only the low-opacity border modifier was replaced, matching the fix proposed in the issue.

## 🧪 Test Plan
- [x] `npm run check` (svelte-check) — 0 errors, 0 warnings
- [ ] `bun run test -- --run` (frontend) — not run (no test coverage for this styling change)
- [ ] `cargo test` (src-tauri) — not applicable, no Rust changes
- [ ] Manually verified in the app — not performed in this environment (no audio/library setup available); this is a one-line Tailwind class swap to a token already used elsewhere in the codebase, so risk is low.

## 📸 Screenshots
Not captured — see Test Plan note above.

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed — N/A (internal style token only)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JTvxhiJs5vX6iityD6nthW)_