### PR TITLE
fix: exit immersive mode when clicking album cover in PlayerBar

### DIFF
--- a/src/lib/components/PlayerBar.svelte
+++ b/src/lib/components/PlayerBar.svelte
@@ -169,6 +169,7 @@
     if (!playerStore.currentSong) return;
     e.stopPropagation();
 
+    collectionStore.exitImmersiveMode();
     const queuePl = await playlistsStore.requireQueue();
     playlistsStore.selectPlaylist(queuePl.id);
     collectionStore.viewPlaylist(queuePl.id);

--- a/src/lib/components/PlayerBar.test.ts
+++ b/src/lib/components/PlayerBar.test.ts
@@ -4,7 +4,8 @@ import { render, fireEvent } from "@testing-library/svelte";
 import PlayerBar from "./PlayerBar.svelte";
 import { playerStore } from "../stores/player.svelte";
 import { collectionStore } from "../stores/collection.svelte";
-import type { Song } from "../types";
+import { playlistsStore } from "../stores/playlists.svelte";
+import type { Song, Playlist } from "../types";
 
 vi.mock("@tauri-apps/api/core", () => ({
   invoke: vi.fn().mockResolvedValue(null),
@@ -82,6 +83,35 @@ describe("PlayerBar.svelte", () => {
     await fireEvent.click(albumLink);
 
     expect(viewAlbumSpy).toHaveBeenCalledWith("Test Album");
+  });
+
+  it("exits immersive mode and navigates to the queue when the album cover is clicked", async () => {
+    playerStore.currentSong = mockSong;
+    playerStore.state = "playing";
+    collectionStore.immersiveMode = true;
+
+    const mockQueue: Playlist = {
+      id: 1,
+      name: "Queue",
+      dynamic_enabled: false,
+      created: 0,
+      updated: 0,
+      track_count: 0,
+      is_queue: true,
+    };
+    vi.spyOn(playlistsStore, "requireQueue").mockResolvedValue(mockQueue);
+    const selectPlaylistSpy = vi.spyOn(playlistsStore, "selectPlaylist").mockImplementation(async () => {});
+    const exitImmersiveModeSpy = vi.spyOn(collectionStore, "exitImmersiveMode");
+    const viewPlaylistSpy = vi.spyOn(collectionStore, "viewPlaylist").mockImplementation(() => {});
+
+    const { getByTitle } = render(PlayerBar);
+    const coverButton = getByTitle("Queue");
+    await fireEvent.click(coverButton);
+
+    expect(exitImmersiveModeSpy).toHaveBeenCalled();
+    expect(collectionStore.immersiveMode).toBe(false);
+    expect(selectPlaylistSpy).toHaveBeenCalledWith(mockQueue.id);
+    expect(viewPlaylistSpy).toHaveBeenCalledWith(mockQueue.id);
   });
 
   it("calls playerStore.resume() when play button is clicked in paused/stopped state", async () => {


### PR DESCRIPTION
## 📋 Summary
- Fixes #426: clicking the album cover in the bottom PlayerBar now exits Immersive Mode before navigating to the Queue, so the UI actually shows the Queue instead of staying flipped to the immersive artwork screen.

## 🔍 Implementation Notes
- `handleCoverClick` in `src/lib/components/PlayerBar.svelte` now calls `collectionStore.exitImmersiveMode()` before resolving/selecting the Queue playlist.

## 🧪 Test Plan
- [x] `npm run check` (svelte-check)
- [x] `npx vitest run` (frontend, 351 tests passing)
- [ ] `cargo test` (src-tauri, if Rust changed) — not applicable, no Rust changes
- [x] Added a unit test in `src/lib/components/PlayerBar.test.ts` covering that clicking the album cover exits immersive mode and navigates to the Queue.

## 📸 Screenshots
Not applicable — no visual/layout change, only a missing store call.

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed — not applicable


---
_Generated by [Claude Code](https://claude.ai/code/session_016CCfg18aYsxzya6q8VdHM3)_