### PR TITLE
refactor: dedup formatDuration/formatTime into shared formatters util

### DIFF
--- a/src/lib/components/AlbumDetailView.svelte
+++ b/src/lib/components/AlbumDetailView.svelte
@@ -6,6 +6,7 @@
   import { playerStore } from "../stores/player.svelte";
   import { playlistsStore } from "../stores/playlists.svelte";
   import { shuffleArray } from "../utils/shuffle";
+  import { formatDuration } from "../utils/formatters";
   import CoverArt from "./CoverArt.svelte";
   import SongRating from "./SongRating.svelte";
   import FavouriteCornerFlag from "./FavouriteCornerFlag.svelte";
@@ -421,14 +422,6 @@
       })
       .catch((err) => console.error(err))
       .finally(() => loading = false);
-  }
-
-  function formatDuration(ns: number | undefined): string {
-    if (!ns) return "0:00";
-    const sec = Math.floor(ns / 1_000_000_000);
-    const m = Math.floor(sec / 60);
-    const s = sec % 60;
-    return `${m}:${s < 10 ? "0" : ""}${s}`;
   }
 
   async function rateSong(song: Song, rating: number) {

--- a/src/lib/components/ArtistDetailView.svelte
+++ b/src/lib/components/ArtistDetailView.svelte
@@ -4,6 +4,7 @@
   import { playerStore } from "../stores/player.svelte";
   import { playlistsStore } from "../stores/playlists.svelte";
   import { shuffleArray } from "../utils/shuffle";
+  import { formatDuration } from "../utils/formatters";
   import CoverArt from "./CoverArt.svelte";
   import CoverStack from "./CoverStack.svelte";
   import AlbumCard from "./AlbumCard.svelte";
@@ -96,14 +97,6 @@
     collectionStore.refreshLibrary();
     tagsStore.load();
     refetchSongs();
-  }
-
-  function formatDuration(ns: number | undefined): string {
-    if (!ns) return "0:00";
-    const sec = Math.floor(ns / 1_000_000_000);
-    const m = Math.floor(sec / 60);
-    const s = sec % 60;
-    return `${m}:${s < 10 ? "0" : ""}${s}`;
   }
 
   async function rateSingle(song: Song, rating: number) {

--- a/src/lib/components/AutoPlaylistDetailView.svelte
+++ b/src/lib/components/AutoPlaylistDetailView.svelte
@@ -6,6 +6,7 @@
   import { playerStore } from "../stores/player.svelte";
   import { playlistsStore } from "../stores/playlists.svelte";
   import { songsToCoverStack } from "../utils/covers";
+  import { formatDuration } from "../utils/formatters";
   import CoverStack from "./CoverStack.svelte";
   import SongRating from "./SongRating.svelte";
   import TagEditor from "./TagEditor.svelte";
@@ -422,14 +423,6 @@ import { shuffleArray } from "../utils/shuffle";
       })
       .catch((err) => console.error(err))
       .finally(() => (loading = false));
-  }
-
-  function formatDuration(ns: number | undefined): string {
-    if (!ns) return "0:00";
-    const sec = Math.floor(ns / 1_000_000_000);
-    const m = Math.floor(sec / 60);
-    const s = sec % 60;
-    return `${m}:${s < 10 ? "0" : ""}${s}`;
   }
 
   async function rateSong(song: Song, rating: number) {

--- a/src/lib/components/CollectionView.svelte
+++ b/src/lib/components/CollectionView.svelte
@@ -13,6 +13,7 @@
   import { prefs, type CollectionViewMode } from "../stores/prefs.svelte";
   import { VirtualList } from "svelte-virtual-list-ts";
   import { getArtistAlbums, getArtistSongs, getArtistGradient } from "../utils/artist";
+  import { formatDuration } from "../utils/formatters";
   import { parseMultiValue } from "../utils/multiValue";
   import ArtistDetailView from "./ArtistDetailView.svelte";
   import AlbumDetailView from "./AlbumDetailView.svelte";
@@ -408,14 +409,6 @@
       const songIds = songs.map((s) => s.id);
       playerStore.playSongs(songIds, 0);
     }
-  }
-
-  function formatDuration(ns: number | undefined): string {
-    if (!ns) return "0:00";
-    const sec = Math.floor(ns / 1_000_000_000);
-    const m = Math.floor(sec / 60);
-    const s = sec % 60;
-    return `${m}:${s < 10 ? "0" : ""}${s}`;
   }
 
   async function handleAddSongToPlaylist(songId: number) {

--- a/src/lib/components/Miniplayer.svelte
+++ b/src/lib/components/Miniplayer.svelte
@@ -4,6 +4,7 @@
   import { collectionStore } from "../stores/collection.svelte";
   import { themeStore } from "../stores/theme.svelte";
   import { i18n } from "../stores/i18n.svelte";
+  import { formatDuration } from "../utils/formatters";
   import CoverArt from "./CoverArt.svelte";
   import WaveformSeekBar from "./WaveformSeekBar.svelte";
   import SongRating from "./SongRating.svelte";
@@ -198,13 +199,6 @@
     };
   });
 
-  function formatTime(nanosec: number | undefined): string {
-    if (nanosec === undefined) return "0:00";
-    const sec = Math.floor(nanosec / 1_000_000_000);
-    const m = Math.floor(sec / 60);
-    const s = sec % 60;
-    return `${m}:${s < 10 ? "0" : ""}${s}`;
-  }
 </script>
 
 <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
@@ -378,8 +372,8 @@
       <div class="flex flex-col gap-1 w-full text-[10px] text-brand-text-secondary/70 px-1">
         <WaveformSeekBar />
         <div class="flex items-center justify-between w-full px-0.5 font-mono text-[9px] opacity-80">
-          <span>{formatTime(playerStore.positionNanosec)}</span>
-          <span>{formatTime(playerStore.currentSong?.length_nanosec)}</span>
+          <span>{formatDuration(playerStore.positionNanosec)}</span>
+          <span>{formatDuration(playerStore.currentSong?.length_nanosec)}</span>
         </div>
       </div>
     </div>

--- a/src/lib/components/PlayerBar.svelte
+++ b/src/lib/components/PlayerBar.svelte
@@ -6,6 +6,7 @@
   import { collectionStore } from "../stores/collection.svelte";
   import { themeStore } from "../stores/theme.svelte";
   import { isSmartPlaylistSpec } from "../utils/filterParser";
+  import { formatDuration } from "../utils/formatters";
   import { prefs } from "../stores/prefs.svelte";
   import CoverArt from "./CoverArt.svelte";
   import SongRating from "./SongRating.svelte";
@@ -51,13 +52,6 @@
 
 
 
-  function formatTime(nanosec: number | undefined): string {
-    if (nanosec === undefined) return "0:00";
-    const sec = Math.floor(nanosec / 1_000_000_000);
-    const m = Math.floor(sec / 60);
-    const s = sec % 60;
-    return `${m}:${s < 10 ? "0" : ""}${s}`;
-  }
 
   let volumePercent = $derived(playerStore.volume * 100);
   let volumeSliderStyle = $derived(
@@ -365,11 +359,11 @@
       <!-- Invisible spacer matching the mode-toggle button's footprint, so the
            waveform + timers stay centered instead of skewing left toward it. -->
       <div class="w-4 h-4 flex-shrink-0" aria-hidden="true"></div>
-      <span>{formatTime(playerStore.positionNanosec)}</span>
+      <span>{formatDuration(playerStore.positionNanosec)}</span>
       <div class="flex-1 flex flex-col gap-1">
         <WaveformSeekBar />
       </div>
-      <span>{formatTime(playerStore.currentSong?.length_nanosec)}</span>
+      <span>{formatDuration(playerStore.currentSong?.length_nanosec)}</span>
       <button
         onclick={() => prefs.toggleSeekBarMode()}
         class="text-brand-text-secondary/50 hover:text-brand-text-primary transition-colors p-0.5 flex-shrink-0"

--- a/src/lib/components/PlaylistView.svelte
+++ b/src/lib/components/PlaylistView.svelte
@@ -5,6 +5,7 @@
   import { playerStore } from "../stores/player.svelte";
   import { collectionStore } from "../stores/collection.svelte";
   import { shuffleArray } from "../utils/shuffle";
+  import { formatDuration } from "../utils/formatters";
   import {
     Trash2,
     ListMusic,
@@ -733,14 +734,6 @@
     } catch (err) {
       console.error("Failed to save Queue as custom playlist:", err);
     }
-  }
-
-  function formatDuration(ns: number | undefined): string {
-    if (!ns) return "0:00";
-    const sec = Math.floor(ns / 1_000_000_000);
-    const m = Math.floor(sec / 60);
-    const s = sec % 60;
-    return `${m}:${s < 10 ? "0" : ""}${s}`;
   }
 
   let currentCoverUrl = $derived.by(() => {

--- a/src/lib/utils/formatters.ts
+++ b/src/lib/utils/formatters.ts
@@ -1,3 +1,11 @@
+export function formatDuration(ns: number | undefined): string {
+  if (!ns) return "0:00";
+  const sec = Math.floor(ns / 1_000_000_000);
+  const m = Math.floor(sec / 60);
+  const s = sec % 60;
+  return `${m}:${s < 10 ? "0" : ""}${s}`;
+}
+
 export function formatDate(timestamp?: number): string {
   if (!timestamp) return "—";
   return new Date(timestamp * 1000).toLocaleDateString();


### PR DESCRIPTION
## 📋 Summary
Item 2 of the [#577](https://github.com/esoltys/luminous/issues/577) code-quality roadmap (stacked on #580). Byte-identical nanoseconds→`m:ss` duration formatting logic was reimplemented locally in 7 components — 5 as `formatDuration`, 2 as `formatTime` — despite `src/lib/utils/formatters.ts` already existing as the home for exactly this kind of helper.

## 🔍 Implementation Notes
- Added `formatDuration` to `src/lib/utils/formatters.ts`.
- Removed the local copy from `AlbumDetailView.svelte`, `ArtistDetailView.svelte`, `AutoPlaylistDetailView.svelte`, `CollectionView.svelte`, `PlaylistView.svelte`, `Miniplayer.svelte`, `PlayerBar.svelte`; all now import the shared helper.
- The two `formatTime`-named call sites (`Miniplayer.svelte`, `PlayerBar.svelte`) were renamed to `formatDuration` for naming consistency, since they're the same function.
- Pure refactor, no behavior change.

## 🧪 Test Plan
- [x] `bun run check` (svelte-check) — 0 errors
- [x] `bun run test:run` (frontend) — 481/481 passed
- [ ] `cargo test` — not applicable, no Rust changes
- [ ] Manually verified in the app — this is pure text formatting reused verbatim from the removed local copies; no UI/behavior change to verify

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed — n/a, no visible change
