### PR TITLE
fix: truncate genre with ellipsis and move song count to line 3 in ArtistCard (#486)

### DIFF
--- a/src/lib/components/ArtistCard.svelte
+++ b/src/lib/components/ArtistCard.svelte
@@ -48,11 +48,15 @@
   >
     {artist.name || i18n.t('collection.unknownArtist')}
   </span>
-  <div class="flex gap-2 justify-center mt-2 text-xs text-brand-text-secondary font-medium">
-    <span>{genreLabel}</span>
-    <span>•</span>
-    <span>{i18n.t('playlists.songsCount', { count: artist.song_count })}</span>
-  </div>
+  <span
+    class="text-xs text-brand-text-secondary font-medium truncate w-full mt-1.5 text-center"
+    title={genreLabel}
+  >
+    {genreLabel}
+  </span>
+  <span class="text-xs text-brand-text-secondary font-medium truncate w-full mt-0.5 text-center">
+    {i18n.t('playlists.songsCount', { count: artist.song_count })}
+  </span>
 </div>
 
 <style>

--- a/src/lib/components/ArtistCard.test.ts
+++ b/src/lib/components/ArtistCard.test.ts
@@ -62,7 +62,10 @@ describe("ArtistCard.svelte", () => {
     });
 
     expect(getByText("Dave Hawkins")).toBeInTheDocument();
-    expect(getByText("Rock")).toBeInTheDocument();
+    const genreEl = getByText("Rock");
+    expect(genreEl).toBeInTheDocument();
+    expect(genreEl).toHaveAttribute("title", "Rock");
+    expect(genreEl.className).toContain("truncate");
     expect(getByText("6 songs")).toBeInTheDocument();
   });
 


### PR DESCRIPTION
## 📋 Summary
Fixes #486

Updates `ArtistCard.svelte` so that long, multi-value genre metadata is truncated to a single line with an ellipsis (`...`) instead of wrapping and expanding the card height unevenly in the Artists collection grid. In addition, moves the song count to line 3 underneath the genre line.

- **Line 1**: Artist name (`truncate`)
- **Line 2**: Genre label (`truncate` with ellipsis and `title` tooltip on hover)
- **Line 3**: Song count (`{count} songs`, centered)

## 🔍 Implementation Notes
- Replaced the flex container row in `ArtistCard.svelte` with separate block-level span elements for the genre and song count.
- Added `truncate`, `w-full`, and `title={genreLabel}` to line 2 for long genre display and hover tooltip.
- Added `mt-0.5`, `truncate`, and `w-full text-center` to line 3 for the song count.
- Updated `ArtistCard.test.ts` to assert that the genre element includes the `title` attribute and `truncate` class.

## 🧪 Test Plan
- [x] `bun run check` (svelte-check)
- [x] `bun run test:run` (frontend)
- [x] Manually verified in the app

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed
