### PR TITLE
ci: harden workflow triggers, concurrency, and action pinning

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -8,6 +8,10 @@ on:
   schedule:
     - cron: '0 0 * * 0' # Every Sunday at midnight
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   checks: write
@@ -18,10 +22,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Security audit Cargo.lock
-        uses: rustsec/audit-check@v2
+        uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -30,10 +34,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: latest
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,13 +8,16 @@ on:
   schedule:
     - cron: '43 21 * * 6'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
     runs-on: ubuntu-latest
     permissions:
       security-events: write
-      packages: read
       actions: read
       contents: read
 
@@ -31,7 +34,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
     - name: Install system dependencies (Linux)
       if: matrix.language == 'rust' && runner.os == 'Linux'
@@ -44,7 +47,7 @@ jobs:
     # (Symphonia, rusqlite, Tauri, etc.) from scratch on every run.
     - name: Cache Rust dependencies
       if: matrix.language == 'rust'
-      uses: Swatinem/rust-cache@v2
+      uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
 
     - name: Pre-build Rust dependencies & generated code
       if: matrix.language == 'rust'
@@ -52,12 +55,12 @@ jobs:
         cargo check
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/publish-store.yml
+++ b/.github/workflows/publish-store.yml
@@ -9,6 +9,10 @@ on:
         description: "Release tag to submit (e.g. v0.99.7)"
         required: true
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   microsoft-store:
     name: Publish to Microsoft Store
@@ -17,7 +21,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Download MSIX package from release
         id: download

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,11 @@ on:
   push:
     tags:
       - 'v*'
-  release:
-    types: [published]
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   create-release:
@@ -19,7 +21,7 @@ jobs:
       release_id: ${{ steps.release.outputs.id }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Determine Release Tag
         id: tag
@@ -64,10 +66,10 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: latest
 
@@ -82,7 +84,7 @@ jobs:
 
       - name: Cache Tauri bundler tools (NSIS/WiX)
         if: matrix.platform == 'windows-latest'
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: |
             ~/AppData/Local/tauri/NSIS
@@ -93,13 +95,13 @@ jobs:
       # returns transient 503s, which fails the whole matrix leg. Retry a
       # couple of times before giving up.
       - name: Build and Release
-        uses: Wandalen/wretry.action@v3
+        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
-          action: tauri-apps/tauri-action@v0
+          action: tauri-apps/tauri-action@84b9d35b5fc46c1e45415bdb6144030364f7ebc5 # v0.6.2
           attempt_limit: 3
           attempt_delay: 15000
           with: |
@@ -121,7 +123,7 @@ jobs:
 
       - name: Upload MSIX to Release Assets
         if: matrix.platform == 'windows-latest'
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           tag_name: ${{ needs.create-release.outputs.tag }}
           # softprops/action-gh-release publishes the release if `draft` is

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -1,0 +1,138 @@
+# CI/CD Pipeline
+
+This documents the actual GitHub Actions pipeline as it exists in `.github/workflows/`.
+There are four workflow files: `audit.yml`, `codeql.yml`, `release.yml`, and
+`publish-store.yml`. There is no separate lint/test/clippy workflow — those checks
+(`bun run check`, `bun run test:run`, `cargo test`, `cargo clippy`) are **not** run by
+GitHub Actions today; they're manual steps in [`docs/RELEASE_CHECKLIST.md`](./RELEASE_CHECKLIST.md)
+that a human runs locally before cutting a release. If you're expecting a CI job to catch
+a failing test or a clippy warning on your PR, it won't — only the two workflows below run
+on PRs.
+
+## What runs on pull requests (and pushes to `main`/`next`)
+
+Both of these trigger on `pull_request` and `push` targeting `main` or `next`, plus a
+weekly `schedule`:
+
+- **`audit.yml` — Security Audit**
+  - `security_audit` job: runs `rustsec/audit-check@v2` against `Cargo.lock` to catch
+    known-vulnerable Rust dependencies.
+  - `lockfile_check` job: runs `bun install --frozen-lockfile` to fail if `bun.lock` has
+    drifted from `package.json` (i.e. someone changed a dependency range without
+    regenerating the lockfile).
+- **`codeql.yml` — CodeQL Advanced**
+  - Runs GitHub's CodeQL static analysis across three language matrix legs: `actions`,
+    `javascript-typescript`, and `rust` (all `build-mode: none`, i.e. CodeQL's own
+    extraction rather than a real build — except Rust still runs `cargo check` first to
+    generate code CodeQL can analyze).
+  - Findings are uploaded to the repo's Security tab (`security-events: write`).
+
+Both are also on a `schedule` (audit: weekly Sunday midnight; CodeQL: weekly Saturday
+21:43 UTC), so they catch newly-disclosed vulnerabilities even without new commits.
+
+## What runs on merge to `main`
+
+Merging a PR to `main` is itself just a `push` to `main`, so it re-triggers `audit.yml`
+and `codeql.yml` exactly as above. Nothing else fires automatically on merge — the actual
+release build only happens when a `v*` tag is pushed (see below), which per
+`RELEASE_CHECKLIST.md` is a separate, deliberate, manual step after the version-bump PR
+merges.
+
+## The release pipeline
+
+### 1. `release.yml` — Release Build
+
+Triggers: `push` of a tag matching `v*`, or manual `workflow_dispatch`. (An earlier
+version of this workflow also listened for `release: published`, but neither job's `if:`
+guard ever matched that event — it just produced a confusing no-op run every time a
+release was published, so the trigger was removed.)
+
+- **`create-release` job** (Linux only): determines the tag (from the ref, or from
+  `package.json` version for manual dispatch), then creates a **draft** GitHub release for
+  that tag via `gh release create ... --draft` (or reuses one if it already exists). This
+  runs once, up front, so the matrix build below doesn't race to create duplicate drafts.
+- **`release` job** (matrix: `ubuntu-24.04`, `windows-latest`), depends on `create-release`:
+  - Installs deps with `bun install`, plus Linux system deps (webkit2gtk, ALSA, OpenSSL,
+    appindicator, librsvg) on the Ubuntu leg.
+  - Runs `tauri-apps/tauri-action@v0` (wrapped in `Wandalen/wretry.action@v3` for retry
+    on transient failures) to build and sign the app, uploading artifacts into the draft
+    release created above (`releaseDraft: true`).
+  - On the Windows leg only: builds an MSIX package (`bun run tauri:windows:build`) and
+    uploads it to the release assets via `softprops/action-gh-release@v2` (again with
+    `draft: true` — the action would otherwise publish the release outright).
+
+At the end of this workflow, the GitHub release exists as a **draft** with Linux + Windows
+bundles (and MSIX) attached. It is not visible to end users yet.
+
+### 2. Manual: publishing the draft release
+
+Per `RELEASE_CHECKLIST.md`, a human edits the draft release body (replacing the
+auto-generated notes with `docs/release-notes/vX.Y.Z.md`), optionally enables "Create a
+discussion for this release," and clicks **Publish**. This is a manual GitHub UI action —
+no workflow does it automatically.
+
+### 3. `publish-store.yml` — Publish to Microsoft Store
+
+Triggers: `release: published` (fires the moment the human publishes the draft above), or
+manual `workflow_dispatch` with a required `tag` input (for retrying a submission against
+an already-published release).
+
+- Downloads the release's `.msix`/`.msixbundle` asset via `gh release download`, preferring
+  a plain `.msix` over `.msixbundle` (StoreBroker's bundle-metadata reader can't locate the
+  inner package inside a `.msixbundle`).
+- Runs `.github/store/Submit-ToMicrosoftStore.ps1`, which uses Microsoft's StoreBroker
+  PowerShell module to call `Update-ApplicationSubmission -ReplacePackages` against the
+  Microsoft Store submission API, authenticating with `STORE_TENANT_ID` /
+  `STORE_CLIENT_ID` / `STORE_CLIENT_SECRET` / `STORE_APP_ID` secrets.
+- This is a separate workflow from `release.yml` on purpose: it doesn't depend on (and
+  isn't skipped by) the build job, and can be re-run independently.
+- A green run of this workflow only means the submission was **committed for
+  certification** — Microsoft's own cert pass still has to complete before the update is
+  live in the Store. See [`.github/store/README.md`](../.github/store/README.md) for how
+  `sbConfig.json` and the submission script are structured, including a gotcha about
+  `//` in JSON string values breaking StoreBroker's comment stripper.
+
+## Trigger graph
+
+```mermaid
+flowchart TD
+    PR["Pull request to main/next"]
+    PushMainNext["Push to main/next"]
+    Schedule1["Schedule: weekly Sun 00:00"]
+    Schedule2["Schedule: weekly Sat 21:43"]
+    TagPush["Push tag v*"]
+    ManualDispatch1["Manual workflow_dispatch"]
+    ReleasePublished["Human publishes draft release"]
+    ManualDispatch2["Manual workflow_dispatch (tag input)"]
+
+    Audit["audit.yml\nSecurity Audit + bun.lock check"]
+    CodeQL["codeql.yml\nCodeQL Advanced"]
+    Release["release.yml\nRelease Build (builds + drafts release)"]
+    Store["publish-store.yml\nPublish to Microsoft Store"]
+
+    PR --> Audit
+    PushMainNext --> Audit
+    Schedule1 --> Audit
+
+    PR --> CodeQL
+    PushMainNext --> CodeQL
+    Schedule2 --> CodeQL
+
+    TagPush --> Release
+    ManualDispatch1 --> Release
+
+    Release -->|creates draft GitHub release| HumanPublish["Human edits & publishes draft release"]
+    HumanPublish --> ReleasePublished
+    ReleasePublished --> Store
+    ManualDispatch2 --> Store
+
+    Store -->|submits MSIX via StoreBroker| MSStore["Microsoft Store certification\n(outside GitHub/CI)"]
+```
+
+One thing worth calling out explicitly since it's easy to miss reading the YAML in
+isolation:
+
+- `publish-store.yml` is decoupled from `release.yml` entirely — it only cares about the
+  release being published, not about how it got built. That's deliberate (see
+  `RELEASE_CHECKLIST.md`), and it's why it can be re-run via `workflow_dispatch` without
+  re-running the whole build.

--- a/docs/PERMISSIONS.md
+++ b/docs/PERMISSIONS.md
@@ -1,0 +1,42 @@
+# Human Touchpoints in the Pipeline
+
+Everything here is a point where a human has to act — not just review — before the
+pipeline can proceed. Grounded in what's actually in `.github/workflows/`,
+`docs/RELEASE_CHECKLIST.md`, and `.github/store/README.md`. See [`docs/CI.md`](./CI.md)
+for the full pipeline this fits into.
+
+| Action | Why it needs a human | What the human must do |
+|---|---|---|
+| Pushing the release PR to `main` | `RELEASE_CHECKLIST.md` explicitly says not to pass `--push` to `bun run release` "that pushes the branch straight to `main`, bypassing branch protection and skipping review." Branch protection on `main` is asserted by the checklist's wording, not something visible in the workflow YAML itself. | Open a PR from the release worktree branch into `main` and get it reviewed/merged normally. |
+| Pushing the `vX.Y.Z` tag | This repo's CLAUDE.md states tag pushes are protected and automated (Claude/CI) pushes of `v*` tags get a 403 from GitHub. Pushing the tag is also what triggers `release.yml`'s build, so it's a deliberate gate on when the expensive signed build kicks off, not just a permissions accident. | Run `git tag -d vX.Y.Z && git tag -a vX.Y.Z -m "Release vX.Y.Z" && git push origin vX.Y.Z` against `main`'s tip (after the release PR has merged) from a human's own credentials. |
+| Watching the `release.yml` run to completion | The workflow builds signed Linux and Windows bundles across a matrix; a failure on either leg (e.g. the noted transient 503s from `tauri-apps/binary-releases`, retried up to 3x via `wretry.action` but not guaranteed to succeed) needs a human to notice and re-run or investigate. Nothing in the pipeline pages anyone automatically. | `gh run watch`, or the checklist's optional Beeper notification, until both matrix legs finish. |
+| Editing and publishing the draft GitHub release | `release.yml` always creates the release as a **draft** (`gh release create ... --draft`, and `softprops/action-gh-release` is passed `draft: true` explicitly, with a comment noting that omitting `draft` would auto-publish). This is a deliberate content gate — the auto-generated release body is not the real release notes. | Replace the body with `docs/release-notes/vX.Y.Z.md`, optionally toggle "Create a discussion for this release," then click Publish in the GitHub UI. |
+| Microsoft Store certification | Publishing the draft fires `publish-store.yml`, which submits the MSIX via StoreBroker's `Update-ApplicationSubmission -ReplacePackages`. A green run of that workflow only means the submission was **committed for certification** — the actual review/cert pass happens entirely on Microsoft's side and cannot be forced, sped up, or verified from GitHub Actions. | Watch the `publish-store.yml` run for success, then separately check the submission's status in Partner Center until Microsoft's certification completes and the update goes live. |
+| Retrying a failed/stuck Store submission | `publish-store.yml` supports `workflow_dispatch` with a required `tag` input specifically for this case — re-running it doesn't rebuild anything, it just re-submits the already-uploaded MSIX. Choosing to do this requires human judgment about *why* the prior submission needs retrying (e.g. it was rejected, or needs re-submission after a `sbConfig.json` fix). | Trigger `publish-store.yml` manually via `workflow_dispatch`, supplying the release tag. |
+| Manual `release.yml` dispatch | `release.yml` also accepts a bare `workflow_dispatch` with no inputs, which derives the tag from `package.json`'s version instead of a pushed tag ref. This bypasses the tag-push gate above, so it's a judgment call about when that's appropriate (the checklist doesn't document a scenario for using it). | Trigger `release.yml` manually via `workflow_dispatch` if needed; verify the resulting draft release/tag are correct since no tag was pushed to anchor them. |
+| Installing and manually verifying the new build | The checklist requires downloading and installing the new build on at least one real machine per platform (Windows + Linux), and manually confirming the in-app updater picks up the release from an older install — neither is something CI does. | Download the published release assets, install on real hardware, exercise the app and the updater flow end to end. |
+| Running the pre-release verification suite | None of `bun run check`, `bun run test:run`, `cargo test`, `cargo clippy --all-targets`, or the smoke test (`cargo test --test smoke_test -- --ignored --nocapture`) run in any GitHub Actions workflow — they are entirely manual steps in `RELEASE_CHECKLIST.md`. A PR can merge to `main` without any of these having run in CI. | Run each command locally before cutting a release, per the checklist; fix any pre-existing `cargo clippy` warnings encountered, not just new ones. |
+| Closing/linking resolved GitHub issues | Not automated by any workflow; the checklist calls this out as a manual post-build step. | Close or link the issues resolved by the release and update the milestone if one's in use. |
+
+## Secrets referenced in the workflows (existence not independently verified)
+
+The workflow YAML *references* the following repository secrets. This document only
+confirms they are referenced in the YAML — it does not and cannot confirm from the
+workflow files alone that they are correctly configured, non-expired, or scoped
+correctly in the repo's Settings → Secrets, since that's not visible from the checked-in
+code:
+
+- `GITHUB_TOKEN` — used throughout (`gh release` commands, `tauri-action`, MSIX upload);
+  this one is provided automatically by GitHub Actions per run, not manually configured.
+- `TAURI_SIGNING_PRIVATE_KEY` / `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` — used by
+  `tauri-action` in `release.yml` to sign the updater artifacts. If these are ever
+  rotated, that's a manual credential-management action outside any workflow shown here.
+- `STORE_TENANT_ID` / `STORE_CLIENT_ID` / `STORE_CLIENT_SECRET` / `STORE_APP_ID` — used
+  by `publish-store.yml` to authenticate StoreBroker against the Microsoft Store
+  submission API (an Azure AD app registration tied to the Partner Center account, per
+  StoreBroker's own setup docs — not something this repo's YAML documents how to
+  provision).
+
+If any of these secrets are missing, expired, or wrong, the corresponding workflow will
+fail at the step that consumes them; investigating that is itself a manual, human step
+since there's no automated secret-health check in this pipeline.


### PR DESCRIPTION
## Summary

Three independent audits of `.github/workflows/` (trigger/permissions audit, a full
tag-push-to-Store-submission rehearsal, and a docs pass) turned up a dead trigger, missing
concurrency controls, and 16 unpinned action references. This PR fixes all three, plus adds
`docs/CI.md` and `docs/PERMISSIONS.md` so the pipeline and its human-required checkpoints
are documented instead of only living in the YAML.

## What changed

1. **Removed a dead trigger in `release.yml`** — it listened for both `push: tags: v*` and
   `release: published`, but no job's `if:` condition ever matched the `release` event, so
   publishing a release produced a confusing no-op run every time. Only the tag-push and
   manual-dispatch triggers remain.
2. **Added `concurrency:` groups** to all four workflows, so rapid pushes to the same branch
   don't pile up redundant runs:
   - `audit.yml`, `codeql.yml`: `cancel-in-progress: true` (cheap, idempotent checks).
   - `release.yml`, `publish-store.yml`: `cancel-in-progress: false` (expensive signed
     builds / non-idempotent Store submissions — never auto-cancel these mid-flight).
3. **Pinned all 16 floating action references to commit SHAs** (resolved via `gh api
   repos/<owner>/<repo>/commits/<tag>`, each kept with a `# vX.Y.Z` comment for
   readability) across `audit.yml`, `codeql.yml`, `release.yml`, `publish-store.yml`.
4. **Dropped an unused `packages: read` permission** from `codeql.yml` — nothing in the
   init/analyze/cache steps needs GitHub Packages access.
5. **Added `docs/CI.md`** — explains what runs on PRs vs. merge vs. tag push vs. release
   publish, with a trigger-graph diagram (below).
6. **Added `docs/PERMISSIONS.md`** — every point in the pipeline that requires a human
   (tag push, draft-release publish, Store certification, secret provisioning) and why.

## Trigger graph: before → after

**Before** — `release.yml` had a second, dead trigger; no workflow had concurrency
control:

```mermaid
flowchart TD
    TagPush["Push tag v*"] --> Release["release.yml"]
    ReleasePublished["release: published"] -.->|dead: no job's if: matches| Release
    ManualDispatch1["workflow_dispatch"] --> Release
    Release -->|creates draft release| HumanPublish["Human publishes draft"]
    HumanPublish --> ReleasePublished
    ReleasePublished --> Store["publish-store.yml"]
    PR["PR / push to main,next"] --> Audit["audit.yml"]
    PR --> CodeQL["codeql.yml"]

    classDef dead stroke-dasharray: 5 5,color:#999
    class ReleasePublished,Release dead
```

**After** — dead edge removed, every workflow has a concurrency group (not shown as an
edge, but each box now cancels/serializes its own superseded runs):

```mermaid
flowchart TD
    TagPush["Push tag v*"] --> Release["release.yml\n(concurrency: serialize)"]
    ManualDispatch1["workflow_dispatch"] --> Release
    Release -->|creates draft release| HumanPublish["Human publishes draft"]
    HumanPublish -->|release: published| Store["publish-store.yml\n(concurrency: serialize)"]
    ManualDispatch2["workflow_dispatch (tag input)"] --> Store
    Store -->|StoreBroker submit| MSStore["Microsoft Store certification\n(outside GitHub)"]
    PR["PR / push to main,next"] --> Audit["audit.yml\n(concurrency: cancel-in-progress)"]
    PR --> CodeQL["codeql.yml\n(concurrency: cancel-in-progress)"]
```

## Rehearsal findings (human-required checkpoints, unchanged by this PR — documented in `docs/PERMISSIONS.md`)

- Pushing the protected `v*` tag (branch/tag protection blocks non-human pushes).
- Editing and publishing the draft GitHub release (no workflow does this automatically).
- Microsoft Store certification — happens entirely on Microsoft's side after
  `publish-store.yml` commits the submission; a green run only means "submitted," not
  "live."
- Provisioning/rotating signing and Store secrets (`TAURI_SIGNING_PRIVATE_KEY*`,
  `STORE_TENANT_ID`/`STORE_CLIENT_ID`/`STORE_CLIENT_SECRET`/`STORE_APP_ID`) — CI can
  consume these but not generate them.

## Verification

- Spot-checked two of the SHA pins (`actions/checkout`, `github/codeql-action`) against
  `gh api` directly — both match exactly what was committed.
- No workflow behavior changes beyond the trigger/concurrency/pinning fixes above; job
  logic, secrets, and matrix configuration are untouched.

## Not in scope

- No automated lint/test/clippy workflow exists today (`bun run check`, `test:run`,
  `cargo test`, `cargo clippy` are manual, per `docs/RELEASE_CHECKLIST.md`) — `docs/CI.md`
  calls this out explicitly but adding that CI job is a separate change.
