### PR TITLE
fix(player): restore loudness normalization gain for cued track on restart (#539)

### DIFF
--- a/src-tauri/src/player.rs
+++ b/src-tauri/src/player.rs
@@ -291,6 +291,14 @@ impl Player {
             }
         }
 
+        let (loudness_gain, loudness_source, loudness_gain_db) =
+            if let Some(ref song) = restored_song {
+                let settings = crate::loudness::get_settings(&db).unwrap_or_default();
+                Self::compute_loudness_gain(&settings, song)
+            } else {
+                (1.0, LoudnessGainSource::Disabled, None)
+            };
+
         let scrobble_point_nanosec = restored_song
             .as_ref()
             .and_then(|s| s.length_nanosec.map(|ns| (ns as u64) / 2));
@@ -306,8 +314,8 @@ impl Player {
             repeat_mode,
             stop_after_current: false,
             volume,
-            current_loudness_source: LoudnessGainSource::Disabled,
-            current_loudness_gain_db: None,
+            current_loudness_source: loudness_source,
+            current_loudness_gain_db: loudness_gain_db,
             playlist_items,
             shuffle_order: Vec::new(),
             current_index,
@@ -322,6 +330,7 @@ impl Player {
 
         if let Some(song) = restored_song {
             if let Ok(engine) = player.audio.try_lock() {
+                engine.set_loudness_gain(loudness_gain);
                 let _ = engine.cue(Box::new(song), restored_position_ns);
             }
         }

--- a/src-tauri/tests/playback_resume_test.rs
+++ b/src-tauri/tests/playback_resume_test.rs
@@ -53,6 +53,93 @@ async fn test_playback_resume_on_startup() {
         state.playlist_item_uuid.as_deref(),
         Some("restored-uuid-999")
     );
+    // By default, loudness normalization is disabled in fresh DB
+    assert_eq!(state.loudness_source, luminous_lib::models::LoudnessGainSource::Disabled);
+    assert_eq!(state.loudness_gain_db, None);
+    let engine_loudness = f32::from_bits(audio.lock().await.loudness_gain.load(std::sync::atomic::Ordering::Relaxed));
+    assert_eq!(engine_loudness, 1.0);
+
+    let _ = std::fs::remove_dir_all(temp_dir);
+}
+
+#[tokio::test]
+async fn test_playback_resume_with_volume_and_analyzed_loudness() {
+    let (db, temp_dir) = setup_test_db();
+    let db_arc = Arc::new(db);
+
+    {
+        let conn = db_arc.pool.get().unwrap();
+        conn.execute(
+            "UPDATE loudness_settings SET enabled = 1, target_lufs = -14.0 WHERE id = 1",
+            [],
+        ).unwrap();
+        conn.execute(
+            "INSERT INTO songs (id, path, title, artist, album, length_nanosec, ebur128_integrated_loudness_lufs)
+             VALUES (202, '/test/analyzed.flac', 'Analyzed Track', 'Artist', 'Album', 180000000000, -8.0)",
+            [],
+        ).unwrap();
+        conn.execute(
+            "INSERT OR REPLACE INTO app_state (key, value) VALUES ('volume', '0.5')",
+            [],
+        ).unwrap();
+        conn.execute(
+            "INSERT OR REPLACE INTO app_state (key, value) VALUES ('last_song_id', '202')",
+            [],
+        ).unwrap();
+        conn.execute(
+            "INSERT OR REPLACE INTO app_state (key, value) VALUES ('last_position_nanosec', '30000000000')",
+            [],
+        ).unwrap();
+    }
+
+    let audio = Arc::new(Mutex::new(AudioEngine::new()));
+    let player = Player::new(db_arc.clone(), audio.clone());
+
+    let state = player.get_state().await;
+    assert_eq!(state.state, PlayState::Paused);
+    assert_eq!(state.volume, 0.5);
+    assert_eq!(audio.lock().await.current_volume(), 0.5);
+
+    // Target -14.0 LUFS with track at -8.0 LUFS -> -6.0 dB gain
+    assert_eq!(state.loudness_source, luminous_lib::models::LoudnessGainSource::Analyzed);
+    assert_eq!(state.loudness_gain_db, Some(-6.0));
+    let engine_loudness = f32::from_bits(audio.lock().await.loudness_gain.load(std::sync::atomic::Ordering::Relaxed));
+    assert!((engine_loudness - 0.5011872).abs() < 1e-4);
+
+    let _ = std::fs::remove_dir_all(temp_dir);
+}
+
+#[tokio::test]
+async fn test_playback_resume_with_fallback_loudness() {
+    let (db, temp_dir) = setup_test_db();
+    let db_arc = Arc::new(db);
+
+    {
+        let conn = db_arc.pool.get().unwrap();
+        conn.execute(
+            "UPDATE loudness_settings SET enabled = 1, fallback_gain_db = -6.0 WHERE id = 1",
+            [],
+        ).unwrap();
+        conn.execute(
+            "INSERT INTO songs (id, path, title, artist, album, length_nanosec)
+             VALUES (303, '/test/unanalyzed.flac', 'Unanalyzed Track', 'Artist', 'Album', 180000000000)",
+            [],
+        ).unwrap();
+        conn.execute(
+            "INSERT OR REPLACE INTO app_state (key, value) VALUES ('last_song_id', '303')",
+            [],
+        ).unwrap();
+    }
+
+    let audio = Arc::new(Mutex::new(AudioEngine::new()));
+    let player = Player::new(db_arc.clone(), audio.clone());
+
+    let state = player.get_state().await;
+    assert_eq!(state.state, PlayState::Paused);
+    assert_eq!(state.loudness_source, luminous_lib::models::LoudnessGainSource::Fallback);
+    assert_eq!(state.loudness_gain_db, Some(-6.0));
+    let engine_loudness = f32::from_bits(audio.lock().await.loudness_gain.load(std::sync::atomic::Ordering::Relaxed));
+    assert!((engine_loudness - 0.5011872).abs() < 1e-4);
 
     let _ = std::fs::remove_dir_all(temp_dir);
 }


### PR DESCRIPTION
## 📋 Summary
Fixes #539. Restores loudness normalization gain on application restart for the cued track so playback resumes at the correct perceived volume rather than un-attenuated full volume.

## 🔍 Implementation Notes
- In `Player::new` (`src-tauri/src/player.rs`), computed `(gain, source, gain_db)` using `Self::compute_loudness_gain` for `restored_song`.
- Passed the computed `gain` to `engine.set_loudness_gain(gain)` so the audio engine's DSP chain has the normalization factor ready before playback starts.
- Initialized `current_loudness_source` and `current_loudness_gain_db` on `Player` so `get_playback_state` and frontend UI indicators reflect the active loudness state on launch.
- Added automated unit and integration tests in `src-tauri/tests/playback_resume_test.rs` covering disabled, analyzed, and fallback loudness normalization restoration on startup.

## 🧪 Test Plan
- [x] `bun run check` (svelte-check)
- [x] `bun run test:run` (frontend)
- [x] `cargo test` (src-tauri)

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed
