### PR TITLE
chore: release v0.99.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2984,7 +2984,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "luminous"
-version = "0.99.6"
+version = "0.99.7"
 dependencies = [
  "anyhow",
  "bs1770",

--- a/docs/release-notes/v0.99.7.md
+++ b/docs/release-notes/v0.99.7.md
@@ -1,0 +1,14 @@
+# Release Notes - Luminous v0.99.7
+
+Infrastructure-only patch release; no user-facing changes.
+
+### 🛠️ Other Improvements
+- **Automated Microsoft Store Submission**: Luminous is now live on the Microsoft
+  Store ([listing](https://apps.microsoft.com/detail/9PNQ2NFSQ7XW)). CI now submits
+  the built MSIX to the Store automatically via a new `microsoft-store` release job,
+  instead of requiring a manual upload through Partner Center for every release. The
+  README's Windows install instructions now point at the Store as the recommended
+  path, alongside the existing direct-download `.exe`/`.msix`.
+
+This release exists to validate the new Store-submission automation end to end.
+There are no changes to the app itself.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "luminous",
-  "version": "0.99.6",
+  "version": "0.99.7",
   "description": "A high-performance home for the music you already own",
   "author": "Eric James Soltys <ericjamessoltys@outlook.com>",
   "license": "MIT",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "luminous"
-version = "0.99.6"
+version = "0.99.7"
 description = "A high-performance home for the music you already own"
 authors = ["Eric James Soltys <ericjamessoltys@outlook.com>"]
 edition = "2021"

--- a/src-tauri/src/commands/window.rs
+++ b/src-tauri/src/commands/window.rs
@@ -191,8 +191,8 @@ pub async fn get_window_geometry(window: WebviewWindow) -> Result<serde_json::Va
     // Ignore placeholder minimized sizes (0x0) or Win32 offscreen minimized coordinates (-32000)
     if width <= 0.0
         || height <= 0.0
-        || x.map_or(false, |coord| coord <= -10000.0)
-        || y.map_or(false, |coord| coord <= -10000.0)
+        || x.is_some_and(|coord| coord <= -10000.0)
+        || y.is_some_and(|coord| coord <= -10000.0)
     {
         return Ok(serde_json::Value::Null);
     }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Luminous Music Player",
   "mainBinaryName": "LuminousMusicPlayer",
-  "version": "0.99.6",
+  "version": "0.99.7",
   "identifier": "org.luminous.music",
   "build": {
     "beforeDevCommand": "bun run dev",


### PR DESCRIPTION
## Summary

Version-bump PR cutting v0.99.7, per `docs/RELEASE_CHECKLIST.md`. This release exists specifically to exercise the new `microsoft-store` CI job (#460) end-to-end for real, now that #421's Store submission automation is in place — 1.0.0 is intentionally being held back until this pipeline is confirmed working.

Infra-only — everything shipping in this release already merged to `main` separately:
- #459 — README Microsoft Store install instructions + `MICROSOFT_STORE_URL` constant
- #460 — the `microsoft-store` CI job itself

This PR's own diff is just the version bump (`package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`, `Cargo.lock`), release notes, and two pre-existing `clippy` warnings fixed while running the release checklist's clippy pass (unrelated `map_or` → `is_some_and` simplifications in `src-tauri/src/commands/window.rs`, not part of the Store work — checklist requires zero warnings, not just no new ones).

## Test plan

- [x] `bun run check` — clean (via `scripts/release.ts`)
- [x] `bun run test:run` — 350 tests passed (via `scripts/release.ts`)
- [x] `cargo check` — clean (via `scripts/release.ts`)
- [x] `cargo test` — all passed (audio smoke test correctly `ignored`, needs real hardware)
- [x] `cargo clippy --all-targets` — clean after fixing the two pre-existing warnings above
- [x] Real-device smoke test (`cargo test --test smoke_test -- --ignored --nocapture`), installing the built app on an actual Windows/Linux machine, and manually exercising `tauri dev` — these need real hardware this session doesn't have; flagging for manual verification before/after tagging, per `docs/RELEASE_CHECKLIST.md`.

## Next steps (not part of this PR)

Per `docs/RELEASE_CHECKLIST.md`: once merged, re-tag `main` at the merge commit and push `v0.99.7` (tag only) to trigger `release.yml`. After the build completes, publish the resulting draft GitHub release to fire the `microsoft-store` job for the first time.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YFebyQHTnTRxPs4JydkonN)_