### PR TITLE
chore: remove dead release:published trigger from release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,6 @@ on:
   push:
     tags:
       - 'v*'
-  release:
-    types: [published]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Content
`release.yml` ("Release Build") listens for `release: types: [published]` in
its `on:` block, but neither the `create-release` nor `release` job's `if:`
condition ever matches `github.event_name == 'release'` — both are gated to
`push` (tag) or `workflow_dispatch` only. So publishing a GitHub release
guarantees a no-op run of this workflow (visible as the "prohibited"/skipped
icon in the Actions list right after publishing v1.0.0).

`publish-store.yml` already owns the `release: published` trigger for the
one thing that's actually supposed to happen on publish — the Microsoft
Store submission — so this workflow doesn't need to listen for it at all.

Purely a trigger removal; no job logic changes.

## Verification
- Diff review only — removes an `on:` entry that no job's `if:` condition
  ever satisfies, so there's no behavior to test.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YFebyQHTnTRxPs4JydkonN)_