### PR TITLE
fix: include albums of tagged artists in collection search results (#571)

### DIFF
--- a/src/lib/stores/collection.svelte.ts
+++ b/src/lib/stores/collection.svelte.ts
@@ -1275,12 +1275,31 @@ class CollectionStore {
   }
 
   get filteredAlbums(): AlbumItem[] {
-    const query = this.searchQuery.trim().toLowerCase();
-    if (query === "") return this.albums;
-    return this.albums.filter(album => 
-      (album.album && album.album.toLowerCase().includes(query)) ||
-      (album.artist && album.artist.toLowerCase().includes(query))
-    );
+    const rawQuery = this.searchQuery.trim();
+    if (rawQuery === "") return this.albums;
+
+    // Check if query is structured search with artist-tag or tag
+    const tagMatch = rawQuery.match(/^(?:artist[-_]?tags?|artisttags?|tags?):(.+)$/i);
+    if (tagMatch) {
+      const tagQuery = tagMatch[1].replace(/^['"]|['"]$/g, "").trim().toLowerCase();
+      if (!tagQuery) return this.albums;
+      return this.albums.filter((album) => {
+        if (!album.artist) return false;
+        const profile = this.artistProfiles[album.artist.toLowerCase()];
+        return profile?.tags?.some((t) => t.toLowerCase().includes(tagQuery)) ?? false;
+      });
+    }
+
+    const query = rawQuery.toLowerCase();
+    return this.albums.filter((album) => {
+      if (album.album && album.album.toLowerCase().includes(query)) return true;
+      if (album.artist && album.artist.toLowerCase().includes(query)) return true;
+      if (album.artist) {
+        const profile = this.artistProfiles[album.artist.toLowerCase()];
+        if (profile?.tags?.some((t) => t.toLowerCase().includes(query))) return true;
+      }
+      return false;
+    });
   }
 
   get filteredArtists(): ArtistItem[] {
@@ -1288,7 +1307,7 @@ class CollectionStore {
     if (rawQuery === "") return this.artists;
 
     // Check if query is structured search with artist-tag or tag
-    const tagMatch = rawQuery.match(/^(?:artist[-_]?tag|tags?):(.+)$/i);
+    const tagMatch = rawQuery.match(/^(?:artist[-_]?tags?|artisttags?|tags?):(.+)$/i);
     if (tagMatch) {
       const tagQuery = tagMatch[1].replace(/^['"]|['"]$/g, "").trim().toLowerCase();
       if (!tagQuery) return this.artists;

--- a/src/lib/stores/collection.test.ts
+++ b/src/lib/stores/collection.test.ts
@@ -208,6 +208,59 @@ describe("CollectionStore", () => {
     expect(collectionStore.filteredArtists[0].name).toBe("The Beatles");
   });
 
+  it("filters albums by artist tags using tag prefix and general search", () => {
+    collectionStore.albums = [
+      { album: "Come On Over", artist: "Shania Twain" } as AlbumItem,
+      { album: "The Woman in Me", artist: "Shania Twain" } as AlbumItem,
+      { album: "Let's Talk About Love", artist: "Celine Dion" } as AlbumItem,
+      { album: "Abbey Road", artist: "The Beatles" } as AlbumItem,
+    ];
+    collectionStore.artistProfiles = {
+      "shania twain": {
+        artist_key: "Shania Twain",
+        tags: ["country", "canadian", "pop"],
+        social_links: [],
+      },
+      "celine dion": {
+        artist_key: "Celine Dion",
+        tags: ["pop", "canadian", "ballad"],
+        social_links: [],
+      },
+      "the beatles": {
+        artist_key: "The Beatles",
+        tags: ["rock", "british", "classic"],
+        social_links: [],
+      },
+    };
+
+    // Explicit tag search with tag: prefix
+    collectionStore.searchQuery = "tag:country";
+    expect(collectionStore.filteredAlbums).toHaveLength(2);
+    expect(collectionStore.filteredAlbums.map((a) => a.album)).toEqual([
+      "Come On Over",
+      "The Woman in Me",
+    ]);
+
+    // Explicit tag search with artist-tag: prefix
+    collectionStore.searchQuery = "artist-tag:canadian";
+    expect(collectionStore.filteredAlbums).toHaveLength(3);
+    expect(collectionStore.filteredAlbums.map((a) => a.album)).toEqual([
+      "Come On Over",
+      "The Woman in Me",
+      "Let's Talk About Love",
+    ]);
+
+    // General keyword search matching artist tag
+    collectionStore.searchQuery = "british";
+    expect(collectionStore.filteredAlbums).toHaveLength(1);
+    expect(collectionStore.filteredAlbums[0].album).toBe("Abbey Road");
+
+    // General keyword search matching album title directly
+    collectionStore.searchQuery = "over";
+    expect(collectionStore.filteredAlbums).toHaveLength(1);
+    expect(collectionStore.filteredAlbums[0].album).toBe("Come On Over");
+  });
+
   it("handles navigation helpers viewArtist and viewAlbum and clears search terms", () => {
     collectionStore.searchQuery = "some search";
     collectionStore.searchResults = [{ id: 1 } as Song];


### PR DESCRIPTION
## 📋 Summary
Fixes #571.

When searching using a tag filter (e.g. `tag:canada`, `artist-tag:canada`, `tags:canada`) or a search keyword matching an artist tag, matching artists and songs were returned, but albums were omitted from the Albums collection view and search suggestions dropdown. This change updates `CollectionStore.filteredAlbums` to check `artistProfiles` tags for albums, matching the behavior in `filteredArtists`.

## 🔍 Implementation Notes
- Updated `CollectionStore.filteredAlbums` in `src/lib/stores/collection.svelte.ts` to parse tag filter prefixes (`tag:`, `tags:`, `artist-tag:`, `artist-tags:`, `artist_tag:`, `artist_tags:`, `artisttag:`, `artisttags:`) and look up the album artist's tags in `this.artistProfiles`.
- In general keyword search mode, albums now also match if their artist's profile tags contain the query term.
- Standardized the tag query prefix regex between `filteredArtists` and `filteredAlbums`.
- Added unit tests in `src/lib/stores/collection.test.ts` covering tag prefixes, general keyword searches matching artist tags, and direct album title searches.

## 🧪 Test Plan
- [x] `bun run check` (svelte-check: 0 errors, 0 warnings)
- [x] `bun run test -- --run` (Vitest: 52/52 test files passed, 480/480 tests)
- [x] Manually verified in the app: added a tag to an artist, searched for `tag:<tag>` and verified matching artist, albums, and songs appear in their respective collection views and suggestions dropdown.

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed
