### PR TITLE
fix(playbar): keep constant padding and drop seekbar at small widths

### DIFF
--- a/src/lib/components/PlayerBar.svelte
+++ b/src/lib/components/PlayerBar.svelte
@@ -16,18 +16,20 @@
 
   const isLinux = typeof navigator !== 'undefined' && navigator.userAgent.includes('Linux');
 
-  // Responsive control trimming (issue #413, refined against real usage):
-  // three named tiers as this floating bar narrows toward the app's 320px
-  // minWidth — Full (>=700px), Compact (400-700px), Minimal (<400px). Cover
-  // art, play/pause, and skip-next are the constant core (shown in all three
-  // tiers); everything else drops out in priority order: expand/shuffle/
-  // repeat/volume+mute first (gone by Compact — the transport+seek block
-  // takes the freed space and sticks to the right edge via `ml-auto` rather
-  // than re-centering in it), then prev and the seek bar itself (gone by
-  // Minimal). 400/700 are hand-tuned breakpoints specific to this bar,
-  // written as literal `min-[Npx]:` arbitrary-value classes because
-  // Tailwind's class scanner can't resolve an interpolated constants.ts
-  // value — don't try to centralize them.
+  // Responsive control trimming (issue #413, refined against real usage,
+  // padding/seekbar fixed under #543): three named tiers as this floating
+  // bar narrows toward the app's 320px minWidth — Full (>=700px), Compact
+  // (400-700px), Minimal (<400px). Cover art, play/pause, and skip-next are
+  // the constant core (shown in all three tiers); everything else drops out
+  // in priority order: expand/shuffle/repeat/volume+mute/waveform seek bar
+  // + time labels first (gone by Compact — the transport block takes the
+  // freed space and sticks to the right edge via `ml-auto` rather than
+  // re-centering in it), then prev (gone by Minimal). Horizontal padding on
+  // the outer bar stays constant across all tiers so cover art never sits
+  // flush against the rounded edges. 400/700 are hand-tuned breakpoints
+  // specific to this bar, written as literal `min-[Npx]:` arbitrary-value
+  // classes because Tailwind's class scanner can't resolve an interpolated
+  // constants.ts value — don't try to centralize them.
 
   import {
     Play,
@@ -225,7 +227,7 @@
   }
 </script>
 
-<footer transition:fly={{ y: 40, duration: 300, easing: cubicOut }} class="h-20 max-w-[1200px] mx-auto bg-brand-playerbar border border-brand-border rounded-[2rem] flex items-center justify-between gap-3 px-3 min-[700px]:px-8 text-brand-text-secondary select-none {themeStore.isGlassTheme || isLinux ? 'glass-surface' : ''} {isLinux ? 'opaque-linux' : ''}">
+<footer transition:fly={{ y: 40, duration: 300, easing: cubicOut }} class="h-20 max-w-[1200px] mx-auto bg-brand-playerbar border border-brand-border rounded-[2rem] flex items-center justify-between gap-3 px-8 text-brand-text-secondary select-none {themeStore.isGlassTheme || isLinux ? 'glass-surface' : ''} {isLinux ? 'opaque-linux' : ''}">
   <div class="flex items-center gap-3 flex-1 min-[700px]:w-1/3 min-[700px]:flex-none min-w-[90px] min-[400px]:min-w-[140px] min-[700px]:min-w-[200px] max-w-sm">
     <button
       onclick={handleCoverClick}
@@ -359,10 +361,10 @@
 
     </div>
 
-    <div class="hidden min-[400px]:flex items-center gap-2.5 w-full text-[10px] text-brand-text-secondary/60">
+    <div class="hidden min-[700px]:flex items-center gap-2.5 w-full text-[10px] text-brand-text-secondary/60">
       <!-- Invisible spacer matching the mode-toggle button's footprint, so the
            waveform + timers stay centered instead of skewing left toward it. -->
-      <div class="hidden min-[700px]:block w-4 h-4 flex-shrink-0" aria-hidden="true"></div>
+      <div class="w-4 h-4 flex-shrink-0" aria-hidden="true"></div>
       <span>{formatTime(playerStore.positionNanosec)}</span>
       <div class="flex-1 flex flex-col gap-1">
         <WaveformSeekBar />
@@ -370,7 +372,7 @@
       <span>{formatTime(playerStore.currentSong?.length_nanosec)}</span>
       <button
         onclick={() => prefs.toggleSeekBarMode()}
-        class="hidden min-[700px]:block text-brand-text-secondary/50 hover:text-brand-text-primary transition-colors p-0.5 flex-shrink-0"
+        class="text-brand-text-secondary/50 hover:text-brand-text-primary transition-colors p-0.5 flex-shrink-0"
         title={prefs.seekBarMode === 'waveform'
           ? i18n.t('playerBar.seekbarModeWaveform', {}, 'Waveform mode — click to switch to frequency bands')
           : i18n.t('playerBar.seekbarModeBands', {}, 'Frequency bands mode — click to switch to waveform')}

--- a/src/lib/components/PlayerBar.test.ts
+++ b/src/lib/components/PlayerBar.test.ts
@@ -290,9 +290,9 @@ describe("PlayerBar.svelte", () => {
     playerStore.state = "playing";
     const { getAllByTitle, getByTitle, container } = render(PlayerBar);
 
-    // Gone by Compact (Full-only): shuffle, repeat, and the whole right
-    // column (volume/mute + expand) — the transport+seek block takes the
-    // freed space instead, sticking to the right edge via ml-auto.
+    // Gone by Compact (Full-only): shuffle, repeat, the seek row, and the
+    // whole right column (volume/mute + expand) — the transport block takes
+    // the freed space instead, sticking to the right edge via ml-auto.
     const shuffleBtn = getAllByTitle(/shuffle/i).find(el => el.querySelector("svg"))!;
     const repeatBtn = getAllByTitle(/repeat/i).find(el => el.querySelector("svg"))!;
     expect(shuffleBtn.closest(".hidden")).toHaveClass("min-[700px]:block");
@@ -302,11 +302,11 @@ describe("PlayerBar.svelte", () => {
     expect(getByTitle(/picture-in-picture/i)).toHaveClass("hidden", "min-[700px]:block");
     const rightColumn = Array.from(container.querySelectorAll("div")).find(d => d.className.includes("justify-end"))!;
     expect(rightColumn).toHaveClass("hidden", "min-[700px]:flex");
-
-    // Gone by Minimal (Compact-and-up only): previous, seek row.
-    expect(getByTitle(/previous song/i)).toHaveClass("hidden", "min-[400px]:block");
     const seekRow = Array.from(container.querySelectorAll("div")).find(d => d.className.includes("gap-2.5"))!;
-    expect(seekRow).toHaveClass("hidden", "min-[400px]:flex");
+    expect(seekRow).toHaveClass("hidden", "min-[700px]:flex");
+
+    // Gone by Minimal (Compact-and-up only): previous.
+    expect(getByTitle(/previous song/i)).toHaveClass("hidden", "min-[400px]:block");
 
     // Never hidden (the constant core): cover art, play/pause, skip-next.
     const coverButton = getByTitle("Queue");


### PR DESCRIPTION
## 📋 Summary
Fixes #543. At smaller window widths the playbar now keeps the same left/right padding used at larger sizes, and the waveform seek bar + elapsed/remaining time labels drop out at the same breakpoint as the other secondary controls, leaving just Prev/Play/Next alongside cover art.

## 🔍 Implementation Notes
- [src/lib/components/PlayerBar.svelte](../src/lib/components/PlayerBar.svelte): outer `<footer>` padding changed from `px-3 min-[700px]:px-8` to a constant `px-8`. The seek row's visibility gate changed from `hidden min-[400px]:flex` to `hidden min-[700px]:flex`, aligning it with shuffle/repeat/volume/expand, which already drop out below 700px. The two inner `min-[700px]:` gates inside that row (spacer div, mode-toggle button) were redundant once the parent itself is gated at 700px, so they were simplified to unconditional visibility. Updated the responsive-tiering comment block to match.
- [src/lib/components/PlayerBar.test.ts](../src/lib/components/PlayerBar.test.ts): updated the tier-class assertions for the seek row to expect `min-[700px]:flex` instead of `min-[400px]:flex`.

## 🧪 Test Plan
- [x] `bun run check` (svelte-check)
- [x] `bun run test -- --run` (frontend)
- [ ] `cargo test` (src-tauri, if Rust changed) — not applicable, no Rust changed
- [x] Manually verified in the app (user confirmed via screenshot at a small window width: consistent padding around cover art, controls-only playbar with no seek row)

## 📸 Screenshots
Before: cover art flush against the rounded bar edges, seek row squeezed in below 700px.
After: consistent padding at all widths, playbar shows only cover art + Prev/Play/Next below 700px (confirmed by user screenshot).

<img width="419" height="469" alt="image-1787426404810" src="https://github.com/user-attachments/assets/07e18522-6d8a-4110-8ac5-5a342b5ff504" />

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed — no docs reference this behavior; visual confirmation done in this PR's review
