### PR TITLE
Add microsoft-store CI job to submit MSIX releases to the Store

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,5 +133,31 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  microsoft-store:
+    name: Publish to Microsoft Store
+    needs: release
+    if: (github.event_name == 'release' && github.event.action == 'published') || github.event_name == 'workflow_dispatch'
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract release version
+        id: get_version
+        run: |
+          VERSION="${TAG_NAME#v}"
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          # tauri-windows-bundle pads to a four-part version (X.Y.Z -> X.Y.Z.0)
+          # for the MSIX filename.
+          echo "msix_version=${VERSION}.0" >> $GITHUB_OUTPUT
+        env:
+          TAG_NAME: ${{ github.event.release.tag_name || github.ref_name }}
 
+      - name: Submit to Microsoft Store
+        uses: microsoft/store-submission@v1
+        with:
+          tenant-id: ${{ secrets.STORE_TENANT_ID }}
+          client-id: ${{ secrets.STORE_CLIENT_ID }}
+          client-secret: ${{ secrets.STORE_CLIENT_SECRET }}
+          app-id: ${{ secrets.STORE_APP_ID }}
+          package-path: "https://github.com/esoltys/luminous/releases/download/v${{ steps.get_version.outputs.version }}/LuminousMusicPlayer_${{ steps.get_version.outputs.msix_version }}_x64.msix"
 


### PR DESCRIPTION
## Summary

Adds the `microsoft-store` CI job for #421, so future releases automatically submit the built MSIX to the Microsoft Store instead of relying on a manual Partner Center upload. All four required secrets (`STORE_TENANT_ID`, `STORE_CLIENT_ID`, `STORE_CLIENT_SECRET`, `STORE_APP_ID`) are now populated in the repo.

This supersedes #388 rather than merging it directly — #388's base predates a substantial rewrite of `release.yml` that's since shipped (the `create-release`/`release` job split, the `wretry.action` retry wrapper, the `CARGO_TARGET_DIR` fix, the `draft: true` fix on the MSIX upload step) and also carries a stale 0.99.2→0.99.3 version bump that would conflict with/regress current `main` (now at 0.99.6). This PR rebuilds just the `microsoft-store` job on top of current `main`, with #388's asset-naming fixes carried forward:

- `LuminousMusicPlayer_` prefix (matches `tauri.conf.json`'s `mainBinaryName`), not the stale `Luminous_` prefix.
- Four-part version padding (`X.Y.Z` → `X.Y.Z.0`) for the MSIX filename, matching what `tauri-windows-bundle` actually produces.

The job fires on `release: published` (or manual `workflow_dispatch`) — same manual-review gate the existing Linux/Windows builds already use (draft release created by CI, human publishes it, then this job submits to the Store).

## Deliberately left out

- **`winget` job**: the `EricSoltys.Luminous` submission to `microsoft/winget-pkgs` hasn't been approved yet, so no manifest exists there for `wingetcreate update` to update from — adding the job now would fail on every release. It'll land in a small follow-up PR once that submission clears (the `WINGET_PAT` secret is already present).
- No version bump / release-notes file — this PR is purely additive to the workflow.

## Test plan

- [x] `bun run check` — clean.
- [x] Validated `release.yml` as syntactically correct YAML.
- [ ] Real validation happens on the next tagged release, since `microsoft/store-submission@v1` can't be dry-run locally.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YFebyQHTnTRxPs4JydkonN)_