### PR TITLE
ci: cache Rust deps and pinned tauri-cli for Windows release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,10 @@ jobs:
     if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) || github.event_name == 'workflow_dispatch'
     permissions:
       contents: write
+    env:
+      # Pinned so the tauri-cli cache key (below) stays stable across runs -
+      # bump this deliberately when we want a newer tauri-cli.
+      TAURI_CLI_VERSION: "2.11.4"
     strategy:
       fail-fast: false
       matrix:
@@ -65,6 +69,13 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      # Caches ~/.cargo/registry, ~/.cargo/git and the workspace target/ dir
+      # (keyed on Cargo.lock + rustc version), so the Windows leg's two full
+      # release compiles (NSIS build, then MSIX build) don't each start from
+      # scratch on every run.
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -108,6 +119,25 @@ jobs:
             releaseDraft: true
             prerelease: false
 
+      # cargo tracks installed-binary versions in .crates.toml/.crates2.json,
+      # so caching those alongside the binary lets `cargo install` below
+      # no-op on a cache hit instead of recompiling tauri-cli (and its
+      # dependency tree - clap, tauri-bundler, resvg, usvg, jsonschema, etc.)
+      # from source on every run.
+      - name: Cache tauri-cli binary (Windows)
+        if: matrix.platform == 'windows-latest'
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/cargo-tauri.exe
+            ~/.cargo/.crates.toml
+            ~/.cargo/.crates2.json
+          key: tauri-cli-windows-${{ env.TAURI_CLI_VERSION }}
+
+      - name: Install tauri-cli (Windows)
+        if: matrix.platform == 'windows-latest'
+        run: cargo install tauri-cli --version "${{ env.TAURI_CLI_VERSION }}"
+
       - name: Build MSIX Package (Windows)
         if: matrix.platform == 'windows-latest'
         # src-tauri is a workspace member (see root Cargo.toml), so Cargo's
@@ -115,9 +145,7 @@ jobs:
         # tauri-windows-bundle assumes the latter unless told otherwise.
         env:
           CARGO_TARGET_DIR: ${{ github.workspace }}/target
-        run: |
-          cargo install tauri-cli
-          bun run tauri:windows:build
+        run: bun run tauri:windows:build
 
       - name: Upload MSIX to Release Assets
         if: matrix.platform == 'windows-latest'


### PR DESCRIPTION
## 📋 Summary
Speeds up the `windows-latest` leg of `release.yml`, which currently compiles the full Rust dependency tree twice (NSIS build, then MSIX build) with no caching beyond the NSIS/WiX toolchain, and recompiles `tauri-cli` from source on every single run.

Addresses #390.

## 🔍 Implementation Notes
- Added [`Swatinem/rust-cache@v2`](https://github.com/Swatinem/rust-cache) right after checkout. It keys on `Cargo.lock` + rustc version and caches `~/.cargo/registry`, `~/.cargo/git`, and the workspace `target/` dir, so the two full release compiles on the Windows leg (and the Linux leg's single compile) reuse work across runs.
- Pinned `tauri-cli` to a specific version (`TAURI_CLI_VERSION` job-level env var, currently `2.11.4`) instead of installing whatever's latest, and cache the installed binary plus cargo's install-tracking metadata (`~/.cargo/bin/cargo-tauri.exe`, `~/.cargo/.crates.toml`, `~/.cargo/.crates2.json`) keyed on that version. `cargo install` recognizes the already-installed version on a cache hit and no-ops instead of recompiling `tauri-cli` and its dependency tree (clap, tauri-bundler, resvg, usvg, jsonschema, etc.) from source.
- Split the old single-line `cargo install tauri-cli && bun run tauri:windows:build` into separate cache/install/build steps so the cache step can gate on `matrix.platform == 'windows-latest'` independently.
- Left steps 1 and 3 (NSIS build vs. MSIX build) as separate `cargo tauri build` invocations — didn't attempt to merge them, since the rust-cache addition already gets most of the win there (only the final link/codegen for the differing `--target`/`--no-bundle` flags needs to redo work, not the whole dependency tree).
- Bumping `tauri-cli` in the future requires bumping `TAURI_CLI_VERSION` deliberately, which also happens to invalidate the cache key automatically.

## 🧪 Test Plan
- [x] YAML syntax validated (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] `bun run check` (svelte-check) — N/A, no frontend changes
- [ ] `bun run test -- --run` (frontend) — N/A, no frontend changes
- [ ] `cargo test` (src-tauri) — N/A, no Rust source changes
- [ ] Actual release build timing improvement can only be verified by a real tag-triggered `release.yml` run (this workflow only runs on `push: tags` / `release: published` / `workflow_dispatch`, so it can't be exercised from a PR)

## 📸 Screenshots
N/A — CI workflow change only.

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed — N/A, no user-facing behavior changed


---
_Generated by [Claude Code](https://claude.ai/code/session_011e9HwMTbdYsouQ4PSB3prg)_