### PR TITLE
Point Windows installs at the Microsoft Store, surface Store URL for updater

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ Luminous is a fast, local-first player for your own audio library — no streami
 
 ## Quick Install
 
-Grab the latest build from the **[Releases page](https://github.com/esoltys/luminous/releases/latest)**.
+[<img src="https://get.microsoft.com/images/en-us%20dark.svg" width="200"/>](https://apps.microsoft.com/detail/9PNQ2NFSQ7XW?launch=true&mode=full)
 
-- **Windows**: download `Luminous_{version}_x64-setup.exe` and run it.
-- **Linux**: download the `.deb` or `.rpm` for your distro from the same release and install it as usual.
+- **Windows**: get it from the **[Microsoft Store](https://apps.microsoft.com/detail/9PNQ2NFSQ7XW)** (recommended — installs and updates automatically), or grab `Luminous_{version}_x64-setup.exe` (or the `.msix`) from the **[Releases page](https://github.com/esoltys/luminous/releases/latest)** for a manual/sideloaded install.
+- **Linux**: download the `.deb` or `.rpm` for your distro from the **[Releases page](https://github.com/esoltys/luminous/releases/latest)** and install it as usual.
 
 > **No AppImage right now.** Tauri's AppImage bundling links against WebKitGTK/Mesa/EGL libraries baked in at build time, and on many host systems that collides with the system's own graphics stack, producing a window that opens fully blank (`Could not create default EGL display: EGL_BAD_PARAMETER`) — this is an [upstream](https://github.com/tauri-apps/tauri/issues/11988) [Tauri/WebKitGTK](https://girishjoshi.io/post/tauri-2.0-appimage-egl-issue-on-wayland/) bug, not something app code can work around, and the only real fix (an experimental, unreleased Tauri bundler branch) isn't stable enough to ship. Use the `.deb`/`.rpm` above, or build your own AppImage locally with `bun run tauri build -b appimage` (see [Building Luminous](#building-luminous)) — a locally built one links against your own system libraries and doesn't hit this.
 

--- a/src/lib/stores/updater.svelte.ts
+++ b/src/lib/stores/updater.svelte.ts
@@ -18,6 +18,7 @@ export interface DownloadProgress {
 
 const UPDATE_CHECK_INTERVAL_MS = 4 * 60 * 60 * 1000; // 4 hours
 const RELEASES_URL = "https://github.com/esoltys/luminous/releases/latest";
+export const MICROSOFT_STORE_URL = "https://apps.microsoft.com/detail/9PNQ2NFSQ7XW";
 
 // Tauri command rejections often surface as a raw string (from a Rust `Err(String)`),
 // not an `Error` instance — `err.message` on a string is always `undefined`.


### PR DESCRIPTION
## Summary

Luminous is now live on the Microsoft Store (`9PNQ2NFSQ7XW`), so this covers the parts of #421 that don't need Partner Center/Azure AD credentials:

- **README**: Windows Quick Install now points at the [Microsoft Store listing](https://apps.microsoft.com/detail/9PNQ2NFSQ7XW) as the recommended install path (auto-updates), while keeping the `.exe`/`.msix` download from Releases for a manual/sideloaded install — per the "keep both" decision on this issue. Added the official "Get it from Microsoft Store" badge.
- **`src/lib/stores/updater.svelte.ts`**: exported a new `MICROSOFT_STORE_URL` constant alongside the existing `RELEASES_URL`, so #420's MSIX "View in Microsoft Store" panel state has a URL to link to once that panel work lands.

## Out of scope for this PR

- The `broadFileSystemAccess` capability question is effectively resolved — the submission was already certified with it declared in `bundle.config.json`.
- Activating the `microsoft-store`/`winget` CI jobs (PR #388) needs `STORE_TENANT_ID`/`STORE_CLIENT_ID`/`STORE_CLIENT_SECRET`/`STORE_APP_ID` GitHub secrets from a Partner Center Azure AD app registration — that's a manual, credential-bearing step for the repo owner, not something this PR automates.
- The actual "View in Microsoft Store" panel UI/locale strings are #420's scope.

## Test plan

- [x] `bun run check` — clean, 0 errors/warnings.
- [x] Reviewed README diff renders correctly as Markdown.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YFebyQHTnTRxPs4JydkonN)_