### PR TITLE
ci: gate PRs on frontend typecheck, frontend tests, and backend tests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,9 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    ignore:
+      # svelte-check's --tsgo mode requires typescript@~6.x installed
+      # alongside @typescript/native-preview@~7.x (the tsgo binary) - bumping
+      # typescript itself past 6.x breaks that dual-version pairing. See #522.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,75 @@
+name: CI
+
+on:
+  push:
+    branches: [ "main", "next" ]
+  pull_request:
+    branches: [ "main", "next" ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  frontend_check:
+    name: Frontend Typecheck
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run svelte-check
+        run: bun run check
+
+  frontend_test:
+    name: Frontend Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run Vitest
+        run: bun run test:run
+
+  backend_test:
+    name: Backend Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+
+      - name: Install system dependencies (Linux)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libasound2-dev libssl-dev pkg-config libayatana-appindicator3-dev
+
+      # Caches the registry, git deps, and target dir across PR builds so
+      # `cargo test` below doesn't recompile the whole dependency graph
+      # (Symphonia, rusqlite, Tauri, etc.) from scratch on every run.
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+        with:
+          workspaces: src-tauri
+
+      - name: Run cargo test
+        working-directory: src-tauri
+        run: cargo test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Install system dependencies (Linux)
         run: |
           sudo apt-get update
-          sudo apt-get install -y libasound2-dev libssl-dev pkg-config libayatana-appindicator3-dev
+          sudo apt-get install -y libasound2-dev libssl-dev pkg-config libglib2.0-dev libgtk-3-dev libwebkit2gtk-4.1-dev libayatana-appindicator3-dev
 
       # Caches the registry, git deps, and target dir across PR builds so
       # `cargo test` below doesn't recompile the whole dependency graph


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/ci.yml` with three jobs on `pull_request`/`push` to `main`/`next`: `bun run check` (svelte-check --tsgo), `bun run test:run` (Vitest), and `cargo test` (backend).
- None of the existing workflows (`audit.yml`, `codeql.yml`, `flatpak.yml`, `release.yml`) run these — `codeql.yml` only runs `cargo check` for its own analysis pass, not the test suite.

## Why
Discovered while triaging open Dependabot PRs: the TypeScript 6→7 bump (#499) breaks svelte-check's `--tsgo` dual-version requirement (it needs both `typescript@~6` and `@typescript/native-preview@~7` installed together). That PR would have merged cleanly since it only happened to also fail the unrelated `bun.lock`/winget manifest drift checks — nothing was actually gating PRs on typecheck or tests.

## Test plan
- [x] Ran `bun run check`, `bun run test:run` (419 passed), and `cargo test` locally to confirm all three commands succeed on `main` as a baseline.
- [x] Confirm the new `CI` workflow runs and passes on this PR itself.