### PR TITLE
Prefer plain .msix over .msixbundle for Store submission

### DIFF
--- a/.github/workflows/publish-store.yml
+++ b/.github/workflows/publish-store.yml
@@ -30,10 +30,14 @@ jobs:
           mkdir -p package
           gh release download "$TAG" --repo "${{ github.repository }}" \
             --pattern "*.msixbundle" --pattern "*.msix" --dir package
-          # Prefer the bundle if both were produced; otherwise fall back to the single .msix.
-          FILE=$(ls package/*.msixbundle 2>/dev/null | head -n1 || true)
+          # Prefer the plain .msix: it's a single x64 package, and StoreBroker's
+          # bundle-metadata reader can't locate the inner package inside the
+          # .msixbundle that tauri-windows-bundle produces (Read-AppPackageBundleMetadata
+          # fails to find the file referenced by the bundle manifest). Fall back to the
+          # bundle only if no plain .msix was uploaded.
+          FILE=$(ls package/*.msix 2>/dev/null | head -n1 || true)
           if [ -z "$FILE" ]; then
-            FILE=$(ls package/*.msix | head -n1)
+            FILE=$(ls package/*.msixbundle | head -n1)
           fi
           echo "Selected package: $FILE"
           echo "path=$FILE" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

The third real `workflow_dispatch` attempt against `v0.99.7` (after #465 and #466's fixes) got further — StoreBroker installed, authenticated, and started reading package metadata — then failed:

```
Read-AppPackageBundleMetadata: ...PackageTool.ps1:2497
Cannot validate argument on parameter 'AppPackagePath'.  cannot be found or is not an .appx nor .msix.
```

StoreBroker's bundle reader (`Read-AppPackageBundleMetadata`) expands the `.msixbundle`, parses its `AppxBundleManifest.xml`, and for each `<Application>` entry does a `Get-ChildItem -Recurse -Include` search for the referenced inner package inside the expanded contents. That search comes up empty against the bundle `tauri-windows-bundle` produces — likely a path-structure mismatch between the two tools. Didn't dig further since there's a simpler fix available.

## Fix

Luminous only ships one architecture (x64) — the release's `.msixbundle` and plain `.msix` assets are nearly identical in size (35,067,697 vs 35,065,879 bytes), confirming the "bundle" here is really just that one `.msix` wrapped in bundle format for no functional benefit. Submit the plain `.msix` instead: it goes through `Read-AppPackageMetadata` directly, with no bundle expansion/search step to go wrong. Flipped the download step's preference order accordingly (falls back to `.msixbundle` only if no plain `.msix` was uploaded).

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — valid YAML
- [x] Confirmed both assets exist on the `v0.99.7` release and are near-identical in size, supporting the "just one package" theory
- [ ] Re-run `workflow_dispatch` against `v0.99.7` once this merges to confirm the submission actually commits

---
_Generated by [Claude Code](https://claude.ai/code/session_01YFebyQHTnTRxPs4JydkonN)_