### PR TITLE
Fix Store submission script failing on Install-PackageProvider under pwsh

### DIFF
--- a/.github/store/Submit-ToMicrosoftStore.ps1
+++ b/.github/store/Submit-ToMicrosoftStore.ps1
@@ -14,7 +14,6 @@ if (-not $env:STORE_TENANT_ID -or -not $env:STORE_CLIENT_ID -or -not $env:STORE_
     throw "STORE_TENANT_ID, STORE_CLIENT_ID, STORE_CLIENT_SECRET and STORE_APP_ID must all be set."
 }
 
-Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force | Out-Null
 Set-PSRepository -Name "PSGallery" -InstallationPolicy Trusted
 Install-Module -Name StoreBroker -Force -Scope CurrentUser
 


### PR DESCRIPTION
## Summary

The first real `workflow_dispatch` run of `publish-store.yml` against `v0.99.7` (after #463 merged) failed immediately on:

```
Install-PackageProvider: D:\a\luminous\luminous\.github\store\Submit-ToMicrosoftStore.ps1:17
No match was found for the specified search criteria for the provider 'NuGet'. The package
provider requires 'PackageManagement' and 'Provider' tags.
```

`Install-PackageProvider -Name NuGet` is a Windows PowerShell 5.1-era bootstrap step I added defensively beyond the proven reference pipeline ([LanceMcCarthy/MediaFileManager](https://github.com/LanceMcCarthy/MediaFileManager)'s `SubmitToMsftStore.ps1`), and it doesn't resolve reliably under `pwsh` (PowerShell 7, which `windows-latest`'s `shell: pwsh` invokes).

## Fix

Drop the `Install-PackageProvider` call. It isn't in the working reference pipeline either — `Install-Module -Name StoreBroker` bootstraps what it needs on its own on GitHub-hosted `windows-latest` runners.

## Test plan

- [x] The failing run confirmed everything *before* this line worked correctly — the download step correctly found and selected `Luminous.Music.Player_0.99.7.0.msixbundle` from the release assets.
- [ ] Re-run `workflow_dispatch` against `v0.99.7` once this merges to confirm `Install-Module -Name StoreBroker` and the rest of the submission flow succeed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YFebyQHTnTRxPs4JydkonN)_