### PR TITLE
docs: track CLAUDE.md, add Store submission status check

### DIFF
--- a/.github/store/Get-StoreSubmissionStatus.ps1
+++ b/.github/store/Get-StoreSubmissionStatus.ps1
@@ -1,0 +1,28 @@
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = "Stop"
+
+if (-not $env:STORE_TENANT_ID -or -not $env:STORE_CLIENT_ID -or -not $env:STORE_CLIENT_SECRET -or -not $env:STORE_APP_ID) {
+    throw "STORE_TENANT_ID, STORE_CLIENT_ID, STORE_CLIENT_SECRET and STORE_APP_ID must all be set."
+}
+
+if (-not (Get-Module -ListAvailable -Name StoreBroker)) {
+    Set-PSRepository -Name "PSGallery" -InstallationPolicy Trusted
+    Install-Module -Name StoreBroker -Force -Scope CurrentUser
+}
+
+$cred = New-Object System.Management.Automation.PSCredential (
+    $env:STORE_CLIENT_ID,
+    (ConvertTo-SecureString $env:STORE_CLIENT_SECRET -AsPlainText -Force)
+)
+Set-StoreBrokerAuthentication -TenantId $env:STORE_TENANT_ID -Credential $cred
+
+$app = Get-Application -AppId $env:STORE_APP_ID
+$submissionId = $app.pendingApplicationSubmission.id
+if (-not $submissionId) {
+    $submissionId = $app.lastPublishedApplicationSubmission.id
+    Write-Host "No pending submission. Reporting last published submission ($submissionId)."
+}
+
+Get-ApplicationSubmission -AppId $env:STORE_APP_ID -SubmissionId $submissionId

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,8 +7,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 The imported `AGENTS.md` above is the canonical instructions file for this repo (commands, architecture, invariants, workflow, design conventions) — it is kept up to date and applies to Claude Code equally. Everything below is Claude-Code-specific and supplements it.
 
 ## Release Process
+- If a release is being initiated from a Cloud Environment (not the user's local machine), STOP immediately and notify the user — cutting a release must be done from a local environment.
 - Tag pushes are protected on this repo: Claude cannot push `v*` tags (GitHub returns 403). When a release tag is needed, prepare everything else, then STOP and give the user the exact command to run (e.g. `git tag -a v1.0.0 -m 'Luminous v1.0.0' && git push origin v1.0.0`).
-- After the tag is pushed, resume by watching the release workflow and verifying the Microsoft Store submission actually went through (not just a green workflow).
+- After the tag is pushed, resume by watching the release workflow and verifying the Microsoft Store submission actually went through (not just a green workflow) — check actual certification status with `.github/store/Get-StoreSubmissionStatus.ps1` (requires `STORE_TENANT_ID`/`STORE_CLIENT_ID`/`STORE_CLIENT_SECRET`/`STORE_APP_ID` as local env vars), not just that `publish-store.yml` ran green.
 
 ### Definition of Done (releases)
 A release is only complete when **all four** of the following hold. Never report a release as done based on CI status alone.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,31 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+@AGENTS.md
+
+The imported `AGENTS.md` above is the canonical instructions file for this repo (commands, architecture, invariants, workflow, design conventions) — it is kept up to date and applies to Claude Code equally. Everything below is Claude-Code-specific and supplements it.
+
+## Release Process
+- Tag pushes are protected on this repo: Claude cannot push `v*` tags (GitHub returns 403). When a release tag is needed, prepare everything else, then STOP and give the user the exact command to run (e.g. `git tag -a v1.0.0 -m 'Luminous v1.0.0' && git push origin v1.0.0`).
+- After the tag is pushed, resume by watching the release workflow and verifying the Microsoft Store submission actually went through (not just a green workflow).
+
+### Definition of Done (releases)
+A release is only complete when **all four** of the following hold. Never report a release as done based on CI status alone.
+1. The release GitHub Actions workflow is green.
+2. A Microsoft Store submission exists and has a submission ID.
+3. The submission version matches the pushed tag.
+4. The GitHub release has the expected artifacts attached.
+
+## CI Monitoring
+- Use `gh run watch <run-id> --exit-status` to monitor a run instead of polling with repeated `gh run list`/API calls. Only fall back to scheduled re-checks for waits expected to exceed 15 minutes.
+- Track the last reported run ID/conclusion and do not re-report a result that was already surfaced to the user.
+
+## Workflows
+- This repo's `.github/workflows/` must not have overlapping triggers: check for duplicate `on:` conditions (e.g. both `push: tags` and `release: published`) before adding or editing a workflow.
+
+## Claude Code specifics
+
+- Use the tools in this harness (Read/Edit/Grep/Glob) instead of shelling out to `cat`/`sed`/`grep`/`find`.
+- Do not run `bun run tauri dev` as a background task — it does not work as expected in this harness. Ask the user to run it themselves and verify manually (AGENTS.md's Version Control section covers the full worktree → walkthrough → approval → merge → close workflow).
+- This project's dedicated worktree convention (`.claude/worktrees/` for Claude, `.worktrees/<name>/` for other assistants) is documented in AGENTS.md under Version Control — follow it for any bug/feature work.

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -48,6 +48,9 @@ manual.
 
 ## Cut the release
 
+- [ ] **If this release is being run from a Cloud Environment (not a local machine),
+      stop here and notify the user.** Cutting a release requires local execution —
+      don't proceed with the steps below from a cloud/remote environment.
 - [ ] `bun run release <version>` to bump the version, run checks, commit, and tag
       locally on the release worktree branch. Don't pass `--push` — that pushes the
       branch straight to `main`, bypassing branch protection and skipping review.
@@ -87,6 +90,17 @@ manual.
       an already-published release. Watch this run too, not just the build — a green run
       only means the submission was committed for certification, not that it's live yet;
       Microsoft's cert pass still has to complete.
+- [ ] Check actual certification status with the same StoreBroker credentials used by
+      `publish-store.yml` (set `STORE_TENANT_ID`/`STORE_CLIENT_ID`/`STORE_CLIENT_SECRET`/
+      `STORE_APP_ID` as local env vars first, from the values used to create those GitHub
+      secrets):
+  ```powershell
+  ./.github/store/Get-StoreSubmissionStatus.ps1
+  ```
+  Confirm `status` moves from `Certification` to `Published` (or check `statusDetails`
+  for errors if it doesn't). This is what actually satisfies "the Microsoft Store
+  submission went through" — a green `publish-store.yml` run only means the submission
+  was committed, not certified/live.
 - [ ] Download and install the new build on at least one real machine per platform
       (Windows + Linux) — don't just trust the CI build succeeded.
 - [ ] Verify the in-app updater picks up the new release from an older installed version


### PR DESCRIPTION
## Summary
- Track `CLAUDE.md` in git (was previously untracked under `.claude/`) and fix a broken `## CI Monitoring` section header left over from a prior edit.
- Add `.github/store/Get-StoreSubmissionStatus.ps1`, a read-only companion to `Submit-ToMicrosoftStore.ps1` that checks Microsoft Store certification status via StoreBroker, reusing the same `STORE_TENANT_ID`/`STORE_CLIENT_ID`/`STORE_CLIENT_SECRET`/`STORE_APP_ID` credentials already used for publishing.
- Fold the status check into `docs/RELEASE_CHECKLIST.md`'s Post-build section, since a green `publish-store.yml` run only means the submission was committed for certification, not that it's actually live.
- Add a guard (in both the checklist and `CLAUDE.md`) to stop and notify the user if a release is initiated from a Cloud Environment, since cutting a release requires local execution.

## Test plan
- [x] Ran `./.github/store/Get-StoreSubmissionStatus.ps1` locally against the live 1.0.0 submission — confirmed it authenticates and returns submission status (`Certification`) for AppId `9PNQ2NFSQ7XW`.
- [x] Skim `docs/RELEASE_CHECKLIST.md` and `CLAUDE.md` diffs for wording/placement.
