### PR TITLE
Fix sbConfig.json breaking StoreBroker's // comment stripper

### DIFF
--- a/.github/store/README.md
+++ b/.github/store/README.md
@@ -25,3 +25,12 @@ for `pricing`, `-UpdatePublishModeAndVisibility` for `targetPublishMode`/
 [USAGE.md](https://github.com/microsoft/StoreBroker/blob/master/Documentation/USAGE.md#the-easy-way)
 for the full switch list. If a future change adds one of those switches, update
 this file first — it won't reflect the real listing until then.
+
+**No `//` in any string value.** StoreBroker's config loader (`Read-ConfigFile`
+in `PackageTool.ps1`) treats this file as JSON-with-comments: it naively
+splits every line on the first `//` and discards the rest before parsing,
+regardless of whether the `//` is inside a string. A `https://` URL in
+`notesForCertification` broke this exact way — the comment stripper truncated
+the line mid-string, producing invalid JSON (`Unterminated string`). Write
+URLs without a scheme (`github.com/...` instead of `https://github.com/...`)
+or escape the slash (`https:\/\/...`) if a value needs one.

--- a/.github/store/sbConfig.json
+++ b/.github/store/sbConfig.json
@@ -41,6 +41,6 @@
     "canInstallOnRemovableMedia": false,
     "automaticBackupEnabled": true,
     "isGameDvrEnabled": false,
-    "notesForCertification": "Luminous is an open-source, offline-first local music player. No account or network access is required to install or use it. Source: https://github.com/esoltys/luminous"
+    "notesForCertification": "Luminous is an open-source, offline-first local music player. No account or network access is required to install or use it. Source: github.com/esoltys/luminous"
   }
 }


### PR DESCRIPTION
## Summary

The re-dispatched `publish-store.yml` run against `v0.99.7` (after #465's fix) got past `Install-Module` and into `New-SubmissionPackage`, then failed:

```
ConvertFrom-Json: ...PackageTool.ps1:3311
Conversion from JSON failed with error: Unterminated string. Expected delimiter: ".
Path 'appSubmission.notesForCertification', line 1, position 1306.
```

Root cause: StoreBroker's `Read-ConfigFile` doesn't parse `sbConfig.json` as plain JSON — it treats it as JSON-with-comments, splitting every line on the first `//` and discarding the rest *before* calling `ConvertFrom-Json` (confirmed in [`PackageTool.ps1`](https://github.com/microsoft/StoreBroker/blob/master/StoreBroker/PackageTool.ps1#L3244-L3311), the `Remove-Comment`/`Read-ConfigFile` functions). It does this blindly, with no awareness of whether the `//` is inside a string literal.

`notesForCertification` in `.github/store/sbConfig.json` contained `Source: https://github.com/esoltys/luminous` — the `//` in `https://` got treated as a comment start, truncating the line mid-string and leaving invalid JSON.

## Fix

- Drop the URL scheme (`github.com/esoltys/luminous` instead of `https://github.com/esoltys/luminous`) so the file has no literal `//` anywhere.
- Documented the gotcha in `.github/store/README.md` so a future edit doesn't reintroduce it — either drop the scheme or use JSON's `\/` escape if a value ever needs a full URL.

## Test plan

- [x] `python3 -c "import json; json.load(...)"` — valid JSON
- [x] `grep -n '//' .github/store/sbConfig.json` — no matches
- [ ] Re-run `workflow_dispatch` against `v0.99.7` once this merges to confirm the submission actually commits

---
_Generated by [Claude Code](https://claude.ai/code/session_01YFebyQHTnTRxPs4JydkonN)_