### PR TITLE
docs: expand v1.0.1 release notes with fixes landed since drafting

### DIFF
--- a/docs/release-notes/v1.0.1.md
+++ b/docs/release-notes/v1.0.1.md
@@ -1,6 +1,21 @@
 # v1.0.1
 
-Maintenance release — no user-facing changes.
+Maintenance release with two small UI fixes.
 
+### 🐛 Fixes
+- **Updater panel now handles deb/rpm installs correctly**, not just MSIX: previously
+  those formats fell through to a dead-end panel that polled for updates but had no
+  working install action. Each externally-managed format (flatpak, deb, rpm, MSIX) now
+  shows the right state, with MSIX getting the official "Get it from Microsoft Store"
+  badge ([#420](https://github.com/esoltys/luminous/issues/420)).
+- **Long genre labels in the Artists grid no longer wrap and unevenly stretch the
+  card** — truncated to one line with an ellipsis and a hover tooltip; song count
+  moved to its own line underneath
+  ([#486](https://github.com/esoltys/luminous/issues/486)).
+
+### 🛠️ Internal
 - Sped up dev builds and PR CI via a dev-profile override and Rust dependency caching
   ([#479](https://github.com/esoltys/luminous/pull/479)).
+- Automated winget manifest generation/validation and hardened CI workflow triggers
+  and concurrency ([#477](https://github.com/esoltys/luminous/issues/477),
+  [#487](https://github.com/esoltys/luminous/pull/487)).


### PR DESCRIPTION
## Summary
- The v1.0.1 release notes were drafted right after the version bump (#488) and only credited #479. Two more user-facing fixes landed on `main` afterward and weren't reflected:
  - Updater panel installer-awareness fix (#420 / #491)
  - ArtistCard genre truncation fix (#486 / #490)
- Reclassified the entry into Fixes vs. Internal so the release notes accurately describe what's shipping in v1.0.1.

## Test plan
- [x] Docs-only change, no build/test impact