### PR TITLE
feat: native desktop notifications on track change

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8,6 +8,7 @@
         "@tailwindcss/vite": "^4.3.3",
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2.7.2",
+        "@tauri-apps/plugin-notification": "^2.3.3",
         "@tauri-apps/plugin-opener": "^2",
         "@tauri-apps/plugin-positioner": "^2.3.3",
         "@tauri-apps/plugin-process": "^2",
@@ -293,6 +294,8 @@
     "@tauri-apps/cli-win32-x64-msvc": ["@tauri-apps/cli-win32-x64-msvc@2.11.4", "", { "os": "win32", "cpu": "x64" }, "sha512-+vDiqBIU5dMISg/wNvX3sF+ZHfgJGJ5T0AcO+EHNXV9GGAG+P5fzodlDXD3QdKCRgZxMoCm5PPvj3BqLNjBthw=="],
 
     "@tauri-apps/plugin-dialog": ["@tauri-apps/plugin-dialog@2.7.2", "", { "dependencies": { "@tauri-apps/api": "^2.11.0" } }, "sha512-pX0IGm1I3I6wc+zeKYcq1GSqogK6okCNX5fOdaNU5ab1AjGS6l1E5wFNjEb7meg7ZFSp0JUs+0jQGQNyOvLrsg=="],
+
+    "@tauri-apps/plugin-notification": ["@tauri-apps/plugin-notification@2.3.3", "", { "dependencies": { "@tauri-apps/api": "^2.8.0" } }, "sha512-Zw+ZH18RJb41G4NrfHgIuofJiymusqN+q8fGUIIV7vyCH+5sSn5coqRv/MWB9qETsUs97vmU045q7OyseCV3Qg=="],
 
     "@tauri-apps/plugin-opener": ["@tauri-apps/plugin-opener@2.5.4", "", { "dependencies": { "@tauri-apps/api": "^2.11.0" } }, "sha512-1HnPkb+AmgO29HBazm4uPLKB+r7zzcTBW1d0fyYp1uP+jwtpoiNDGKMMzz58SFp49nOIrxdE3aUJtT57lfO9CQ=="],
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@tailwindcss/vite": "^4.3.3",
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-dialog": "^2.7.2",
+    "@tauri-apps/plugin-notification": "^2.3.3",
     "@tauri-apps/plugin-opener": "^2",
     "@tauri-apps/plugin-positioner": "^2.3.3",
     "@tauri-apps/plugin-process": "^2",

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -12,6 +12,9 @@
     "positioner:default",
     "updater:default",
     "process:allow-restart",
+    "notification:allow-is-permission-granted",
+    "notification:allow-request-permission",
+    "notification:allow-notify",
     {
       "identifier": "fs:allow-read",
       "allow": [

--- a/src-tauri/src/collection.rs
+++ b/src-tauri/src/collection.rs
@@ -1715,10 +1715,7 @@ fn attach_album_ratings(conn: &rusqlite::Connection, items: &mut [HomeItem]) -> 
 }
 
 /// Retrieve customizable profile for an artist from SQLite (#473).
-pub fn get_artist_profile_conn(
-    conn: &rusqlite::Connection,
-    artist: &str,
-) -> Result<ArtistProfile> {
+pub fn get_artist_profile_conn(conn: &rusqlite::Connection, artist: &str) -> Result<ArtistProfile> {
     let mut stmt = conn.prepare(
         "SELECT artist_key, website, tags, social_links, bio FROM artist_profiles WHERE artist_key = ?1 COLLATE NOCASE",
     )?;
@@ -2109,7 +2106,10 @@ pub(crate) fn read_tags(path: &Path) -> Result<Song> {
         candidate_tags.push(primary);
     }
     for t in tagged_file.tags() {
-        if !candidate_tags.iter().any(|existing| std::ptr::eq(*existing, t)) {
+        if !candidate_tags
+            .iter()
+            .any(|existing| std::ptr::eq(*existing, t))
+        {
             candidate_tags.push(t);
         }
     }
@@ -2183,9 +2183,7 @@ pub(crate) fn read_tags(path: &Path) -> Result<Song> {
         }
 
         if song.grouping.is_none() {
-            song.grouping = tag
-                .get_string(ItemKey::ContentGroup)
-                .map(|s| s.to_string());
+            song.grouping = tag.get_string(ItemKey::ContentGroup).map(|s| s.to_string());
         }
         if song.initial_key.is_none() {
             song.initial_key = tag.get_string(ItemKey::InitialKey).map(|s| s.to_string());
@@ -2468,7 +2466,8 @@ pub(crate) const SONG_SELECT_COLS: &str = "
 /// and `row_to_song_at`'s field order — `cargo test` in `collection.rs`
 /// exercises every column through `row_to_song`, so a mismatch fails loudly
 /// there instead of silently defaulting a field at a call site.
-pub(crate) const SONG_SELECT_COLS_QUALIFIED: &str = "s.id, s.source, s.filetype, s.path, s.url, s.stream_url,
+pub(crate) const SONG_SELECT_COLS_QUALIFIED: &str =
+    "s.id, s.source, s.filetype, s.path, s.url, s.stream_url,
     s.title, s.titlesort, s.artist, s.artistsort,
     s.album, s.albumsort, s.album_artist, s.album_artist_sort,
     s.composer, s.composersort, s.performer, s.performersort,
@@ -5335,7 +5334,10 @@ mod tests {
         // Retrieve saved profile (case-insensitive key match)
         let loaded = get_artist_profile_conn(&conn, "shania twain").unwrap();
         assert_eq!(loaded.artist_key, "Shania Twain");
-        assert_eq!(loaded.website, Some("https://www.shaniatwain.com".to_string()));
+        assert_eq!(
+            loaded.website,
+            Some("https://www.shaniatwain.com".to_string())
+        );
         assert_eq!(loaded.tags, vec!["pop", "country", "canadian"]);
         assert_eq!(loaded.social_links.len(), 2);
         assert_eq!(loaded.social_links[0].platform, "instagram");

--- a/src-tauri/src/commands/collection.rs
+++ b/src-tauri/src/commands/collection.rs
@@ -276,7 +276,5 @@ pub async fn get_all_artist_profiles(
     state: State<'_, AppState>,
 ) -> Result<Vec<ArtistProfile>, String> {
     let scanner = CollectionScanner::new(state.db.clone());
-    scanner
-        .get_all_artist_profiles()
-        .map_err(|e| e.to_string())
+    scanner.get_all_artist_profiles().map_err(|e| e.to_string())
 }

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -193,6 +193,43 @@ pub async fn set_minimize_to_tray_enabled(
     Ok(())
 }
 
+/// Reads the persisted preference directly from the DB — unlike
+/// [`get_minimize_to_tray_enabled`] this has no in-memory mirror because
+/// nothing on the Rust side needs to act on it; the frontend alone decides
+/// whether to send a notification on track change.
+#[tauri::command]
+pub fn get_track_notifications_enabled(state: State<'_, AppState>) -> bool {
+    let Ok(conn) = state.db.pool.get() else {
+        return false;
+    };
+    conn.query_row(
+        "SELECT value FROM app_state WHERE key = 'track_notifications_enabled'",
+        [],
+        |row| row.get::<_, String>(0),
+    )
+    .map(|v| v == "true")
+    .unwrap_or(false)
+}
+
+/// Fire-and-forget like [`set_app_setting`] — always `Ok`.
+#[tauri::command]
+pub async fn set_track_notifications_enabled(
+    state: State<'_, AppState>,
+    enabled: bool,
+) -> Result<(), String> {
+    let Ok(conn) = state.db.pool.get() else {
+        log::error!("Failed to persist track_notifications_enabled setting: no DB connection");
+        return Ok(());
+    };
+    if let Err(e) = conn.execute(
+        "INSERT OR REPLACE INTO app_state (key, value) VALUES ('track_notifications_enabled', ?1)",
+        rusqlite::params![enabled.to_string()],
+    ) {
+        log::error!("Failed to persist track_notifications_enabled setting: {e}");
+    }
+    Ok(())
+}
+
 #[tauri::command]
 pub fn get_commit_hash() -> String {
     option_env!("BUILD_COMMIT_HASH").unwrap_or("").to_string()

--- a/src-tauri/src/commands/tags.rs
+++ b/src-tauri/src/commands/tags.rs
@@ -76,6 +76,11 @@ pub async fn get_songs_by_genre_edge(
 ) -> Result<Vec<Song>, String> {
     let manager = TagManager::new(state.db.clone());
     manager
-        .get_songs_by_genre_edge(&root_tag, &child_tag, limit.unwrap_or(50), mode.unwrap_or_default())
+        .get_songs_by_genre_edge(
+            &root_tag,
+            &child_tag,
+            limit.unwrap_or(50),
+            mode.unwrap_or_default(),
+        )
         .map_err(|e| e.to_string())
 }

--- a/src-tauri/src/covermanager.rs
+++ b/src-tauri/src/covermanager.rs
@@ -108,12 +108,7 @@ impl CoverManager {
         let picture = tagged_file
             .primary_tag()
             .and_then(|t| t.pictures().first())
-            .or_else(|| {
-                tagged_file
-                    .tags()
-                    .iter()
-                    .find_map(|t| t.pictures().first())
-            });
+            .or_else(|| tagged_file.tags().iter().find_map(|t| t.pictures().first()));
 
         let picture = match picture {
             Some(p) => p,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -827,6 +827,8 @@ pub fn run() {
             commands::settings::set_fade_settings,
             commands::settings::get_minimize_to_tray_enabled,
             commands::settings::set_minimize_to_tray_enabled,
+            commands::settings::get_track_notifications_enabled,
+            commands::settings::set_track_notifications_enabled,
             install_format::get_install_format,
             // Stats commands
             commands::stats::set_song_rating,

--- a/src-tauri/src/playlist.rs
+++ b/src-tauri/src/playlist.rs
@@ -984,7 +984,10 @@ impl PlaylistManager {
                         candidate_tags.push(primary);
                     }
                     for t in tagged.tags() {
-                        if !candidate_tags.iter().any(|existing| std::ptr::eq(*existing, t)) {
+                        if !candidate_tags
+                            .iter()
+                            .any(|existing| std::ptr::eq(*existing, t))
+                        {
                             candidate_tags.push(t);
                         }
                     }

--- a/src-tauri/src/tags.rs
+++ b/src-tauri/src/tags.rs
@@ -73,13 +73,17 @@ impl TagManager {
         for values in lists {
             let Some(root) = values.first() else { continue };
             let root_key = root.to_lowercase();
-            let root_entry = root_counts.entry(root_key.clone()).or_insert_with(|| (root.clone(), 0));
+            let root_entry = root_counts
+                .entry(root_key.clone())
+                .or_insert_with(|| (root.clone(), 0));
             root_entry.1 += 1;
 
             let children = child_counts.entry(root_key).or_default();
             for child in &values[1..] {
                 let child_key = child.to_lowercase();
-                let child_entry = children.entry(child_key).or_insert_with(|| (child.clone(), 0));
+                let child_entry = children
+                    .entry(child_key)
+                    .or_insert_with(|| (child.clone(), 0));
                 child_entry.1 += 1;
             }
         }
@@ -157,7 +161,11 @@ impl TagManager {
     }
 
     /// Songs with no genre value at all — the "No Genre" browsable group.
-    pub fn get_songs_without_genre(&self, limit: i64, mode: QueuePopulationMode) -> Result<Vec<Song>> {
+    pub fn get_songs_without_genre(
+        &self,
+        limit: i64,
+        mode: QueuePopulationMode,
+    ) -> Result<Vec<Song>> {
         let conn = self.db.pool.get()?;
         let (extra_where, order_by) = mode_query_fragments(mode);
         let sql = format!(
@@ -313,9 +321,7 @@ impl TagManager {
                     return false;
                 };
                 main.to_lowercase() == root_target
-                    && values[1..]
-                        .iter()
-                        .any(|v| v.to_lowercase() == child_target)
+                    && values[1..].iter().any(|v| v.to_lowercase() == child_target)
             })
             .take(limit.max(0) as usize)
             .collect();
@@ -359,7 +365,10 @@ mod tests {
         let manager = TagManager::new(db.clone());
         let tags = manager.list_all_tags().unwrap();
         assert_eq!(tags.len(), 2);
-        let metal = tags.iter().find(|t| t.name.eq_ignore_ascii_case("metal")).unwrap();
+        let metal = tags
+            .iter()
+            .find(|t| t.name.eq_ignore_ascii_case("metal"))
+            .unwrap();
         assert_eq!(metal.song_count, 2);
 
         let _ = std::fs::remove_dir_all(dir);
@@ -433,7 +442,10 @@ mod tests {
         let metal = graph.iter().find(|g| g.main_tag == "Metal").unwrap();
         assert!(metal.children.iter().any(|c| c.name == "Symphonic Metal"));
         let classical = graph.iter().find(|g| g.main_tag == "Classical").unwrap();
-        assert!(classical.children.iter().any(|c| c.name == "Symphonic Metal"));
+        assert!(classical
+            .children
+            .iter()
+            .any(|c| c.name == "Symphonic Metal"));
 
         let _ = std::fs::remove_dir_all(dir);
     }
@@ -471,7 +483,11 @@ mod tests {
         let by_main = manager
             .get_songs_by_main_tag("Ambient Folk", 50, QueuePopulationMode::All)
             .unwrap();
-        assert_eq!(by_main.len(), 1, "main-tag match excludes the subgenre-only song");
+        assert_eq!(
+            by_main.len(),
+            1,
+            "main-tag match excludes the subgenre-only song"
+        );
         assert_eq!(by_main[0].genre.as_deref(), Some("Ambient Folk"));
 
         let _ = std::fs::remove_dir_all(dir);
@@ -490,13 +506,19 @@ mod tests {
             .get_songs_by_genre_edge("Metal", "Symphonic Metal", 50, QueuePopulationMode::All)
             .unwrap();
         assert_eq!(under_metal.len(), 1);
-        assert_eq!(under_metal[0].genre.as_deref(), Some("Metal; Symphonic Metal"));
+        assert_eq!(
+            under_metal[0].genre.as_deref(),
+            Some("Metal; Symphonic Metal")
+        );
 
         let under_classical = manager
             .get_songs_by_genre_edge("Classical", "Symphonic Metal", 50, QueuePopulationMode::All)
             .unwrap();
         assert_eq!(under_classical.len(), 1);
-        assert_eq!(under_classical[0].genre.as_deref(), Some("Classical; Symphonic Metal"));
+        assert_eq!(
+            under_classical[0].genre.as_deref(),
+            Some("Classical; Symphonic Metal")
+        );
 
         let _ = std::fs::remove_dir_all(dir);
     }

--- a/src/lib/components/FoldersView.svelte
+++ b/src/lib/components/FoldersView.svelte
@@ -450,6 +450,18 @@
             label={i18n.t('settings.minimizeToTrayLabel')}
           />
         </div>
+
+        <div class="flex items-center justify-between gap-4 py-4">
+          <div class="flex flex-col gap-0.5 min-w-0">
+            <span class="text-sm font-medium text-brand-text-primary">{i18n.t('settings.trackNotificationsLabel')}</span>
+            <p class="text-xs text-brand-text-secondary">{i18n.t('settings.trackNotificationsHint')}</p>
+          </div>
+          <Toggle
+            checked={prefs.trackNotificationsEnabled}
+            onchange={(v) => prefs.setTrackNotificationsEnabled(v)}
+            label={i18n.t('settings.trackNotificationsLabel')}
+          />
+        </div>
       </div>
 
       {#if updaterStore.isExternallyManaged}

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -222,6 +222,8 @@ export const en = {
     ratingStyleHint: "Choose Heart to mark songs as favourites, or 5-star for half-step ratings — both save to the same rating.",
     minimizeToTrayLabel: "Minimize to tray",
     minimizeToTrayHint: "Closing the window hides Luminous to the system tray instead of quitting.",
+    trackNotificationsLabel: "Song change notifications",
+    trackNotificationsHint: "Show a desktop notification when a new track begins playing",
     appAndUpdatesTitle: "Application & Updates",
     updateCheckNowBtn: "Check for Updates",
     updateChecking: "Checking...",

--- a/src/lib/locales/fr.ts
+++ b/src/lib/locales/fr.ts
@@ -222,6 +222,8 @@ export const fr = {
     ratingStyleHint: "Choisissez Cœur pour marquer les chansons comme favorites, ou 5 étoiles pour des notes par demi-étoile — les deux utilisent la même note.",
     minimizeToTrayLabel: "Réduire dans la barre système",
     minimizeToTrayHint: "Fermer la fenêtre masque Luminous dans la barre système au lieu de quitter l'application.",
+    trackNotificationsLabel: "Notifications de changement de morceau",
+    trackNotificationsHint: "Afficher une notification de bureau lorsqu'un nouveau morceau commence",
     appAndUpdatesTitle: "Application & Mises à jour",
     updateCheckNowBtn: "Rechercher des mises à jour",
     updateChecking: "Vérification...",

--- a/src/lib/stores/player.svelte.ts
+++ b/src/lib/stores/player.svelte.ts
@@ -1,12 +1,15 @@
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { open } from "@tauri-apps/plugin-dialog";
+import { isPermissionGranted, sendNotification } from "@tauri-apps/plugin-notification";
 import type { PlaybackState, Playlist, PlaylistItem, Song, ShuffleMode, RepeatMode, PlayState, LoudnessGainSource, PlayContext } from "../types";
+import { getCoverArtUrl } from "../types";
 import { applySongStats, type SongStatsPayload } from "../utils/stats";
 import { themeStore } from "./theme.svelte";
 import { toastStore } from "./toast.svelte";
 import { playlistsStore } from "./playlists.svelte";
 import { i18n } from "./i18n.svelte";
+import { prefs } from "./prefs.svelte";
 
 export class PlayerStore {
   state = $state<PlayState>("stopped");
@@ -83,6 +86,9 @@ export class PlayerStore {
         this.currentSong = event.payload.song || undefined;
         themeStore.updateArtworkColors(this.currentSong);
         await this.syncQueueTrackPosition();
+        if (this.currentSong) {
+          this.notifyTrackChange(this.currentSong);
+        }
       });
 
       // A song couldn't be opened/decoded (e.g. its file just vanished —
@@ -142,6 +148,61 @@ export class PlayerStore {
         "error"
       );
     }
+  }
+
+  /** Native desktop notification on track change (#524) — opt-in via
+   * Settings > General (`prefs.trackNotificationsEnabled`); permission is
+   * requested when the user turns the toggle on (see `prefs.svelte.ts`), so
+   * this only checks that it was actually granted. Best-effort throughout:
+   * a missing preference, ungranted permission, or unresolvable cover art
+   * just means no notification (or an icon-less one) — never an error that
+   * could interrupt playback. */
+  private notifyTrackChange(song: Song) {
+    if (!prefs.trackNotificationsEnabled) return;
+    void (async () => {
+      try {
+        if (!(await isPermissionGranted())) return;
+        const icon = await this.resolveNotificationIcon(song);
+        sendNotification({
+          title: song.title || i18n.t("collection.unknownSong"),
+          body: [song.artist, song.album].filter((v): v is string => !!v).join(" — "),
+          icon: icon ?? undefined,
+        });
+      } catch (err) {
+        console.error("Failed to send track-change notification:", err);
+      }
+    })();
+  }
+
+  /** Mirrors the art-resolution branches in `themeStore.updateArtworkColors`
+   * (manual override → automatic/album art → embedded art via
+   * `get_cover_art_uri`). Kept local rather than shared since it only needs
+   * to produce a best-effort icon URL, not drive theme extraction. */
+  private async resolveNotificationIcon(song: Song): Promise<string | null> {
+    if (song.art_manual) {
+      if (song.art_manual.startsWith("http://") || song.art_manual.startsWith("https://") || song.art_manual.startsWith("/")) {
+        return song.art_manual;
+      }
+      return getCoverArtUrl(`luminous-art://${song.art_manual}`);
+    }
+    if (song.art_automatic) {
+      if (song.art_automatic.startsWith("http://") || song.art_automatic.startsWith("https://") || song.art_automatic.startsWith("/")) {
+        return song.art_automatic;
+      }
+      if (song.art_automatic.startsWith("album-")) {
+        return getCoverArtUrl(`luminous-art://${song.art_automatic}`);
+      }
+      return getCoverArtUrl(`luminous-art://local/${song.art_automatic}`);
+    }
+    if (song.art_embedded) {
+      try {
+        const uri = await invoke<string | null>("get_cover_art_uri", { songId: song.id });
+        return uri ? getCoverArtUrl(uri) : null;
+      } catch {
+        return null;
+      }
+    }
+    return null;
   }
 
   private updateState(state: PlaybackState) {

--- a/src/lib/stores/player.test.ts
+++ b/src/lib/stores/player.test.ts
@@ -3,6 +3,8 @@ import { PlayerStore } from "./player.svelte";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { playlistsStore } from "./playlists.svelte";
+import { prefs } from "./prefs.svelte";
+import { isPermissionGranted, sendNotification } from "@tauri-apps/plugin-notification";
 
 describe("PlayerStore", () => {
   let store: PlayerStore;
@@ -165,5 +167,82 @@ describe("PlayerStore", () => {
     expect(store.currentSong).toBeUndefined();
 
     if (originalListenImpl) vi.mocked(listen).mockImplementation(originalListenImpl);
+  });
+
+  describe("track-change desktop notifications (#524)", () => {
+    it("sends a notification with title/artist/album when enabled and permitted", async () => {
+      prefs.trackNotificationsEnabled = true;
+      vi.mocked(isPermissionGranted).mockResolvedValueOnce(true);
+
+      const originalListenImpl = vi.mocked(listen).getMockImplementation();
+      let trackChangedCallback: ((event: { payload: { song: unknown } }) => void) | undefined;
+      vi.mocked(listen).mockImplementation(async (event: string, callback: any) => {
+        if (event === "track-changed") trackChangedCallback = callback;
+        return () => {};
+      });
+
+      store = new PlayerStore();
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      trackChangedCallback?.({
+        payload: { song: { id: 1, title: "Test Song", artist: "Test Artist", album: "Test Album" } },
+      });
+      // Flush the fire-and-forget notifyTrackChange() microtask chain.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(sendNotification).toHaveBeenCalledWith(
+        expect.objectContaining({ title: "Test Song", body: "Test Artist — Test Album" })
+      );
+
+      prefs.trackNotificationsEnabled = false;
+      if (originalListenImpl) vi.mocked(listen).mockImplementation(originalListenImpl);
+    });
+
+    it("does not send a notification when the preference is disabled", async () => {
+      prefs.trackNotificationsEnabled = false;
+
+      const originalListenImpl = vi.mocked(listen).getMockImplementation();
+      let trackChangedCallback: ((event: { payload: { song: unknown } }) => void) | undefined;
+      vi.mocked(listen).mockImplementation(async (event: string, callback: any) => {
+        if (event === "track-changed") trackChangedCallback = callback;
+        return () => {};
+      });
+
+      store = new PlayerStore();
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      trackChangedCallback?.({ payload: { song: { id: 1, title: "Test Song" } } });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(sendNotification).not.toHaveBeenCalled();
+
+      if (originalListenImpl) vi.mocked(listen).mockImplementation(originalListenImpl);
+    });
+
+    it("does not send a notification when enabled but OS permission isn't granted", async () => {
+      prefs.trackNotificationsEnabled = true;
+      vi.mocked(isPermissionGranted).mockResolvedValueOnce(false);
+
+      const originalListenImpl = vi.mocked(listen).getMockImplementation();
+      let trackChangedCallback: ((event: { payload: { song: unknown } }) => void) | undefined;
+      vi.mocked(listen).mockImplementation(async (event: string, callback: any) => {
+        if (event === "track-changed") trackChangedCallback = callback;
+        return () => {};
+      });
+
+      store = new PlayerStore();
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      trackChangedCallback?.({ payload: { song: { id: 1, title: "Test Song" } } });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(sendNotification).not.toHaveBeenCalled();
+
+      prefs.trackNotificationsEnabled = false;
+      if (originalListenImpl) vi.mocked(listen).mockImplementation(originalListenImpl);
+    });
   });
 });

--- a/src/lib/stores/prefs.svelte.ts
+++ b/src/lib/stores/prefs.svelte.ts
@@ -1,4 +1,5 @@
 import { invoke } from "@tauri-apps/api/core";
+import { isPermissionGranted, requestPermission } from "@tauri-apps/plugin-notification";
 
 export type RatingStyle = "heart" | "stars";
 export type SeekBarMode = "waveform" | "bands";
@@ -29,6 +30,9 @@ class PrefsStore {
   genreViewMode = $state<GenreViewMode>("genre");
   /** Off by default — closing the window quits unless explicitly opted in. */
   minimizeToTray = $state<boolean>(false);
+  /** Off by default — desktop notifications are opt-in and request OS
+   * permission the first time they're enabled (#524). */
+  trackNotificationsEnabled = $state<boolean>(false);
 
   async init() {
     const prefs = await invoke<UiPreferences>("get_ui_preferences");
@@ -41,6 +45,7 @@ class PrefsStore {
     this.playlistsCustomViewMode = prefs.playlists_custom_view_mode;
     this.genreViewMode = prefs.genre_view_mode;
     this.minimizeToTray = await invoke<boolean>("get_minimize_to_tray_enabled");
+    this.trackNotificationsEnabled = await invoke<boolean>("get_track_notifications_enabled");
   }
 
   /** Persist the whole current state — fire-and-forget on the backend. */
@@ -103,6 +108,26 @@ class PrefsStore {
   setMinimizeToTray(enabled: boolean) {
     this.minimizeToTray = enabled;
     invoke("set_minimize_to_tray_enabled", { enabled });
+  }
+
+  /** Not part of `save()` — persisted via its own dedicated command (see
+   * `setMinimizeToTray`). Requests OS notification permission the moment
+   * the user opts in, so the very next track change can notify without a
+   * second round-trip; declining permission just means notifications stay
+   * silent until the user grants it via the OS, not a hard failure. */
+  async setTrackNotificationsEnabled(enabled: boolean) {
+    this.trackNotificationsEnabled = enabled;
+    invoke("set_track_notifications_enabled", { enabled });
+    if (enabled) {
+      try {
+        const granted = await isPermissionGranted();
+        if (!granted) {
+          await requestPermission();
+        }
+      } catch (err) {
+        console.error("Failed to request notification permission:", err);
+      }
+    }
   }
 }
 

--- a/src/lib/stores/prefs.test.ts
+++ b/src/lib/stores/prefs.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { prefs } from "./prefs.svelte";
+import { invoke } from "@tauri-apps/api/core";
+import { isPermissionGranted, requestPermission } from "@tauri-apps/plugin-notification";
+
+describe("PrefsStore - track change notifications (#524)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prefs.trackNotificationsEnabled = false;
+  });
+
+  it("persists the preference and requests no permission when disabling", async () => {
+    await prefs.setTrackNotificationsEnabled(false);
+
+    expect(prefs.trackNotificationsEnabled).toBe(false);
+    expect(invoke).toHaveBeenCalledWith("set_track_notifications_enabled", { enabled: false });
+    expect(requestPermission).not.toHaveBeenCalled();
+  });
+
+  it("requests OS permission when enabling and permission isn't already granted", async () => {
+    vi.mocked(isPermissionGranted).mockResolvedValueOnce(false);
+
+    await prefs.setTrackNotificationsEnabled(true);
+
+    expect(prefs.trackNotificationsEnabled).toBe(true);
+    expect(invoke).toHaveBeenCalledWith("set_track_notifications_enabled", { enabled: true });
+    expect(isPermissionGranted).toHaveBeenCalled();
+    expect(requestPermission).toHaveBeenCalled();
+  });
+
+  it("does not re-request permission when already granted", async () => {
+    vi.mocked(isPermissionGranted).mockResolvedValueOnce(true);
+
+    await prefs.setTrackNotificationsEnabled(true);
+
+    expect(requestPermission).not.toHaveBeenCalled();
+  });
+
+  it("swallows a permission-check failure without throwing", async () => {
+    vi.mocked(isPermissionGranted).mockRejectedValueOnce(new Error("boom"));
+
+    await expect(prefs.setTrackNotificationsEnabled(true)).resolves.toBeUndefined();
+    expect(prefs.trackNotificationsEnabled).toBe(true);
+  });
+});

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -125,6 +125,16 @@ vi.mock("@tauri-apps/plugin-process", () => {
   };
 });
 
+// Mock Tauri notification plugin (desktop notifications on track change, #524) —
+// defaults to "not granted"/no-op; tests override with vi.mocked(...) as needed.
+vi.mock("@tauri-apps/plugin-notification", () => {
+  return {
+    isPermissionGranted: vi.fn().mockResolvedValue(false),
+    requestPermission: vi.fn().mockResolvedValue("granted"),
+    sendNotification: vi.fn(),
+  };
+});
+
 // jsdom doesn't implement canvas rendering, so components that draw to a
 // <canvas> (e.g. WaveformSeekBar) spam "not implemented" console noise on
 // every render. Tests here only mount components, they don't assert on


### PR DESCRIPTION
## 📋 Summary
Adds native OS desktop notifications when playback moves to a new track — title, artist, album, and (best-effort) cover art icon — surfaced via `tauri-plugin-notification`. Controlled by a new opt-in "Song change notifications" toggle under Settings > General. Off by default, and enabling it requests OS notification permission on the spot. Fixes #524.

## 🔍 Implementation Notes
- **Plugin wiring**: `tauri-plugin-notification = "2"` was already declared in `src-tauri/Cargo.toml` and registered via `.plugin(tauri_plugin_notification::init())` in `src-tauri/src/lib.rs` — verified rather than assumed, per the issue's own instruction. Only the frontend package (`@tauri-apps/plugin-notification`) and capability permissions (`notification:allow-is-permission-granted`, `notification:allow-request-permission`, `notification:allow-notify`) needed to be added.
- **Preference persistence**: rather than shoehorning a boolean into `UiPreferences::fields()` (which is typed as `&mut String` with fixed enum-style domains, e.g. `rating_style`, `seekbar_mode`), I followed the existing `minimize_to_tray` precedent already in `commands/settings.rs`: dedicated `get_track_notifications_enabled` / `set_track_notifications_enabled` commands, fire-and-forget on write (per the Command pattern invariant), reading/writing a single `app_state` KV row. Unlike `minimize_to_tray`, there's no in-memory `AtomicBool` mirror in `AppState`, because nothing on the Rust side needs to act on this preference — only the frontend decides whether to fire a notification.
- **Frontend store** (`src/lib/stores/prefs.svelte.ts`): mirrors the field as `trackNotificationsEnabled`; `setTrackNotificationsEnabled()` persists it and, only when turning it on, calls `isPermissionGranted()` / `requestPermission()` from the plugin. Declining permission just leaves notifications silent (caught, logged, never thrown).
- **Dispatch** (`src/lib/stores/player.svelte.ts`): hooks into the existing `track-changed` event listener (no new IPC event invented). `notifyTrackChange()` checks the preference and `isPermissionGranted()`, then calls `sendNotification({ title, body: "Artist — Album", icon })`. Icon resolution mirrors `themeStore.updateArtworkColors`'s branches (manual art override → automatic/album art → embedded art via the existing `get_cover_art_uri` command) — kept as a local private method since it only needs a best-effort icon URL, not full theme-color extraction.
- **Default-off rationale**: notifications are opt-in per the issue's own requirement, and the permission-request flow only fires once the user explicitly turns the toggle on — no notification permission is requested on first launch.
- **Localization**: added `settings.trackNotificationsLabel` / `settings.trackNotificationsHint` to `en.ts` and `fr.ts`, following the imperative "instructive, not descriptive" hint voice used by neighboring toggles (e.g. `watchRealtimeHint`, `crossfadeManualHint`) — "Show a desktop notification when a new track begins playing."
- **UI location**: verified `FoldersView.svelte` is in fact still the home for Settings > General (hosts the existing `minimizeToTray` toggle); added the new toggle directly below it, following the same row markup/styling.
- **Known limitation — cover art icon**: the `icon` option on `sendNotification` is passed a best-effort URL (either the app's `luminous-art://` custom-protocol URI, or an `http://luminous-art.localhost/...` URL on Windows). I could not verify at build/test time whether the underlying native notifier on each platform (Windows Action Center, macOS Notification Center, Linux via `notify-rust`/D-Bus) actually resolves either of those into an icon — native notification icons conventionally expect a real on-disk file path, not a webview-only custom protocol or `http://` URL. Worth a **manual smoke test per platform** before treating the icon as reliable; the title/body text itself doesn't depend on this and will always be correct.
- **Pre-commit hook side effect (pre-existing bug, out of scope for this PR)**: `.githooks/pre-commit` runs `cargo fmt` across the *entire* crate (not scoped to staged files) and then re-stages *every* modified `.rs` file under `src-tauri`, not just the ones originally staged. This repo already had unformatted drift in `collection.rs`, `commands/collection.rs`, `commands/tags.rs`, `covermanager.rs`, `playlist.rs`, and `tags.rs` (confirmed via a standalone `cargo fmt --check` on a clean `origin/main` checkout, before I touched anything), and committing any Rust change in this worktree unavoidably swept those pre-existing, purely-whitespace fixes into this commit too — the hook makes it effectively impossible to avoid without bypassing hooks (which policy disallows). Those 6 files' diffs in this PR are 100% mechanical `cargo fmt` output with zero semantic change; flagging per AGENTS.md's Bug Handling section so the hook itself can be fixed (scope its `cargo fmt`/re-add to only originally-staged files) in a follow-up.

## 🧪 Test Plan
- [x] `bun run check` (svelte-check) — 0 errors, 0 warnings
- [x] `bun run test -- --run` (frontend) — 426/426 passed, including new `prefs.test.ts` (permission-request flow) and new notification-dispatch cases added to `player.test.ts`
- [x] `cargo test` (src-tauri) — full suite green (166 lib unit tests + all Cucumber BDD suites + integration tests), plus `cargo clippy --all-targets -- -D warnings` clean and `cargo fmt --check` clean on every file this PR intentionally touches
- [ ] Manually verified in the app — not done: this harness has no working `bun run tauri dev` (per `CLAUDE.md`), so I could not open Settings, toggle the preference, trigger the OS permission prompt, or observe a real native notification (with or without icon) on any platform. Recommend a manual pass on Windows/macOS/Linux before merge, specifically checking whether the cover art icon actually renders (see Implementation Notes).

## 📸 Screenshots
No screenshot could be captured in this environment — no `bun run tauri dev` available in this harness (per `.claude/CLAUDE.md`). The new toggle is the second row under Settings > General, directly below the existing "Minimize to tray" toggle, using the same label/hint/Toggle row layout (`src/lib/components/FoldersView.svelte`).

## ✅ Checklist
- [x] No unrelated changes bundled in — with one documented exception: the pre-commit hook's whole-crate `cargo fmt` incidentally reformatted 6 pre-existing, already-unformatted files (see Implementation Notes) as a side effect I could not avoid without bypassing git hooks.
- [x] Docs/screenshots updated if user-facing behavior changed — no screenshots regenerated (harness limitation, see above); no other docs reference this settings area.

---
_Generated by [Claude Code](https://claude.ai/code/session_019pNkhBtwuw69qswRQHj9yM)_