### PR TITLE
refactor(test): consolidate duplicated vitest setup into vitest.setup.ts

### DIFF
--- a/src/lib/components/AlbumCard.test.ts
+++ b/src/lib/components/AlbumCard.test.ts
@@ -7,10 +7,6 @@ import { prefs } from "../stores/prefs.svelte";
 import { invoke } from "@tauri-apps/api/core";
 import type { AlbumItem } from "../types";
 
-vi.mock("@tauri-apps/api/event", () => ({
-  listen: vi.fn().mockResolvedValue(() => {}),
-}));
-
 describe("AlbumCard.svelte", () => {
   const mockAlbum: AlbumItem = {
     album: "Fake Nudes",

--- a/src/lib/components/AlbumDetailView.test.ts
+++ b/src/lib/components/AlbumDetailView.test.ts
@@ -11,10 +11,6 @@ vi.mock("@tauri-apps/api/core", () => ({
   invoke: vi.fn().mockResolvedValue([]),
 }));
 
-vi.mock("@tauri-apps/api/event", () => ({
-  listen: vi.fn().mockResolvedValue(() => {}),
-}));
-
 vi.mock("@tauri-apps/api/window", () => ({
   getCurrentWindow: () => ({
     innerSize: () => Promise.resolve({ width: 800, height: 600 }),

--- a/src/lib/components/AlbumRowCard.test.ts
+++ b/src/lib/components/AlbumRowCard.test.ts
@@ -7,10 +7,6 @@ import { prefs } from "../stores/prefs.svelte";
 import { invoke } from "@tauri-apps/api/core";
 import type { AlbumItem } from "../types";
 
-vi.mock("@tauri-apps/api/event", () => ({
-  listen: vi.fn().mockResolvedValue(() => {}),
-}));
-
 describe("AlbumRowCard.svelte", () => {
   const mockAlbum: AlbumItem = {
     album: "Fake Nudes",

--- a/src/lib/components/AlbumTagEditor.test.ts
+++ b/src/lib/components/AlbumTagEditor.test.ts
@@ -8,17 +8,6 @@ vi.mock("@tauri-apps/api/core", () => ({
   invoke: vi.fn(),
 }));
 
-vi.mock("@tauri-apps/api/event", () => ({
-  listen: vi.fn().mockResolvedValue(() => {}),
-}));
-
-if (typeof Element !== "undefined" && !Element.prototype.animate) {
-  Element.prototype.animate = vi.fn().mockReturnValue({
-    finished: Promise.resolve(),
-    cancel: () => {},
-  }) as any;
-}
-
 describe("AlbumTagEditor.svelte", () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/src/lib/components/ArtistCard.test.ts
+++ b/src/lib/components/ArtistCard.test.ts
@@ -8,10 +8,6 @@ vi.mock("@tauri-apps/api/core", () => ({
   invoke: vi.fn().mockResolvedValue([]),
 }));
 
-vi.mock("@tauri-apps/api/event", () => ({
-  listen: vi.fn().mockResolvedValue(() => {}),
-}));
-
 describe("ArtistCard.svelte", () => {
   const mockArtist: ArtistItem = {
     name: "Dave Hawkins",

--- a/src/lib/components/ArtistRowCard.test.ts
+++ b/src/lib/components/ArtistRowCard.test.ts
@@ -8,10 +8,6 @@ vi.mock("@tauri-apps/api/core", () => ({
   invoke: vi.fn().mockResolvedValue([]),
 }));
 
-vi.mock("@tauri-apps/api/event", () => ({
-  listen: vi.fn().mockResolvedValue(() => {}),
-}));
-
 describe("ArtistRowCard.svelte", () => {
   const mockArtist: ArtistItem = {
     name: "Dave Hawkins",

--- a/src/lib/components/CollectionView.test.ts
+++ b/src/lib/components/CollectionView.test.ts
@@ -17,10 +17,6 @@ vi.mock("@tauri-apps/api/core", () => ({
   invoke: vi.fn().mockResolvedValue([]),
 }));
 
-vi.mock("@tauri-apps/api/event", () => ({
-  listen: vi.fn().mockResolvedValue(() => {}),
-}));
-
 describe("CollectionView.svelte", () => {
   const mockSongs: Song[] = [
     {

--- a/src/lib/components/Equalizer.test.ts
+++ b/src/lib/components/Equalizer.test.ts
@@ -8,10 +8,6 @@ vi.mock("@tauri-apps/api/core", () => ({
   invoke: vi.fn(),
 }));
 
-vi.mock("@tauri-apps/api/event", () => ({
-  listen: vi.fn().mockResolvedValue(() => {}),
-}));
-
 describe("Equalizer.svelte", () => {
   const defaultEqConfig = {
     enabled: true,

--- a/src/lib/components/Miniplayer.test.ts
+++ b/src/lib/components/Miniplayer.test.ts
@@ -10,10 +10,6 @@ vi.mock("@tauri-apps/api/core", () => ({
   invoke: vi.fn().mockResolvedValue(null),
 }));
 
-vi.mock("@tauri-apps/api/event", () => ({
-  listen: vi.fn().mockResolvedValue(() => {}),
-}));
-
 vi.mock("@tauri-apps/api/window", () => ({
   getCurrentWindow: vi.fn().mockReturnValue({
     startResizing: vi.fn().mockResolvedValue(undefined),

--- a/src/lib/components/PlayerBar.test.ts
+++ b/src/lib/components/PlayerBar.test.ts
@@ -11,17 +11,6 @@ vi.mock("@tauri-apps/api/core", () => ({
   invoke: vi.fn().mockResolvedValue(null),
 }));
 
-vi.mock("@tauri-apps/api/event", () => ({
-  listen: vi.fn().mockResolvedValue(() => {}),
-}));
-
-if (typeof Element !== "undefined" && !Element.prototype.animate) {
-  Element.prototype.animate = vi.fn().mockReturnValue({
-    finished: Promise.resolve(),
-    cancel: () => {},
-  }) as any;
-}
-
 describe("PlayerBar.svelte", () => {
   const mockSong: Song = {
     id: 42,

--- a/src/lib/components/PlaylistView.test.ts
+++ b/src/lib/components/PlaylistView.test.ts
@@ -10,10 +10,6 @@ vi.mock("@tauri-apps/api/core", () => ({
   invoke: vi.fn().mockResolvedValue([]),
 }));
 
-vi.mock("@tauri-apps/api/event", () => ({
-  listen: vi.fn().mockResolvedValue(() => {}),
-}));
-
 describe("PlaylistView.svelte", () => {
   const mockPlaylist: Playlist = {
     id: 1,

--- a/src/lib/components/RightPanel.test.ts
+++ b/src/lib/components/RightPanel.test.ts
@@ -9,10 +9,6 @@ vi.mock("@tauri-apps/api/core", () => ({
   invoke: vi.fn().mockResolvedValue(null),
 }));
 
-vi.mock("@tauri-apps/api/event", () => ({
-  listen: vi.fn().mockResolvedValue(() => {}),
-}));
-
 describe("RightPanel.svelte", () => {
   const mockSong: Song = {
     id: 42,

--- a/src/lib/components/TagEditor.test.ts
+++ b/src/lib/components/TagEditor.test.ts
@@ -8,18 +8,6 @@ vi.mock("@tauri-apps/api/core", () => ({
   invoke: vi.fn(),
 }));
 
-vi.mock("@tauri-apps/api/event", () => ({
-  listen: vi.fn().mockResolvedValue(() => {}),
-}));
-
-// Polyfill element.animate for jsdom environment used in Svelte transitions/animations
-if (typeof Element !== "undefined" && !Element.prototype.animate) {
-  Element.prototype.animate = vi.fn().mockReturnValue({
-    finished: Promise.resolve(),
-    cancel: () => {},
-  }) as any;
-}
-
 describe("TagEditor.svelte", () => {
   const mockSongDetails = {
     id: 10,

--- a/src/lib/components/TopNavigation.test.ts
+++ b/src/lib/components/TopNavigation.test.ts
@@ -1,25 +1,11 @@
 import "@testing-library/jest-dom";
 import { describe, it, expect, vi, beforeEach } from "vitest";
-
-if (typeof Element !== "undefined") {
-  Element.prototype.animate = vi.fn().mockReturnValue({
-    finished: Promise.resolve(),
-    cancel: () => {},
-    addEventListener: () => {},
-    removeEventListener: () => {},
-  }) as any;
-}
-
 import { render, fireEvent } from "@testing-library/svelte";
 import TopNavigation from "./TopNavigation.svelte";
 import { collectionStore } from "../stores/collection.svelte";
 
 vi.mock("@tauri-apps/api/core", () => ({
   invoke: vi.fn().mockResolvedValue([]),
-}));
-
-vi.mock("@tauri-apps/api/event", () => ({
-  listen: vi.fn().mockResolvedValue(() => {}),
 }));
 
 describe("TopNavigation.svelte", () => {

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -145,3 +145,15 @@ if (typeof HTMLCanvasElement !== "undefined") {
     globalAlpha: 1,
   })) as unknown as typeof HTMLCanvasElement.prototype.getContext;
 }
+
+// jsdom doesn't implement the Web Animations API, so components that call
+// element.animate() for Svelte transitions/animations throw. Tests here
+// don't assert on animation timing, so a minimal no-op stub is enough.
+if (typeof Element !== "undefined" && !Element.prototype.animate) {
+  Element.prototype.animate = vi.fn().mockReturnValue({
+    finished: Promise.resolve(),
+    cancel: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+  }) as any;
+}


### PR DESCRIPTION
## 📋 Summary
Item 3 of the [#577](https://github.com/esoltys/luminous/issues/577) code-quality roadmap (stacked on #581, which stacks on #580). `vitest.setup.ts` already exists as the shared home for jsdom test-environment shims, but 16 test files hand-copied an identical `@tauri-apps/api/event` `listen()` mock and 4 hand-copied an identical `Element.prototype.animate` polyfill anyway.

## 🔍 Implementation Notes
- Moved the `Element.prototype.animate` jsdom polyfill into `vitest.setup.ts`, guarded the same way the local copies were (`if (typeof Element !== "undefined" && !Element.prototype.animate)`), so a test that still wants to override `animate` itself can.
- Deleted the identical local `vi.mock("@tauri-apps/api/event", ...)` block from all 16 files that had it — the global setup already registers a functionally equivalent mock.
- Deleted the local `Element.prototype.animate` polyfill from the 4 files that had it.
- Left each file's own `@tauri-apps/api/core` `invoke` mock untouched — those differ meaningfully per test (different return values/command dispatch), so they aren't true duplication and consolidating them isn't in scope for this item.
- Pure test-infrastructure cleanup, no production code touched, no behavior change.

## 🧪 Test Plan
- [x] `bun run check` (svelte-check) — 0 errors
- [x] `bun run test:run` (frontend) — 481/481 passed
- [ ] `cargo test` — not applicable, no Rust changes
- [ ] Manually verified in the app — n/a, test-infrastructure-only change

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed — n/a, no visible change
