### PR TITLE
docs: add Epic issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/epic.md
+++ b/.github/ISSUE_TEMPLATE/epic.md
@@ -1,0 +1,19 @@
+---
+name: 🏗️ Epic (Internal / Dev Template)
+description: Internal template for tracking a multi-issue effort at a glance
+title: 'Epic: '
+labels: []
+---
+
+## ⭐ Epic
+<!-- A clear and concise description of the overall effort this epic tracks, why it matters, and how it's scoped. Link to relevant docs (e.g. AGENTS.md product scope) if the scoping decision needs justification. -->
+
+This issue tracks the overall effort at a glance. Implementation detail lives in the sub-issues below, not here.
+
+## Sub-issues
+<!-- Checklist of the issues that make up this epic. Check off closed ones; leave open ones unchecked. -->
+
+- [ ] #0 — <!-- short description -->
+
+## Related
+<!-- Optional: adjacent issues that inform or overlap with this epic but aren't part of its scope. -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,9 @@ A release is only complete when **all four** of the following hold. Never report
 ## Workflows
 - This repo's `.github/workflows/` must not have overlapping triggers: check for duplicate `on:` conditions (e.g. both `push: tags` and `release: published`) before adding or editing a workflow.
 
+## GitHub issue/PR body formatting
+- GitHub renders a single `\n` within a paragraph as a hard line break (not CommonMark's soft-wrap-to-space behavior). Never hand-wrap prose paragraphs in an issue/PR body at ~80-100 cols like source code — write each paragraph and each bullet as one unwrapped line, or the rendered body shows spurious mid-sentence line breaks.
+
 ## Claude Code specifics
 
 - Use the tools in this harness (Read/Edit/Grep/Glob) instead of shelling out to `cat`/`sed`/`grep`/`find`.


### PR DESCRIPTION
## Summary
- Add `.github/ISSUE_TEMPLATE/epic.md`, an internal/dev-style template for "Epic:" tracking issues (⭐ Epic / Sub-issues / Related sections), matching the structure already used by #419 and #510.
- Add a note to `CLAUDE.md` that GitHub renders a single `\n` as a hard line break in issue/PR bodies, so prose should be written as one unwrapped line per paragraph rather than hand-wrapped — learned while fixing spurious line breaks in #510's description.
