### PR TITLE
Move Microsoft Store submission into its own workflow

### DIFF
--- a/.github/workflows/publish-store.yml
+++ b/.github/workflows/publish-store.yml
@@ -1,0 +1,36 @@
+name: "Publish to Microsoft Store"
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to submit (e.g. v0.99.7)"
+        required: true
+
+jobs:
+  microsoft-store:
+    name: Publish to Microsoft Store
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract release version
+        id: get_version
+        run: |
+          TAG="${{ github.event.release.tag_name || inputs.tag }}"
+          VERSION="${TAG#v}"
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          # tauri-windows-bundle pads to a four-part version (X.Y.Z -> X.Y.Z.0)
+          # for the MSIX filename.
+          echo "msix_version=${VERSION}.0" >> $GITHUB_OUTPUT
+
+      - name: Submit to Microsoft Store
+        uses: microsoft/store-submission@v1
+        with:
+          tenant-id: ${{ secrets.STORE_TENANT_ID }}
+          client-id: ${{ secrets.STORE_CLIENT_ID }}
+          client-secret: ${{ secrets.STORE_CLIENT_SECRET }}
+          app-id: ${{ secrets.STORE_APP_ID }}
+          package-path: "https://github.com/esoltys/luminous/releases/download/v${{ steps.get_version.outputs.version }}/LuminousMusicPlayer_${{ steps.get_version.outputs.msix_version }}_x64.msix"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,31 +133,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  microsoft-store:
-    name: Publish to Microsoft Store
-    needs: release
-    if: (github.event_name == 'release' && github.event.action == 'published') || github.event_name == 'workflow_dispatch'
-    permissions:
-      contents: read
-    runs-on: ubuntu-latest
-    steps:
-      - name: Extract release version
-        id: get_version
-        run: |
-          VERSION="${TAG_NAME#v}"
-          echo "version=${VERSION}" >> $GITHUB_OUTPUT
-          # tauri-windows-bundle pads to a four-part version (X.Y.Z -> X.Y.Z.0)
-          # for the MSIX filename.
-          echo "msix_version=${VERSION}.0" >> $GITHUB_OUTPUT
-        env:
-          TAG_NAME: ${{ github.event.release.tag_name || github.ref_name }}
-
-      - name: Submit to Microsoft Store
-        uses: microsoft/store-submission@v1
-        with:
-          tenant-id: ${{ secrets.STORE_TENANT_ID }}
-          client-id: ${{ secrets.STORE_CLIENT_ID }}
-          client-secret: ${{ secrets.STORE_CLIENT_SECRET }}
-          app-id: ${{ secrets.STORE_APP_ID }}
-          package-path: "https://github.com/esoltys/luminous/releases/download/v${{ steps.get_version.outputs.version }}/LuminousMusicPlayer_${{ steps.get_version.outputs.msix_version }}_x64.msix"
-

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -77,6 +77,12 @@ manual.
       this release" so it also posts as an Announcement in GitHub Discussions, then
       publish it (the workflow creates it as a draft with `prerelease: false`, so it's
       just sitting there until published).
+- [ ] Publishing fires [`publish-store.yml`](../.github/workflows/publish-store.yml),
+      which submits the MSIX to the Microsoft Store. It's a separate workflow from
+      `release.yml` on purpose — it doesn't depend on (and isn't skipped by) the build
+      job, and can be re-run independently via `workflow_dispatch` with a `tag` input if
+      a submission needs to be retried against an already-published release. Watch this
+      run too, not just the build.
 - [ ] Download and install the new build on at least one real machine per platform
       (Windows + Linux) — don't just trust the CI build succeeded.
 - [ ] Verify the in-app updater picks up the new release from an older installed version


### PR DESCRIPTION
## Summary

Fixes the bug found while validating #421's `microsoft-store` job on v0.99.7's real publish: the job never ran.

Root cause — `microsoft-store` had `needs: release` (carried over from PR #388's older single-job workflow shape). GitHub Actions skips a job when its `needs` dependency was itself skipped, **regardless of the job's own `if` condition**. `release` only runs on `push`/`workflow_dispatch` (it always skips on a `release: published` event, by design — it shouldn't rebuild on publish). So on publish, `create-release`, `release`, and `microsoft-store` all showed "skipped" — confirmed on the actual v0.99.7 run.

`microsoft-store` doesn't consume any `needs.release` outputs — it downloads the already-built MSIX from the release's own asset URL, which was uploaded in the earlier tag-push run. The dependency was both wrong and unnecessary.

## Fix

- Removed `microsoft-store` from `release.yml`.
- Added it as its own workflow, `publish-store.yml`, triggered independently by `release: published` or `workflow_dispatch` (now with a `tag` input, so an already-published release can be resubmitted without needing a fake new tag/release).

This also addresses feedback that Store submission shouldn't be coupled to the same lockstep timing as the release build/draft/publish flow — publishing a GitHub release and submitting to the Store are now two independent triggers instead of one job silently riding on another's skip state.

## Test plan

- [x] Both workflow files validated as syntactically correct YAML.
- [ ] Real validation: after merge, manually trigger `publish-store.yml` via `workflow_dispatch` with `tag: v0.99.7` to retroactively submit the already-published v0.99.7 release — this is the actual first real run of the Store submission.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YFebyQHTnTRxPs4JydkonN)_