### PR TITLE
chore: release v1.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2984,7 +2984,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "luminous"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "bs1770",

--- a/docs/release-notes/v1.0.1.md
+++ b/docs/release-notes/v1.0.1.md
@@ -1,0 +1,6 @@
+# v1.0.1
+
+Maintenance release — no user-facing changes.
+
+- Sped up dev builds and PR CI via a dev-profile override and Rust dependency caching
+  ([#479](https://github.com/esoltys/luminous/pull/479)).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "luminous",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A high-performance home for the music you already own",
   "author": "Eric James Soltys <ericjamessoltys@outlook.com>",
   "license": "MIT",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "luminous"
-version = "1.0.0"
+version = "1.0.1"
 description = "A high-performance home for the music you already own"
 authors = ["Eric James Soltys <ericjamessoltys@outlook.com>"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Luminous Music Player",
   "mainBinaryName": "LuminousMusicPlayer",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "identifier": "org.luminous.music",
   "build": {
     "beforeDevCommand": "bun run dev",


### PR DESCRIPTION
## Summary

Version-bump-only patch release. No user-facing changes.

- Bumps version to 1.0.1 in `package.json` / `Cargo.toml`.
- Adds `docs/release-notes/v1.0.1.md`.
- Covers [#479](https://github.com/esoltys/luminous/pull/479) (dev-profile build speedup +
  Rust dep caching for PR CI) — the only commit merged to `main` since `v1.0.0`.

## Verification

- `bun run check` — clean
- `bun run test:run` — 350/350 passed
- `cargo test` (src-tauri) — all suites passed
- `cargo clippy --all-targets` (src-tauri) — zero warnings
- `cargo test --test smoke_test -- --ignored --nocapture` — passed (real audio device, run by @esoltys)
- Manual `bun run tauri dev` exercise (import/scan, playback, playlists, tag editing, equalizer) — passed (run by @esoltys)
- `audit.yml` / `codeql.yml` — green on `main`

## Not in this PR

Tag push, GitHub release publish, and Microsoft Store submission are credential-gated —
handled after this PR merges, per `docs/RELEASE_CHECKLIST.md`.