### PR TITLE
fix: avoid shell interpolation of release tag/asset in winget script

### DIFF
--- a/scripts/submit-winget.ts
+++ b/scripts/submit-winget.ts
@@ -12,7 +12,7 @@
 // only the local manifest folder is (re)generated — nothing is submitted
 // upstream. --check regenerates into a temp dir and diffs against the
 // latest committed version folder, exiting non-zero on drift.
-import { execSync } from "child_process";
+import { execFileSync, execSync } from "child_process";
 import * as crypto from "crypto";
 import * as fs from "fs";
 import * as path from "path";
@@ -79,8 +79,9 @@ async function fetchReleaseInfo(version: string): Promise<ReleaseInfo> {
   const tag = `v${version}`;
   console.log(`Fetching release ${tag} from GitHub...`);
 
-  const assetsJson = execSync(
-    `gh release view ${tag} --json assets -q ".assets[].name"`,
+  const assetsJson = execFileSync(
+    "gh",
+    ["release", "view", tag, "--json", "assets", "-q", ".assets[].name"],
     { cwd: rootDir, encoding: "utf-8" }
   );
   const assetNames = assetsJson.split("\n").map(s => s.trim()).filter(Boolean);
@@ -96,7 +97,7 @@ async function fetchReleaseInfo(version: string): Promise<ReleaseInfo> {
   fs.mkdirSync(scratchDir, { recursive: true });
 
   console.log(`Downloading ${exeAsset}...`);
-  execSync(`gh release download ${tag} -p "${exeAsset}" -D "${scratchDir}"`, {
+  execFileSync("gh", ["release", "download", tag, "-p", exeAsset, "-D", scratchDir], {
     cwd: rootDir,
     stdio: "inherit"
   });


### PR DESCRIPTION
## Summary
- CodeQL flagged two `execSync` calls in `scripts/submit-winget.ts` (release view/download) as shell commands built from uncontrolled input — the release tag and asset name, both derived from the CLI `<version>` argument.
- Switch both to `execFileSync` with an argument array so nothing is interpolated into a shell string.

Found while reviewing the [main → next sync PR #504](https://github.com/esoltys/luminous/pull/504); backported here since the vulnerable code originates on `main` (#477/#493).

## Test plan
- [x] `bun run check` — 0 errors