### PR TITLE
Speed up dev builds and PR CI via dev-profile override and Rust caching

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -39,6 +39,13 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y libasound2-dev libssl-dev pkg-config libglib2.0-dev libgtk-3-dev libwebkit2gtk-4.1-dev
 
+    # Caches the registry, git deps, and target dir across PR builds so
+    # `cargo check` below doesn't recompile the whole dependency graph
+    # (Symphonia, rusqlite, Tauri, etc.) from scratch on every run.
+    - name: Cache Rust dependencies
+      if: matrix.language == 'rust'
+      uses: Swatinem/rust-cache@v2
+
     - name: Pre-build Rust dependencies & generated code
       if: matrix.language == 'rust'
       run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,12 @@ opt-level = "s"   # optimize for size in release builds
 [profile.dev]
 opt-level = 0
 debug = true
+
+# Debug builds leave dependency crates fully unoptimized by default, which is
+# noticeably slow for dependency-heavy code paths (Symphonia audio decoding,
+# rusqlite DB access, serde_json/chrono parsing of large JSON — 10-30x slower
+# unoptimized per #436). Optimize only the dependency graph here; the app's
+# own crate stays at opt-level 0 above for fast incremental compiles and full
+# debug info.
+[profile.dev.package."*"]
+opt-level = 2


### PR DESCRIPTION
## 📋 Summary
Addresses #436. Adds a Cargo dev-profile override to optimize dependency crates in debug builds, and extends the same idea to CI: caches Rust build artifacts on the CodeQL PR workflow, which was the only PR-triggered workflow actually compiling the Rust crate from scratch on every run.

## 🔍 Implementation Notes
- `Cargo.toml` (workspace root, not `src-tauri/Cargo.toml`): added `[profile.dev.package."*"]` with `opt-level = 2`. This project is a Cargo workspace (`src-tauri` is a member), and Cargo requires profile settings to live in the workspace root manifest — a profile section in a member's `Cargo.toml` is silently ignored. The existing `[profile.dev]` block (app's own crate, `opt-level = 0`, full debug info) is untouched, so incremental app-code rebuilds stay fast while dependency-heavy paths (Symphonia decoding, rusqlite, serde_json/chrono parsing) get optimized.
- `.github/workflows/codeql.yml`: added a `Swatinem/rust-cache@v2` step before the `cargo check` step (gated to the `rust` matrix leg, same as the existing system-deps/build steps). This is the only workflow that triggers on `pull_request` and actually builds the Rust crate (`audit.yml`'s cargo-audit and bun-lockfile checks don't compile the crate), so it's the one PR build that benefits from dependency caching. `release.yml`/`publish-store.yml` aren't PR-triggered and were left alone.

## 🧪 Test Plan
- [x] `cargo metadata --no-deps` — confirms the workspace manifest is still valid TOML and resolves correctly after the profile change.
- [x] Validated `codeql.yml` YAML syntax.
- [ ] `bun run check` (svelte-check) — no frontend changes in this PR.
- [ ] `bun run test -- --run` (frontend) — no frontend changes in this PR.
- [ ] `cargo test` (src-tauri) — no Rust source changes, only build config; sandbox lacks the system libs (`libwebkit2gtk-4.1-dev` etc.) the CodeQL job installs, so a full local `cargo check`/`cargo test` wasn't runnable here. Verification per the issue (before/after timing of a CPU-heavy dev-mode operation) should be done against `cargo tauri dev` on a machine with those deps installed.
- [ ] Manually verified in the app — see above; CI (`codeql.yml`'s rust job) will exercise `cargo check` with the new profile on the next run.

## 📸 Screenshots
Not applicable — build configuration only, no user-facing behavior change.

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed — not applicable, no user-facing changes


---
_Generated by [Claude Code](https://claude.ai/code/session_01GjKqSEP14XjssqxHu1zEW4)_