### PR TITLE
fix: ignore winget validate schema-header warnings in CI

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -73,9 +73,14 @@ jobs:
         run: bun run scripts/submit-winget.ts --check
 
       # winget validate needs the multi-file manifest pointed at its version
-      # folder, not an individual file — see #477.
+      # folder, not an individual file — see #477. --ignore-warnings because
+      # winget validate exits non-zero on ANY warning by default, including a
+      # "schema header URL does not match expected pattern" warning that
+      # depends on the runner's own winget build having our exact schema $id
+      # baked in — a real mismatch/error still fails without --ignore-warnings.
       - name: Validate winget manifest with winget CLI
         shell: bash
         run: |
+          winget --version
           latest=$(ls -1 winget/manifests/e/EricSoltys/LuminousMusicPlayer | sort -t. -k1,1n -k2,2n -k3,3n | tail -1)
-          winget validate --manifest "winget/manifests/e/EricSoltys/LuminousMusicPlayer/$latest"
+          winget validate --manifest "winget/manifests/e/EricSoltys/LuminousMusicPlayer/$latest" --ignore-warnings

--- a/scripts/submit-winget.ts
+++ b/scripts/submit-winget.ts
@@ -209,7 +209,14 @@ function writeManifests(targetDir: string, info: ReleaseInfo) {
 function validateManifest(dir: string) {
   console.log(`\nValidating manifest at ${dir}...`);
   try {
-    execSync(`winget validate --manifest "${dir}"`, { cwd: rootDir, stdio: "inherit" });
+    // `winget validate` throws (nonzero exit) on ANY warning by default, not
+    // just hard errors — e.g. a "schema header URL does not match the
+    // expected pattern" warning when the running winget build's embedded
+    // schema $id doesn't byte-for-byte match our header, which varies by
+    // winget version (seen on GitHub's windows-latest runner but not
+    // locally). --ignore-warnings keeps real errors failing while not
+    // gating on that version-dependent noise.
+    execSync(`winget validate --manifest "${dir}" --ignore-warnings`, { cwd: rootDir, stdio: "inherit" });
   } catch {
     throw new Error("winget manifest validation failed. See output above.");
   }


### PR DESCRIPTION
## 📋 Summary
Follow-up to #493 — the new "winget Manifest Drift Check" CI job failed on main after merge (run [32312829380](https://github.com/esoltys/luminous/actions/runs/32312829380)): `winget validate` exited non-zero on a "schema header URL does not match the expected pattern" warning.

## 🔍 Implementation Notes
`winget validate` throws on **any** warning by default, not just hard errors (`ThrowOnWarning` defaults true in winget-cli's `ValidateCommand.cpp` unless `--ignore-warnings` is passed). Our schema header (`# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json`) matches the exact convention used in accepted winget-pkgs manifests and their own "good" test fixtures — but winget-cli additionally byte-compares it against the running binary's embedded schema `$id`, which is version-dependent. It validated clean locally (`winget` 1.29.290) but warned on GitHub's `windows-latest` runner's bundled version.

Added `--ignore-warnings` to both the CI step and `scripts/submit-winget.ts`'s `validateManifest()`, plus a `winget --version` print in CI for future debugging. Real manifest errors (bad schema, missing fields, etc.) still fail the build — only the warning tier is suppressed.

## 🧪 Test Plan
- [x] `winget validate --manifest winget/manifests/e/EricSoltys/LuminousMusicPlayer/1.0.0 --ignore-warnings` — succeeds locally
- [x] `bun run check` — 0 errors
- [ ] Confirm the CI job goes green on this PR

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed — N/A, CI/tooling only