### PR TITLE
fix: make Ctrl-1 toggle sidebar compact/expanded, not hide it

### DIFF
--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -1024,7 +1024,7 @@ export const en = {
     closeSearch: "Close search dropdown",
     goBack: "Go back",
     goForward: "Go forward",
-    toggleSidebar: "Toggle left sidebar",
+    toggleSidebar: "Toggle sidebar (compact / expanded)",
     toggleImmersive: "Toggle immersion mode",
     toggleRightPanel: "Toggle right panel",
     toggleMiniplayer: "Toggle miniplayer",

--- a/src/lib/locales/fr.ts
+++ b/src/lib/locales/fr.ts
@@ -1000,7 +1000,7 @@ export const fr = {
     closeSearch: "Fermer le menu de recherche",
     goBack: "Retour",
     goForward: "Avancer",
-    toggleSidebar: "Basculer la barre latérale gauche",
+    toggleSidebar: "Basculer la barre latérale (compacte / étendue)",
     toggleImmersive: "Basculer le mode immersion",
     toggleRightPanel: "Basculer le panneau droit",
     toggleMiniplayer: "Basculer le mini-lecteur",

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -75,7 +75,7 @@
           break;
         case '1':
           e.preventDefault();
-          collectionStore.toggleSidebar();
+          collectionStore.toggleSidebarCompact();
           break;
         case '2':
           e.preventDefault();


### PR DESCRIPTION
## 📋 Summary
Fixes #541. `Ctrl-1`/`Cmd-1` called `collectionStore.toggleSidebar()`, which fully hides/shows the sidebar. That didn't match the hamburger button in `TopNavigation.svelte`, which calls `collectionStore.toggleSidebarCompact()` to toggle the sidebar's width between compact and expanded while keeping it open. `Ctrl-1` now calls `toggleSidebarCompact()` to match the hamburger button's behavior.

## 🔍 Implementation Notes
- `src/routes/+layout.svelte`: the `'1'` case in `handleGlobalHotkeys` now calls `collectionStore.toggleSidebarCompact()` instead of `collectionStore.toggleSidebar()`.
- `src/lib/locales/en.ts` / `src/lib/locales/fr.ts`: updated the `shortcuts.toggleSidebar` label shown in `KeyboardShortcutsModal.svelte` (used only for the Ctrl-1 row) from "Toggle left sidebar" to "Toggle sidebar (compact / expanded)" so the shortcut description matches the corrected behavior — mirrors the existing `topNav.toggleSidebarCompact` wording used on the hamburger button's tooltip.
- No new test harness added: there's no existing test file exercising `+layout.svelte`'s global hotkey handler, and `collectionStore.toggleSidebarCompact()` itself is already covered by `src/lib/stores/collection.test.ts`.

## 🧪 Test Plan
- [x] `bun run check` (svelte-check) — 0 errors, 0 warnings
- [x] `bun run test:run` (frontend) — 49 files / 461 tests passed
- [ ] `cargo test` (src-tauri, if Rust changed) — not applicable, no Rust changed
- [ ] Manually verified in the app (describe what you did)

## 📸 Screenshots
Not applicable — behavioral fix only, no visual change to the shortcut modal beyond the corrected label text.

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed (shortcut description text updated in `en.ts`/`fr.ts`)

Closes #541


---
_Generated by [Claude Code](https://claude.ai/code/session_01EqZvBTdViPjPMtp7fZ8TtE)_