### PR TITLE
refactor: extract shared SongTable component (#577 item 4)

### DIFF
--- a/src/lib/components/AlbumDetailView.svelte
+++ b/src/lib/components/AlbumDetailView.svelte
@@ -6,7 +6,6 @@
   import { playerStore } from "../stores/player.svelte";
   import { playlistsStore } from "../stores/playlists.svelte";
   import { shuffleArray } from "../utils/shuffle";
-  import { formatDuration } from "../utils/formatters";
   import CoverArt from "./CoverArt.svelte";
   import SongRating from "./SongRating.svelte";
   import FavouriteCornerFlag from "./FavouriteCornerFlag.svelte";
@@ -16,26 +15,19 @@
   import SongContextMenu from "./SongContextMenu.svelte";
   import GenreChips from "./GenreChips.svelte";
   import { tagsStore } from "../stores/tags.svelte";
-  import SortableHeader from "./SortableHeader.svelte";
   import SongSelectionToolbar from "./SongSelectionToolbar.svelte";
-  import EmptyState from "./EmptyState.svelte";
   import PlayShuffleButtons from "./PlayShuffleButtons.svelte";
-  import NowPlayingBars from "./NowPlayingBars.svelte";
   import IconActionButton from "./IconActionButton.svelte";
   import LinkButton from "./LinkButton.svelte";
   import ColumnSelector from "./ColumnSelector.svelte";
-  import { Play, Plus, Edit3, RefreshCw, Clock, Music } from "lucide-svelte";
+  import SongTable, { type SongTableRow } from "./SongTable.svelte";
+  import { Plus, Edit3, RefreshCw } from "lucide-svelte";
   import type { Song, AlbumItem, PlayContext } from "../types";
   import { getCoverArtUrl, resolveArtUrl } from "../types";
   import { i18n } from "../stores/i18n.svelte";
   import { toastStore } from "../stores/toast.svelte";
-  import { formatTrackNumber } from "../utils/artist";
-  import { parseMultiValue } from "../utils/multiValue";
-  import { formatDate, formatFileSize, formatSampleRate, formatBitDepth, formatChannels } from "../utils/formatters";
-  import { formatDateAdded } from "../utils/date";
+  import { compareSongs } from "../utils/songSort";
   import { rememberScroll } from "../utils/scrollMemory";
-  import { SONG_TABLE_COLUMNS } from "../utils/songColumns";
-  import { columnResize } from "../utils/columnResize";
 
   let { albumName }: { albumName: string } = $props();
 
@@ -70,79 +62,15 @@
     }
   }
 
-  let selectedSongIds = $state<Set<number>>(new Set());
-  let lastSelectedSongId = $state<number | null>(null);
+  let selectedKeys = $state<Set<string>>(new Set());
 
-  function handleContextMenu(event: MouseEvent, song: Song) {
-    event.preventDefault();
-    if (!selectedSongIds.has(song.id)) {
-      selectedSongIds = new Set([song.id]);
-      lastSelectedSongId = song.id;
-    }
-    contextMenuState = { x: event.clientX, y: event.clientY, song };
-  }
-
-  function handleSongClick(e: MouseEvent, song: Song) {
-    if (e.shiftKey && lastSelectedSongId !== null) {
-      const idx1 = songs.findIndex((s) => s.id === lastSelectedSongId);
-      const idx2 = songs.findIndex((s) => s.id === song.id);
-      if (idx1 !== -1 && idx2 !== -1) {
-        const start = Math.min(idx1, idx2);
-        const end = Math.max(idx1, idx2);
-        const newSet = new Set(e.ctrlKey || e.metaKey ? selectedSongIds : []);
-        for (let i = start; i <= end; i++) {
-          newSet.add(songs[i].id);
-        }
-        selectedSongIds = newSet;
-      }
-    } else if (e.ctrlKey || e.metaKey) {
-      const newSet = new Set(selectedSongIds);
-      if (newSet.has(song.id)) {
-        newSet.delete(song.id);
-      } else {
-        newSet.add(song.id);
-      }
-      selectedSongIds = newSet;
-      lastSelectedSongId = song.id;
-    } else if (selectedSongIds.size === 1 && selectedSongIds.has(song.id)) {
-      selectedSongIds = new Set();
-      lastSelectedSongId = null;
-    } else {
-      selectedSongIds = new Set([song.id]);
-      lastSelectedSongId = song.id;
-    }
-  }
-
-  function handleKeydown(e: KeyboardEvent) {
-    if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === "a") {
-      const target = e.target as HTMLElement;
-      if (target && (target.tagName === "INPUT" || target.tagName === "TEXTAREA")) return;
-      e.preventDefault();
-      selectedSongIds = new Set(songs.map((s) => s.id));
-    } else if (e.key === "Escape") {
-      selectedSongIds = new Set();
-    }
-  }
-
-  function handleWindowMouseDown(e: MouseEvent) {
-    if (selectedSongIds.size === 0) return;
-    const target = e.target as HTMLElement;
-    if (!target) return;
-    if (
-      target.closest("[data-song-row]") ||
-      target.closest("[role='menu']") ||
-      target.closest("[data-floating-toolbar]") ||
-      target.closest("button") ||
-      target.closest("input")
-    ) {
-      return;
-    }
-    selectedSongIds = new Set();
+  function handleRowContextMenu(event: MouseEvent, row: SongTableRow) {
+    if (row.song) contextMenuState = { x: event.clientX, y: event.clientY, song: row.song };
   }
 
   async function handleBulkAddToPlaylist() {
-    if (selectedSongIds.size === 0) return;
-    const songIds = Array.from(selectedSongIds);
+    if (selectedKeys.size === 0) return;
+    const songIds = Array.from(selectedKeys, Number);
     const targetPlaylist = playlistsStore.activeCustomPlaylist;
     const isQueue = !targetPlaylist || targetPlaylist.is_queue;
 
@@ -163,8 +91,8 @@
   }
 
   function handlePlaySelected() {
-    if (selectedSongIds.size === 0) return;
-    const selectedList = songs.filter((s) => selectedSongIds.has(s.id));
+    if (selectedKeys.size === 0) return;
+    const selectedList = songs.filter((s) => selectedKeys.has(String(s.id)));
     if (selectedList.length > 0) {
       playerStore.playSongs(selectedList.map((s) => s.id), 0, undefined, albumPlayContext());
     }
@@ -263,11 +191,12 @@
   let sortField = $state<AlbumSortField>("track");
   let sortAsc = $state(true);
 
-  function toggleSort(field: AlbumSortField) {
-    if (sortField === field) {
+  function toggleSort(field: string) {
+    const f = field as AlbumSortField;
+    if (sortField === f) {
       sortAsc = !sortAsc;
     } else {
-      sortField = field;
+      sortField = f;
       sortAsc = true;
     }
   }
@@ -277,38 +206,8 @@
       if (sortAsc) return songs;
       return [...songs].reverse();
     }
-
     const field = sortField as keyof Song;
-    return [...songs].sort((a, b) => {
-      let valA: unknown = a[field];
-      let valB: unknown = b[field];
-
-      if (sortField === "title") {
-        valA = a.titlesort?.trim() || a.title;
-        valB = b.titlesort?.trim() || b.title;
-      } else if (sortField === "artist") {
-        valA = a.album_artist_sort?.trim() || a.artistsort?.trim() || a.album_artist || a.artist;
-        valB = b.album_artist_sort?.trim() || b.artistsort?.trim() || b.album_artist || b.artist;
-      } else if (sortField === "composer") {
-        valA = a.composersort?.trim() || a.composer;
-        valB = b.composersort?.trim() || b.composer;
-      } else if (sortField === "genre") {
-        valA = a.genresort?.trim() || a.genre;
-        valB = b.genresort?.trim() || b.genre;
-      }
-
-      if (valA === undefined || valA === null) return sortAsc ? 1 : -1;
-      if (valB === undefined || valB === null) return sortAsc ? -1 : 1;
-
-      if (typeof valA === "string" && typeof valB === "string") {
-        const cmp = valA.localeCompare(valB);
-        return sortAsc ? cmp : -cmp;
-      }
-      if (typeof valA === "number" && typeof valB === "number") {
-        return sortAsc ? valA - valB : valB - valA;
-      }
-      return 0;
-    });
+    return [...songs].sort((a, b) => compareSongs(a, b, field, sortAsc));
   });
 
   // Default column widths (px or fr) — used when no saved width exists for a column.
@@ -321,19 +220,20 @@
     lastplayed: "90px", added: "90px", duration: "80px", path: "2fr", actions: "80px",
   };
 
-  // Mirrors CollectionView/PlaylistView/AutoPlaylistDetailView's identical
-  // formula so all four song-table views share one column configuration.
-  let gridColsStyle = $derived.by(() => {
-    const vc = collectionStore.visibleColumns;
-    const cw = collectionStore.columnWidths;
-    const cols: string[] = ["36px"]; // play indicator always present
-    for (const { key } of SONG_TABLE_COLUMNS) {
-      if (!vc[key]) continue;
-      const saved = cw[key];
-      cols.push(saved !== undefined ? `${saved}px` : (ALBUM_COL_DEFAULTS[key] ?? "80px"));
-    }
-    return `grid-template-columns: ${cols.join(" ")}`;
-  });
+  function songToRow(song: Song): SongTableRow {
+    const disconnected = !song.unavailable && collectionStore.isPathOnDisconnectedDrive(song.path);
+    return {
+      key: String(song.id),
+      song,
+      disabled: song.unavailable || disconnected,
+      disabledTooltip: disconnected ? i18n.t("collection.driveDisconnectedTooltip") : undefined,
+    };
+  }
+
+  let tableRows = $derived(sortedSongs.map(songToRow));
+  // Range (shift-click) selection matches natural track order, not the
+  // currently displayed sort — preserving the existing behavior.
+  let rangeSelectionRows = $derived(songs.map(songToRow));
 
   function goBack() {
     collectionStore.selectedAlbumName = null;
@@ -584,517 +484,24 @@
 
   <div class="relative z-10 px-6 py-6" class:pb-28={!!playerStore.currentSong}>
     <div class="border border-brand-border rounded-lg bg-brand-sidebar/50 backdrop-blur-xl shadow-2xl overflow-hidden">
-      <div class="sticky top-0 z-10 flex flex-col rounded-t-lg bg-brand-sidebar/80 backdrop-blur-md border-b border-brand-border text-[10px] text-brand-text-primary uppercase tracking-wider font-semibold select-none">
-        <div class="grid items-center py-2.5 px-4" style={gridColsStyle}>
-          <div class="text-center w-9"></div>
-          {#if collectionStore.visibleColumns.track}
-            <div use:columnResize={{ column: "track", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-            <SortableHeader
-              active={sortField === "track"}
-              {sortAsc}
-              onclick={() => toggleSort("track")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-            >
-              {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-1rem)]">{i18n.t('collection.tableHeaderTrack')} {arrow}</span>{/snippet}
-            </SortableHeader>
-            </div>
-          {/if}
-          {#if collectionStore.visibleColumns.title}
-            <div use:columnResize={{ column: "title", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-            <SortableHeader
-              active={sortField === "title"}
-              {sortAsc}
-              onclick={() => toggleSort("title")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-            >
-              {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-1rem)]">{i18n.t('collection.tableHeaderTitle')} {arrow}</span>{/snippet}
-            </SortableHeader>
-            </div>
-          {/if}
-          {#if collectionStore.visibleColumns.artist}
-            <div use:columnResize={{ column: "artist", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-            <SortableHeader
-              active={sortField === "artist"}
-              {sortAsc}
-              onclick={() => toggleSort("artist")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-            >
-              {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-1rem)]">{i18n.t('collection.tableHeaderArtist')} {arrow}</span>{/snippet}
-            </SortableHeader>
-            </div>
-          {/if}
-          {#if collectionStore.visibleColumns.album}
-            <div use:columnResize={{ column: "album", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-            <SortableHeader
-              active={sortField === "album"}
-              {sortAsc}
-              onclick={() => toggleSort("album")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-            >
-              {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-1rem)]">{i18n.t('collection.tableHeaderAlbum')} {arrow}</span>{/snippet}
-            </SortableHeader>
-            </div>
-          {/if}
-          {#if collectionStore.visibleColumns.composer}
-            <div use:columnResize={{ column: "composer", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-            <SortableHeader
-              active={sortField === "composer"}
-              {sortAsc}
-              onclick={() => toggleSort("composer")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-            >
-              {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderComposer')} {arrow}</span>{/snippet}
-            </SortableHeader>
-            </div>
-          {/if}
-          {#if collectionStore.visibleColumns.album_artist}
-            <div use:columnResize={{ column: "album_artist", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-            <SortableHeader
-              active={sortField === "album_artist"}
-              {sortAsc}
-              onclick={() => toggleSort("album_artist")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-            >
-              {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderAlbumArtist')} {arrow}</span>{/snippet}
-            </SortableHeader>
-            </div>
-          {/if}
-          {#if collectionStore.visibleColumns.format}
-            <div use:columnResize={{ column: "format", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-            <SortableHeader
-              active={sortField === "filetype"}
-              {sortAsc}
-              onclick={() => toggleSort("filetype")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-            >
-              {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderFormat')} {arrow}</span>{/snippet}
-            </SortableHeader>
-            </div>
-          {/if}
-          {#if collectionStore.visibleColumns.year}
-            <div use:columnResize={{ column: "year", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-            <SortableHeader
-              active={sortField === "year"}
-              {sortAsc}
-              onclick={() => toggleSort("year")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-            >
-              {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderYear')} {arrow}</span>{/snippet}
-            </SortableHeader>
-            </div>
-          {/if}
-          {#if collectionStore.visibleColumns.genre}
-            <div use:columnResize={{ column: "genre", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-            <SortableHeader
-              active={sortField === "genre"}
-              {sortAsc}
-              onclick={() => toggleSort("genre")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-            >
-              {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderGenre')} {arrow}</span>{/snippet}
-            </SortableHeader>
-            </div>
-          {/if}
-          {#if collectionStore.visibleColumns.grouping}
-            <div use:columnResize={{ column: "grouping", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-            <SortableHeader
-              active={sortField === "grouping"}
-              {sortAsc}
-              onclick={() => toggleSort("grouping")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-            >
-              {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderGrouping')} {arrow}</span>{/snippet}
-            </SortableHeader>
-            </div>
-          {/if}
-          {#if collectionStore.visibleColumns.bpm}
-            <div use:columnResize={{ column: "bpm", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-            <SortableHeader
-              active={sortField === "bpm"}
-              {sortAsc}
-              onclick={() => toggleSort("bpm")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-            >
-              {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderBpm')} {arrow}</span>{/snippet}
-            </SortableHeader>
-            </div>
-          {/if}
-          {#if collectionStore.visibleColumns.initial_key}
-            <div use:columnResize={{ column: "initial_key", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-            <SortableHeader
-              active={sortField === "initial_key"}
-              {sortAsc}
-              onclick={() => toggleSort("initial_key")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-            >
-              {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderInitialKey')} {arrow}</span>{/snippet}
-            </SortableHeader>
-            </div>
-          {/if}
-          {#if collectionStore.visibleColumns.bitrate}
-            <div use:columnResize={{ column: "bitrate", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-            <SortableHeader
-              active={sortField === "bitrate"}
-              {sortAsc}
-              onclick={() => toggleSort("bitrate")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-            >
-              {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderBitrate')} {arrow}</span>{/snippet}
-            </SortableHeader>
-            </div>
-          {/if}
-          {#if collectionStore.visibleColumns.samplerate}
-            <div use:columnResize={{ column: "samplerate", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-            <SortableHeader
-              active={sortField === "samplerate"}
-              {sortAsc}
-              onclick={() => toggleSort("samplerate")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-            >
-              {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderSampleRate')} {arrow}</span>{/snippet}
-            </SortableHeader>
-            </div>
-          {/if}
-          {#if collectionStore.visibleColumns.bitdepth}
-            <div use:columnResize={{ column: "bitdepth", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-            <SortableHeader
-              active={sortField === "bitdepth"}
-              {sortAsc}
-              onclick={() => toggleSort("bitdepth")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-            >
-              {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderBitDepth')} {arrow}</span>{/snippet}
-            </SortableHeader>
-            </div>
-          {/if}
-          {#if collectionStore.visibleColumns.channels}
-            <div use:columnResize={{ column: "channels", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-            <SortableHeader
-              active={sortField === "channels"}
-              {sortAsc}
-              onclick={() => toggleSort("channels")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-            >
-              {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderChannels')} {arrow}</span>{/snippet}
-            </SortableHeader>
-            </div>
-          {/if}
-          {#if collectionStore.visibleColumns.filesize}
-            <div use:columnResize={{ column: "filesize", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-            <SortableHeader
-              active={sortField === "filesize"}
-              {sortAsc}
-              onclick={() => toggleSort("filesize")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-            >
-              {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderFileSize')} {arrow}</span>{/snippet}
-            </SortableHeader>
-            </div>
-          {/if}
-          {#if collectionStore.visibleColumns.rating}
-            <div use:columnResize={{ column: "rating", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-            <SortableHeader
-              active={sortField === "rating"}
-              {sortAsc}
-              onclick={() => toggleSort("rating")}
-              class="flex items-center justify-center hover:text-brand-text-primary transition-colors font-semibold uppercase tracking-wider min-w-0 w-full"
-            >
-              {#snippet label(arrow)}<span class="truncate">{i18n.t('collection.tableHeaderRating')} {arrow}</span>{/snippet}
-            </SortableHeader>
-            </div>
-          {/if}
-          {#if collectionStore.visibleColumns.playcount}
-            <div use:columnResize={{ column: "playcount", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-            <SortableHeader
-              active={sortField === "playcount"}
-              {sortAsc}
-              onclick={() => toggleSort("playcount")}
-              class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-            >
-              {#snippet label(arrow)}<span class="truncate">{i18n.t('collection.tableHeaderPlays')} {arrow}</span>{/snippet}
-            </SortableHeader>
-            </div>
-          {/if}
-          {#if collectionStore.visibleColumns.skipcount}
-            <div use:columnResize={{ column: "skipcount", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-            <SortableHeader
-              active={sortField === "skipcount"}
-              {sortAsc}
-              onclick={() => toggleSort("skipcount")}
-              class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-            >
-              {#snippet label(arrow)}<span class="truncate">{i18n.t('collection.tableHeaderSkips')} {arrow}</span>{/snippet}
-            </SortableHeader>
-            </div>
-          {/if}
-          {#if collectionStore.visibleColumns.lastplayed}
-            <div use:columnResize={{ column: "lastplayed", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-            <SortableHeader
-              active={sortField === "lastplayed"}
-              {sortAsc}
-              onclick={() => toggleSort("lastplayed")}
-              class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-            >
-              {#snippet label(arrow)}<span class="truncate">{i18n.t('collection.tableHeaderLastPlayed')} {arrow}</span>{/snippet}
-            </SortableHeader>
-            </div>
-          {/if}
-          {#if collectionStore.visibleColumns.added}
-            <div use:columnResize={{ column: "added", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-            <SortableHeader
-              active={sortField === "added"}
-              {sortAsc}
-              onclick={() => toggleSort("added")}
-              class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-            >
-              {#snippet label(arrow)}<span class="truncate">{i18n.t('collection.tableHeaderAdded')} {arrow}</span>{/snippet}
-            </SortableHeader>
-            </div>
-          {/if}
-          {#if collectionStore.visibleColumns.duration}
-            <div use:columnResize={{ column: "duration", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-            <SortableHeader
-              active={sortField === "length_nanosec"}
-              {sortAsc}
-              onclick={() => toggleSort("length_nanosec")}
-              class="flex items-center justify-center hover:text-brand-text-primary transition-colors font-semibold uppercase tracking-wider min-w-0 w-full"
-            >
-              {#snippet label(arrow)}<Clock class="w-3.5 h-3.5 shrink-0" /> {arrow}{/snippet}
-            </SortableHeader>
-            </div>
-          {/if}
-          {#if collectionStore.visibleColumns.path}
-            <div use:columnResize={{ column: "path", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-            <SortableHeader
-              active={sortField === "path"}
-              {sortAsc}
-              onclick={() => toggleSort("path")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-            >
-              {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderPath')} {arrow}</span>{/snippet}
-            </SortableHeader>
-            </div>
-          {/if}
-          {#if collectionStore.visibleColumns.actions}
-            <div use:columnResize={{ column: "actions", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden text-center">{i18n.t('collection.tableHeaderActions')}</div>
-          {/if}
-        </div>
-      </div>
-
-      <div class="divide-y divide-brand-border/40 rounded-b-lg overflow-hidden">
-        {#if loading}
-          <div class="flex items-center justify-center py-16">
-            <div class="text-brand-text-primary text-sm">{i18n.t('home.loading')}</div>
-          </div>
-        {:else if sortedSongs.length === 0}
-          <div class="py-16 text-center select-none">
-            <EmptyState icon={Music} title={i18n.t('collection.noSongsTitle')} />
-          </div>
-        {:else}
-          {#each sortedSongs as song, index (song.id)}
-            {@const disconnected = !song.unavailable && collectionStore.isPathOnDisconnectedDrive(song.path)}
-            {@const disabled = song.unavailable || disconnected}
-            <!-- svelte-ignore a11y_no_static_element_interactions -->
-            <!-- svelte-ignore a11y_click_events_have_key_events -->
-            <div
-              data-song-row="true"
-              onclick={(e) => !disabled && handleSongClick(e, song)}
-              ondblclick={() => !disabled && handlePlaySong(song)}
-              oncontextmenu={(e) => !disabled && handleContextMenu(e, song)}
-              style={gridColsStyle}
-              title={disconnected ? i18n.t('collection.driveDisconnectedTooltip') : undefined}
-              class="grid items-center hover:bg-brand-sidebar/40 group transition-colors py-2 px-4 text-sm
-                {disabled ? 'opacity-50 cursor-not-allowed' : ''}
-                {selectedSongIds.has(song.id) ? 'bg-brand-accent/20 border-l-2 border-brand-accent text-brand-accent-text-hover' : (playerStore.currentSong && playerStore.currentSong.id === song.id ? 'bg-brand-accent/10 text-brand-accent-text-hover' : '')}"
-            >
-              <div class="text-center flex justify-center relative w-9 h-6 items-center">
-                {#if playerStore.currentSong && playerStore.currentSong.id === song.id && playerStore.state === 'playing'}
-                  <div class="flex items-center justify-center gap-0.5 h-3.5 w-3.5 absolute group-hover:opacity-0 transition-opacity">
-                    <NowPlayingBars />
-                  </div>
-                {/if}
-                <button
-                  onclick={(e) => { e.stopPropagation(); if (!disabled) handlePlaySong(song); }}
-                  class="absolute flex items-center justify-center opacity-0 group-hover:opacity-100 text-brand-accent-text hover:text-brand-accent-text-hover transition-all duration-150 disabled:opacity-0 disabled:cursor-not-allowed"
-                  disabled={disabled}
-                  title={disconnected ? i18n.t('collection.driveDisconnectedTooltip') : i18n.t('collection.playSong')}
-                >
-                  <Play class="w-3.5 h-3.5 fill-current" />
-                </button>
-              </div>
-
-              {#if collectionStore.visibleColumns.track}
-                <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium">
-                  {formatTrackNumber(song.track, song.disc, discCount, index)}
-                </div>
-              {/if}
-
-              {#if collectionStore.visibleColumns.title}
-                <div class="font-medium truncate pr-4 flex items-center gap-2 min-w-0">
-                  <span class="truncate {playerStore.currentSong && playerStore.currentSong.id === song.id ? 'text-brand-accent-text-hover' : 'text-brand-text-primary'}">
-                    {song.title || i18n.t('collection.unknownSong')}
-                  </span>
-                </div>
-              {/if}
-
-              {#if collectionStore.visibleColumns.artist}
-                <div class="text-brand-text-primary truncate pr-4 flex items-center min-w-0">
-                  {#if song.artist}
-                    {#each parseMultiValue(song.artist) as name, i (name)}
-                      {#if i > 0}<span class="text-brand-text-primary/50 shrink-0">,&nbsp;</span>{/if}
-                      <LinkButton
-                        onclick={(e) => { e.stopPropagation(); collectionStore.viewArtist(name); }}
-                        class="text-brand-text-primary truncate min-w-0"
-                        title={i18n.t('collection.filterByArtist', { artist: name })}
-                      >
-                        {name}
-                      </LinkButton>
-                    {/each}
-                  {:else}
-                    <span class="text-brand-text-primary truncate min-w-0">{i18n.t('collection.unknownArtist')}</span>
-                  {/if}
-                </div>
-              {/if}
-
-              {#if collectionStore.visibleColumns.album}
-                <div class="text-brand-text-primary truncate pr-4 min-w-0 text-xs font-medium">
-                  {song.album || i18n.t('collection.unknownAlbum')}
-                </div>
-              {/if}
-
-              {#if collectionStore.visibleColumns.composer}
-                <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium" title={song.composer}>
-                  {song.composer || "—"}
-                </div>
-              {/if}
-              {#if collectionStore.visibleColumns.album_artist}
-                <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium" title={song.album_artist}>
-                  {song.album_artist || "—"}
-                </div>
-              {/if}
-              {#if collectionStore.visibleColumns.format}
-                <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-semibold uppercase">
-                  {song.filetype ? song.filetype.toUpperCase() : "—"}
-                </div>
-              {/if}
-              {#if collectionStore.visibleColumns.year}
-                <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium">
-                  {song.year || "—"}
-                </div>
-              {/if}
-              {#if collectionStore.visibleColumns.genre}
-                <div class="truncate pr-2 min-w-0" title={song.genre}>
-                  {#if song.genre}
-                    <GenreChips genre={song.genre} />
-                  {:else}
-                    <span class="text-brand-text-secondary text-xs font-medium">—</span>
-                  {/if}
-                </div>
-              {/if}
-              {#if collectionStore.visibleColumns.grouping}
-                <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium" title={song.grouping}>
-                  {song.grouping || "—"}
-                </div>
-              {/if}
-              {#if collectionStore.visibleColumns.bpm}
-                <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium">
-                  {song.bpm || "—"}
-                </div>
-              {/if}
-              {#if collectionStore.visibleColumns.initial_key}
-                <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium">
-                  {song.initial_key || "—"}
-                </div>
-              {/if}
-              {#if collectionStore.visibleColumns.bitrate}
-                <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium">
-                  {song.bitrate ? `${song.bitrate}k` : "—"}
-                </div>
-              {/if}
-              {#if collectionStore.visibleColumns.samplerate}
-                <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium">
-                  {formatSampleRate(song.samplerate)}
-                </div>
-              {/if}
-              {#if collectionStore.visibleColumns.bitdepth}
-                <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium">
-                  {formatBitDepth(song.bitdepth)}
-                </div>
-              {/if}
-              {#if collectionStore.visibleColumns.channels}
-                <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium">
-                  {formatChannels(song.channels)}
-                </div>
-              {/if}
-              {#if collectionStore.visibleColumns.filesize}
-                <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium">
-                  {formatFileSize(song.filesize)}
-                </div>
-              {/if}
-
-              {#if collectionStore.visibleColumns.rating}
-                <div class="flex justify-center">
-                  <SongRating rating={song.rating} onRate={(r) => rateSong(song, r)} />
-                </div>
-              {/if}
-
-              {#if collectionStore.visibleColumns.playcount}
-                <div class="text-center text-brand-text-primary font-medium">
-                  {song.playcount ?? 0}
-                </div>
-              {/if}
-              {#if collectionStore.visibleColumns.skipcount}
-                <div class="text-center text-brand-text-primary font-medium text-xs">
-                  {song.skipcount ?? 0}
-                </div>
-              {/if}
-              {#if collectionStore.visibleColumns.lastplayed}
-                <div class="text-center text-brand-text-primary text-xs whitespace-nowrap">
-                  {formatDate(song.lastplayed)}
-                </div>
-              {/if}
-              {#if collectionStore.visibleColumns.added}
-                <div class="text-center text-brand-text-primary text-xs whitespace-nowrap">
-                  {formatDateAdded(song.added)}
-                </div>
-              {/if}
-
-              {#if collectionStore.visibleColumns.duration}
-                <div class="text-center text-brand-text-primary text-xs font-medium">
-                  {formatDuration(song.length_nanosec)}
-                </div>
-              {/if}
-
-              {#if collectionStore.visibleColumns.path}
-                <div class="text-brand-text-primary truncate pr-4 min-w-0 text-xs font-medium" title={song.path}>
-                  {song.path || "—"}
-                </div>
-              {/if}
-
-              {#if collectionStore.visibleColumns.actions}
-                <div class="flex items-center justify-center gap-2.5">
-                  <button
-                    onclick={() => handleAddSongToPlaylist(song.id)}
-                    class="text-brand-text-primary hover:text-brand-accent-text transition-colors"
-                    title={playlistsStore.activeCustomPlaylist
-                      ? i18n.t('collection.addPlaylistTooltip', { name: playlistsStore.activeCustomPlaylist.name })
-                      : i18n.t('collection.addPlaylistTooltipDefault')}
-                  >
-                    <Plus class="w-4 h-4" />
-                  </button>
-                  <button
-                    onclick={() => openTagEditor(song.id)}
-                    class="text-brand-text-primary hover:text-brand-accent-text transition-colors"
-                    title={i18n.t('collection.editTagsTooltip')}
-                  >
-                    <Edit3 class="w-4 h-4" />
-                  </button>
-                </div>
-              {/if}
-            </div>
-          {/each}
-        {/if}
-      </div>
+      <SongTable
+        rows={tableRows}
+        rangeSelectionOrder={rangeSelectionRows}
+        mode="track"
+        {discCount}
+        leadingColumnWidth="36px"
+        colDefaults={ALBUM_COL_DEFAULTS}
+        {sortField}
+        {sortAsc}
+        onToggleSort={toggleSort}
+        bind:selectedKeys
+        {loading}
+        onRowDoubleClick={(row) => row.song && handlePlaySong(row.song)}
+        onRowContextMenu={handleRowContextMenu}
+        onRate={rateSong}
+        onAddToPlaylist={(song) => handleAddSongToPlaylist(song.id)}
+        onEditTags={(song) => openTagEditor(song.id)}
+      />
     </div>
   </div>
 </div>
@@ -1127,25 +534,23 @@
   />
 {/if}
 
-<svelte:window onkeydown={handleKeydown} onmousedown={handleWindowMouseDown} />
-
 {#if contextMenuState}
   {@const song = contextMenuState.song}
   <SongContextMenu
     x={contextMenuState.x}
     y={contextMenuState.y}
     {song}
-    selectedCount={selectedSongIds.size}
-    selectedSongIds={Array.from(selectedSongIds)}
+    selectedCount={selectedKeys.size}
+    selectedSongIds={Array.from(selectedKeys, Number)}
     onPlay={() => {
-      if (selectedSongIds.size > 1) {
+      if (selectedKeys.size > 1) {
         handlePlaySelected();
       } else {
         handlePlaySong(song);
       }
     }}
     onAddToPlaylist={() => {
-      if (selectedSongIds.size > 1) {
+      if (selectedKeys.size > 1) {
         handleBulkAddToPlaylist();
       } else {
         handleAddSongToPlaylist(song.id);
@@ -1158,12 +563,12 @@
   />
 {/if}
 
-{#if selectedSongIds.size > 0}
+{#if selectedKeys.size > 0}
   <SongSelectionToolbar
-    count={selectedSongIds.size}
+    count={selectedKeys.size}
     onPlaySelected={handlePlaySelected}
     onAddToPlaylist={handleBulkAddToPlaylist}
-    onClear={() => { selectedSongIds = new Set(); }}
+    onClear={() => { selectedKeys = new Set(); }}
   />
 {/if}
 
@@ -1176,4 +581,3 @@
     display: none;
   }
 </style>
-

--- a/src/lib/components/ArtistDetailView.svelte
+++ b/src/lib/components/ArtistDetailView.svelte
@@ -11,30 +11,25 @@
   import PlaylistCard from "./PlaylistCard.svelte";
   import AlbumContextMenu from "./AlbumContextMenu.svelte";
   import SongContextMenu from "./SongContextMenu.svelte";
-  import GenreChips from "./GenreChips.svelte";
   import { tagsStore } from "../stores/tags.svelte";
   import TagEditor from "./TagEditor.svelte";
-  import SongRating from "./SongRating.svelte";
-  import SortableHeader from "./SortableHeader.svelte";
-  import NowPlayingBars from "./NowPlayingBars.svelte";
   import ColumnSelector from "./ColumnSelector.svelte";
   import HorizontalScrollRow from "./HorizontalScrollRow.svelte";
   import PlayShuffleButtons from "./PlayShuffleButtons.svelte";
   import ArtistProfileEditor from "./ArtistProfileEditor.svelte";
   import SocialIcon from "./SocialIcon.svelte";
-  import { Play, Plus, Edit3, Clock, ExternalLink } from "lucide-svelte";
+  import SongSelectionToolbar from "./SongSelectionToolbar.svelte";
+  import SongTable, { type SongTableRow } from "./SongTable.svelte";
+  import { Edit3, ExternalLink } from "lucide-svelte";
   import type { Song, Playlist, AlbumItem, PlayContext, ArtistProfile } from "../types";
   import { resolveSocialUrl, formatDisplayLabel } from "../utils/artistSocials";
-  import { getArtistAlbums, classifyRelease, formatTrackNumber } from "../utils/artist";
+  import { getArtistAlbums, classifyRelease } from "../utils/artist";
   import { songsToCoverStack } from "../utils/covers";
   import { isSmartPlaylistSpec } from "../utils/filterParser";
   import { i18n } from "../stores/i18n.svelte";
   import { toastStore } from "../stores/toast.svelte";
   import { rememberScroll } from "../utils/scrollMemory";
-  import { formatDate, formatFileSize, formatSampleRate, formatBitDepth, formatChannels } from "../utils/formatters";
-  import { formatDateAdded } from "../utils/date";
-  import { SONG_TABLE_COLUMNS } from "../utils/songColumns";
-  import { columnResize } from "../utils/columnResize";
+  import { compareSongs } from "../utils/songSort";
 
   let { artistName }: { artistName: string } = $props();
 
@@ -48,6 +43,7 @@
   let editingSongId = $state<number | null>(null);
   let isEditorOpen = $state(false);
   let isBioExpanded = $state(false);
+  let selectedKeys = $state<Set<string>>(new Set());
 
   let artistProfile = $derived(collectionStore.getArtistProfile(artistName));
   let hasWebsite = $derived(!!artistProfile?.website);
@@ -78,9 +74,34 @@
     albumContextMenuState = { x: event.clientX, y: event.clientY, album };
   }
 
-  function handleSingleContextMenu(event: MouseEvent, song: Song) {
-    event.preventDefault();
-    singleContextMenuState = { x: event.clientX, y: event.clientY, song };
+  function handleRowContextMenu(event: MouseEvent, row: SongTableRow) {
+    if (row.song) singleContextMenuState = { x: event.clientX, y: event.clientY, song: row.song };
+  }
+
+  function handlePlaySelected() {
+    if (selectedKeys.size === 0) return;
+    const selectedList = singleSongs.filter((s) => selectedKeys.has(String(s.id)));
+    if (selectedList.length > 0) {
+      playerStore.playSongs(selectedList.map((s) => s.id), 0);
+    }
+  }
+
+  async function handleBulkAddSinglesToPlaylist() {
+    if (selectedKeys.size === 0) return;
+    const songIds = Array.from(selectedKeys, Number);
+    const targetPlaylist = playlistsStore.activeCustomPlaylist;
+    const isQueue = !targetPlaylist || targetPlaylist.is_queue;
+
+    if (isQueue) {
+      {
+        await playlistsStore.addSongsToQueue(songIds);
+        const label = songIds.length === 1 ? "1 song" : `${songIds.length} songs`;
+        toastStore.show(i18n.t("playlists.addedToQueueSuccess", { name: label }, `Added ${label} to Queue`));
+      }
+    } else {
+      await playlistsStore.addSongsToPlaylist(targetPlaylist.id, songIds);
+      toastStore.show(i18n.t("playlists.addedToPlaylistSuccess", { name: targetPlaylist.name }, `Added to ${targetPlaylist.name}`));
+    }
   }
 
   function openTagEditor(songId: number) {
@@ -112,11 +133,12 @@
   let singleSortField = $state<SingleSortField>("track");
   let singleSortAsc = $state(true);
 
-  function toggleSingleSort(field: SingleSortField) {
-    if (singleSortField === field) {
+  function toggleSingleSort(field: string) {
+    const f = field as SingleSortField;
+    if (singleSortField === f) {
       singleSortAsc = !singleSortAsc;
     } else {
-      singleSortField = field;
+      singleSortField = f;
       singleSortAsc = true;
     }
   }
@@ -246,38 +268,8 @@
       if (singleSortAsc) return singleSongs;
       return [...singleSongs].reverse();
     }
-
     const field = singleSortField as keyof Song;
-    return [...singleSongs].sort((a, b) => {
-      let valA: unknown = a[field];
-      let valB: unknown = b[field];
-
-      if (singleSortField === "title") {
-        valA = a.titlesort?.trim() || a.title;
-        valB = b.titlesort?.trim() || b.title;
-      } else if (singleSortField === "artist") {
-        valA = a.album_artist_sort?.trim() || a.artistsort?.trim() || a.album_artist || a.artist;
-        valB = b.album_artist_sort?.trim() || b.artistsort?.trim() || b.album_artist || b.artist;
-      } else if (singleSortField === "composer") {
-        valA = a.composersort?.trim() || a.composer;
-        valB = b.composersort?.trim() || b.composer;
-      } else if (singleSortField === "genre") {
-        valA = a.genresort?.trim() || a.genre;
-        valB = b.genresort?.trim() || b.genre;
-      }
-
-      if (valA === undefined || valA === null) return singleSortAsc ? 1 : -1;
-      if (valB === undefined || valB === null) return singleSortAsc ? -1 : 1;
-
-      if (typeof valA === "string" && typeof valB === "string") {
-        const cmp = valA.localeCompare(valB);
-        return singleSortAsc ? cmp : -cmp;
-      }
-      if (typeof valA === "number" && typeof valB === "number") {
-        return singleSortAsc ? valA - valB : valB - valA;
-      }
-      return 0;
-    });
+    return [...singleSongs].sort((a, b) => compareSongs(a, b, field, singleSortAsc));
   });
 
   // Mirrors AlbumDetailView/CollectionView/PlaylistView/AutoPlaylistDetailView's
@@ -292,19 +284,19 @@
     lastplayed: "90px", added: "90px", duration: "80px", path: "2fr", actions: "80px",
   };
 
-  let gridColsStyle = $derived.by(() => {
-    const vc = collectionStore.visibleColumns;
-    const cw = collectionStore.columnWidths;
-    const cols: string[] = ["36px"]; // play indicator always present
-    for (const { key } of SONG_TABLE_COLUMNS) {
-      if (!vc[key]) continue;
-      const saved = cw[key];
-      cols.push(saved !== undefined ? `${saved}px` : (ARTIST_COL_DEFAULTS[key] ?? "80px"));
-    }
-    return `grid-template-columns: ${cols.join(" ")}`;
-  });
-
   let singleDiscCount = $derived(singleSongs.reduce((max, s) => Math.max(max, s.disc ?? 1), 1));
+
+  function songToRow(song: Song): SongTableRow {
+    const disconnected = !song.unavailable && collectionStore.isPathOnDisconnectedDrive(song.path);
+    return {
+      key: String(song.id),
+      song,
+      disabled: song.unavailable || disconnected,
+      disabledTooltip: disconnected ? i18n.t("collection.driveDisconnectedTooltip") : undefined,
+    };
+  }
+
+  let singleTableRows = $derived(sortedSingleSongs.map(songToRow));
 
   function openAlbum(album: AlbumItem) {
     collectionStore.viewAlbum(album.album || "");
@@ -537,500 +529,22 @@
       <div class="flex flex-col gap-3">
         <h2 class="text-xl font-semibold text-brand-text-primary">{i18n.t('artistDetail.singlesFilter', { count: singleSongs.length })}</h2>
         <div class="border border-brand-border rounded-lg bg-brand-sidebar/50 backdrop-blur-xl shadow-2xl overflow-hidden">
-          <div class="sticky top-0 z-10 flex flex-col rounded-t-lg bg-brand-sidebar/80 backdrop-blur-md border-b border-brand-border text-[10px] text-brand-text-primary uppercase tracking-wider font-semibold select-none">
-            <div class="grid items-center py-2.5 px-4" style={gridColsStyle}>
-              <div class="text-center w-9"></div>
-              {#if collectionStore.visibleColumns.track}
-                <div use:columnResize={{ column: "track", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-                <SortableHeader
-                  active={singleSortField === "track"}
-                  sortAsc={singleSortAsc}
-                  onclick={() => toggleSingleSort("track")}
-                  class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-                >
-                  {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-1rem)]">{i18n.t('collection.tableHeaderTrack')} {arrow}</span>{/snippet}
-                </SortableHeader>
-                </div>
-              {/if}
-              {#if collectionStore.visibleColumns.title}
-                <div use:columnResize={{ column: "title", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-                <SortableHeader
-                  active={singleSortField === "title"}
-                  sortAsc={singleSortAsc}
-                  onclick={() => toggleSingleSort("title")}
-                  class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-                >
-                  {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-1rem)]">{i18n.t('collection.tableHeaderTitle')} {arrow}</span>{/snippet}
-                </SortableHeader>
-                </div>
-              {/if}
-              {#if collectionStore.visibleColumns.artist}
-                <div use:columnResize={{ column: "artist", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-                <SortableHeader
-                  active={singleSortField === "artist"}
-                  sortAsc={singleSortAsc}
-                  onclick={() => toggleSingleSort("artist")}
-                  class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-                >
-                  {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-1rem)]">{i18n.t('collection.tableHeaderArtist')} {arrow}</span>{/snippet}
-                </SortableHeader>
-                </div>
-              {/if}
-              {#if collectionStore.visibleColumns.album}
-                <div use:columnResize={{ column: "album", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-                <SortableHeader
-                  active={singleSortField === "album"}
-                  sortAsc={singleSortAsc}
-                  onclick={() => toggleSingleSort("album")}
-                  class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-                >
-                  {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-1rem)]">{i18n.t('collection.tableHeaderAlbum')} {arrow}</span>{/snippet}
-                </SortableHeader>
-                </div>
-              {/if}
-              {#if collectionStore.visibleColumns.composer}
-                <div use:columnResize={{ column: "composer", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-                <SortableHeader
-                  active={singleSortField === "composer"}
-                  sortAsc={singleSortAsc}
-                  onclick={() => toggleSingleSort("composer")}
-                  class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-                >
-                  {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderComposer')} {arrow}</span>{/snippet}
-                </SortableHeader>
-                </div>
-              {/if}
-              {#if collectionStore.visibleColumns.album_artist}
-                <div use:columnResize={{ column: "album_artist", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-                <SortableHeader
-                  active={singleSortField === "album_artist"}
-                  sortAsc={singleSortAsc}
-                  onclick={() => toggleSingleSort("album_artist")}
-                  class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-                >
-                  {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderAlbumArtist')} {arrow}</span>{/snippet}
-                </SortableHeader>
-                </div>
-              {/if}
-              {#if collectionStore.visibleColumns.format}
-                <div use:columnResize={{ column: "format", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-                <SortableHeader
-                  active={singleSortField === "filetype"}
-                  sortAsc={singleSortAsc}
-                  onclick={() => toggleSingleSort("filetype")}
-                  class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-                >
-                  {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderFormat')} {arrow}</span>{/snippet}
-                </SortableHeader>
-                </div>
-              {/if}
-              {#if collectionStore.visibleColumns.year}
-                <div use:columnResize={{ column: "year", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-                <SortableHeader
-                  active={singleSortField === "year"}
-                  sortAsc={singleSortAsc}
-                  onclick={() => toggleSingleSort("year")}
-                  class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-                >
-                  {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderYear')} {arrow}</span>{/snippet}
-                </SortableHeader>
-                </div>
-              {/if}
-              {#if collectionStore.visibleColumns.genre}
-                <div use:columnResize={{ column: "genre", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-                <SortableHeader
-                  active={singleSortField === "genre"}
-                  sortAsc={singleSortAsc}
-                  onclick={() => toggleSingleSort("genre")}
-                  class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-                >
-                  {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderGenre')} {arrow}</span>{/snippet}
-                </SortableHeader>
-                </div>
-              {/if}
-              {#if collectionStore.visibleColumns.grouping}
-                <div use:columnResize={{ column: "grouping", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-                <SortableHeader
-                  active={singleSortField === "grouping"}
-                  sortAsc={singleSortAsc}
-                  onclick={() => toggleSingleSort("grouping")}
-                  class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-                >
-                  {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderGrouping')} {arrow}</span>{/snippet}
-                </SortableHeader>
-                </div>
-              {/if}
-              {#if collectionStore.visibleColumns.bpm}
-                <div use:columnResize={{ column: "bpm", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-                <SortableHeader
-                  active={singleSortField === "bpm"}
-                  sortAsc={singleSortAsc}
-                  onclick={() => toggleSingleSort("bpm")}
-                  class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-                >
-                  {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderBpm')} {arrow}</span>{/snippet}
-                </SortableHeader>
-                </div>
-              {/if}
-              {#if collectionStore.visibleColumns.initial_key}
-                <div use:columnResize={{ column: "initial_key", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-                <SortableHeader
-                  active={singleSortField === "initial_key"}
-                  sortAsc={singleSortAsc}
-                  onclick={() => toggleSingleSort("initial_key")}
-                  class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-                >
-                  {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderInitialKey')} {arrow}</span>{/snippet}
-                </SortableHeader>
-                </div>
-              {/if}
-              {#if collectionStore.visibleColumns.bitrate}
-                <div use:columnResize={{ column: "bitrate", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-                <SortableHeader
-                  active={singleSortField === "bitrate"}
-                  sortAsc={singleSortAsc}
-                  onclick={() => toggleSingleSort("bitrate")}
-                  class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-                >
-                  {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderBitrate')} {arrow}</span>{/snippet}
-                </SortableHeader>
-                </div>
-              {/if}
-              {#if collectionStore.visibleColumns.samplerate}
-                <div use:columnResize={{ column: "samplerate", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-                <SortableHeader
-                  active={singleSortField === "samplerate"}
-                  sortAsc={singleSortAsc}
-                  onclick={() => toggleSingleSort("samplerate")}
-                  class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-                >
-                  {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderSampleRate')} {arrow}</span>{/snippet}
-                </SortableHeader>
-                </div>
-              {/if}
-              {#if collectionStore.visibleColumns.bitdepth}
-                <div use:columnResize={{ column: "bitdepth", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-                <SortableHeader
-                  active={singleSortField === "bitdepth"}
-                  sortAsc={singleSortAsc}
-                  onclick={() => toggleSingleSort("bitdepth")}
-                  class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-                >
-                  {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderBitDepth')} {arrow}</span>{/snippet}
-                </SortableHeader>
-                </div>
-              {/if}
-              {#if collectionStore.visibleColumns.channels}
-                <div use:columnResize={{ column: "channels", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-                <SortableHeader
-                  active={singleSortField === "channels"}
-                  sortAsc={singleSortAsc}
-                  onclick={() => toggleSingleSort("channels")}
-                  class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-                >
-                  {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderChannels')} {arrow}</span>{/snippet}
-                </SortableHeader>
-                </div>
-              {/if}
-              {#if collectionStore.visibleColumns.filesize}
-                <div use:columnResize={{ column: "filesize", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-                <SortableHeader
-                  active={singleSortField === "filesize"}
-                  sortAsc={singleSortAsc}
-                  onclick={() => toggleSingleSort("filesize")}
-                  class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-                >
-                  {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderFileSize')} {arrow}</span>{/snippet}
-                </SortableHeader>
-                </div>
-              {/if}
-              {#if collectionStore.visibleColumns.rating}
-                <div use:columnResize={{ column: "rating", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-                <SortableHeader
-                  active={singleSortField === "rating"}
-                  sortAsc={singleSortAsc}
-                  onclick={() => toggleSingleSort("rating")}
-                  class="flex items-center justify-center hover:text-brand-text-primary transition-colors font-semibold uppercase tracking-wider min-w-0 w-full"
-                >
-                  {#snippet label(arrow)}<span class="truncate">{i18n.t('collection.tableHeaderRating')} {arrow}</span>{/snippet}
-                </SortableHeader>
-                </div>
-              {/if}
-              {#if collectionStore.visibleColumns.playcount}
-                <div use:columnResize={{ column: "playcount", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-                <SortableHeader
-                  active={singleSortField === "playcount"}
-                  sortAsc={singleSortAsc}
-                  onclick={() => toggleSingleSort("playcount")}
-                  class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-                >
-                  {#snippet label(arrow)}<span class="truncate">{i18n.t('collection.tableHeaderPlays')} {arrow}</span>{/snippet}
-                </SortableHeader>
-                </div>
-              {/if}
-              {#if collectionStore.visibleColumns.skipcount}
-                <div use:columnResize={{ column: "skipcount", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-                <SortableHeader
-                  active={singleSortField === "skipcount"}
-                  sortAsc={singleSortAsc}
-                  onclick={() => toggleSingleSort("skipcount")}
-                  class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-                >
-                  {#snippet label(arrow)}<span class="truncate">{i18n.t('collection.tableHeaderSkips')} {arrow}</span>{/snippet}
-                </SortableHeader>
-                </div>
-              {/if}
-              {#if collectionStore.visibleColumns.lastplayed}
-                <div use:columnResize={{ column: "lastplayed", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-                <SortableHeader
-                  active={singleSortField === "lastplayed"}
-                  sortAsc={singleSortAsc}
-                  onclick={() => toggleSingleSort("lastplayed")}
-                  class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-                >
-                  {#snippet label(arrow)}<span class="truncate">{i18n.t('collection.tableHeaderLastPlayed')} {arrow}</span>{/snippet}
-                </SortableHeader>
-                </div>
-              {/if}
-              {#if collectionStore.visibleColumns.added}
-                <div use:columnResize={{ column: "added", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-                <SortableHeader
-                  active={singleSortField === "added"}
-                  sortAsc={singleSortAsc}
-                  onclick={() => toggleSingleSort("added")}
-                  class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-                >
-                  {#snippet label(arrow)}<span class="truncate">{i18n.t('collection.tableHeaderAdded')} {arrow}</span>{/snippet}
-                </SortableHeader>
-                </div>
-              {/if}
-              {#if collectionStore.visibleColumns.duration}
-                <div use:columnResize={{ column: "duration", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-                <SortableHeader
-                  active={singleSortField === "length_nanosec"}
-                  sortAsc={singleSortAsc}
-                  onclick={() => toggleSingleSort("length_nanosec")}
-                  class="flex items-center justify-center hover:text-brand-text-primary transition-colors font-semibold uppercase tracking-wider min-w-0 w-full"
-                >
-                  {#snippet label(arrow)}<Clock class="w-3.5 h-3.5 shrink-0" /> {arrow}{/snippet}
-                </SortableHeader>
-                </div>
-              {/if}
-              {#if collectionStore.visibleColumns.path}
-                <div use:columnResize={{ column: "path", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-                <SortableHeader
-                  active={singleSortField === "path"}
-                  sortAsc={singleSortAsc}
-                  onclick={() => toggleSingleSort("path")}
-                  class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-                >
-                  {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderPath')} {arrow}</span>{/snippet}
-                </SortableHeader>
-                </div>
-              {/if}
-              {#if collectionStore.visibleColumns.actions}
-                <div use:columnResize={{ column: "actions", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden text-center">{i18n.t('collection.tableHeaderActions')}</div>
-              {/if}
-            </div>
-          </div>
-
-          <div class="divide-y divide-brand-border/40 rounded-b-lg overflow-hidden">
-            {#each sortedSingleSongs as song, index (song.id)}
-              {@const disconnected = !song.unavailable && collectionStore.isPathOnDisconnectedDrive(song.path)}
-              {@const disabled = song.unavailable || disconnected}
-              <!-- svelte-ignore a11y_no_static_element_interactions -->
-              <!-- svelte-ignore a11y_click_events_have_key_events -->
-              <div
-                data-song-row="true"
-                ondblclick={() => !disabled && handlePlaySingle(song)}
-                oncontextmenu={(e) => !disabled && handleSingleContextMenu(e, song)}
-                style={gridColsStyle}
-                title={disconnected ? i18n.t('collection.driveDisconnectedTooltip') : undefined}
-                class="grid items-center hover:bg-brand-sidebar/40 group transition-colors py-2 px-4 text-sm
-                  {disabled ? 'opacity-50 cursor-not-allowed' : ''}
-                  {playerStore.currentSong && playerStore.currentSong.id === song.id ? 'bg-brand-accent/10 text-brand-accent-text-hover' : ''}"
-              >
-                <div class="text-center flex justify-center relative w-9 h-6 items-center">
-                  {#if playerStore.currentSong && playerStore.currentSong.id === song.id && playerStore.state === 'playing'}
-                    <div class="flex items-center justify-center gap-0.5 h-3.5 w-3.5 absolute group-hover:opacity-0 transition-opacity">
-                      <NowPlayingBars />
-                    </div>
-                  {/if}
-                  <button
-                    onclick={(e) => { e.stopPropagation(); if (!disabled) handlePlaySingle(song); }}
-                    class="absolute flex items-center justify-center opacity-0 group-hover:opacity-100 text-brand-accent-text hover:text-brand-accent-text-hover transition-all duration-150 disabled:opacity-0 disabled:cursor-not-allowed"
-                    disabled={disabled}
-                    title={disconnected ? i18n.t('collection.driveDisconnectedTooltip') : i18n.t('collection.playSong')}
-                  >
-                    <Play class="w-3.5 h-3.5 fill-current" />
-                  </button>
-                </div>
-
-                {#if collectionStore.visibleColumns.track}
-                  <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium">
-                    {formatTrackNumber(song.track, song.disc, singleDiscCount, index)}
-                  </div>
-                {/if}
-
-                {#if collectionStore.visibleColumns.title}
-                  <div class="font-medium truncate pr-4 flex items-center gap-2 min-w-0">
-                    <CoverArt
-                      songId={song.id}
-                      artEmbedded={song.art_embedded}
-                      artAutomatic={song.art_automatic}
-                      artManual={song.art_manual}
-                      sizeClass="w-7 h-7 rounded shrink-0"
-                    />
-                    <span class="truncate {playerStore.currentSong && playerStore.currentSong.id === song.id ? 'text-brand-accent-text-hover' : 'text-brand-text-primary'}">
-                      {song.title || i18n.t('collection.unknownSong')}
-                    </span>
-                  </div>
-                {/if}
-
-                {#if collectionStore.visibleColumns.artist}
-                  <div class="text-brand-text-primary truncate pr-4 min-w-0 text-xs font-medium">
-                    {song.artist || i18n.t('collection.unknownArtist')}
-                  </div>
-                {/if}
-
-                {#if collectionStore.visibleColumns.album}
-                  <div class="text-brand-text-primary truncate pr-4 min-w-0 text-xs font-medium">
-                    {song.album || i18n.t('collection.unknownAlbum')}
-                  </div>
-                {/if}
-
-                {#if collectionStore.visibleColumns.composer}
-                  <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium" title={song.composer}>
-                    {song.composer || "—"}
-                  </div>
-                {/if}
-                {#if collectionStore.visibleColumns.album_artist}
-                  <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium" title={song.album_artist}>
-                    {song.album_artist || "—"}
-                  </div>
-                {/if}
-                {#if collectionStore.visibleColumns.format}
-                  <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-semibold uppercase">
-                    {song.filetype ? song.filetype.toUpperCase() : "—"}
-                  </div>
-                {/if}
-                {#if collectionStore.visibleColumns.year}
-                  <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium">
-                    {song.year || "—"}
-                  </div>
-                {/if}
-                {#if collectionStore.visibleColumns.genre}
-                  <div class="truncate pr-2 min-w-0" title={song.genre}>
-                    {#if song.genre}
-                      <GenreChips genre={song.genre} />
-                    {:else}
-                      <span class="text-brand-text-secondary text-xs font-medium">—</span>
-                    {/if}
-                  </div>
-                {/if}
-                {#if collectionStore.visibleColumns.grouping}
-                  <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium" title={song.grouping}>
-                    {song.grouping || "—"}
-                  </div>
-                {/if}
-                {#if collectionStore.visibleColumns.bpm}
-                  <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium">
-                    {song.bpm || "—"}
-                  </div>
-                {/if}
-                {#if collectionStore.visibleColumns.initial_key}
-                  <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium">
-                    {song.initial_key || "—"}
-                  </div>
-                {/if}
-                {#if collectionStore.visibleColumns.bitrate}
-                  <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium">
-                    {song.bitrate ? `${song.bitrate}k` : "—"}
-                  </div>
-                {/if}
-                {#if collectionStore.visibleColumns.samplerate}
-                  <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium">
-                    {formatSampleRate(song.samplerate)}
-                  </div>
-                {/if}
-                {#if collectionStore.visibleColumns.bitdepth}
-                  <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium">
-                    {formatBitDepth(song.bitdepth)}
-                  </div>
-                {/if}
-                {#if collectionStore.visibleColumns.channels}
-                  <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium">
-                    {formatChannels(song.channels)}
-                  </div>
-                {/if}
-                {#if collectionStore.visibleColumns.filesize}
-                  <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium">
-                    {formatFileSize(song.filesize)}
-                  </div>
-                {/if}
-
-                {#if collectionStore.visibleColumns.rating}
-                  <div class="flex justify-center">
-                    <SongRating rating={song.rating} onRate={(r) => rateSingle(song, r)} />
-                  </div>
-                {/if}
-
-                {#if collectionStore.visibleColumns.playcount}
-                  <div class="text-center text-brand-text-primary font-medium">
-                    {song.playcount ?? 0}
-                  </div>
-                {/if}
-                {#if collectionStore.visibleColumns.skipcount}
-                  <div class="text-center text-brand-text-primary font-medium text-xs">
-                    {song.skipcount ?? 0}
-                  </div>
-                {/if}
-                {#if collectionStore.visibleColumns.lastplayed}
-                  <div class="text-center text-brand-text-primary text-xs whitespace-nowrap">
-                    {formatDate(song.lastplayed)}
-                  </div>
-                {/if}
-                {#if collectionStore.visibleColumns.added}
-                  <div class="text-center text-brand-text-primary text-xs whitespace-nowrap">
-                    {formatDateAdded(song.added)}
-                  </div>
-                {/if}
-
-                {#if collectionStore.visibleColumns.duration}
-                  <div class="text-center text-brand-text-primary text-xs font-medium">
-                    {formatDuration(song.length_nanosec)}
-                  </div>
-                {/if}
-
-                {#if collectionStore.visibleColumns.path}
-                  <div class="text-brand-text-primary truncate pr-4 min-w-0 text-xs font-medium" title={song.path}>
-                    {song.path || "—"}
-                  </div>
-                {/if}
-
-                {#if collectionStore.visibleColumns.actions}
-                  <div class="flex items-center justify-center gap-2.5">
-                    <button
-                      onclick={(e) => { e.stopPropagation(); handleAddSingleToPlaylist(song.id); }}
-                      class="text-brand-text-primary hover:text-brand-accent-text transition-colors"
-                      title={playlistsStore.activeCustomPlaylist
-                        ? i18n.t('collection.addPlaylistTooltip', { name: playlistsStore.activeCustomPlaylist.name })
-                        : i18n.t('collection.addPlaylistTooltipDefault')}
-                    >
-                      <Plus class="w-4 h-4" />
-                    </button>
-                    <button
-                      onclick={(e) => { e.stopPropagation(); openTagEditor(song.id); }}
-                      class="text-brand-text-primary hover:text-brand-accent-text transition-colors"
-                      title={i18n.t('collection.editTagsTooltip')}
-                    >
-                      <Edit3 class="w-4 h-4" />
-                    </button>
-                  </div>
-                {/if}
-              </div>
-            {/each}
-          </div>
+          <SongTable
+            rows={singleTableRows}
+            mode="track"
+            discCount={singleDiscCount}
+            leadingColumnWidth="36px"
+            colDefaults={ARTIST_COL_DEFAULTS}
+            sortField={singleSortField}
+            sortAsc={singleSortAsc}
+            onToggleSort={toggleSingleSort}
+            bind:selectedKeys
+            onRowDoubleClick={(row) => row.song && handlePlaySingle(row.song)}
+            onRowContextMenu={handleRowContextMenu}
+            onRate={rateSingle}
+            onAddToPlaylist={(song) => handleAddSingleToPlaylist(song.id)}
+            onEditTags={(song) => openTagEditor(song.id)}
+          />
         </div>
       </div>
     {/if}
@@ -1112,8 +626,22 @@
     x={singleContextMenuState.x}
     y={singleContextMenuState.y}
     {song}
-    onPlay={() => handlePlaySingle(song)}
-    onAddToPlaylist={() => handleAddSingleToPlaylist(song.id)}
+    selectedCount={selectedKeys.size}
+    selectedSongIds={Array.from(selectedKeys, Number)}
+    onPlay={() => {
+      if (selectedKeys.size > 1) {
+        handlePlaySelected();
+      } else {
+        handlePlaySingle(song);
+      }
+    }}
+    onAddToPlaylist={() => {
+      if (selectedKeys.size > 1) {
+        handleBulkAddSinglesToPlaylist();
+      } else {
+        handleAddSingleToPlaylist(song.id);
+      }
+    }}
     onEditTags={() => openTagEditor(song.id)}
     onClose={() => { singleContextMenuState = null; }}
   />
@@ -1132,6 +660,15 @@
   isOpen={isEditorOpen}
   onClose={() => { isEditorOpen = false; }}
 />
+
+{#if selectedKeys.size > 0}
+  <SongSelectionToolbar
+    count={selectedKeys.size}
+    onPlaySelected={handlePlaySelected}
+    onAddToPlaylist={handleBulkAddSinglesToPlaylist}
+    onClear={() => { selectedKeys = new Set(); }}
+  />
+{/if}
 
 <style>
   :global(.carousel-scroll) {

--- a/src/lib/components/AutoPlaylistDetailView.svelte
+++ b/src/lib/components/AutoPlaylistDetailView.svelte
@@ -6,42 +6,33 @@
   import { playerStore } from "../stores/player.svelte";
   import { playlistsStore } from "../stores/playlists.svelte";
   import { songsToCoverStack } from "../utils/covers";
-  import { formatDuration } from "../utils/formatters";
   import CoverStack from "./CoverStack.svelte";
-  import SongRating from "./SongRating.svelte";
   import TagEditor from "./TagEditor.svelte";
   import SongContextMenu from "./SongContextMenu.svelte";
-  import GenreChips from "./GenreChips.svelte";
+  import EmptyState from "./EmptyState.svelte";
   import { tagsStore } from "../stores/tags.svelte";
   import PopulationModeTabs from "./PopulationModeTabs.svelte";
-  import SortableHeader from "./SortableHeader.svelte";
   import SongSelectionToolbar from "./SongSelectionToolbar.svelte";
-  import EmptyState from "./EmptyState.svelte";
   import PlayShuffleButtons from "./PlayShuffleButtons.svelte";
-  import NowPlayingBars from "./NowPlayingBars.svelte";
   import IconActionButton from "./IconActionButton.svelte";
-  import LinkButton from "./LinkButton.svelte";
-  import { parseMultiValue } from "../utils/multiValue";
   import ColumnSelector from "./ColumnSelector.svelte";
   import Input from "./Input.svelte";
   import ContextMenu from "./ContextMenu.svelte";
   import ContextMenuItem from "./ContextMenuItem.svelte";
   import ContextMenuDivider from "./ContextMenuDivider.svelte";
-  import { Clock, Play, Plus, FolderPlus, Edit3, DiscAlbum, Music, Gauge, RefreshCw, Heart, Calendar, Hourglass, Search, RotateCcw, RotateCw, MoreHorizontal, X, Trash2, Eraser } from "lucide-svelte";
-import { shuffleArray } from "../utils/shuffle";
-  import { formatDate, formatFileSize, formatSampleRate, formatBitDepth, formatChannels } from "../utils/formatters";
-  import { formatDateAdded } from "../utils/date";
+  import SongTable, { type SongTableRow } from "./SongTable.svelte";
+  import { Clock, Plus, FolderPlus, Music, Gauge, RefreshCw, Heart, Calendar, Hourglass, Search, RotateCcw, RotateCw, MoreHorizontal, X, Eraser } from "lucide-svelte";
+  import { shuffleArray } from "../utils/shuffle";
   import type { PlaylistItem, QueuePopulationMode, Song } from "../types";
   import { i18n } from "../stores/i18n.svelte";
   import { toastStore } from "../stores/toast.svelte";
   import { getPopulationModeSuffix, getBpmBucketLabel } from "../utils/playlist";
   import { genreColorHsl, resolveGenreColorIndex } from "../utils/genrePalette";
   import { rememberScroll } from "../utils/scrollMemory";
+  import { compareSongs } from "../utils/songSort";
   import Modal from "./Modal.svelte";
   import Button from "./Button.svelte";
   import AlbumTagEditor from "./AlbumTagEditor.svelte";
-  import { SONG_TABLE_COLUMNS } from "../utils/songColumns";
-  import { columnResize } from "../utils/columnResize";
 
   let { view }: { view: AutoPlaylistRef } = $props();
 
@@ -57,18 +48,6 @@ import { shuffleArray } from "../utils/shuffle";
     lastplayed: "90px", added: "90px", duration: "80px", path: "2fr", actions: "80px",
   };
 
-  let gridColsStyle = $derived.by(() => {
-    const cols: string[] = ["56px"]; // play indicator + position number, always present
-    const vc = collectionStore.visibleColumns;
-    const cw = collectionStore.columnWidths;
-    for (const { key } of SONG_TABLE_COLUMNS) {
-      if (key === "track") continue; // autoplaylist uses position instead of track#
-      if (!vc[key]) continue;
-      const saved = cw[key];
-      cols.push(saved !== undefined ? `${saved}px` : (AUTOPLAYLIST_COL_DEFAULTS[key] ?? "80px"));
-    }
-    return `grid-template-columns: ${cols.join(" ")}`;
-  });
   let genre = $derived(view.genre);
   let decade = $derived(view.decade);
   let bpm = $derived(view.bpm);
@@ -84,8 +63,7 @@ import { shuffleArray } from "../utils/shuffle";
   let showSaveModal = $state(false);
   let savePlaylistName = $state("");
 
-  let selectedSongIds = $state<Set<number>>(new Set());
-  let lastSelectedSongId = $state<number | null>(null);
+  let selectedKeys = $state<Set<string>>(new Set());
 
   /** Hover quick-action, ported from the old GenreBrowseView drill-down
    * (#548) — opens the full-album tag editor for whichever album the
@@ -96,85 +74,22 @@ import { shuffleArray } from "../utils/shuffle";
     editingAlbumSongs = await invoke<Song[]>("get_songs_by_album", { album: song.album });
   }
 
-  function handleContextMenu(event: MouseEvent, song: Song) {
-    event.preventDefault();
-    if (!selectedSongIds.has(song.id)) {
-      selectedSongIds = new Set([song.id]);
-      lastSelectedSongId = song.id;
-    }
-    contextMenuState = { x: event.clientX, y: event.clientY, song };
-  }
-
-  function handleSongClick(e: MouseEvent, song: Song) {
-    if (e.shiftKey && lastSelectedSongId !== null) {
-      const idx1 = songs.findIndex((s) => s.id === lastSelectedSongId);
-      const idx2 = songs.findIndex((s) => s.id === song.id);
-      if (idx1 !== -1 && idx2 !== -1) {
-        const start = Math.min(idx1, idx2);
-        const end = Math.max(idx1, idx2);
-        const newSet = new Set(e.ctrlKey || e.metaKey ? selectedSongIds : []);
-        for (let i = start; i <= end; i++) {
-          newSet.add(songs[i].id);
-        }
-        selectedSongIds = newSet;
-      }
-    } else if (e.ctrlKey || e.metaKey) {
-      const newSet = new Set(selectedSongIds);
-      if (newSet.has(song.id)) {
-        newSet.delete(song.id);
-      } else {
-        newSet.add(song.id);
-      }
-      selectedSongIds = newSet;
-      lastSelectedSongId = song.id;
-    } else if (selectedSongIds.size === 1 && selectedSongIds.has(song.id)) {
-      selectedSongIds = new Set();
-      lastSelectedSongId = null;
-    } else {
-      selectedSongIds = new Set([song.id]);
-      lastSelectedSongId = song.id;
-    }
-  }
-
-  function handleKeydown(e: KeyboardEvent) {
-    if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === "a") {
-      const target = e.target as HTMLElement;
-      if (target && (target.tagName === "INPUT" || target.tagName === "TEXTAREA")) return;
-      e.preventDefault();
-      selectedSongIds = new Set(songs.map((s) => s.id));
-    } else if (e.key === "Escape") {
-      selectedSongIds = new Set();
-    }
-  }
-
-  function handleWindowMouseDown(e: MouseEvent) {
-    if (selectedSongIds.size === 0) return;
-    const target = e.target as HTMLElement;
-    if (!target) return;
-    if (
-      target.closest("[data-song-row]") ||
-      target.closest("[role='menu']") ||
-      target.closest("[data-floating-toolbar]") ||
-      target.closest("button") ||
-      target.closest("input")
-    ) {
-      return;
-    }
-    selectedSongIds = new Set();
+  function handleRowContextMenu(event: MouseEvent, row: SongTableRow) {
+    if (row.song) contextMenuState = { x: event.clientX, y: event.clientY, song: row.song };
   }
 
   async function handleBulkAddToPlaylist() {
-    if (selectedSongIds.size === 0) return;
+    if (selectedKeys.size === 0) return;
     if (playlistsStore.activeCustomPlaylist) {
-      await playlistsStore.addSongsToPlaylist(playlistsStore.activeCustomPlaylist.id, Array.from(selectedSongIds));
+      await playlistsStore.addSongsToPlaylist(playlistsStore.activeCustomPlaylist.id, Array.from(selectedKeys, Number));
     } else {
       toastStore.show(i18n.t("collection.selectPlaylistFirstAlert"));
     }
   }
 
   function handlePlaySelected() {
-    if (selectedSongIds.size === 0) return;
-    const selectedList = songs.filter((s) => selectedSongIds.has(s.id));
+    if (selectedKeys.size === 0) return;
+    const selectedList = songs.filter((s) => selectedKeys.has(String(s.id)));
     if (selectedList.length > 0) {
       playerStore.playSongs(selectedList.map((s) => s.id), 0, playlistId, undefined, displayName);
     }
@@ -460,11 +375,12 @@ import { shuffleArray } from "../utils/shuffle";
   let sortField = $state<AutoPlaylistSortField>("default");
   let sortAsc = $state(true);
 
-  function toggleSort(field: AutoPlaylistSortField) {
-    if (sortField === field) {
+  function toggleSort(field: string) {
+    const f = field as AutoPlaylistSortField;
+    if (sortField === f) {
       sortAsc = !sortAsc;
     } else {
-      sortField = field;
+      sortField = f;
       sortAsc = true;
     }
   }
@@ -511,38 +427,26 @@ import { shuffleArray } from "../utils/shuffle";
       return sortAsc ? list : [...list].reverse();
     }
     const field = sortField as keyof Song;
-    return [...list].sort((a, b) => {
-      let valA: unknown = a[field];
-      let valB: unknown = b[field];
-
-      if (sortField === "title") {
-        valA = a.titlesort?.trim() || a.title;
-        valB = b.titlesort?.trim() || b.title;
-      } else if (sortField === "artist") {
-        valA = a.album_artist_sort?.trim() || a.artistsort?.trim() || a.album_artist || a.artist;
-        valB = b.album_artist_sort?.trim() || b.artistsort?.trim() || b.album_artist || b.artist;
-      } else if (sortField === "composer") {
-        valA = a.composersort?.trim() || a.composer;
-        valB = b.composersort?.trim() || b.composer;
-      } else if (sortField === "genre") {
-        valA = a.genresort?.trim() || a.genre;
-        valB = b.genresort?.trim() || b.genre;
-      }
-
-      if (valA === undefined || valA === null) return sortAsc ? 1 : -1;
-      if (valB === undefined || valB === null) return sortAsc ? -1 : 1;
-
-      if (typeof valA === "string" && typeof valB === "string") {
-        const cmp = valA.localeCompare(valB);
-        return sortAsc ? cmp : -cmp;
-      } else {
-        const cmp = (valA as number) - (valB as number);
-        return sortAsc ? cmp : -cmp;
-      }
-    });
+    return [...list].sort((a, b) => compareSongs(a, b, field, sortAsc));
   });
 
+  function songToRow(song: Song): SongTableRow {
+    const disconnected = !song.unavailable && collectionStore.isPathOnDisconnectedDrive(song.path);
+    return {
+      key: String(song.id),
+      song,
+      disabled: song.unavailable || disconnected,
+      disabledTooltip: disconnected ? i18n.t("collection.driveDisconnectedTooltip") : undefined,
+    };
+  }
+
+  let tableRows = $derived(sortedSongs.map(songToRow));
+
 </script>
+
+{#snippet autoPlaylistEmptyState()}
+  <EmptyState icon={Music} title={emptyStateMessage} />
+{/snippet}
 
 <div
   class="flex-1 flex flex-col overflow-y-auto carousel-scroll bg-brand-main text-brand-text-secondary h-full"
@@ -685,527 +589,25 @@ import { shuffleArray } from "../utils/shuffle";
 
   <div class="px-6 py-6 flex flex-col" class:pb-28={!!playerStore.currentSong}>
     <div class="border border-brand-border/60 rounded-xl bg-brand-sidebar/30 backdrop-blur-md relative overflow-hidden">
-      <div class="sticky top-0 z-20 flex flex-col bg-brand-sidebar border-b border-brand-border text-xs text-brand-text-primary uppercase tracking-wider font-semibold select-none">
-        <div role="row" class="grid items-center py-3 px-4" style={gridColsStyle}>
-          <SortableHeader
-            active={sortField === "track" || sortField === "default"}
-            {sortAsc}
-            onclick={() => toggleSort("track")}
-            class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 font-semibold uppercase tracking-wider min-w-0"
-          >
-            {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-1rem)]">{i18n.t('playlists.tableHeaderTrack')} {arrow}</span>{/snippet}
-          </SortableHeader>
-          {#if collectionStore.visibleColumns.title}
-            <div use:columnResize={{ column: "title", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-            <SortableHeader
-              active={sortField === "title"}
-              {sortAsc}
-              onclick={() => toggleSort("title")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-            >
-              {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-1rem)]">{i18n.t('playlists.tableHeaderTitle')} {arrow}</span>{/snippet}
-            </SortableHeader>
-            </div>
-          {/if}
-          {#if collectionStore.visibleColumns.artist}
-            <div use:columnResize={{ column: "artist", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-            <SortableHeader
-              active={sortField === "artist"}
-              {sortAsc}
-              onclick={() => toggleSort("artist")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-            >
-              {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-1rem)]">{i18n.t('playlists.tableHeaderArtist')} {arrow}</span>{/snippet}
-            </SortableHeader>
-            </div>
-          {/if}
-          {#if collectionStore.visibleColumns.album}
-            <div use:columnResize={{ column: "album", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-            <SortableHeader
-              active={sortField === "album"}
-              {sortAsc}
-              onclick={() => toggleSort("album")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-            >
-              {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-1rem)]">{i18n.t('collection.tableHeaderAlbum')} {arrow}</span>{/snippet}
-            </SortableHeader>
-            </div>
-          {/if}
-
-          {#if collectionStore.visibleColumns.composer}
-            <div use:columnResize={{ column: "composer", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-            <SortableHeader
-              active={sortField === "composer"}
-              {sortAsc}
-              onclick={() => toggleSort("composer")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-            >
-              {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderComposer')} {arrow}</span>{/snippet}
-            </SortableHeader>
-            </div>
-          {/if}
-          {#if collectionStore.visibleColumns.album_artist}
-            <div use:columnResize={{ column: "album_artist", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-            <SortableHeader
-              active={sortField === "album_artist"}
-              {sortAsc}
-              onclick={() => toggleSort("album_artist")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-            >
-              {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderAlbumArtist')} {arrow}</span>{/snippet}
-            </SortableHeader>
-            </div>
-          {/if}
-          {#if collectionStore.visibleColumns.format}
-            <div use:columnResize={{ column: "format", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-            <SortableHeader
-              active={sortField === "filetype"}
-              {sortAsc}
-              onclick={() => toggleSort("filetype")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-            >
-              {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderFormat')} {arrow}</span>{/snippet}
-            </SortableHeader>
-            </div>
-          {/if}
-          {#if collectionStore.visibleColumns.year}
-            <div use:columnResize={{ column: "year", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-            <SortableHeader
-              active={sortField === "year"}
-              {sortAsc}
-              onclick={() => toggleSort("year")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-            >
-              {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderYear')} {arrow}</span>{/snippet}
-            </SortableHeader>
-            </div>
-          {/if}
-          {#if collectionStore.visibleColumns.genre}
-            <div use:columnResize={{ column: "genre", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-            <SortableHeader
-              active={sortField === "genre"}
-              {sortAsc}
-              onclick={() => toggleSort("genre")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-            >
-              {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderGenre')} {arrow}</span>{/snippet}
-            </SortableHeader>
-            </div>
-          {/if}
-          {#if collectionStore.visibleColumns.grouping}
-            <div use:columnResize={{ column: "grouping", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-            <SortableHeader
-              active={sortField === "grouping"}
-              {sortAsc}
-              onclick={() => toggleSort("grouping")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-            >
-              {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderGrouping')} {arrow}</span>{/snippet}
-            </SortableHeader>
-            </div>
-          {/if}
-          {#if collectionStore.visibleColumns.bpm}
-            <div use:columnResize={{ column: "bpm", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-            <SortableHeader
-              active={sortField === "bpm"}
-              {sortAsc}
-              onclick={() => toggleSort("bpm")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-            >
-              {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderBpm')} {arrow}</span>{/snippet}
-            </SortableHeader>
-            </div>
-          {/if}
-          {#if collectionStore.visibleColumns.initial_key}
-            <div use:columnResize={{ column: "initial_key", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-            <SortableHeader
-              active={sortField === "initial_key"}
-              {sortAsc}
-              onclick={() => toggleSort("initial_key")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-            >
-              {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderInitialKey')} {arrow}</span>{/snippet}
-            </SortableHeader>
-            </div>
-          {/if}
-          {#if collectionStore.visibleColumns.bitrate}
-            <div use:columnResize={{ column: "bitrate", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-            <SortableHeader
-              active={sortField === "bitrate"}
-              {sortAsc}
-              onclick={() => toggleSort("bitrate")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-            >
-              {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderBitrate')} {arrow}</span>{/snippet}
-            </SortableHeader>
-            </div>
-          {/if}
-          {#if collectionStore.visibleColumns.samplerate}
-            <div use:columnResize={{ column: "samplerate", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-            <SortableHeader
-              active={sortField === "samplerate"}
-              {sortAsc}
-              onclick={() => toggleSort("samplerate")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-            >
-              {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderSampleRate')} {arrow}</span>{/snippet}
-            </SortableHeader>
-            </div>
-          {/if}
-          {#if collectionStore.visibleColumns.bitdepth}
-            <div use:columnResize={{ column: "bitdepth", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-            <SortableHeader
-              active={sortField === "bitdepth"}
-              {sortAsc}
-              onclick={() => toggleSort("bitdepth")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-            >
-              {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderBitDepth')} {arrow}</span>{/snippet}
-            </SortableHeader>
-            </div>
-          {/if}
-          {#if collectionStore.visibleColumns.channels}
-            <div use:columnResize={{ column: "channels", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-            <SortableHeader
-              active={sortField === "channels"}
-              {sortAsc}
-              onclick={() => toggleSort("channels")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-            >
-              {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderChannels')} {arrow}</span>{/snippet}
-            </SortableHeader>
-            </div>
-          {/if}
-          {#if collectionStore.visibleColumns.filesize}
-            <div use:columnResize={{ column: "filesize", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-            <SortableHeader
-              active={sortField === "filesize"}
-              {sortAsc}
-              onclick={() => toggleSort("filesize")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-            >
-              {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderFileSize')} {arrow}</span>{/snippet}
-            </SortableHeader>
-            </div>
-          {/if}
-          {#if collectionStore.visibleColumns.rating}
-            <div use:columnResize={{ column: "rating", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-            <SortableHeader
-              active={sortField === "rating"}
-              {sortAsc}
-              onclick={() => toggleSort("rating")}
-              class="flex items-center justify-center hover:text-brand-text-primary transition-colors font-semibold uppercase tracking-wider min-w-0 w-full"
-            >
-              {#snippet label(arrow)}<span class="truncate">{i18n.t('collection.tableHeaderRating')} {arrow}</span>{/snippet}
-            </SortableHeader>
-            </div>
-          {/if}
-          {#if collectionStore.visibleColumns.playcount}
-            <div use:columnResize={{ column: "playcount", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-            <SortableHeader
-              active={sortField === "playcount"}
-              {sortAsc}
-              onclick={() => toggleSort("playcount")}
-              class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-            >
-              {#snippet label(arrow)}<span class="truncate">{i18n.t('collection.tableHeaderPlays')} {arrow}</span>{/snippet}
-            </SortableHeader>
-            </div>
-          {/if}
-          {#if collectionStore.visibleColumns.skipcount}
-            <div use:columnResize={{ column: "skipcount", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-            <SortableHeader
-              active={sortField === "skipcount"}
-              {sortAsc}
-              onclick={() => toggleSort("skipcount")}
-              class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-            >
-              {#snippet label(arrow)}<span class="truncate">{i18n.t('collection.tableHeaderSkips')} {arrow}</span>{/snippet}
-            </SortableHeader>
-            </div>
-          {/if}
-          {#if collectionStore.visibleColumns.lastplayed}
-            <div use:columnResize={{ column: "lastplayed", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-            <SortableHeader
-              active={sortField === "lastplayed"}
-              {sortAsc}
-              onclick={() => toggleSort("lastplayed")}
-              class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-            >
-              {#snippet label(arrow)}<span class="truncate">{i18n.t('collection.tableHeaderLastPlayed')} {arrow}</span>{/snippet}
-            </SortableHeader>
-            </div>
-          {/if}
-          {#if collectionStore.visibleColumns.added}
-            <div use:columnResize={{ column: "added", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-            <SortableHeader
-              active={sortField === "added"}
-              {sortAsc}
-              onclick={() => toggleSort("added")}
-              class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-            >
-              {#snippet label(arrow)}<span class="truncate">{i18n.t('collection.tableHeaderAdded')} {arrow}</span>{/snippet}
-            </SortableHeader>
-            </div>
-          {/if}
-          {#if collectionStore.visibleColumns.duration}
-            <div use:columnResize={{ column: "duration", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-            <SortableHeader
-              active={sortField === "length_nanosec"}
-              {sortAsc}
-              onclick={() => toggleSort("length_nanosec")}
-              class="flex items-center justify-center hover:text-brand-text-primary transition-colors font-semibold uppercase tracking-wider min-w-0 w-full"
-            >
-              {#snippet label(arrow)}<Clock class="w-4 h-4 shrink-0" /> {arrow}{/snippet}
-            </SortableHeader>
-            </div>
-          {/if}
-          {#if collectionStore.visibleColumns.path}
-            <div use:columnResize={{ column: "path", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-            <SortableHeader
-              active={sortField === "path"}
-              {sortAsc}
-              onclick={() => toggleSort("path")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-            >
-              {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderPath')} {arrow}</span>{/snippet}
-            </SortableHeader>
-            </div>
-          {/if}
-          {#if collectionStore.visibleColumns.actions}
-            <div use:columnResize={{ column: "actions", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden text-center">{i18n.t('collection.tableHeaderActions')}</div>
-          {/if}
-        </div>
-      </div>
-
-      <div class="divide-y divide-brand-border/40">
-        {#if loading}
-          <div class="py-16 text-center text-brand-text-primary text-sm">
-            {i18n.t('home.loading')}
-          </div>
-        {:else if sortedSongs.length === 0}
-          <div class="py-16 text-center select-none">
-            <EmptyState icon={Music} title={emptyStateMessage} />
-          </div>
-        {:else}
-          {#each sortedSongs as song, index (song.id)}
-            {@const disconnected = !song.unavailable && collectionStore.isPathOnDisconnectedDrive(song.path)}
-            {@const disabled = song.unavailable || disconnected}
-            <div
-              role="row"
-              tabindex="0"
-              onkeydown={(e) => {
-                if (e.key === 'Enter' && !disabled) handlePlaySong(song);
-              }}
-              data-song-row="true"
-              onclick={(e) => !disabled && handleSongClick(e, song)}
-              ondblclick={() => !disabled && handlePlaySong(song)}
-              oncontextmenu={(e) => handleContextMenu(e, song)}
-              title={disconnected ? i18n.t('collection.driveDisconnectedTooltip') : undefined}
-              class="grid items-center py-2.5 px-4 group transition-all duration-150 select-none text-sm border-b border-brand-border/40
-                {disabled ? 'opacity-50 cursor-not-allowed' : ''}
-                {selectedSongIds.has(song.id) ? 'bg-brand-accent/20 text-brand-accent-text-hover' : (playerStore.currentSong && playerStore.currentSong.id === song.id ? 'bg-brand-accent/10 text-brand-accent-text-hover' : 'hover:bg-brand-sidebar/40')}"
-              style={gridColsStyle}
-            >
-              <div class="text-center text-brand-text-primary font-medium relative min-w-0">
-                <div class="relative w-9 h-4 mx-auto flex items-center justify-center">
-                  {#if playerStore.currentSong && playerStore.currentSong.id === song.id && playerStore.state === 'playing'}
-                    <div class="flex items-center justify-center gap-0.5 h-4 w-4 absolute inset-0 group-hover:opacity-0 transition-opacity">
-                      <NowPlayingBars />
-                    </div>
-                  {:else}
-                    <span class="absolute inset-0 flex items-center justify-center group-hover:opacity-0 transition-opacity whitespace-nowrap">
-                      {index + 1}
-                    </span>
-                  {/if}
-                  <button
-                    onclick={(e) => { e.stopPropagation(); if (!disabled) handlePlaySong(song); }}
-                    class="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 text-brand-accent-text hover:text-brand-accent-text-hover transition-opacity disabled:opacity-0 disabled:cursor-not-allowed"
-                    disabled={disabled}
-                    title={disconnected ? i18n.t('collection.driveDisconnectedTooltip') : i18n.t('collection.playSong')}
-                  >
-                    <Play class="w-4 h-4 fill-current" />
-                  </button>
-                </div>
-              </div>
-              {#if collectionStore.visibleColumns.title}
-                <div class="font-medium truncate pr-4 min-w-0 {selectedSongIds.has(song.id) || (playerStore.currentSong && playerStore.currentSong.id === song.id) ? 'text-brand-accent-text-hover' : 'text-brand-text-primary'}">
-                  <span class="truncate min-w-0" title={song.title}>{song.title || i18n.t('collection.unknownSong')}</span>
-                </div>
-              {/if}
-              {#if collectionStore.visibleColumns.artist}
-                <div class="text-brand-text-primary truncate pr-4 flex items-center min-w-0">
-                  {#if song.artist}
-                    {#each parseMultiValue(song.artist) as name, i (name)}
-                      {#if i > 0}<span class="text-brand-text-primary/50 shrink-0">,&nbsp;</span>{/if}
-                      <LinkButton
-                        onclick={(e) => { e.stopPropagation(); collectionStore.viewArtist(name); }}
-                        class="text-brand-text-primary truncate min-w-0"
-                        title={i18n.t('collection.filterByArtist', { artist: name })}
-                      >
-                        {name}
-                      </LinkButton>
-                    {/each}
-                  {:else}
-                    <span class="text-brand-text-primary truncate min-w-0">{i18n.t('collection.unknownArtist')}</span>
-                  {/if}
-                </div>
-              {/if}
-              {#if collectionStore.visibleColumns.album}
-                <div class="text-brand-text-primary truncate pr-4 min-w-0">
-                  {#if song.album}
-                    <LinkButton
-                      onclick={(e) => { e.stopPropagation(); collectionStore.viewAlbum(song.album || ""); }}
-                      class="text-brand-text-primary truncate min-w-0"
-                      title={i18n.t('collection.filterByAlbum', { album: song.album })}
-                    >
-                      {song.album}
-                    </LinkButton>
-                  {:else}
-                    <span class="text-brand-text-primary truncate min-w-0">{i18n.t('collection.unknownAlbum')}</span>
-                  {/if}
-                </div>
-              {/if}
-
-              {#if collectionStore.visibleColumns.composer}
-                <div class="text-brand-text-primary truncate pr-4 min-w-0 text-xs font-medium" title={song.composer}>
-                  {song.composer || "—"}
-                </div>
-              {/if}
-              {#if collectionStore.visibleColumns.album_artist}
-                <div class="text-brand-text-primary truncate pr-4 min-w-0 text-xs font-medium" title={song.album_artist}>
-                  {song.album_artist || "—"}
-                </div>
-              {/if}
-              {#if collectionStore.visibleColumns.format}
-                <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-semibold uppercase">
-                  {song.filetype ? song.filetype.toUpperCase() : "—"}
-                </div>
-              {/if}
-              {#if collectionStore.visibleColumns.year}
-                <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium">
-                  {song.year || "—"}
-                </div>
-              {/if}
-              {#if collectionStore.visibleColumns.genre}
-                <div class="truncate pr-2 min-w-0" title={song.genre}>
-                  {#if song.genre}
-                    <GenreChips genre={song.genre} />
-                  {:else}
-                    <span class="text-brand-text-secondary text-xs font-medium">—</span>
-                  {/if}
-                </div>
-              {/if}
-              {#if collectionStore.visibleColumns.grouping}
-                <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium" title={song.grouping}>
-                  {song.grouping || "—"}
-                </div>
-              {/if}
-              {#if collectionStore.visibleColumns.bpm}
-                <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium">
-                  {song.bpm || "—"}
-                </div>
-              {/if}
-              {#if collectionStore.visibleColumns.initial_key}
-                <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium">
-                  {song.initial_key || "—"}
-                </div>
-              {/if}
-              {#if collectionStore.visibleColumns.bitrate}
-                <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium">
-                  {song.bitrate ? `${song.bitrate}k` : "—"}
-                </div>
-              {/if}
-              {#if collectionStore.visibleColumns.samplerate}
-                <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium">
-                  {formatSampleRate(song.samplerate)}
-                </div>
-              {/if}
-              {#if collectionStore.visibleColumns.bitdepth}
-                <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium">
-                  {formatBitDepth(song.bitdepth)}
-                </div>
-              {/if}
-              {#if collectionStore.visibleColumns.channels}
-                <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium">
-                  {formatChannels(song.channels)}
-                </div>
-              {/if}
-              {#if collectionStore.visibleColumns.filesize}
-                <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium">
-                  {formatFileSize(song.filesize)}
-                </div>
-              {/if}
-              {#if collectionStore.visibleColumns.rating}
-                <div class="flex justify-center min-w-0" onclick={(e) => e.stopPropagation()} role="presentation">
-                  <SongRating rating={song.rating} onRate={(r) => rateSong(song, r)} />
-                </div>
-              {/if}
-              {#if collectionStore.visibleColumns.playcount}
-                <div class="text-center text-brand-text-primary text-xs min-w-0">
-                  {song.playcount || 0}
-                </div>
-              {/if}
-              {#if collectionStore.visibleColumns.skipcount}
-                <div class="text-center text-brand-text-primary text-xs min-w-0">
-                  {song.skipcount || 0}
-                </div>
-              {/if}
-              {#if collectionStore.visibleColumns.lastplayed}
-                <div class="text-center text-brand-text-primary text-xs whitespace-nowrap">
-                  {formatDate(song.lastplayed)}
-                </div>
-              {/if}
-              {#if collectionStore.visibleColumns.added}
-                <div class="text-center text-brand-text-primary text-xs whitespace-nowrap">
-                  {formatDateAdded(song.added)}
-                </div>
-              {/if}
-              {#if collectionStore.visibleColumns.duration}
-                <div class="text-center text-brand-text-primary text-xs min-w-0">
-                  {formatDuration(song.length_nanosec)}
-                </div>
-              {/if}
-              {#if collectionStore.visibleColumns.path}
-                <div class="text-brand-text-primary truncate pr-4 min-w-0 text-xs font-medium" title={song.path}>
-                  {song.path || "—"}
-                </div>
-              {/if}
-
-              {#if collectionStore.visibleColumns.actions}
-                <div class="text-center min-w-0">
-                  <div class="flex items-center justify-center gap-2.5">
-                    <button
-                      onclick={(e) => { e.stopPropagation(); handleAddSongToPlaylist(song.id); }}
-                      class="text-brand-text-primary hover:text-brand-accent-text transition-colors"
-                      title={playlistsStore.activeCustomPlaylist
-                        ? i18n.t('collection.addPlaylistTooltip', { name: playlistsStore.activeCustomPlaylist.name })
-                        : i18n.t('collection.addPlaylistTooltipDefault')}
-                    >
-                      <Plus class="w-4 h-4" />
-                    </button>
-                    <button
-                      onclick={(e) => { e.stopPropagation(); openTagEditor(song.id); }}
-                      class="text-brand-text-primary hover:text-brand-accent-text transition-colors"
-                      title={i18n.t('songTags.editSongTooltip', {}, 'Edit Song')}
-                    >
-                      <Edit3 class="w-4 h-4" />
-                    </button>
-                    <button
-                      onclick={(e) => { e.stopPropagation(); openAlbumEditor(song); }}
-                      class="text-brand-text-primary hover:text-brand-accent-text transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
-                      disabled={!song.album}
-                      title={i18n.t('songTags.editAlbumTooltip', {}, 'Edit Album')}
-                    >
-                      <DiscAlbum class="w-4 h-4" />
-                    </button>
-                  </div>
-                </div>
-              {/if}
-            </div>
-          {/each}
-        {/if}
-      </div>
+      <SongTable
+        rows={tableRows}
+        mode="position"
+        leadingColumnWidth="56px"
+        colDefaults={AUTOPLAYLIST_COL_DEFAULTS}
+        {sortField}
+        {sortAsc}
+        onToggleSort={toggleSort}
+        positionSortField="default"
+        bind:selectedKeys
+        {loading}
+        emptyState={autoPlaylistEmptyState}
+        onRowDoubleClick={(row) => row.song && handlePlaySong(row.song)}
+        onRowContextMenu={handleRowContextMenu}
+        onRate={rateSong}
+        onAddToPlaylist={(song) => handleAddSongToPlaylist(song.id)}
+        onEditTags={(song) => openTagEditor(song.id)}
+        onEditAlbum={openAlbumEditor}
+      />
     </div>
 
   </div>
@@ -1237,25 +639,23 @@ import { shuffleArray } from "../utils/shuffle";
   />
 {/if}
 
-<svelte:window onkeydown={handleKeydown} onmousedown={handleWindowMouseDown} />
-
 {#if contextMenuState}
   {@const song = contextMenuState.song}
   <SongContextMenu
     x={contextMenuState.x}
     y={contextMenuState.y}
     {song}
-    selectedCount={selectedSongIds.size}
-    selectedSongIds={Array.from(selectedSongIds)}
+    selectedCount={selectedKeys.size}
+    selectedSongIds={Array.from(selectedKeys, Number)}
     onPlay={() => {
-      if (selectedSongIds.size > 1) {
+      if (selectedKeys.size > 1) {
         handlePlaySelected();
       } else {
         handlePlaySong(song);
       }
     }}
     onAddToPlaylist={() => {
-      if (selectedSongIds.size > 1) {
+      if (selectedKeys.size > 1) {
         handleBulkAddToPlaylist();
       } else {
         handleAddSongToPlaylist(song.id);
@@ -1268,12 +668,12 @@ import { shuffleArray } from "../utils/shuffle";
   />
 {/if}
 
-{#if selectedSongIds.size > 0}
+{#if selectedKeys.size > 0}
   <SongSelectionToolbar
-    count={selectedSongIds.size}
+    count={selectedKeys.size}
     onPlaySelected={handlePlaySelected}
     onAddToPlaylist={handleBulkAddToPlaylist}
-    onClear={() => { selectedSongIds = new Set(); }}
+    onClear={() => { selectedKeys = new Set(); }}
   />
 {/if}
 

--- a/src/lib/components/CollectionView.svelte
+++ b/src/lib/components/CollectionView.svelte
@@ -6,19 +6,15 @@
   import CoverArt from "./CoverArt.svelte";
   import SongRating from "./SongRating.svelte";
   import TagEditor from "./TagEditor.svelte";
-  import { Play, Plus, Clock, FileText, Music, DiscAlbum, Mic2, Edit3, Columns, LayoutGrid, Rows3 } from "lucide-svelte";
+  import { Play, Plus, Music, DiscAlbum, Mic2, Columns, LayoutGrid, Rows3 } from "lucide-svelte";
   import type { Song, AlbumItem, ArtistItem } from "../types";
   import { i18n } from "../stores/i18n.svelte";
   import { toastStore } from "../stores/toast.svelte";
   import { prefs, type CollectionViewMode } from "../stores/prefs.svelte";
-  import { VirtualList } from "svelte-virtual-list-ts";
   import { getArtistAlbums, getArtistSongs, getArtistGradient } from "../utils/artist";
-  import { formatDuration } from "../utils/formatters";
-  import { parseMultiValue } from "../utils/multiValue";
   import ArtistDetailView from "./ArtistDetailView.svelte";
   import AlbumDetailView from "./AlbumDetailView.svelte";
   import GenreBrowseView from "./GenreBrowseView.svelte";
-  import GenreChips from "./GenreChips.svelte";
   import { tagsStore } from "../stores/tags.svelte";
   import SongContextMenu from "./SongContextMenu.svelte";
   import AlbumContextMenu from "./AlbumContextMenu.svelte";
@@ -26,18 +22,13 @@
   import ArtistCard from "./ArtistCard.svelte";
   import AlbumRowCard from "./AlbumRowCard.svelte";
   import ArtistRowCard from "./ArtistRowCard.svelte";
-  import SortableHeader from "./SortableHeader.svelte";
   import Select from "./Select.svelte";
-  import NowPlayingBars from "./NowPlayingBars.svelte";
-  import LinkButton from "./LinkButton.svelte";
   import ColumnSelector from "./ColumnSelector.svelte";
   import LibraryWelcome from "./LibraryWelcome.svelte";
   import SearchEmptyState from "./SearchEmptyState.svelte";
-  import { formatDate, formatFileSize, formatSampleRate, formatBitDepth, formatChannels } from "../utils/formatters";
-  import { formatDateAdded } from "../utils/date";
+  import SongTable, { type SongTableRow } from "./SongTable.svelte";
   import { SONG_TABLE_COLUMNS } from "../utils/songColumns";
-  import { rememberScroll, watchScrollMemory } from "../utils/scrollMemory";
-  import { columnResize } from "../utils/columnResize";
+  import { rememberScroll } from "../utils/scrollMemory";
 
   // activeSubTab and activeTab are managed globally via collectionStore
 
@@ -46,16 +37,10 @@
   let contextMenuState = $state<{ x: number; y: number; song: Song } | null>(null);
   let albumContextMenuState = $state<{ x: number; y: number; album: AlbumItem } | null>(null);
 
-  let selectedSongIds = $state<Set<number>>(new Set());
-  let lastSelectedSongId = $state<number | null>(null);
+  let selectedKeys = $state<Set<string>>(new Set());
 
-  function handleContextMenu(event: MouseEvent, song: Song) {
-    event.preventDefault();
-    if (!selectedSongIds.has(song.id)) {
-      selectedSongIds = new Set([song.id]);
-      lastSelectedSongId = song.id;
-    }
-    contextMenuState = { x: event.clientX, y: event.clientY, song };
+  function handleRowContextMenu(event: MouseEvent, row: SongTableRow) {
+    if (row.song) contextMenuState = { x: event.clientX, y: event.clientY, song: row.song };
   }
 
   function handleAlbumContextMenu(event: MouseEvent, album: AlbumItem) {
@@ -63,78 +48,18 @@
     albumContextMenuState = { x: event.clientX, y: event.clientY, album };
   }
 
-  function handleSongClick(e: MouseEvent, song: Song) {
-    if (e.shiftKey && lastSelectedSongId !== null) {
-      const idx1 = filteredSongs.findIndex((s) => s.id === lastSelectedSongId);
-      const idx2 = filteredSongs.findIndex((s) => s.id === song.id);
-      if (idx1 !== -1 && idx2 !== -1) {
-        const start = Math.min(idx1, idx2);
-        const end = Math.max(idx1, idx2);
-        const newSet = new Set(e.ctrlKey || e.metaKey ? selectedSongIds : []);
-        for (let i = start; i <= end; i++) {
-          newSet.add(filteredSongs[i].id);
-        }
-        selectedSongIds = newSet;
-      }
-    } else if (e.ctrlKey || e.metaKey) {
-      const newSet = new Set(selectedSongIds);
-      if (newSet.has(song.id)) {
-        newSet.delete(song.id);
-      } else {
-        newSet.add(song.id);
-      }
-      selectedSongIds = newSet;
-      lastSelectedSongId = song.id;
-    } else if (selectedSongIds.size === 1 && selectedSongIds.has(song.id)) {
-      selectedSongIds = new Set();
-      lastSelectedSongId = null;
-    } else {
-      selectedSongIds = new Set([song.id]);
-      lastSelectedSongId = song.id;
-    }
-  }
-
-  function handleKeydown(e: KeyboardEvent) {
-    if (collectionStore.activeTab !== "collection" || collectionStore.activeSubTab !== "songs") return;
-
-    if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === "a") {
-      const target = e.target as HTMLElement;
-      if (target && (target.tagName === "INPUT" || target.tagName === "TEXTAREA")) return;
-      e.preventDefault();
-      selectedSongIds = new Set(filteredSongs.map((s) => s.id));
-    } else if (e.key === "Escape") {
-      selectedSongIds = new Set();
-    }
-  }
-
-  function handleWindowMouseDown(e: MouseEvent) {
-    if (selectedSongIds.size === 0) return;
-    const target = e.target as HTMLElement;
-    if (!target) return;
-    if (
-      target.closest("[data-song-row]") ||
-      target.closest("[role='menu']") ||
-      target.closest("[data-floating-toolbar]") ||
-      target.closest("button") ||
-      target.closest("input")
-    ) {
-      return;
-    }
-    selectedSongIds = new Set();
-  }
-
   async function handleBulkAddToPlaylist() {
-    if (selectedSongIds.size === 0) return;
+    if (selectedKeys.size === 0) return;
     if (playlistsStore.activeCustomPlaylist) {
-      await playlistsStore.addSongsToPlaylist(playlistsStore.activeCustomPlaylist.id, Array.from(selectedSongIds));
+      await playlistsStore.addSongsToPlaylist(playlistsStore.activeCustomPlaylist.id, Array.from(selectedKeys, Number));
     } else {
       toastStore.show(i18n.t("collection.selectPlaylistFirstAlert"));
     }
   }
 
   function handlePlaySelected() {
-    if (selectedSongIds.size === 0) return;
-    const selectedList = filteredSongs.filter((s) => selectedSongIds.has(s.id));
+    if (selectedKeys.size === 0) return;
+    const selectedList = filteredSongs.filter((s) => selectedKeys.has(String(s.id)));
     if (selectedList.length > 0) {
       playerStore.playSongs(selectedList.map((s) => s.id), 0);
     }
@@ -338,51 +263,6 @@
     lastplayed: "90px", added: "90px", duration: "80px", path: "2fr", actions: "80px",
   };
 
-  let gridColsStyle = $derived.by(() => {
-    const vc = collectionStore.visibleColumns;
-    const cw = collectionStore.columnWidths;
-    const cols: string[] = ["36px"]; // play indicator always present
-    for (const { key } of SONG_TABLE_COLUMNS) {
-      if (!vc[key]) continue;
-      const saved = cw[key];
-      cols.push(saved !== undefined ? `${saved}px` : (COLLECTION_COL_DEFAULTS[key] ?? "80px"));
-    }
-    return `grid-template-columns: ${cols.join(" ")}`;
-  });
-
-  // The song rows live inside <VirtualList>'s scrolling viewport, which
-  // reserves layout width for its own vertical scrollbar; the sticky header
-  // sits outside that viewport and doesn't. On platforms with a non-overlay
-  // scrollbar (e.g. Windows), that gutter makes the header's grid track a
-  // few pixels wider than the rows' grid track, misaligning every column
-  // after the ones that can absorb it. Measure the actual scrollbar width
-  // and pad the header by the same amount so both grids compute identical
-  // track widths.
-  let songsTableContainer = $state<HTMLDivElement | undefined>(undefined);
-  let scrollbarWidth = $state(0);
-
-  $effect(() => {
-    if (!songsTableContainer) return;
-    const viewport = songsTableContainer.querySelector<HTMLElement>("svelte-virtual-list-viewport");
-    if (!viewport) return;
-    const update = () => {
-      scrollbarWidth = viewport.offsetWidth - viewport.clientWidth;
-    };
-    update();
-    const observer = new ResizeObserver(update);
-    observer.observe(viewport);
-    return () => observer.disconnect();
-  });
-
-  // VirtualList renders its own <svelte-virtual-list-viewport> scrolling element
-  // inside songsTableContainer, so it can't be reached with a template `use:` ref.
-  $effect(() => {
-    if (!songsTableContainer) return;
-    const viewport = songsTableContainer.querySelector<HTMLElement>("svelte-virtual-list-viewport");
-    if (!viewport) return;
-    return watchScrollMemory(viewport, "collection:songs");
-  });
-
   function toggleSort(field: keyof Song) {
     if (sortField === field) {
       sortAsc = !sortAsc;
@@ -432,9 +312,35 @@
   async function rateSong(song: Song, rating: number) {
     song.rating = await invoke<number>("set_song_rating", { songId: song.id, rating });
   }
+
+  function songToRow(song: Song): SongTableRow {
+    const disconnected = !song.unavailable && collectionStore.isPathOnDisconnectedDrive(song.path);
+    return {
+      key: String(song.id),
+      song,
+      disabled: song.unavailable || disconnected,
+      disabledTooltip: disconnected ? i18n.t("collection.driveDisconnectedTooltip") : undefined,
+    };
+  }
+
+  let tableRows = $derived(filteredSongs.map(songToRow));
 </script>
 
-<svelte:window onkeydown={handleKeydown} onmousedown={handleWindowMouseDown} />
+{#snippet songsEmptyState()}
+  {#if filteredSongs.length === 0 && collectionStore.searchQuery}
+    <SearchEmptyState
+      icon={Music}
+      title={i18n.t('collection.noSongsTitle')}
+      matchQueryText={i18n.t('collection.noTracksMatchQuery')}
+      query={collectionStore.searchQuery}
+      onReset={() => { collectionStore.searchQuery = ""; collectionStore.search(""); }}
+    />
+  {:else}
+    <!-- Library has no songs at all yet (no watched folders) — a distinct
+         welcome moment, not a "your search/filters found nothing" state. -->
+    <LibraryWelcome />
+  {/if}
+{/snippet}
 
 {#if collectionStore.selectedAlbumName !== null}
   <AlbumDetailView albumName={collectionStore.selectedAlbumName} />
@@ -472,538 +378,25 @@
     </div>
 
     <div class="flex-1 px-6 pt-2 overflow-hidden flex flex-col {playerStore.currentSong ? 'pb-28' : 'pb-6'}">
-      <div bind:this={songsTableContainer} class="flex-1 overflow-hidden border border-brand-border rounded-lg bg-brand-sidebar/40 flex flex-col min-h-0">
-        <div class="sticky top-0 z-20 flex flex-col bg-brand-sidebar border-b border-brand-border text-xs text-brand-text-secondary uppercase tracking-wider font-semibold select-none">
-          <div class="grid items-center py-3 px-4" style="{gridColsStyle}; padding-right: calc(1rem + {scrollbarWidth}px)">
-            <div class="text-center w-9"></div>
-            {#if collectionStore.visibleColumns.track}
-              <div use:columnResize={{ column: "track", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-              <SortableHeader
-                active={sortField === "track"}
-                {sortAsc}
-                onclick={() => toggleSort("track")}
-                class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-              >
-                {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-1rem)]">{i18n.t('collection.tableHeaderTrack')} {arrow}</span>{/snippet}
-              </SortableHeader>
-              </div>
-            {/if}
-            {#if collectionStore.visibleColumns.title}
-              <div use:columnResize={{ column: "title", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-              <SortableHeader
-                active={sortField === "title"}
-                {sortAsc}
-                onclick={() => toggleSort("title")}
-                class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-              >
-                {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-1rem)]">{i18n.t('collection.tableHeaderTitle')} {arrow}</span>{/snippet}
-              </SortableHeader>
-              </div>
-            {/if}
-            {#if collectionStore.visibleColumns.artist}
-              <div use:columnResize={{ column: "artist", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-              <SortableHeader
-                active={sortField === "artist"}
-                {sortAsc}
-                onclick={() => toggleSort("artist")}
-                class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-              >
-                {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-1rem)]">{i18n.t('collection.tableHeaderArtist')} {arrow}</span>{/snippet}
-              </SortableHeader>
-              </div>
-            {/if}
-            {#if collectionStore.visibleColumns.album}
-              <div use:columnResize={{ column: "album", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-              <SortableHeader
-                active={sortField === "album"}
-                {sortAsc}
-                onclick={() => toggleSort("album")}
-                class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-              >
-                {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-1rem)]">{i18n.t('collection.tableHeaderAlbum')} {arrow}</span>{/snippet}
-              </SortableHeader>
-              </div>
-            {/if}
-            {#if collectionStore.visibleColumns.composer}
-              <div use:columnResize={{ column: "composer", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-              <SortableHeader
-                active={sortField === "composer"}
-                {sortAsc}
-                onclick={() => toggleSort("composer")}
-                class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-              >
-                {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderComposer')} {arrow}</span>{/snippet}
-              </SortableHeader>
-              </div>
-            {/if}
-            {#if collectionStore.visibleColumns.album_artist}
-              <div use:columnResize={{ column: "album_artist", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-              <SortableHeader
-                active={sortField === "album_artist"}
-                {sortAsc}
-                onclick={() => toggleSort("album_artist")}
-                class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-              >
-                {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderAlbumArtist')} {arrow}</span>{/snippet}
-              </SortableHeader>
-              </div>
-            {/if}
-            {#if collectionStore.visibleColumns.format}
-              <div use:columnResize={{ column: "format", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-              <SortableHeader
-                active={sortField === "filetype"}
-                {sortAsc}
-                onclick={() => toggleSort("filetype")}
-                class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-              >
-                {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderFormat')} {arrow}</span>{/snippet}
-              </SortableHeader>
-              </div>
-            {/if}
-            {#if collectionStore.visibleColumns.year}
-              <div use:columnResize={{ column: "year", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-              <SortableHeader
-                active={sortField === "year"}
-                {sortAsc}
-                onclick={() => toggleSort("year")}
-                class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-              >
-                {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderYear')} {arrow}</span>{/snippet}
-              </SortableHeader>
-              </div>
-            {/if}
-            {#if collectionStore.visibleColumns.genre}
-              <div use:columnResize={{ column: "genre", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-              <SortableHeader
-                active={sortField === "genre"}
-                {sortAsc}
-                onclick={() => toggleSort("genre")}
-                class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-              >
-                {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderGenre')} {arrow}</span>{/snippet}
-              </SortableHeader>
-              </div>
-            {/if}
-            {#if collectionStore.visibleColumns.grouping}
-              <div use:columnResize={{ column: "grouping", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-              <SortableHeader
-                active={sortField === "grouping"}
-                {sortAsc}
-                onclick={() => toggleSort("grouping")}
-                class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-              >
-                {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderGrouping')} {arrow}</span>{/snippet}
-              </SortableHeader>
-              </div>
-            {/if}
-            {#if collectionStore.visibleColumns.bpm}
-              <div use:columnResize={{ column: "bpm", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-              <SortableHeader
-                active={sortField === "bpm"}
-                {sortAsc}
-                onclick={() => toggleSort("bpm")}
-                class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-              >
-                {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderBpm')} {arrow}</span>{/snippet}
-              </SortableHeader>
-              </div>
-            {/if}
-            {#if collectionStore.visibleColumns.initial_key}
-              <div use:columnResize={{ column: "initial_key", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-              <SortableHeader
-                active={sortField === "initial_key"}
-                {sortAsc}
-                onclick={() => toggleSort("initial_key")}
-                class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-              >
-                {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderInitialKey')} {arrow}</span>{/snippet}
-              </SortableHeader>
-              </div>
-            {/if}
-            {#if collectionStore.visibleColumns.bitrate}
-              <div use:columnResize={{ column: "bitrate", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-              <SortableHeader
-                active={sortField === "bitrate"}
-                {sortAsc}
-                onclick={() => toggleSort("bitrate")}
-                class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-              >
-                {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderBitrate')} {arrow}</span>{/snippet}
-              </SortableHeader>
-              </div>
-            {/if}
-            {#if collectionStore.visibleColumns.samplerate}
-              <div use:columnResize={{ column: "samplerate", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-              <SortableHeader
-                active={sortField === "samplerate"}
-                {sortAsc}
-                onclick={() => toggleSort("samplerate")}
-                class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-              >
-                {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderSampleRate')} {arrow}</span>{/snippet}
-              </SortableHeader>
-              </div>
-            {/if}
-            {#if collectionStore.visibleColumns.bitdepth}
-              <div use:columnResize={{ column: "bitdepth", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-              <SortableHeader
-                active={sortField === "bitdepth"}
-                {sortAsc}
-                onclick={() => toggleSort("bitdepth")}
-                class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-              >
-                {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderBitDepth')} {arrow}</span>{/snippet}
-              </SortableHeader>
-              </div>
-            {/if}
-            {#if collectionStore.visibleColumns.channels}
-              <div use:columnResize={{ column: "channels", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-              <SortableHeader
-                active={sortField === "channels"}
-                {sortAsc}
-                onclick={() => toggleSort("channels")}
-                class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-              >
-                {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderChannels')} {arrow}</span>{/snippet}
-              </SortableHeader>
-              </div>
-            {/if}
-            {#if collectionStore.visibleColumns.filesize}
-              <div use:columnResize={{ column: "filesize", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-              <SortableHeader
-                active={sortField === "filesize"}
-                {sortAsc}
-                onclick={() => toggleSort("filesize")}
-                class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-              >
-                {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderFileSize')} {arrow}</span>{/snippet}
-              </SortableHeader>
-              </div>
-            {/if}
-            {#if collectionStore.visibleColumns.rating}
-              <div use:columnResize={{ column: "rating", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-              <SortableHeader
-                active={sortField === "rating"}
-                {sortAsc}
-                onclick={() => toggleSort("rating")}
-                class="flex items-center justify-center hover:text-brand-text-primary transition-colors font-semibold uppercase tracking-wider min-w-0 w-full"
-              >
-                {#snippet label(arrow)}<span class="truncate">{i18n.t('collection.tableHeaderRating')} {arrow}</span>{/snippet}
-              </SortableHeader>
-              </div>
-            {/if}
-            {#if collectionStore.visibleColumns.playcount}
-              <div use:columnResize={{ column: "playcount", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-              <SortableHeader
-                active={sortField === "playcount"}
-                {sortAsc}
-                onclick={() => toggleSort("playcount")}
-                class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-              >
-                {#snippet label(arrow)}<span class="truncate">{i18n.t('collection.tableHeaderPlays')} {arrow}</span>{/snippet}
-              </SortableHeader>
-              </div>
-            {/if}
-            {#if collectionStore.visibleColumns.skipcount}
-              <div use:columnResize={{ column: "skipcount", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-              <SortableHeader
-                active={sortField === "skipcount"}
-                {sortAsc}
-                onclick={() => toggleSort("skipcount")}
-                class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-              >
-                {#snippet label(arrow)}<span class="truncate">{i18n.t('collection.tableHeaderSkips')} {arrow}</span>{/snippet}
-              </SortableHeader>
-              </div>
-            {/if}
-            {#if collectionStore.visibleColumns.lastplayed}
-              <div use:columnResize={{ column: "lastplayed", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-              <SortableHeader
-                active={sortField === "lastplayed"}
-                {sortAsc}
-                onclick={() => toggleSort("lastplayed")}
-                class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-              >
-                {#snippet label(arrow)}<span class="truncate">{i18n.t('collection.tableHeaderLastPlayed')} {arrow}</span>{/snippet}
-              </SortableHeader>
-              </div>
-            {/if}
-            {#if collectionStore.visibleColumns.added}
-              <div use:columnResize={{ column: "added", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-              <SortableHeader
-                active={sortField === "added"}
-                {sortAsc}
-                onclick={() => toggleSort("added")}
-                class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-              >
-                {#snippet label(arrow)}<span class="truncate">{i18n.t('collection.tableHeaderAdded')} {arrow}</span>{/snippet}
-              </SortableHeader>
-              </div>
-            {/if}
-            {#if collectionStore.visibleColumns.duration}
-              <div use:columnResize={{ column: "duration", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-              <SortableHeader
-                active={sortField === "length_nanosec"}
-                {sortAsc}
-                onclick={() => toggleSort("length_nanosec")}
-                class="flex items-center justify-center hover:text-brand-text-primary transition-colors font-semibold uppercase tracking-wider min-w-0 w-full"
-              >
-                {#snippet label(arrow)}<Clock class="w-4 h-4 shrink-0" /> {arrow}{/snippet}
-              </SortableHeader>
-              </div>
-            {/if}
-            {#if collectionStore.visibleColumns.path}
-              <div use:columnResize={{ column: "path", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-              <SortableHeader
-                active={sortField === "path"}
-                {sortAsc}
-                onclick={() => toggleSort("path")}
-                class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-              >
-                {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderPath')} {arrow}</span>{/snippet}
-              </SortableHeader>
-              </div>
-            {/if}
-            {#if collectionStore.visibleColumns.actions}
-              <div use:columnResize={{ column: "actions", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden text-center">{i18n.t('collection.tableHeaderActions')}</div>
-            {/if}
-          </div>
-        </div>
-
-        <div class="flex-1 min-h-0 relative">
-          {#if filteredSongs.length === 0 && collectionStore.searchQuery}
-            <div class="py-16 text-center">
-              <SearchEmptyState
-                icon={Music}
-                title={i18n.t('collection.noSongsTitle')}
-                matchQueryText={i18n.t('collection.noTracksMatchQuery')}
-                query={collectionStore.searchQuery}
-                onReset={() => { collectionStore.searchQuery = ""; collectionStore.search(""); }}
-              />
-            </div>
-          {:else if filteredSongs.length === 0}
-            <!-- Library has no songs at all yet (no watched folders) — a distinct
-                 welcome moment, not a "your search/filters found nothing" state. -->
-            <div class="py-16 text-center">
-              <LibraryWelcome />
-            </div>
-          {:else}
-            {#key gridColsStyle}
-            <VirtualList items={filteredSongs} itemHeight={41}>
-              {#snippet children({ item: song }: { item: Song })}
-              {@const disconnected = !song.unavailable && collectionStore.isPathOnDisconnectedDrive(song.path)}
-              {@const disabled = song.unavailable || disconnected}
-              <!-- svelte-ignore a11y_no_static_element_interactions -->
-              <!-- svelte-ignore a11y_click_events_have_key_events -->
-              <div
-                data-song-row="true"
-                onclick={(e) => !disabled && handleSongClick(e, song)}
-                ondblclick={() => !disabled && handlePlaySong(song)}
-                oncontextmenu={(e) => !disabled && handleContextMenu(e, song)}
-                style={gridColsStyle}
-                title={disconnected ? i18n.t('collection.driveDisconnectedTooltip') : undefined}
-                class="grid items-center border-b border-brand-border/40 hover:bg-brand-sidebar/40 group transition-colors py-2.5 px-4 text-sm
-                  {disabled ? 'opacity-50 cursor-not-allowed' : ''}
-                  {selectedSongIds.has(song.id) ? 'bg-brand-accent/20 border-l-2 border-brand-accent text-brand-accent-text-hover' : (playerStore.currentSong && playerStore.currentSong.id === song.id ? 'bg-brand-accent/10 text-brand-accent-text-hover' : '')}"
-              >
-                <div class="text-center flex justify-center relative w-9 h-6 items-center">
-                  {#if playerStore.currentSong && playerStore.currentSong.id === song.id && playerStore.state === 'playing'}
-                    <div class="flex items-center justify-center gap-0.5 h-4 w-4 absolute group-hover:opacity-0 transition-opacity">
-                      <NowPlayingBars />
-                    </div>
-                  {/if}
-                  <button
-                    onclick={() => !disabled && handlePlaySong(song)}
-                    class="absolute flex items-center justify-center opacity-0 group-hover:opacity-100 text-brand-accent-text hover:text-brand-accent-text-hover transition-all duration-150 disabled:opacity-0 disabled:cursor-not-allowed"
-                    disabled={disabled}
-                    title={disconnected ? i18n.t('collection.driveDisconnectedTooltip') : i18n.t('collection.playSong')}
-                  >
-                    <Play class="w-4 h-4 fill-current" />
-                  </button>
-                </div>
-                {#if collectionStore.visibleColumns.track}
-                  <div class="text-brand-text-secondary truncate pr-2 min-w-0 text-xs font-medium">
-                    {song.track !== undefined && song.track !== null ? song.track : "—"}
-                  </div>
-                {/if}
-                {#if collectionStore.visibleColumns.title}
-                  <div class="font-medium truncate pr-4 flex items-center gap-2 min-w-0">
-                    <CoverArt
-                      songId={song.id}
-                      artEmbedded={song.art_embedded}
-                      artAutomatic={song.art_automatic}
-                      artManual={song.art_manual}
-                      sizeClass="w-7 h-7 rounded shrink-0"
-                    />
-                    <span
-                      class="truncate min-w-0 font-medium {playerStore.currentSong && playerStore.currentSong.id === song.id ? 'text-brand-accent-text-hover' : 'text-brand-text-primary'}"
-                      title={song.title || i18n.t('collection.unknownSong')}
-                    >
-                      {song.title || i18n.t('collection.unknownSong')}
-                    </span>
-                  </div>
-                {/if}
-                {#if collectionStore.visibleColumns.artist}
-                  <div class="text-brand-text-secondary truncate pr-4 flex items-center min-w-0">
-                    {#if song.artist}
-                      {#each parseMultiValue(song.artist) as name, i (name)}
-                        {#if i > 0}<span class="text-brand-text-secondary/50 shrink-0">,&nbsp;</span>{/if}
-                        <LinkButton
-                          onclick={(e) => { e.stopPropagation(); collectionStore.viewArtist(name); }}
-                          class="text-brand-text-secondary truncate min-w-0"
-                          title={i18n.t('collection.filterByArtist', { artist: name })}
-                        >
-                          {name}
-                        </LinkButton>
-                      {/each}
-                    {:else}
-                      <span class="text-brand-text-secondary truncate min-w-0">{i18n.t('collection.unknownArtist')}</span>
-                    {/if}
-                  </div>
-                {/if}
-                {#if collectionStore.visibleColumns.album}
-                  <div class="text-brand-text-secondary truncate pr-4 flex items-center min-w-0">
-                    {#if song.album}
-                      <LinkButton
-                        onclick={(e) => { e.stopPropagation(); collectionStore.viewAlbum(song.album || ""); }}
-                        class="text-brand-text-secondary truncate min-w-0"
-                        title={i18n.t('collection.filterByAlbum', { album: song.album })}
-                      >
-                        {song.album}
-                      </LinkButton>
-                    {:else}
-                      <span class="text-brand-text-secondary truncate min-w-0">{i18n.t('collection.unknownAlbum')}</span>
-                    {/if}
-                  </div>
-                {/if}
-                {#if collectionStore.visibleColumns.composer}
-                  <div class="text-brand-text-secondary truncate pr-4 min-w-0 text-xs font-medium" title={song.composer}>
-                    {song.composer || "—"}
-                  </div>
-                {/if}
-                {#if collectionStore.visibleColumns.album_artist}
-                  <div class="text-brand-text-secondary truncate pr-4 min-w-0 text-xs font-medium" title={song.album_artist}>
-                    {song.album_artist || "—"}
-                  </div>
-                {/if}
-                {#if collectionStore.visibleColumns.format}
-                  <div class="text-brand-text-secondary truncate pr-2 min-w-0 text-xs font-semibold uppercase">
-                    {song.filetype ? song.filetype.toUpperCase() : "—"}
-                  </div>
-                {/if}
-                {#if collectionStore.visibleColumns.year}
-                  <div class="text-brand-text-secondary truncate pr-2 min-w-0 text-xs font-medium">
-                    {song.year || "—"}
-                  </div>
-                {/if}
-                {#if collectionStore.visibleColumns.genre}
-                  <div class="truncate pr-2 min-w-0" title={song.genre}>
-                    {#if song.genre}
-                      <GenreChips genre={song.genre} />
-                    {:else}
-                      <span class="text-brand-text-secondary text-xs font-medium">—</span>
-                    {/if}
-                  </div>
-                {/if}
-                {#if collectionStore.visibleColumns.grouping}
-                  <div class="text-brand-text-secondary truncate pr-2 min-w-0 text-xs font-medium" title={song.grouping}>
-                    {song.grouping || "—"}
-                  </div>
-                {/if}
-                {#if collectionStore.visibleColumns.bpm}
-                  <div class="text-brand-text-secondary truncate pr-2 min-w-0 text-xs font-medium">
-                    {song.bpm || "—"}
-                  </div>
-                {/if}
-                {#if collectionStore.visibleColumns.initial_key}
-                  <div class="text-brand-text-secondary truncate pr-2 min-w-0 text-xs font-medium">
-                    {song.initial_key || "—"}
-                  </div>
-                {/if}
-                {#if collectionStore.visibleColumns.bitrate}
-                  <div class="text-brand-text-secondary truncate pr-2 min-w-0 text-xs font-medium">
-                    {song.bitrate ? `${song.bitrate}k` : "—"}
-                  </div>
-                {/if}
-                {#if collectionStore.visibleColumns.samplerate}
-                  <div class="text-brand-text-secondary truncate pr-2 min-w-0 text-xs font-medium">
-                    {formatSampleRate(song.samplerate)}
-                  </div>
-                {/if}
-                {#if collectionStore.visibleColumns.bitdepth}
-                  <div class="text-brand-text-secondary truncate pr-2 min-w-0 text-xs font-medium">
-                    {formatBitDepth(song.bitdepth)}
-                  </div>
-                {/if}
-                {#if collectionStore.visibleColumns.channels}
-                  <div class="text-brand-text-secondary truncate pr-2 min-w-0 text-xs font-medium">
-                    {formatChannels(song.channels)}
-                  </div>
-                {/if}
-                {#if collectionStore.visibleColumns.filesize}
-                  <div class="text-brand-text-secondary truncate pr-2 min-w-0 text-xs font-medium">
-                    {formatFileSize(song.filesize)}
-                  </div>
-                {/if}
-                {#if collectionStore.visibleColumns.rating}
-                  <div class="flex justify-center">
-                    <SongRating rating={song.rating} onRate={(r) => rateSong(song, r)} />
-                  </div>
-                {/if}
-                {#if collectionStore.visibleColumns.playcount}
-                  <div class="text-center text-brand-text-secondary font-medium text-xs">
-                    {song.playcount ?? 0}
-                  </div>
-                {/if}
-                {#if collectionStore.visibleColumns.skipcount}
-                  <div class="text-center text-brand-text-secondary font-medium text-xs">
-                    {song.skipcount ?? 0}
-                  </div>
-                {/if}
-                {#if collectionStore.visibleColumns.lastplayed}
-                  <div class="text-center text-brand-text-secondary text-xs whitespace-nowrap">
-                    {formatDate(song.lastplayed)}
-                  </div>
-                {/if}
-                {#if collectionStore.visibleColumns.added}
-                  <div class="text-center text-brand-text-secondary text-xs whitespace-nowrap">
-                    {formatDateAdded(song.added)}
-                  </div>
-                {/if}
-                {#if collectionStore.visibleColumns.duration}
-                  <div class="text-center text-brand-text-secondary font-medium text-xs">{formatDuration(song.length_nanosec)}</div>
-                {/if}
-                {#if collectionStore.visibleColumns.path}
-                  <div class="text-brand-text-secondary truncate pr-4 min-w-0 text-xs font-medium" title={song.path}>
-                    {song.path || "—"}
-                  </div>
-                {/if}
-                {#if collectionStore.visibleColumns.actions}
-                  <div class="flex items-center justify-center gap-2.5">
-                    <button
-                      onclick={() => handleAddSongToPlaylist(song.id)}
-                      class="text-brand-text-secondary hover:text-brand-accent-text transition-colors"
-                      title={playlistsStore.activeCustomPlaylist
-                        ? i18n.t('collection.addPlaylistTooltip', { name: playlistsStore.activeCustomPlaylist.name })
-                        : i18n.t('collection.addPlaylistTooltipDefault')}
-                    >
-                      <Plus class="w-4 h-4" />
-                    </button>
-                    <button
-                      onclick={() => openTagEditor(song.id)}
-                      class="text-brand-text-secondary hover:text-brand-accent-text transition-colors"
-                      title={i18n.t('collection.editTagsTooltip')}
-                    >
-                      <Edit3 class="w-4 h-4" />
-                    </button>
-                  </div>
-                {/if}
-              </div>
-              {/snippet}
-            </VirtualList>
-            {/key}
-          {/if}
-        </div>
+      <div class="flex-1 overflow-hidden border border-brand-border rounded-lg bg-brand-sidebar/40 flex flex-col min-h-0">
+        <SongTable
+          rows={tableRows}
+          mode="track"
+          leadingColumnWidth="36px"
+          colDefaults={COLLECTION_COL_DEFAULTS}
+          {sortField}
+          {sortAsc}
+          onToggleSort={(f) => toggleSort(f as keyof Song)}
+          bind:selectedKeys
+          onRowDoubleClick={(row) => row.song && handlePlaySong(row.song)}
+          onRowContextMenu={handleRowContextMenu}
+          onRate={rateSong}
+          onAddToPlaylist={(song) => handleAddSongToPlaylist(song.id)}
+          onEditTags={(song) => openTagEditor(song.id)}
+          virtualized
+          scrollMemoryKey="collection:songs"
+          emptyState={songsEmptyState}
+        />
       </div>
     </div>
 
@@ -1200,17 +593,17 @@
     x={contextMenuState.x}
     y={contextMenuState.y}
     {song}
-    selectedCount={selectedSongIds.size}
-    selectedSongIds={Array.from(selectedSongIds)}
+    selectedCount={selectedKeys.size}
+    selectedSongIds={Array.from(selectedKeys, Number)}
     onPlay={() => {
-      if (selectedSongIds.size > 1) {
+      if (selectedKeys.size > 1) {
         handlePlaySelected();
       } else {
         handlePlaySong(song);
       }
     }}
     onAddToPlaylist={() => {
-      if (selectedSongIds.size > 1) {
+      if (selectedKeys.size > 1) {
         handleBulkAddToPlaylist();
       } else {
         handleAddSongToPlaylist(song.id);
@@ -1255,10 +648,10 @@
   />
 {/if}
 
-{#if selectedSongIds.size > 0 && collectionStore.activeSubTab === 'songs'}
+{#if selectedKeys.size > 0 && collectionStore.activeSubTab === 'songs'}
   <div data-floating-toolbar="true" class="absolute left-1/2 -translate-x-1/2 z-40 bg-brand-sidebar/95 border border-brand-border/80 shadow-2xl rounded-full px-5 py-2.5 flex items-center gap-4 text-xs font-semibold backdrop-blur-xl animate-in fade-in slide-in-from-bottom-4 duration-200" class:bottom-6={!playerStore.currentSong} class:bottom-28={!!playerStore.currentSong}>
     <span class="text-brand-accent-text font-bold">
-      {i18n.t('playlists.selectedCount', { count: selectedSongIds.size })}
+      {i18n.t('playlists.selectedCount', { count: selectedKeys.size })}
     </span>
     <div class="h-4 w-px bg-brand-border/60"></div>
     <button
@@ -1281,7 +674,7 @@
     </button>
     <div class="h-4 w-px bg-brand-border/60"></div>
     <button
-      onclick={() => { selectedSongIds = new Set(); }}
+      onclick={() => { selectedKeys = new Set(); }}
       class="text-brand-text-secondary hover:text-brand-text-primary transition-colors"
     >
       {i18n.t('playlists.clearSelection')}

--- a/src/lib/components/PlaylistView.svelte
+++ b/src/lib/components/PlaylistView.svelte
@@ -5,16 +5,13 @@
   import { playerStore } from "../stores/player.svelte";
   import { collectionStore } from "../stores/collection.svelte";
   import { shuffleArray } from "../utils/shuffle";
-  import { formatDuration } from "../utils/formatters";
   import {
     Trash2,
     ListMusic,
     RotateCcw,
     RotateCw,
-    Edit3,
     AlertTriangle,
     Play,
-    GripVertical,
     FolderInput,
     FileOutput,
     Pencil,
@@ -29,31 +26,23 @@
     MoreHorizontal,
     Eraser,
     Sparkles,
-    Plus,
     FolderPlus
   } from "lucide-svelte";
-  import { getCoverArtUrl, resolveArtUrl } from "../types";
+  import { resolveArtUrl } from "../types";
   import { i18n } from "../stores/i18n.svelte";
   import type { PlaylistItem, Song } from "../types";
   import { parseSearchRules, isSmartPlaylistSpec } from "../utils/filterParser";
   import { rememberScroll } from "../utils/scrollMemory";
   import { invoke } from "@tauri-apps/api/core";
   import { open, save } from "@tauri-apps/plugin-dialog";
-  import SongRating from "./SongRating.svelte";
   import TagEditor from "./TagEditor.svelte";
-  import GenreChips from "./GenreChips.svelte";
   import { tagsStore } from "../stores/tags.svelte";
   import CoverArt from "./CoverArt.svelte";
   import CoverStack from "./CoverStack.svelte";
   import PlaylistContextMenu from "./PlaylistContextMenu.svelte";
   import ConfirmDialog from "./ConfirmDialog.svelte";
   import Modal from "./Modal.svelte";
-  import SortableHeader from "./SortableHeader.svelte";
-  import NowPlayingBars from "./NowPlayingBars.svelte";
-  import LinkButton from "./LinkButton.svelte";
-  import { parseMultiValue } from "../utils/multiValue";
   import ColumnSelector from "./ColumnSelector.svelte";
-  import { Clock } from "lucide-svelte";
   import Button from "./Button.svelte";
   import Input from "./Input.svelte";
   import IconActionButton from "./IconActionButton.svelte";
@@ -61,11 +50,11 @@
   import ContextMenuItem from "./ContextMenuItem.svelte";
   import ContextMenuDivider from "./ContextMenuDivider.svelte";
   import { portal } from "../utils/portal";
-  import { formatDate, formatFileSize, formatSampleRate, formatBitDepth, formatChannels } from "../utils/formatters";
+  import { formatSampleRate, formatBitDepth, formatChannels, formatFileSize, formatDate, formatDuration } from "../utils/formatters";
   import { formatDateAdded } from "../utils/date";
   import { CONTEXT_MENU_WIDTH_PX } from "../constants";
-  import { SONG_TABLE_COLUMNS } from "../utils/songColumns";
-  import { columnResize } from "../utils/columnResize";
+  import { compareSongs } from "../utils/songSort";
+  import SongTable, { type SongTableRow } from "./SongTable.svelte";
 
   // Default column widths (px or fr) — used when no saved width exists for a column.
   const PLAYLIST_COL_DEFAULTS: Partial<Record<keyof typeof collectionStore.visibleColumns, string>> = {
@@ -76,19 +65,6 @@
     filesize: "75px", rating: "96px", playcount: "70px", skipcount: "70px",
     lastplayed: "90px", added: "90px", duration: "80px", path: "2fr", actions: "80px",
   };
-
-  let gridColsStyle = $derived.by(() => {
-    const cols: string[] = ["48px"]; // position column always present
-    const vc = collectionStore.visibleColumns;
-    const cw = collectionStore.columnWidths;
-    for (const { key } of SONG_TABLE_COLUMNS) {
-      if (key === "track") continue; // playlist uses position instead of track#
-      if (!vc[key]) continue;
-      const saved = cw[key];
-      cols.push(saved !== undefined ? `${saved}px` : (PLAYLIST_COL_DEFAULTS[key] ?? "80px"));
-    }
-    return `grid-template-columns: ${cols.join(" ")}`;
-  });
   import {
     COVER_STACK_OFFSET_X_PX,
     COVER_STACK_OFFSET_Y_PX,
@@ -96,8 +72,6 @@
     COVER_STACK_SCALE_STEP,
     COVER_STACK_OPACITY_STEP,
   } from "../constants";
-
-  const POINTER_DRAG_THRESHOLD_PX = 4;
 
   let editingSongId = $state<number | null>(null);
 
@@ -107,7 +81,6 @@
   let filterQuery = $state("");
 
   let selectedUuids = $state<Set<string>>(new Set());
-  let lastSelectedIndex = $state<number | null>(null);
 
   let contextMenuState = $state<{ x: number; y: number; item: PlaylistItem } | null>(null);
 
@@ -257,11 +230,12 @@
   let sortField = $state<PlaylistSortField>("position");
   let sortAsc = $state(true);
 
-  function toggleSort(field: PlaylistSortField) {
-    if (sortField === field) {
+  function toggleSort(field: string) {
+    const f = field as PlaylistSortField;
+    if (sortField === f) {
       sortAsc = !sortAsc;
     } else {
-      sortField = field;
+      sortField = f;
       sortAsc = true;
     }
   }
@@ -312,42 +286,12 @@
       return sortAsc ? result : [...result].reverse();
     }
 
-    const fieldName = sortField as string;
+    const field = sortField as keyof Song;
     return [...result].sort((a, b) => {
-      let valA: unknown = a.song ? (a.song as Record<string, any>)[fieldName] : undefined;
-      let valB: unknown = b.song ? (b.song as Record<string, any>)[fieldName] : undefined;
-
-      if (a.song && b.song) {
-        const songA = a.song;
-        const songB = b.song;
-        if (fieldName === "title") {
-          valA = songA.titlesort?.trim() || songA.title;
-          valB = songB.titlesort?.trim() || songB.title;
-        } else if (fieldName === "artist") {
-          valA = songA.album_artist_sort?.trim() || songA.artistsort?.trim() || songA.album_artist || songA.artist;
-          valB = songB.album_artist_sort?.trim() || songB.artistsort?.trim() || songB.album_artist || songB.artist;
-        } else if (fieldName === "album") {
-          valA = songA.albumsort?.trim() || songA.album;
-          valB = songB.albumsort?.trim() || songB.album;
-        } else if (fieldName === "composer") {
-          valA = songA.composersort?.trim() || songA.composer;
-          valB = songB.composersort?.trim() || songB.composer;
-        } else if (fieldName === "genre") {
-          valA = songA.genresort?.trim() || songA.genre;
-          valB = songB.genresort?.trim() || songB.genre;
-        }
-      }
-
-      if (valA === undefined || valA === null) return sortAsc ? 1 : -1;
-      if (valB === undefined || valB === null) return sortAsc ? -1 : 1;
-
-      if (typeof valA === "string" && typeof valB === "string") {
-        const cmp = valA.localeCompare(valB);
-        return sortAsc ? cmp : -cmp;
-      } else {
-        const cmp = (valA as number) - (valB as number);
-        return sortAsc ? cmp : -cmp;
-      }
+      if (!a.song && !b.song) return 0;
+      if (!a.song) return sortAsc ? 1 : -1;
+      if (!b.song) return sortAsc ? -1 : 1;
+      return compareSongs(a.song, b.song, field, sortAsc);
     });
   });
 
@@ -426,6 +370,30 @@
 
   let duplicateCount = $derived(duplicateUuids.length);
 
+  function itemToRow(item: PlaylistItem): SongTableRow {
+    const trueUnavailable = isItemUnavailable(item);
+    const disconnected = !trueUnavailable && collectionStore.isPathOnDisconnectedDrive(item.song?.path);
+    return {
+      key: item.uuid,
+      song: item.song,
+      disabled: trueUnavailable || disconnected,
+      disabledTooltip: trueUnavailable
+        ? i18n.t("playlists.fileNotFoundTooltip")
+        : disconnected
+          ? i18n.t("collection.driveDisconnectedTooltip")
+          : undefined,
+      disabledVariant: trueUnavailable ? "strikethrough" : "dim",
+      isDuplicate: duplicateUuids.includes(item.uuid),
+      underlyingIndex: playlistsStore.activePlaylistTracks.findIndex((t) => t.uuid === item.uuid),
+    };
+  }
+
+  let tableRows = $derived(filteredTracks.map(itemToRow));
+  // Range (shift-click) selection and drag-target resolution both operate on
+  // the underlying (unfiltered) playlist order — preserving the existing
+  // behavior from before this table was consolidated.
+  let rangeSelectionRows = $derived(playlistsStore.activePlaylistTracks.map(itemToRow));
+
   function removeDuplicates() {
     if (activePlaylist && duplicateCount > 0) {
       playlistsStore.deduplicatePlaylist(activePlaylist.id);
@@ -482,90 +450,49 @@
     }
   }
 
-  async function rateItem(item: PlaylistItem, rating: number) {
-    if (!item.song) return;
-    item.song.rating = await invoke<number>("set_song_rating", {
-      songId: item.song.id,
-      rating,
-    });
+  async function rateSong(song: Song, rating: number) {
+    song.rating = await invoke<number>("set_song_rating", { songId: song.id, rating });
   }
 
-  function handleRowClick(event: MouseEvent, item: PlaylistItem) {
-    if (pointerDragJustEnded) return;
-    const actualIndex = playlistsStore.activePlaylistTracks.findIndex((t) => t.uuid === item.uuid);
+  let trackByUuid = $derived(new Map(playlistsStore.activePlaylistTracks.map((t) => [t.uuid, t])));
 
-    if (event.shiftKey && lastSelectedIndex !== null && lastSelectedIndex !== -1) {
-      const start = Math.min(lastSelectedIndex, actualIndex);
-      const end = Math.max(lastSelectedIndex, actualIndex);
-      const nextSet = new Set(selectedUuids);
-      for (let i = start; i <= end; i++) {
-        const track = playlistsStore.activePlaylistTracks[i];
-        if (track) nextSet.add(track.uuid);
-      }
-      selectedUuids = nextSet;
-    } else if (event.ctrlKey || event.metaKey) {
-      const nextSet = new Set(selectedUuids);
-      if (nextSet.has(item.uuid)) {
-        nextSet.delete(item.uuid);
-      } else {
-        nextSet.add(item.uuid);
-      }
-      selectedUuids = nextSet;
-      lastSelectedIndex = actualIndex;
-    } else if (selectedUuids.size === 1 && selectedUuids.has(item.uuid)) {
-      selectedUuids = new Set();
-      lastSelectedIndex = null;
-    } else {
-      selectedUuids = new Set([item.uuid]);
-      lastSelectedIndex = actualIndex;
-    }
+  function handleRowContextMenu(event: MouseEvent, row: SongTableRow) {
+    const item = trackByUuid.get(row.key);
+    if (item) contextMenuState = { x: event.clientX, y: event.clientY, item };
   }
 
-  function handleKeydown(event: KeyboardEvent) {
+  function handleDeleteKey(event: KeyboardEvent) {
     const target = event.target as HTMLElement | null;
     if (target && (target.tagName === "INPUT" || target.tagName === "TEXTAREA")) return;
-
     if (event.key === "Delete" || event.key === "Backspace") {
       if (selectedUuids.size > 0 && activePlaylist) {
         event.preventDefault();
         playlistsStore.removeItemsFromPlaylist(activePlaylist.id, Array.from(selectedUuids));
         selectedUuids = new Set();
-        lastSelectedIndex = null;
       }
-    } else if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === "a") {
-      event.preventDefault();
-      selectedUuids = new Set(filteredTracks.map((t) => t.uuid));
-    } else if (event.key === "Escape") {
-      selectedUuids = new Set();
-      lastSelectedIndex = null;
     }
   }
 
-  function handleWindowMouseDown(e: MouseEvent) {
-    if (selectedUuids.size === 0) return;
-    const target = e.target as HTMLElement;
-    if (!target) return;
-    if (
-      target.closest("[data-playlist-row]") ||
-      target.closest("[role='menu']") ||
-      target.closest("[data-floating-toolbar]") ||
-      target.closest("button") ||
-      target.closest("input")
-    ) {
-      return;
-    }
-    selectedUuids = new Set();
-    lastSelectedIndex = null;
-  }
+  function handleReorder(fromIndex: number, toIndex: number, selectedRowKeys: string[]) {
+    if (!activePlaylist) return;
+    const targetTrack = playlistsStore.activePlaylistTracks[toIndex];
+    if (!targetTrack) return;
 
-  function handleContextMenu(event: MouseEvent, item: PlaylistItem) {
-    event.preventDefault();
-    if (!selectedUuids.has(item.uuid)) {
-      selectedUuids = new Set([item.uuid]);
-      const actualIndex = playlistsStore.activePlaylistTracks.findIndex((t) => t.uuid === item.uuid);
-      lastSelectedIndex = actualIndex;
+    if (selectedRowKeys.length > 1) {
+      const selectedIndices = playlistsStore.activePlaylistTracks
+        .map((t, idx) => ({ uuid: t.uuid, idx }))
+        .filter((entry) => selectedRowKeys.includes(entry.uuid))
+        .map((entry) => entry.idx);
+
+      if (selectedIndices.length > 0) {
+        playlistsStore.reorderItemsBatch(activePlaylist.id, selectedIndices, toIndex);
+      }
+    } else {
+      const sourceTrack = playlistsStore.activePlaylistTracks[fromIndex];
+      if (sourceTrack && sourceTrack.uuid !== targetTrack.uuid) {
+        playlistsStore.reorderItemByUuid(activePlaylist.id, sourceTrack.uuid, targetTrack.uuid);
+      }
     }
-    contextMenuState = { x: event.clientX, y: event.clientY, item };
   }
 
   function playSelected() {
@@ -583,104 +510,7 @@
     if (selectedUuids.size > 0 && activePlaylist) {
       playlistsStore.removeItemsFromPlaylist(activePlaylist.id, Array.from(selectedUuids));
       selectedUuids = new Set();
-      lastSelectedIndex = null;
     }
-  }
-
-  let draggedIndex = $state<number | null>(null);
-  let dragOverIndex = $state<number | null>(null);
-
-  // Tauri's `dragDropEnabled` window option (required for OS file-drop-to-import) intercepts
-  // drag-and-drop at the webview level, which prevents the native HTML5 Drag and Drop API from
-  // ever firing `dragstart` for in-page elements. Row reordering is implemented with plain
-  // pointer-event tracking instead: pointerdown starts a potential drag, pointermove (once past
-  // a small movement threshold, so plain clicks aren't hijacked) tracks the row under the cursor
-  // via `document.elementFromPoint()`, and pointerup commits the reorder.
-  let pointerDragStartIndex: number | null = null;
-  let pointerDragStartX = 0;
-  let pointerDragStartY = 0;
-  let pointerDragJustEnded = false;
-
-  function commitReorder(targetIndex: number) {
-    if (!activePlaylist) return;
-    const targetTrack = playlistsStore.activePlaylistTracks[targetIndex];
-    if (!targetTrack) return;
-
-    if (selectedUuids.size > 1) {
-      const selectedIndices = playlistsStore.activePlaylistTracks
-        .map((t, idx) => ({ uuid: t.uuid, idx }))
-        .filter((entry) => selectedUuids.has(entry.uuid))
-        .map((entry) => entry.idx);
-
-      if (selectedIndices.length > 0) {
-        playlistsStore.reorderItemsBatch(activePlaylist.id, selectedIndices, targetIndex);
-      }
-    } else if (draggedIndex !== null && playlistsStore.activePlaylistTracks[draggedIndex]) {
-      const sourceUuid = playlistsStore.activePlaylistTracks[draggedIndex].uuid;
-      if (sourceUuid !== targetTrack.uuid) {
-        playlistsStore.reorderItemByUuid(activePlaylist.id, sourceUuid, targetTrack.uuid);
-      }
-    }
-  }
-
-  function handleRowPointerDown(event: PointerEvent, index: number, item: PlaylistItem) {
-    if (isItemUnavailable(item) || event.button !== 0) return;
-    // Don't hijack pointer events (and thus clicks) meant for an interactive child of the row,
-    // e.g. the Artist/Album LinkButton — setPointerCapture would steal the subsequent click
-    // before the button's own onclick can fire, silently blocking navigation.
-    if ((event.target as HTMLElement | null)?.closest("button, a, input, select, textarea, [data-interactive]")) {
-      return;
-    }
-    pointerDragStartIndex = index;
-    pointerDragStartX = event.clientX;
-    pointerDragStartY = event.clientY;
-    // With the window's dragDropEnabled option on, WebView2 can hijack an in-progress mouse
-    // gesture into a native OS drag once it crosses the platform's drag threshold, silently
-    // stopping pointermove/pointerup from reaching the DOM. Explicit pointer capture pins
-    // subsequent events to this element (and this JS event loop) instead, preventing that.
-    const target = event.currentTarget as HTMLElement;
-    target.setPointerCapture?.(event.pointerId);
-    window.addEventListener("pointermove", handlePointerDragMove);
-    window.addEventListener("pointerup", handlePointerDragUp);
-  }
-
-  function handlePointerDragMove(event: PointerEvent) {
-    if (pointerDragStartIndex === null) return;
-
-    if (draggedIndex === null) {
-      const dx = event.clientX - pointerDragStartX;
-      const dy = event.clientY - pointerDragStartY;
-      if (Math.hypot(dx, dy) < POINTER_DRAG_THRESHOLD_PX) return;
-
-      draggedIndex = pointerDragStartIndex;
-      const item = playlistsStore.activePlaylistTracks[pointerDragStartIndex];
-      if (item && !selectedUuids.has(item.uuid)) {
-        selectedUuids = new Set([item.uuid]);
-        lastSelectedIndex = pointerDragStartIndex;
-      }
-    }
-
-    const target = document.elementFromPoint(event.clientX, event.clientY);
-    const row = target instanceof Element ? target.closest<HTMLElement>("[data-playlist-row]") : null;
-    const rowIndex = row?.dataset.index;
-    dragOverIndex = rowIndex !== undefined ? parseInt(rowIndex, 10) : null;
-  }
-
-  function handlePointerDragUp() {
-    window.removeEventListener("pointermove", handlePointerDragMove);
-    window.removeEventListener("pointerup", handlePointerDragUp);
-
-    if (draggedIndex !== null && dragOverIndex !== null) {
-      commitReorder(dragOverIndex);
-      pointerDragJustEnded = true;
-      setTimeout(() => {
-        pointerDragJustEnded = false;
-      }, 0);
-    }
-
-    pointerDragStartIndex = null;
-    draggedIndex = null;
-    dragOverIndex = null;
   }
 
   async function handlePlayAll() {
@@ -749,7 +579,20 @@
   });
 </script>
 
-<svelte:window onkeydown={handleKeydown} onmousedown={handleWindowMouseDown} />
+{#snippet playlistEmptyState()}
+  <div class="py-12 text-center text-brand-text-primary/45 select-none">
+    <ListMusic class="w-12 h-12 mx-auto mb-2 text-brand-text-primary/30" />
+    {#if filterQuery}
+      {i18n.t("playlists.noFilterResults", { query: filterQuery })}
+    {:else if isQueue}
+      {i18n.t("playlists.emptyQueueText")}
+    {:else}
+      {i18n.t("playlists.emptyPlaylistTitle")}
+    {/if}
+  </div>
+{/snippet}
+
+<svelte:window onkeydown={handleDeleteKey} />
 
 <div class="flex-1 flex flex-col overflow-hidden bg-brand-main text-brand-text-secondary h-full relative select-none">
   {#if currentCoverUrl}
@@ -981,581 +824,30 @@
 
     <div class="p-6 flex flex-col" class:pb-28={!!playerStore.currentSong}>
       <div class="border border-brand-border/60 rounded-xl bg-brand-sidebar/30 backdrop-blur-md relative overflow-hidden">
-      <div class="sticky top-0 z-20 flex flex-col bg-brand-sidebar border-b border-brand-border text-xs text-brand-text-primary uppercase tracking-wider font-semibold select-none">
-        <div role="row" class="grid items-center py-3 px-4" style={gridColsStyle}>
-          <SortableHeader
-            active={sortField === "position"}
-            {sortAsc}
-            onclick={() => toggleSort("position")}
-            class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 font-semibold uppercase tracking-wider min-w-0"
-          >
-            {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-1rem)]">{i18n.t("playlists.tableHeaderTrack")} {arrow}</span>{/snippet}
-          </SortableHeader>
-          {#if collectionStore.visibleColumns.title}
-            <div use:columnResize={{ column: "title", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-            <SortableHeader
-              active={sortField === "title"}
-              {sortAsc}
-              onclick={() => toggleSort("title")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-            >
-              {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-1rem)]">{i18n.t("playlists.tableHeaderTitle")} {arrow}</span>{/snippet}
-            </SortableHeader>
-            </div>
-          {/if}
-          {#if collectionStore.visibleColumns.artist}
-            <div use:columnResize={{ column: "artist", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-            <SortableHeader
-              active={sortField === "artist"}
-              {sortAsc}
-              onclick={() => toggleSort("artist")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-            >
-              {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-1rem)]">{i18n.t("playlists.tableHeaderArtist")} {arrow}</span>{/snippet}
-            </SortableHeader>
-            </div>
-          {/if}
-          {#if collectionStore.visibleColumns.album}
-            <div use:columnResize={{ column: "album", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-            <SortableHeader
-              active={sortField === "album"}
-              {sortAsc}
-              onclick={() => toggleSort("album")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-            >
-              {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-1rem)]">{i18n.t("collection.tableHeaderAlbum")} {arrow}</span>{/snippet}
-            </SortableHeader>
-            </div>
-          {/if}
-
-          {#if collectionStore.visibleColumns.composer}
-            <div use:columnResize={{ column: "composer", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-            <SortableHeader
-              active={sortField === "composer"}
-              {sortAsc}
-              onclick={() => toggleSort("composer")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-            >
-              {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderComposer')} {arrow}</span>{/snippet}
-            </SortableHeader>
-            </div>
-          {/if}
-          {#if collectionStore.visibleColumns.album_artist}
-            <div use:columnResize={{ column: "album_artist", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-            <SortableHeader
-              active={sortField === "album_artist"}
-              {sortAsc}
-              onclick={() => toggleSort("album_artist")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-            >
-              {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderAlbumArtist')} {arrow}</span>{/snippet}
-            </SortableHeader>
-            </div>
-          {/if}
-          {#if collectionStore.visibleColumns.format}
-            <div use:columnResize={{ column: "format", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-            <SortableHeader
-              active={sortField === "filetype"}
-              {sortAsc}
-              onclick={() => toggleSort("filetype")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-            >
-              {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderFormat')} {arrow}</span>{/snippet}
-            </SortableHeader>
-            </div>
-          {/if}
-          {#if collectionStore.visibleColumns.year}
-            <div use:columnResize={{ column: "year", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-            <SortableHeader
-              active={sortField === "year"}
-              {sortAsc}
-              onclick={() => toggleSort("year")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-            >
-              {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderYear')} {arrow}</span>{/snippet}
-            </SortableHeader>
-            </div>
-          {/if}
-          {#if collectionStore.visibleColumns.genre}
-            <div use:columnResize={{ column: "genre", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-            <SortableHeader
-              active={sortField === "genre"}
-              {sortAsc}
-              onclick={() => toggleSort("genre")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-            >
-              {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderGenre')} {arrow}</span>{/snippet}
-            </SortableHeader>
-            </div>
-          {/if}
-          {#if collectionStore.visibleColumns.grouping}
-            <div use:columnResize={{ column: "grouping", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-            <SortableHeader
-              active={sortField === "grouping"}
-              {sortAsc}
-              onclick={() => toggleSort("grouping")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-            >
-              {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderGrouping')} {arrow}</span>{/snippet}
-            </SortableHeader>
-            </div>
-          {/if}
-          {#if collectionStore.visibleColumns.bpm}
-            <div use:columnResize={{ column: "bpm", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-            <SortableHeader
-              active={sortField === "bpm"}
-              {sortAsc}
-              onclick={() => toggleSort("bpm")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-            >
-              {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderBpm')} {arrow}</span>{/snippet}
-            </SortableHeader>
-            </div>
-          {/if}
-          {#if collectionStore.visibleColumns.initial_key}
-            <div use:columnResize={{ column: "initial_key", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-            <SortableHeader
-              active={sortField === "initial_key"}
-              {sortAsc}
-              onclick={() => toggleSort("initial_key")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-            >
-              {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderInitialKey')} {arrow}</span>{/snippet}
-            </SortableHeader>
-            </div>
-          {/if}
-          {#if collectionStore.visibleColumns.bitrate}
-            <div use:columnResize={{ column: "bitrate", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-            <SortableHeader
-              active={sortField === "bitrate"}
-              {sortAsc}
-              onclick={() => toggleSort("bitrate")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-            >
-              {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderBitrate')} {arrow}</span>{/snippet}
-            </SortableHeader>
-            </div>
-          {/if}
-          {#if collectionStore.visibleColumns.samplerate}
-            <div use:columnResize={{ column: "samplerate", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-            <SortableHeader
-              active={sortField === "samplerate"}
-              {sortAsc}
-              onclick={() => toggleSort("samplerate")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-            >
-              {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderSampleRate')} {arrow}</span>{/snippet}
-            </SortableHeader>
-            </div>
-          {/if}
-          {#if collectionStore.visibleColumns.bitdepth}
-            <div use:columnResize={{ column: "bitdepth", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-            <SortableHeader
-              active={sortField === "bitdepth"}
-              {sortAsc}
-              onclick={() => toggleSort("bitdepth")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-            >
-              {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderBitDepth')} {arrow}</span>{/snippet}
-            </SortableHeader>
-            </div>
-          {/if}
-          {#if collectionStore.visibleColumns.channels}
-            <div use:columnResize={{ column: "channels", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-            <SortableHeader
-              active={sortField === "channels"}
-              {sortAsc}
-              onclick={() => toggleSort("channels")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-            >
-              {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderChannels')} {arrow}</span>{/snippet}
-            </SortableHeader>
-            </div>
-          {/if}
-          {#if collectionStore.visibleColumns.filesize}
-            <div use:columnResize={{ column: "filesize", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-            <SortableHeader
-              active={sortField === "filesize"}
-              {sortAsc}
-              onclick={() => toggleSort("filesize")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-            >
-              {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderFileSize')} {arrow}</span>{/snippet}
-            </SortableHeader>
-            </div>
-          {/if}
-          {#if collectionStore.visibleColumns.rating}
-            <div use:columnResize={{ column: "rating", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-            <SortableHeader
-              active={sortField === "rating"}
-              {sortAsc}
-              onclick={() => toggleSort("rating")}
-              class="flex items-center justify-center hover:text-brand-text-primary transition-colors font-semibold uppercase tracking-wider min-w-0 w-full"
-            >
-              {#snippet label(arrow)}<span class="truncate">{i18n.t('collection.tableHeaderRating')} {arrow}</span>{/snippet}
-            </SortableHeader>
-            </div>
-          {/if}
-          {#if collectionStore.visibleColumns.playcount}
-            <div use:columnResize={{ column: "playcount", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-            <SortableHeader
-              active={sortField === "playcount"}
-              {sortAsc}
-              onclick={() => toggleSort("playcount")}
-              class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-            >
-              {#snippet label(arrow)}<span class="truncate">{i18n.t('collection.tableHeaderPlays')} {arrow}</span>{/snippet}
-            </SortableHeader>
-            </div>
-          {/if}
-          {#if collectionStore.visibleColumns.skipcount}
-            <div use:columnResize={{ column: "skipcount", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-            <SortableHeader
-              active={sortField === "skipcount"}
-              {sortAsc}
-              onclick={() => toggleSort("skipcount")}
-              class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-            >
-              {#snippet label(arrow)}<span class="truncate">{i18n.t('collection.tableHeaderSkips')} {arrow}</span>{/snippet}
-            </SortableHeader>
-            </div>
-          {/if}
-          {#if collectionStore.visibleColumns.lastplayed}
-            <div use:columnResize={{ column: "lastplayed", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-            <SortableHeader
-              active={sortField === "lastplayed"}
-              {sortAsc}
-              onclick={() => toggleSort("lastplayed")}
-              class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-            >
-              {#snippet label(arrow)}<span class="truncate">{i18n.t('collection.tableHeaderLastPlayed')} {arrow}</span>{/snippet}
-            </SortableHeader>
-            </div>
-          {/if}
-          {#if collectionStore.visibleColumns.added}
-            <div use:columnResize={{ column: "added", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-            <SortableHeader
-              active={sortField === "added"}
-              {sortAsc}
-              onclick={() => toggleSort("added")}
-              class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-            >
-              {#snippet label(arrow)}<span class="truncate">{i18n.t('collection.tableHeaderAdded')} {arrow}</span>{/snippet}
-            </SortableHeader>
-            </div>
-          {/if}
-          {#if collectionStore.visibleColumns.duration}
-            <div use:columnResize={{ column: "duration", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-            <SortableHeader
-              active={sortField === "length_nanosec"}
-              {sortAsc}
-              onclick={() => toggleSort("length_nanosec")}
-              class="flex items-center justify-center hover:text-brand-text-primary transition-colors font-semibold uppercase tracking-wider min-w-0 w-full"
-            >
-              {#snippet label(arrow)}<Clock class="w-4 h-4 shrink-0" /> {arrow}{/snippet}
-            </SortableHeader>
-            </div>
-          {/if}
-          {#if collectionStore.visibleColumns.path}
-            <div use:columnResize={{ column: "path", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden">
-            <SortableHeader
-              active={sortField === "path"}
-              {sortAsc}
-              onclick={() => toggleSort("path")}
-              class="text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full"
-            >
-              {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-0.5rem)]">{i18n.t('collection.tableHeaderPath')} {arrow}</span>{/snippet}
-            </SortableHeader>
-            </div>
-          {/if}
-          {#if collectionStore.visibleColumns.actions}
-            <div use:columnResize={{ column: "actions", onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) }} class="relative overflow-hidden text-center">{i18n.t('collection.tableHeaderActions')}</div>
-          {/if}
-        </div>
-      </div>
-
-      <div class="divide-y divide-brand-border/40">
-        {#each filteredTracks as item, index (item.uuid)}
-          {@const trueUnavailable = isItemUnavailable(item)}
-          {@const disconnected = !trueUnavailable && collectionStore.isPathOnDisconnectedDrive(item.song?.path)}
-          {@const unavailable = trueUnavailable || disconnected}
-          {@const isDuplicate = duplicateUuids.includes(item.uuid)}
-          {@const isSelected = selectedUuids.has(item.uuid)}
-          {@const actualIndex = playlistsStore.activePlaylistTracks.findIndex(t => t.uuid === item.uuid)}
-          {@const isItemPlaying = (playerStore.playlistItemUuid && playerStore.playlistItemUuid === item.uuid) || (playerStore.currentSong && item.song && playerStore.currentSong.id === item.song.id)}
-          <div
-            role="row"
-            tabindex="0"
-            onkeydown={(e) => {
-              if (e.key === 'Enter' && !unavailable) handlePlayPlaylistItem(item);
-            }}
-            data-playlist-row="true"
-            data-index={actualIndex}
-            onpointerdown={(e) => handleRowPointerDown(e, actualIndex, item)}
-            onclick={(e) => handleRowClick(e, item)}
-            oncontextmenu={(e) => handleContextMenu(e, item)}
-            ondblclick={() => !unavailable && !pointerDragJustEnded && handlePlayPlaylistItem(item)}
-            class="grid items-center py-2.5 px-4 group transition-all duration-150 select-none text-sm border-b border-brand-border/40
-              {unavailable
-                ? 'opacity-50 cursor-not-allowed'
-                : 'cursor-grab active:cursor-grabbing'}
-              {isSelected ? 'bg-brand-accent/20 text-brand-accent-text-hover' : 'hover:bg-brand-sidebar/40'}
-              {!unavailable && !isSelected && isItemPlaying ? 'bg-brand-accent/10 text-brand-accent-text-hover' : ''}
-              {dragOverIndex === actualIndex && draggedIndex !== null && draggedIndex !== actualIndex
-                ? (actualIndex < draggedIndex ? 'border-t-2! border-t-brand-accent bg-brand-accent/5' : 'border-b-2! border-b-brand-accent bg-brand-accent/5')
-                : ''
-              }"
-            style={gridColsStyle}
-          >
-            <div class="text-center text-brand-text-primary font-medium relative min-w-0 cursor-grab active:cursor-grabbing">
-              <div class="relative w-5 h-4 mx-auto flex items-center justify-center">
-                <GripVertical class="w-3.5 h-3.5 opacity-0 group-hover:opacity-60 text-brand-text-primary transition-opacity shrink-0 absolute -left-3 top-0.5 pointer-events-none" />
-                {#if isItemPlaying && playerStore.state === "playing"}
-                  <div class="flex items-center justify-center gap-0.5 h-4 w-4 absolute inset-0 group-hover:opacity-0 transition-opacity">
-                    <NowPlayingBars />
-                  </div>
-                {:else}
-                  <span class="absolute inset-0 flex items-center justify-center group-hover:opacity-0 transition-opacity">
-                    {actualIndex + 1}
-                  </span>
-                {/if}
-                <button
-                  onclick={(e) => { e.stopPropagation(); if (!unavailable) handlePlayPlaylistItem(item); }}
-                  class="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 text-brand-accent-text hover:text-brand-accent-text-hover transition-opacity disabled:opacity-0 disabled:cursor-not-allowed"
-                  disabled={unavailable}
-                  title={i18n.t("playlists.playTrack")}
-                >
-                  <Play class="w-4 h-4 fill-current" />
-                </button>
-              </div>
-            </div>
-
-            {#if collectionStore.visibleColumns.title}
-              <div class="font-medium truncate pr-4 min-w-0 {isSelected || (!unavailable && playerStore.playlistItemUuid === item.uuid) ? 'text-brand-accent-text-hover' : unavailable ? 'text-brand-text-primary' : 'text-brand-text-primary'}">
-                <div class="flex items-center gap-2 max-w-full">
-                  {#if trueUnavailable}
-                    <span title={i18n.t("playlists.fileNotFoundTooltip")}>
-                      <AlertTriangle class="w-3.5 h-3.5 shrink-0 text-amber-400/80" />
-                    </span>
-                    <span class="truncate line-through decoration-brand-text-secondary/40">
-                      {item.song?.title ?? i18n.t("collection.unknownSong")}
-                    </span>
-                  {:else if disconnected}
-                    <span title={i18n.t("collection.driveDisconnectedTooltip")}>
-                      <AlertTriangle class="w-3.5 h-3.5 shrink-0 text-amber-400/80" />
-                    </span>
-                    <span class="truncate">
-                      {item.song?.title ?? i18n.t("collection.unknownSong")}
-                    </span>
-                  {:else if item.song?.title}
-                    {#if isDuplicate}
-                      <span
-                        class="px-1.5 py-0.5 text-[10px] font-bold rounded bg-brand-accent/20 text-brand-accent-text border border-brand-accent/30 shrink-0"
-                        title={i18n.t("playlists.duplicateTrackFlag")}
-                      >
-                        {i18n.t("playlists.duplicateTrackFlag")}
-                      </span>
-                    {/if}
-                    <span
-                      class="truncate min-w-0 font-medium {playerStore.playlistItemUuid === item.uuid ? 'text-brand-accent-text-hover' : 'text-brand-text-primary'}"
-                      title={item.song.title}
-                    >
-                      {item.song.title}
-                    </span>
-                  {:else}
-                    <span class="truncate min-w-0">{i18n.t("collection.unknownSong")}</span>
-                  {/if}
-                </div>
-              </div>
-            {/if}
-
-            {#if collectionStore.visibleColumns.artist}
-              <div class="text-brand-text-primary truncate pr-4 flex items-center min-w-0">
-                {#if trueUnavailable}
-                  <span class="text-brand-text-primary italic text-xs">{i18n.t("playlists.fileNotFoundText")}</span>
-                {:else if disconnected}
-                  <span class="text-brand-text-primary italic text-xs">{i18n.t("collection.driveDisconnectedText")}</span>
-                {:else if item.song?.artist}
-                  {#each parseMultiValue(item.song.artist) as name, i (name)}
-                    {#if i > 0}<span class="text-brand-text-primary/50 shrink-0">,&nbsp;</span>{/if}
-                    <LinkButton
-                      onclick={(e) => { e.stopPropagation(); collectionStore.viewArtist(name); }}
-                      class="text-brand-text-primary truncate min-w-0"
-                      title={i18n.t("collection.filterByArtist", { artist: name })}
-                    >
-                      {name}
-                    </LinkButton>
-                  {/each}
-                {:else}
-                  <span class="text-brand-text-primary truncate min-w-0">{i18n.t("collection.unknownArtist")}</span>
-                {/if}
-              </div>
-            {/if}
-
-            {#if collectionStore.visibleColumns.album}
-              <div class="text-brand-text-primary truncate pr-4 min-w-0">
-                {#if unavailable}
-                  <span class="text-brand-text-primary italic text-xs truncate min-w-0">{item.song?.album ?? ""}</span>
-                {:else if item.song?.album}
-                  <LinkButton
-                    onclick={(e) => { e.stopPropagation(); collectionStore.viewAlbum(item.song?.album || ""); }}
-                    class="text-brand-text-primary truncate min-w-0"
-                    title={i18n.t("collection.filterByAlbum", { album: item.song.album })}
-                  >
-                    {item.song.album}
-                  </LinkButton>
-                {:else}
-                  <span class="text-brand-text-primary truncate min-w-0">{i18n.t("collection.unknownAlbum")}</span>
-                {/if}
-              </div>
-            {/if}
-
-            {#if collectionStore.visibleColumns.composer}
-              <div class="text-brand-text-primary truncate pr-4 min-w-0 text-xs font-medium" title={item.song?.composer}>
-                {item.song?.composer || "—"}
-              </div>
-            {/if}
-            {#if collectionStore.visibleColumns.album_artist}
-              <div class="text-brand-text-primary truncate pr-4 min-w-0 text-xs font-medium" title={item.song?.album_artist}>
-                {item.song?.album_artist || "—"}
-              </div>
-            {/if}
-            {#if collectionStore.visibleColumns.format}
-              <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-semibold uppercase">
-                {item.song?.filetype ? item.song.filetype.toUpperCase() : "—"}
-              </div>
-            {/if}
-            {#if collectionStore.visibleColumns.year}
-              <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium">
-                {item.song?.year || "—"}
-              </div>
-            {/if}
-            {#if collectionStore.visibleColumns.genre}
-              <div class="truncate pr-2 min-w-0" title={item.song?.genre}>
-                {#if item.song?.genre}
-                  <GenreChips genre={item.song.genre} />
-                {:else}
-                  <span class="text-brand-text-secondary text-xs font-medium">—</span>
-                {/if}
-              </div>
-            {/if}
-            {#if collectionStore.visibleColumns.grouping}
-              <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium" title={item.song?.grouping}>
-                {item.song?.grouping || "—"}
-              </div>
-            {/if}
-            {#if collectionStore.visibleColumns.bpm}
-              <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium">
-                {item.song?.bpm || "—"}
-              </div>
-            {/if}
-            {#if collectionStore.visibleColumns.initial_key}
-              <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium">
-                {item.song?.initial_key || "—"}
-              </div>
-            {/if}
-            {#if collectionStore.visibleColumns.bitrate}
-              <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium">
-                {item.song?.bitrate ? `${item.song.bitrate}k` : "—"}
-              </div>
-            {/if}
-            {#if collectionStore.visibleColumns.samplerate}
-              <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium">
-                {formatSampleRate(item.song?.samplerate)}
-              </div>
-            {/if}
-            {#if collectionStore.visibleColumns.bitdepth}
-              <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium">
-                {formatBitDepth(item.song?.bitdepth)}
-              </div>
-            {/if}
-            {#if collectionStore.visibleColumns.channels}
-              <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium">
-                {formatChannels(item.song?.channels)}
-              </div>
-            {/if}
-            {#if collectionStore.visibleColumns.filesize}
-              <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium">
-                {formatFileSize(item.song?.filesize)}
-              </div>
-            {/if}
-            {#if collectionStore.visibleColumns.rating}
-              <div class="flex justify-center min-w-0" onclick={(e) => e.stopPropagation()} role="presentation">
-                {#if item.song && !unavailable}
-                  <SongRating rating={item.song.rating} onRate={(r) => rateItem(item, r)} />
-                {/if}
-              </div>
-            {/if}
-            {#if collectionStore.visibleColumns.playcount}
-              <div class="text-center text-brand-text-primary text-xs min-w-0">
-                {item.song?.playcount || 0}
-              </div>
-            {/if}
-            {#if collectionStore.visibleColumns.skipcount}
-              <div class="text-center text-brand-text-primary text-xs min-w-0">
-                {item.song?.skipcount || 0}
-              </div>
-            {/if}
-            {#if collectionStore.visibleColumns.lastplayed}
-              <div class="text-center text-brand-text-primary text-xs whitespace-nowrap">
-                {formatDate(item.song?.lastplayed)}
-              </div>
-            {/if}
-            {#if collectionStore.visibleColumns.added}
-              <div class="text-center text-brand-text-primary text-xs whitespace-nowrap">
-                {formatDateAdded(item.song?.added)}
-              </div>
-            {/if}
-            {#if collectionStore.visibleColumns.duration}
-              <div class="text-center text-brand-text-primary text-xs min-w-0">
-                {formatDuration(item.song?.length_nanosec)}
-              </div>
-            {/if}
-            {#if collectionStore.visibleColumns.path}
-              <div class="text-brand-text-primary truncate pr-4 min-w-0 text-xs font-medium" title={item.song?.path}>
-                {item.song?.path || "—"}
-              </div>
-            {/if}
-
-            {#if collectionStore.visibleColumns.actions}
-              <div class="text-center min-w-0">
-                <div class="flex items-center justify-center gap-2.5">
-                  <button
-                    onclick={(e) => { e.stopPropagation(); item.song?.id && !unavailable && openTagEditor(item.song.id); }}
-                    class="text-brand-text-primary/60 hover:text-brand-accent-text transition-colors disabled:opacity-30"
-                    title={i18n.t("collection.editTagsTooltip")}
-                    disabled={!item.song || unavailable}
-                  >
-                    <Edit3 class="w-4 h-4" />
-                  </button>
-                  <button
-                    onclick={(e) => { e.stopPropagation(); handleRemoveItem(item.uuid); }}
-                    class="text-brand-text-primary/60 hover:text-red-400 transition-colors"
-                    title={i18n.t("playlists.removeFromPlaylist")}
-                  >
-                    <Trash2 class="w-4 h-4" />
-                  </button>
-                </div>
-              </div>
-            {/if}
-          </div>
-        {/each}
-
-        {#if filteredTracks.length === 0}
-          <div class="py-12 text-center text-brand-text-primary/45 select-none">
-            <ListMusic class="w-12 h-12 mx-auto mb-2 text-brand-text-primary/30" />
-            {#if filterQuery}
-              {i18n.t("playlists.noFilterResults", { query: filterQuery })}
-            {:else if isQueue}
-              {i18n.t("playlists.emptyQueueText")}
-            {:else}
-              {i18n.t("playlists.emptyPlaylistTitle")}
-            {/if}
-          </div>
-        {/if}
+        <SongTable
+          rows={tableRows}
+          rangeSelectionOrder={rangeSelectionRows}
+          mode="position"
+          leadingColumnWidth="48px"
+          colDefaults={PLAYLIST_COL_DEFAULTS}
+          {sortField}
+          {sortAsc}
+          onToggleSort={toggleSort}
+          positionSortField="position"
+          bind:selectedKeys={selectedUuids}
+          emptyState={playlistEmptyState}
+          onRowDoubleClick={(row) => activePlaylist && playerStore.playPlaylistItemByUuid(activePlaylist.id, row.key)}
+          onRowContextMenu={handleRowContextMenu}
+          onRate={rateSong}
+          onEditTags={(song) => openTagEditor(song.id)}
+          onRemoveFromPlaylist={(row) => handleRemoveItem(row.key)}
+          onReorder={handleReorder}
+          isRowPlaying={(row) => (!!playerStore.playlistItemUuid && playerStore.playlistItemUuid === row.key) || (!!playerStore.currentSong && !!row.song && playerStore.currentSong.id === row.song.id)}
+          interactiveWhenDisabled
+          disabledPlaceholder
+        />
       </div>
     </div>
-  </div>
   </div>
 
     {#if selectedUuids.size > 0}
@@ -1580,7 +872,7 @@
         </button>
         <div class="h-4 w-px bg-brand-border/60"></div>
         <button
-          onclick={() => { selectedUuids = new Set(); lastSelectedIndex = null; }}
+          onclick={() => { selectedUuids = new Set(); }}
           class="text-brand-text-primary hover:text-brand-text-primary transition-colors"
         >
           {i18n.t("playlists.clearSelection")}

--- a/src/lib/components/PlaylistView.test.ts
+++ b/src/lib/components/PlaylistView.test.ts
@@ -145,12 +145,12 @@ describe("PlaylistView.svelte", () => {
 
   it("handles pointer-based drag reordering of playlist items", async () => {
     // Tauri's dragDropEnabled window option blocks native HTML5 drag events, so reordering
-    // is implemented with pointer events instead (see PlaylistView.svelte handleRowPointerDown).
+    // is implemented with pointer events instead (see SongTable.svelte handleRowPointerDown).
     const reorderSpy = vi.spyOn(playlistsStore, "reorderItemByUuid");
     const { getByText } = render(PlaylistView);
 
-    const rowOne = getByText("Track One").closest("[data-playlist-row]")! as HTMLElement;
-    const rowThree = getByText("Track Three").closest("[data-playlist-row]")! as HTMLElement;
+    const rowOne = getByText("Track One").closest("[data-song-row]")! as HTMLElement;
+    const rowThree = getByText("Track Three").closest("[data-song-row]")! as HTMLElement;
 
     document.elementFromPoint = vi.fn().mockReturnValue(rowThree);
 
@@ -166,8 +166,8 @@ describe("PlaylistView.svelte", () => {
     const reorderSpy = vi.spyOn(playlistsStore, "reorderItemByUuid");
     const { getByText } = render(PlaylistView);
 
-    const rowOne = getByText("Track One").closest("[data-playlist-row]")! as HTMLElement;
-    const rowThree = getByText("Track Three").closest("[data-playlist-row]")! as HTMLElement;
+    const rowOne = getByText("Track One").closest("[data-song-row]")! as HTMLElement;
+    const rowThree = getByText("Track Three").closest("[data-song-row]")! as HTMLElement;
 
     const elementFromPointMock = vi.fn().mockReturnValue(rowThree);
     document.elementFromPoint = elementFromPointMock;
@@ -247,8 +247,8 @@ describe("PlaylistView.svelte", () => {
   it("handles multi-selection with Shift+Click and shows batch floating bar", async () => {
     const { getByText, queryByText } = render(PlaylistView);
 
-    const rowOne = getByText("Track One").closest("[data-playlist-row]")!;
-    const rowThree = getByText("Track Three").closest("[data-playlist-row]")!;
+    const rowOne = getByText("Track One").closest("[data-song-row]")!;
+    const rowThree = getByText("Track Three").closest("[data-song-row]")!;
 
     await fireEvent.click(rowOne);
     await fireEvent.click(rowThree, { shiftKey: true });
@@ -264,7 +264,7 @@ describe("PlaylistView.svelte", () => {
 
   it("opens context menu on right-click", async () => {
     const { getByText, getAllByText } = render(PlaylistView);
-    const rowOne = getByText("Track One").closest("[data-playlist-row]")!;
+    const rowOne = getByText("Track One").closest("[data-song-row]")!;
 
     await fireEvent.contextMenu(rowOne);
 

--- a/src/lib/components/SongTable.svelte
+++ b/src/lib/components/SongTable.svelte
@@ -26,11 +26,13 @@
   import { parseMultiValue } from "../utils/multiValue";
   import { SONG_TABLE_COLUMNS } from "../utils/songColumns";
   import { columnResize } from "../utils/columnResize";
+  import { watchScrollMemory } from "../utils/scrollMemory";
   import type { VisibleColumns } from "../stores/collection.svelte";
   import SortableHeader from "./SortableHeader.svelte";
   import SongRating from "./SongRating.svelte";
   import GenreChips from "./GenreChips.svelte";
   import LinkButton from "./LinkButton.svelte";
+  import CoverArt from "./CoverArt.svelte";
   import NowPlayingBars from "./NowPlayingBars.svelte";
   import EmptyState from "./EmptyState.svelte";
   import { Play, Plus, Edit3, Trash2, GripVertical, AlertTriangle, Music, Clock } from "lucide-svelte";
@@ -69,6 +71,8 @@
     /** When set, position rows show a drag handle and pointer-based reorder is enabled (PlaylistView only). */
     onReorder?: (fromIndex: number, toIndex: number, selectedKeys: string[]) => void;
     virtualized?: boolean;
+    /** Persists/restores virtualized scroll position — only used when `virtualized` is true. */
+    scrollMemoryKey?: string;
   }
 
   let {
@@ -92,6 +96,7 @@
     onEditTags,
     onReorder,
     virtualized = false,
+    scrollMemoryKey,
   }: Props = $props();
 
   let lastSelectedKey = $state<string | null>(null);
@@ -99,6 +104,36 @@
     const m = new Map<string, number>();
     rows.forEach((r, i) => m.set(r.key, i));
     return m;
+  });
+
+  // The virtualized body's <svelte-virtual-list-viewport> reserves layout
+  // width for its own scrollbar; the sticky header sits outside that
+  // viewport and doesn't. On platforms with a non-overlay scrollbar (e.g.
+  // Windows), that gutter makes the header's grid track a few pixels wider
+  // than the rows' grid track, misaligning every column after the ones that
+  // can absorb it. Measure the actual scrollbar width and pad the header by
+  // the same amount so both grids compute identical track widths.
+  let bodyContainer = $state<HTMLDivElement | undefined>(undefined);
+  let scrollbarWidth = $state(0);
+
+  $effect(() => {
+    if (!virtualized || !bodyContainer) return;
+    const viewport = bodyContainer.querySelector<HTMLElement>("svelte-virtual-list-viewport");
+    if (!viewport) return;
+    const update = () => {
+      scrollbarWidth = viewport.offsetWidth - viewport.clientWidth;
+    };
+    update();
+    const observer = new ResizeObserver(update);
+    observer.observe(viewport);
+    return () => observer.disconnect();
+  });
+
+  $effect(() => {
+    if (!virtualized || !scrollMemoryKey || !bodyContainer) return;
+    const viewport = bodyContainer.querySelector<HTMLElement>("svelte-virtual-list-viewport");
+    if (!viewport) return;
+    return watchScrollMemory(viewport, scrollMemoryKey);
   });
 
   let orderForRange = $derived(rangeSelectionOrder ?? rows);
@@ -304,12 +339,22 @@
 
 {#snippet bodyCell(col: (typeof SONG_TABLE_COLUMNS)[number], song: Song, row: SongTableRow)}
   {#if col.key === "track"}
-    <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium">
+    <div class="text-brand-text-secondary truncate pr-2 min-w-0 text-xs font-medium">
       {formatTrackNumber(song.track, song.disc, discCount, keyIndex.get(row.key) ?? 0)}
     </div>
   {:else if col.key === "title"}
     <div class="font-medium truncate pr-4 flex items-center gap-2 min-w-0">
-      <span class="truncate {playerStore.currentSong && playerStore.currentSong.id === song.id ? 'text-brand-accent-text-hover' : 'text-brand-text-primary'} {row.disabledVariant === 'strikethrough' && rowDisabled(row) ? 'line-through' : ''}">
+      <CoverArt
+        songId={song.id}
+        artEmbedded={song.art_embedded}
+        artAutomatic={song.art_automatic}
+        artManual={song.art_manual}
+        sizeClass="w-7 h-7 rounded shrink-0"
+      />
+      <span
+        class="truncate text-brand-text-primary {row.disabledVariant === 'strikethrough' && rowDisabled(row) ? 'line-through' : ''}"
+        title={song.title || i18n.t("collection.unknownSong")}
+      >
         {song.title || i18n.t("collection.unknownSong")}
       </span>
       {#if row.disabledVariant === "strikethrough" && rowDisabled(row)}
@@ -317,40 +362,50 @@
       {/if}
     </div>
   {:else if col.key === "artist"}
-    <div class="text-brand-text-primary truncate pr-4 flex items-center min-w-0">
+    <div class="text-brand-text-secondary truncate pr-4 flex items-center min-w-0">
       {#if song.artist}
         {#each parseMultiValue(song.artist) as name, i (name)}
-          {#if i > 0}<span class="text-brand-text-primary/50 shrink-0">,&nbsp;</span>{/if}
+          {#if i > 0}<span class="text-brand-text-secondary/50 shrink-0">,&nbsp;</span>{/if}
           <LinkButton
             onclick={(e) => { e.stopPropagation(); collectionStore.viewArtist(name); }}
-            class="text-brand-text-primary truncate min-w-0"
+            class="text-brand-text-secondary truncate min-w-0"
             title={i18n.t("collection.filterByArtist", { artist: name })}
           >
             {name}
           </LinkButton>
         {/each}
       {:else}
-        <span class="text-brand-text-primary truncate min-w-0">{i18n.t("collection.unknownArtist")}</span>
+        <span class="text-brand-text-secondary truncate min-w-0">{i18n.t("collection.unknownArtist")}</span>
       {/if}
     </div>
   {:else if col.key === "album"}
-    <div class="text-brand-text-primary truncate pr-4 min-w-0 text-xs font-medium">
-      {song.album || i18n.t("collection.unknownAlbum")}
+    <div class="text-brand-text-secondary truncate pr-4 flex items-center min-w-0">
+      {#if song.album}
+        <LinkButton
+          onclick={(e) => { e.stopPropagation(); collectionStore.viewAlbum(song.album || ""); }}
+          class="text-brand-text-secondary truncate min-w-0"
+          title={i18n.t("collection.filterByAlbum", { album: song.album })}
+        >
+          {song.album}
+        </LinkButton>
+      {:else}
+        <span class="text-brand-text-secondary truncate min-w-0">{i18n.t("collection.unknownAlbum")}</span>
+      {/if}
     </div>
   {:else if col.key === "composer"}
-    <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium" title={song.composer}>
+    <div class="text-brand-text-secondary truncate pr-2 min-w-0 text-xs font-medium" title={song.composer}>
       {song.composer || "—"}
     </div>
   {:else if col.key === "album_artist"}
-    <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium" title={song.album_artist}>
+    <div class="text-brand-text-secondary truncate pr-2 min-w-0 text-xs font-medium" title={song.album_artist}>
       {song.album_artist || "—"}
     </div>
   {:else if col.key === "format"}
-    <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-semibold uppercase">
+    <div class="text-brand-text-secondary truncate pr-2 min-w-0 text-xs font-semibold uppercase">
       {song.filetype ? song.filetype.toUpperCase() : "—"}
     </div>
   {:else if col.key === "year"}
-    <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium">
+    <div class="text-brand-text-secondary truncate pr-2 min-w-0 text-xs font-medium">
       {song.year || "—"}
     </div>
   {:else if col.key === "genre"}
@@ -362,35 +417,35 @@
       {/if}
     </div>
   {:else if col.key === "grouping"}
-    <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium" title={song.grouping}>
+    <div class="text-brand-text-secondary truncate pr-2 min-w-0 text-xs font-medium" title={song.grouping}>
       {song.grouping || "—"}
     </div>
   {:else if col.key === "bpm"}
-    <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium">
+    <div class="text-brand-text-secondary truncate pr-2 min-w-0 text-xs font-medium">
       {song.bpm || "—"}
     </div>
   {:else if col.key === "initial_key"}
-    <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium">
+    <div class="text-brand-text-secondary truncate pr-2 min-w-0 text-xs font-medium">
       {song.initial_key || "—"}
     </div>
   {:else if col.key === "bitrate"}
-    <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium">
+    <div class="text-brand-text-secondary truncate pr-2 min-w-0 text-xs font-medium">
       {song.bitrate ? `${song.bitrate}k` : "—"}
     </div>
   {:else if col.key === "samplerate"}
-    <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium">
+    <div class="text-brand-text-secondary truncate pr-2 min-w-0 text-xs font-medium">
       {formatSampleRate(song.samplerate)}
     </div>
   {:else if col.key === "bitdepth"}
-    <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium">
+    <div class="text-brand-text-secondary truncate pr-2 min-w-0 text-xs font-medium">
       {formatBitDepth(song.bitdepth)}
     </div>
   {:else if col.key === "channels"}
-    <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium">
+    <div class="text-brand-text-secondary truncate pr-2 min-w-0 text-xs font-medium">
       {formatChannels(song.channels)}
     </div>
   {:else if col.key === "filesize"}
-    <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium">
+    <div class="text-brand-text-secondary truncate pr-2 min-w-0 text-xs font-medium">
       {formatFileSize(song.filesize)}
     </div>
   {:else if col.key === "rating"}
@@ -398,27 +453,27 @@
       <SongRating rating={song.rating} onRate={(r) => onRate(song, r)} />
     </div>
   {:else if col.key === "playcount"}
-    <div class="text-center text-brand-text-primary font-medium">
+    <div class="text-center text-brand-text-secondary font-medium text-xs">
       {song.playcount ?? 0}
     </div>
   {:else if col.key === "skipcount"}
-    <div class="text-center text-brand-text-primary font-medium text-xs">
+    <div class="text-center text-brand-text-secondary font-medium text-xs">
       {song.skipcount ?? 0}
     </div>
   {:else if col.key === "lastplayed"}
-    <div class="text-center text-brand-text-primary text-xs whitespace-nowrap">
+    <div class="text-center text-brand-text-secondary text-xs whitespace-nowrap">
       {formatDate(song.lastplayed)}
     </div>
   {:else if col.key === "added"}
-    <div class="text-center text-brand-text-primary text-xs whitespace-nowrap">
+    <div class="text-center text-brand-text-secondary text-xs whitespace-nowrap">
       {formatDateAdded(song.added)}
     </div>
   {:else if col.key === "duration"}
-    <div class="text-center text-brand-text-primary text-xs font-medium">
+    <div class="text-center text-brand-text-secondary text-xs font-medium">
       {formatDuration(song.length_nanosec)}
     </div>
   {:else if col.key === "path"}
-    <div class="text-brand-text-primary truncate pr-4 min-w-0 text-xs font-medium" title={song.path}>
+    <div class="text-brand-text-secondary truncate pr-4 min-w-0 text-xs font-medium" title={song.path}>
       {song.path || "—"}
     </div>
   {:else if col.key === "actions"}
@@ -426,7 +481,7 @@
       {#if onAddToPlaylist}
         <button
           onclick={() => onAddToPlaylist?.(song)}
-          class="text-brand-text-primary hover:text-brand-accent-text transition-colors"
+          class="text-brand-text-secondary hover:text-brand-accent-text transition-colors"
           title={i18n.t("collection.addPlaylistTooltipDefault")}
         >
           <Plus class="w-4 h-4" />
@@ -434,7 +489,7 @@
       {/if}
       <button
         onclick={() => onEditTags(song)}
-        class="text-brand-text-primary hover:text-brand-accent-text transition-colors"
+        class="text-brand-text-secondary hover:text-brand-accent-text transition-colors"
         title={i18n.t("collection.editTagsTooltip")}
       >
         <Edit3 class="w-4 h-4" />
@@ -442,7 +497,7 @@
       {#if onRemoveFromPlaylist}
         <button
           onclick={() => onRemoveFromPlaylist?.(row)}
-          class="text-brand-text-primary hover:text-red-400 transition-colors"
+          class="text-brand-text-secondary hover:text-red-400 transition-colors"
           title={i18n.t("playlists.removeFromPlaylist")}
         >
           <Trash2 class="w-4 h-4" />
@@ -495,11 +550,11 @@
     onpointerdown={(e) => handleRowPointerDown(e, row)}
     style={gridColsStyle}
     title={row.disabledTooltip}
-    class="grid items-center hover:bg-brand-sidebar/40 group transition-colors py-2 px-4 text-sm
+    class="grid items-center border-b border-brand-border/40 hover:bg-brand-sidebar/40 group transition-colors py-2.5 px-4 text-sm
       {disabled ? 'opacity-50 cursor-not-allowed' : ''}
       {onReorder ? 'cursor-grab active:cursor-grabbing' : ''}
       {draggedIndex !== null && dragOverIndex === row.underlyingIndex ? 'border-t-2! border-brand-accent' : ''}
-      {selectedKeys.has(row.key) ? 'bg-brand-accent/20 border-l-2 border-brand-accent text-brand-accent-text-hover' : (song && playerStore.currentSong && playerStore.currentSong.id === song.id ? 'bg-brand-accent/10 text-brand-accent-text-hover' : '')}"
+      {selectedKeys.has(row.key) ? 'bg-brand-accent/20 border-l-2 border-brand-accent text-brand-accent-text-hover' : (song && playerStore.currentSong && playerStore.currentSong.id === song.id ? 'bg-brand-accent/10' : '')}"
   >
     {@render leadingCell(row, displayIndex)}
     {#if song}
@@ -512,8 +567,8 @@
   </div>
 {/snippet}
 
-<div class="sticky top-0 z-10 flex flex-col rounded-t-lg bg-brand-sidebar/80 backdrop-blur-md border-b border-brand-border text-[10px] text-brand-text-primary uppercase tracking-wider font-semibold select-none">
-  <div class="grid items-center py-2.5 px-4" style={gridColsStyle}>
+<div class="sticky top-0 z-10 flex flex-col rounded-t-lg bg-brand-sidebar border-b border-brand-border text-xs text-brand-text-secondary uppercase tracking-wider font-semibold select-none">
+  <div class="grid items-center py-3 px-4" style="{gridColsStyle}{virtualized ? `; padding-right: calc(1rem + ${scrollbarWidth}px)` : ''}">
     <div class="text-center w-9"></div>
     {#each SONG_TABLE_COLUMNS as col (col.key)}
       {#if !(mode === "position" && col.key === "track") && collectionStore.visibleColumns[col.key]}
@@ -525,7 +580,8 @@
 
 <!-- svelte-ignore a11y_no_static_element_interactions -->
 <div
-  class="divide-y divide-brand-border/40 rounded-b-lg overflow-hidden"
+  bind:this={bodyContainer}
+  class="rounded-b-lg overflow-hidden"
   onpointermove={handlePointerDragMove}
   onpointerup={handlePointerDragUp}
 >

--- a/src/lib/components/SongTable.svelte
+++ b/src/lib/components/SongTable.svelte
@@ -8,7 +8,7 @@
     song: Song | undefined;
     disabled?: boolean;
     disabledTooltip?: string;
-    /** "dim" (default) just lowers opacity; "strikethrough" also strikes the title and shows a warning icon (PlaylistView's unavailable/disconnected treatment). */
+    /** "dim" (default) just lowers row opacity; "strikethrough" also strikes the title text. A warning icon shows in the title cell whenever the row is disabled, regardless of variant. */
     disabledVariant?: "dim" | "strikethrough";
     isDuplicate?: boolean;
     /** Position of this row in the caller's underlying (unfiltered) order — required when `onReorder` is provided. */
@@ -74,6 +74,18 @@
     onReorder?: (fromIndex: number, toIndex: number, selectedKeys: string[]) => void;
     /** When set in "position" mode, the leading column header becomes a sortable control for this field instead of a plain label. */
     positionSortField?: string;
+    /** When true, disabled rows stay selectable/right-clickable (PlaylistView, so an unavailable track can still be selected and removed) — only play/double-click and drag stay blocked. */
+    interactiveWhenDisabled?: boolean;
+    /** When true, disabled rows show `disabledTooltip` in place of the artist/album cell content instead of the song's real (possibly stale) values (PlaylistView). */
+    disabledPlaceholder?: boolean;
+    /**
+     * Overrides how a row is identified as "currently playing" — defaults to
+     * matching `song.id` against `playerStore.currentSong`. PlaylistView
+     * needs the more precise `playerStore.playlistItemUuid` match too, since
+     * the same song can appear more than once in a playlist and only one
+     * instance is actually playing.
+     */
+    isRowPlaying?: (row: SongTableRow) => boolean;
     virtualized?: boolean;
     /** Persists/restores virtualized scroll position — only used when `virtualized` is true. */
     scrollMemoryKey?: string;
@@ -101,9 +113,17 @@
     onEditAlbum,
     onReorder,
     positionSortField,
+    interactiveWhenDisabled = false,
+    disabledPlaceholder = false,
+    isRowPlaying,
     virtualized = false,
     scrollMemoryKey,
   }: Props = $props();
+
+  function rowIsPlaying(row: SongTableRow): boolean {
+    if (isRowPlaying) return isRowPlaying(row);
+    return !!row.song && !!playerStore.currentSong && playerStore.currentSong.id === row.song.id;
+  }
 
   let lastSelectedKey = $state<string | null>(null);
   let keyIndex = $derived.by(() => {
@@ -227,7 +247,7 @@
   }
 
   function handleRowPointerDown(e: PointerEvent, row: SongTableRow) {
-    if (!onReorder || row.underlyingIndex === undefined) return;
+    if (!onReorder || row.underlyingIndex === undefined || row.disabled) return;
     const target = e.target as HTMLElement;
     if (target.closest("button, a, input, select, textarea, [data-interactive]")) return;
     if (e.button !== 0) return;
@@ -235,7 +255,13 @@
     pointerDragStartX = e.clientX;
     pointerDragStartY = e.clientY;
     draggedIndex = row.underlyingIndex;
-    (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+    // With the window's dragDropEnabled option on, WebView2 can hijack an in-progress mouse
+    // gesture into a native OS drag once it crosses the platform's drag threshold, silently
+    // stopping pointermove/pointerup from reaching the DOM. Explicit pointer capture pins
+    // subsequent events to this element (and this JS event loop) instead, preventing that.
+    (e.currentTarget as HTMLElement).setPointerCapture?.(e.pointerId);
+    window.addEventListener("pointermove", handlePointerDragMove);
+    window.addEventListener("pointerup", handlePointerDragUp);
   }
 
   function handlePointerDragMove(e: PointerEvent) {
@@ -252,6 +278,8 @@
   }
 
   function handlePointerDragUp() {
+    window.removeEventListener("pointermove", handlePointerDragMove);
+    window.removeEventListener("pointerup", handlePointerDragUp);
     if (pointerDragArmed && dragOverIndex !== null) {
       commitReorder(dragOverIndex);
     }
@@ -317,6 +345,12 @@
   function rowDisabled(row: SongTableRow): boolean {
     return !!row.disabled;
   }
+
+  // Body cells use primary text throughout — secondary was too low-contrast
+  // to read comfortably.
+  function secondaryColor(_song: Song): string {
+    return "text-brand-text-primary";
+  }
 </script>
 
 {#snippet headerCell(col: (typeof SONG_TABLE_COLUMNS)[number])}
@@ -345,7 +379,7 @@
 
 {#snippet bodyCell(col: (typeof SONG_TABLE_COLUMNS)[number], song: Song, row: SongTableRow)}
   {#if col.key === "track"}
-    <div class="text-brand-text-secondary truncate pr-2 min-w-0 text-xs font-medium">
+    <div class="{secondaryColor(song)} truncate pr-2 min-w-0 text-xs font-medium">
       {formatTrackNumber(song.track, song.disc, discCount, keyIndex.get(row.key) ?? 0)}
     </div>
   {:else if col.key === "title"}
@@ -357,61 +391,75 @@
         artManual={song.art_manual}
         sizeClass="w-7 h-7 rounded shrink-0"
       />
+      {#if rowDisabled(row)}
+        <span title={row.disabledTooltip}>
+          <AlertTriangle class="w-3.5 h-3.5 shrink-0 text-amber-400/80" />
+        </span>
+      {/if}
+      {#if row.isDuplicate}
+        <span
+          class="px-1.5 py-0.5 text-[10px] font-bold rounded bg-brand-accent/20 text-brand-accent-text border border-brand-accent/30 shrink-0"
+          title={i18n.t("playlists.duplicateTrackFlag")}
+        >
+          {i18n.t("playlists.duplicateTrackFlag")}
+        </span>
+      {/if}
       <span
         class="truncate text-brand-text-primary {row.disabledVariant === 'strikethrough' && rowDisabled(row) ? 'line-through' : ''}"
         title={song.title || i18n.t("collection.unknownSong")}
       >
         {song.title || i18n.t("collection.unknownSong")}
       </span>
-      {#if row.disabledVariant === "strikethrough" && rowDisabled(row)}
-        <AlertTriangle class="w-3.5 h-3.5 shrink-0 text-amber-500" />
-      {/if}
     </div>
   {:else if col.key === "artist"}
-    <div class="text-brand-text-secondary truncate pr-4 flex items-center min-w-0">
-      {#if song.artist}
+    <div class="{secondaryColor(song)} truncate pr-4 flex items-center min-w-0">
+      {#if disabledPlaceholder && rowDisabled(row)}
+        <span class="text-brand-text-secondary italic text-xs">{row.disabledTooltip}</span>
+      {:else if song.artist}
         {#each parseMultiValue(song.artist) as name, i (name)}
-          {#if i > 0}<span class="text-brand-text-secondary/50 shrink-0">,&nbsp;</span>{/if}
+          {#if i > 0}<span class="{secondaryColor(song)}/50 shrink-0">,&nbsp;</span>{/if}
           <LinkButton
             onclick={(e) => { e.stopPropagation(); collectionStore.viewArtist(name); }}
-            class="text-brand-text-secondary truncate min-w-0"
+            class="{secondaryColor(song)} truncate min-w-0"
             title={i18n.t("collection.filterByArtist", { artist: name })}
           >
             {name}
           </LinkButton>
         {/each}
       {:else}
-        <span class="text-brand-text-secondary truncate min-w-0">{i18n.t("collection.unknownArtist")}</span>
+        <span class="{secondaryColor(song)} truncate min-w-0">{i18n.t("collection.unknownArtist")}</span>
       {/if}
     </div>
   {:else if col.key === "album"}
-    <div class="text-brand-text-secondary truncate pr-4 flex items-center min-w-0">
-      {#if song.album}
+    <div class="{secondaryColor(song)} truncate pr-4 flex items-center min-w-0">
+      {#if disabledPlaceholder && rowDisabled(row)}
+        <span class="text-brand-text-secondary italic text-xs">{song.album ?? ""}</span>
+      {:else if song.album}
         <LinkButton
           onclick={(e) => { e.stopPropagation(); collectionStore.viewAlbum(song.album || ""); }}
-          class="text-brand-text-secondary truncate min-w-0"
+          class="{secondaryColor(song)} truncate min-w-0"
           title={i18n.t("collection.filterByAlbum", { album: song.album })}
         >
           {song.album}
         </LinkButton>
       {:else}
-        <span class="text-brand-text-secondary truncate min-w-0">{i18n.t("collection.unknownAlbum")}</span>
+        <span class="{secondaryColor(song)} truncate min-w-0">{i18n.t("collection.unknownAlbum")}</span>
       {/if}
     </div>
   {:else if col.key === "composer"}
-    <div class="text-brand-text-secondary truncate pr-2 min-w-0 text-xs font-medium" title={song.composer}>
+    <div class="{secondaryColor(song)} truncate pr-2 min-w-0 text-xs font-medium" title={song.composer}>
       {song.composer || "—"}
     </div>
   {:else if col.key === "album_artist"}
-    <div class="text-brand-text-secondary truncate pr-2 min-w-0 text-xs font-medium" title={song.album_artist}>
+    <div class="{secondaryColor(song)} truncate pr-2 min-w-0 text-xs font-medium" title={song.album_artist}>
       {song.album_artist || "—"}
     </div>
   {:else if col.key === "format"}
-    <div class="text-brand-text-secondary truncate pr-2 min-w-0 text-xs font-semibold uppercase">
+    <div class="{secondaryColor(song)} truncate pr-2 min-w-0 text-xs font-semibold uppercase">
       {song.filetype ? song.filetype.toUpperCase() : "—"}
     </div>
   {:else if col.key === "year"}
-    <div class="text-brand-text-secondary truncate pr-2 min-w-0 text-xs font-medium">
+    <div class="{secondaryColor(song)} truncate pr-2 min-w-0 text-xs font-medium">
       {song.year || "—"}
     </div>
   {:else if col.key === "genre"}
@@ -419,39 +467,39 @@
       {#if song.genre}
         <GenreChips genre={song.genre} />
       {:else}
-        <span class="text-brand-text-secondary text-xs font-medium">—</span>
+        <span class="{secondaryColor(song)} text-xs font-medium">—</span>
       {/if}
     </div>
   {:else if col.key === "grouping"}
-    <div class="text-brand-text-secondary truncate pr-2 min-w-0 text-xs font-medium" title={song.grouping}>
+    <div class="{secondaryColor(song)} truncate pr-2 min-w-0 text-xs font-medium" title={song.grouping}>
       {song.grouping || "—"}
     </div>
   {:else if col.key === "bpm"}
-    <div class="text-brand-text-secondary truncate pr-2 min-w-0 text-xs font-medium">
+    <div class="{secondaryColor(song)} truncate pr-2 min-w-0 text-xs font-medium">
       {song.bpm || "—"}
     </div>
   {:else if col.key === "initial_key"}
-    <div class="text-brand-text-secondary truncate pr-2 min-w-0 text-xs font-medium">
+    <div class="{secondaryColor(song)} truncate pr-2 min-w-0 text-xs font-medium">
       {song.initial_key || "—"}
     </div>
   {:else if col.key === "bitrate"}
-    <div class="text-brand-text-secondary truncate pr-2 min-w-0 text-xs font-medium">
+    <div class="{secondaryColor(song)} truncate pr-2 min-w-0 text-xs font-medium">
       {song.bitrate ? `${song.bitrate}k` : "—"}
     </div>
   {:else if col.key === "samplerate"}
-    <div class="text-brand-text-secondary truncate pr-2 min-w-0 text-xs font-medium">
+    <div class="{secondaryColor(song)} truncate pr-2 min-w-0 text-xs font-medium">
       {formatSampleRate(song.samplerate)}
     </div>
   {:else if col.key === "bitdepth"}
-    <div class="text-brand-text-secondary truncate pr-2 min-w-0 text-xs font-medium">
+    <div class="{secondaryColor(song)} truncate pr-2 min-w-0 text-xs font-medium">
       {formatBitDepth(song.bitdepth)}
     </div>
   {:else if col.key === "channels"}
-    <div class="text-brand-text-secondary truncate pr-2 min-w-0 text-xs font-medium">
+    <div class="{secondaryColor(song)} truncate pr-2 min-w-0 text-xs font-medium">
       {formatChannels(song.channels)}
     </div>
   {:else if col.key === "filesize"}
-    <div class="text-brand-text-secondary truncate pr-2 min-w-0 text-xs font-medium">
+    <div class="{secondaryColor(song)} truncate pr-2 min-w-0 text-xs font-medium">
       {formatFileSize(song.filesize)}
     </div>
   {:else if col.key === "rating"}
@@ -459,27 +507,27 @@
       <SongRating rating={song.rating} onRate={(r) => onRate(song, r)} />
     </div>
   {:else if col.key === "playcount"}
-    <div class="text-center text-brand-text-secondary font-medium text-xs">
+    <div class="text-center {secondaryColor(song)} font-medium text-xs">
       {song.playcount ?? 0}
     </div>
   {:else if col.key === "skipcount"}
-    <div class="text-center text-brand-text-secondary font-medium text-xs">
+    <div class="text-center {secondaryColor(song)} font-medium text-xs">
       {song.skipcount ?? 0}
     </div>
   {:else if col.key === "lastplayed"}
-    <div class="text-center text-brand-text-secondary text-xs whitespace-nowrap">
+    <div class="text-center {secondaryColor(song)} text-xs whitespace-nowrap">
       {formatDate(song.lastplayed)}
     </div>
   {:else if col.key === "added"}
-    <div class="text-center text-brand-text-secondary text-xs whitespace-nowrap">
+    <div class="text-center {secondaryColor(song)} text-xs whitespace-nowrap">
       {formatDateAdded(song.added)}
     </div>
   {:else if col.key === "duration"}
-    <div class="text-center text-brand-text-secondary text-xs font-medium">
+    <div class="text-center {secondaryColor(song)} text-xs font-medium">
       {formatDuration(song.length_nanosec)}
     </div>
   {:else if col.key === "path"}
-    <div class="text-brand-text-secondary truncate pr-4 min-w-0 text-xs font-medium" title={song.path}>
+    <div class="{secondaryColor(song)} truncate pr-4 min-w-0 text-xs font-medium" title={song.path}>
       {song.path || "—"}
     </div>
   {:else if col.key === "actions"}
@@ -526,12 +574,11 @@
 {#snippet leadingCell(row: SongTableRow, displayIndex: number)}
   {@const song = row.song}
   <div class="text-center flex justify-center relative w-9 h-6 items-center">
-    {#if song && playerStore.currentSong && playerStore.currentSong.id === song.id && playerStore.state === "playing"}
+    {#if song && rowIsPlaying(row) && playerStore.state === "playing"}
       <div class="flex items-center justify-center gap-0.5 h-3.5 w-3.5 absolute group-hover:opacity-0 transition-opacity">
         <NowPlayingBars />
       </div>
-    {/if}
-    {#if mode === "position"}
+    {:else if mode === "position"}
       <span class="absolute text-xs font-medium text-brand-text-secondary group-hover:opacity-0 transition-opacity">{displayIndex + 1}</span>
     {/if}
     {#if song}
@@ -559,9 +606,9 @@
     data-index={row.underlyingIndex}
     role="row"
     tabindex="0"
-    onclick={(e) => song && !disabled && handleRowClick(e, row)}
+    onclick={(e) => song && (!disabled || interactiveWhenDisabled) && handleRowClick(e, row)}
     ondblclick={() => song && !disabled && onRowDoubleClick(row)}
-    oncontextmenu={(e) => song && !disabled && handleRowContextMenu(e, row)}
+    oncontextmenu={(e) => song && (!disabled || interactiveWhenDisabled) && handleRowContextMenu(e, row)}
     onkeydown={(e) => { if (e.key === "Enter" && song && !disabled) onRowDoubleClick(row); }}
     onpointerdown={(e) => handleRowPointerDown(e, row)}
     style={gridColsStyle}
@@ -570,7 +617,7 @@
       {disabled ? 'opacity-50 cursor-not-allowed' : ''}
       {onReorder ? 'cursor-grab active:cursor-grabbing' : ''}
       {draggedIndex !== null && dragOverIndex === row.underlyingIndex ? 'border-t-2! border-brand-accent' : ''}
-      {selectedKeys.has(row.key) ? 'bg-brand-accent/20 border-l-2 border-brand-accent text-brand-accent-text-hover' : (song && playerStore.currentSong && playerStore.currentSong.id === song.id ? 'bg-brand-accent/10' : '')}"
+      {selectedKeys.has(row.key) ? 'bg-brand-accent/20 border-l-2 border-brand-accent text-brand-accent-text-hover' : (song && rowIsPlaying(row) ? 'bg-brand-accent/10' : '')}"
   >
     {@render leadingCell(row, displayIndex)}
     {#if song}
@@ -584,7 +631,7 @@
 {/snippet}
 
 <div class="sticky top-0 z-10 flex flex-col rounded-t-lg bg-brand-sidebar border-b border-brand-border text-xs text-brand-text-secondary uppercase tracking-wider font-semibold select-none">
-  <div class="grid items-center py-3 px-4" style="{gridColsStyle}{virtualized ? `; padding-right: calc(1rem + ${scrollbarWidth}px)` : ''}">
+  <div role="row" class="grid items-center py-3 px-4" style="{gridColsStyle}{virtualized ? `; padding-right: calc(1rem + ${scrollbarWidth}px)` : ''}">
     {#if mode === "position" && positionSortField}
       <SortableHeader
         active={sortField === positionSortField}
@@ -605,12 +652,9 @@
   </div>
 </div>
 
-<!-- svelte-ignore a11y_no_static_element_interactions -->
 <div
   bind:this={bodyContainer}
   class="rounded-b-lg overflow-hidden {virtualized ? 'flex-1 min-h-0 relative' : ''}"
-  onpointermove={handlePointerDragMove}
-  onpointerup={handlePointerDragUp}
 >
   {#if loading}
     <div class="flex items-center justify-center py-16">

--- a/src/lib/components/SongTable.svelte
+++ b/src/lib/components/SongTable.svelte
@@ -35,7 +35,7 @@
   import CoverArt from "./CoverArt.svelte";
   import NowPlayingBars from "./NowPlayingBars.svelte";
   import EmptyState from "./EmptyState.svelte";
-  import { Play, Plus, Edit3, Trash2, GripVertical, AlertTriangle, Music, Clock } from "lucide-svelte";
+  import { Play, Plus, Edit3, Trash2, GripVertical, AlertTriangle, Music, Clock, DiscAlbum } from "lucide-svelte";
   import { VirtualList } from "svelte-virtual-list-ts";
   import type { Snippet } from "svelte";
 
@@ -68,8 +68,12 @@
     onAddToPlaylist?: (song: Song) => void;
     onRemoveFromPlaylist?: (row: SongTableRow) => void;
     onEditTags: (song: Song) => void;
+    /** Adds a per-row "edit this song's album" quick action (AutoPlaylistDetailView only). */
+    onEditAlbum?: (song: Song) => void;
     /** When set, position rows show a drag handle and pointer-based reorder is enabled (PlaylistView only). */
     onReorder?: (fromIndex: number, toIndex: number, selectedKeys: string[]) => void;
+    /** When set in "position" mode, the leading column header becomes a sortable control for this field instead of a plain label. */
+    positionSortField?: string;
     virtualized?: boolean;
     /** Persists/restores virtualized scroll position — only used when `virtualized` is true. */
     scrollMemoryKey?: string;
@@ -94,7 +98,9 @@
     onAddToPlaylist,
     onRemoveFromPlaylist,
     onEditTags,
+    onEditAlbum,
     onReorder,
+    positionSortField,
     virtualized = false,
     scrollMemoryKey,
   }: Props = $props();
@@ -494,6 +500,16 @@
       >
         <Edit3 class="w-4 h-4" />
       </button>
+      {#if onEditAlbum}
+        <button
+          onclick={() => onEditAlbum?.(song)}
+          class="text-brand-text-secondary hover:text-brand-accent-text transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+          disabled={!song.album}
+          title={i18n.t("songTags.editAlbumTooltip", {}, "Edit Album")}
+        >
+          <DiscAlbum class="w-4 h-4" />
+        </button>
+      {/if}
       {#if onRemoveFromPlaylist}
         <button
           onclick={() => onRemoveFromPlaylist?.(row)}
@@ -569,7 +585,18 @@
 
 <div class="sticky top-0 z-10 flex flex-col rounded-t-lg bg-brand-sidebar border-b border-brand-border text-xs text-brand-text-secondary uppercase tracking-wider font-semibold select-none">
   <div class="grid items-center py-3 px-4" style="{gridColsStyle}{virtualized ? `; padding-right: calc(1rem + ${scrollbarWidth}px)` : ''}">
-    <div class="text-center w-9"></div>
+    {#if mode === "position" && positionSortField}
+      <SortableHeader
+        active={sortField === positionSortField}
+        {sortAsc}
+        onclick={() => onToggleSort(positionSortField)}
+        class="text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 font-semibold uppercase tracking-wider min-w-0"
+      >
+        {#snippet label(arrow)}<span class="truncate max-w-[calc(100%-1rem)]">{i18n.t('playlists.tableHeaderTrack')} {arrow}</span>{/snippet}
+      </SortableHeader>
+    {:else}
+      <div class="text-center w-9"></div>
+    {/if}
     {#each SONG_TABLE_COLUMNS as col (col.key)}
       {#if !(mode === "position" && col.key === "track") && collectionStore.visibleColumns[col.key]}
         {@render headerCell(col)}
@@ -581,7 +608,7 @@
 <!-- svelte-ignore a11y_no_static_element_interactions -->
 <div
   bind:this={bodyContainer}
-  class="rounded-b-lg overflow-hidden"
+  class="rounded-b-lg overflow-hidden {virtualized ? 'flex-1 min-h-0 relative' : ''}"
   onpointermove={handlePointerDragMove}
   onpointerup={handlePointerDragUp}
 >

--- a/src/lib/components/SongTable.svelte
+++ b/src/lib/components/SongTable.svelte
@@ -1,0 +1,559 @@
+<script lang="ts" module>
+  import type { Song } from "../types";
+
+  /** One renderable row. `song` is optional because a playlist item can point at an unavailable/missing song. */
+  export interface SongTableRow {
+    /** Stable identity for selection/keying — `String(song.id)` for song-keyed views, `item.uuid` for playlist views. */
+    key: string;
+    song: Song | undefined;
+    disabled?: boolean;
+    disabledTooltip?: string;
+    /** "dim" (default) just lowers opacity; "strikethrough" also strikes the title and shows a warning icon (PlaylistView's unavailable/disconnected treatment). */
+    disabledVariant?: "dim" | "strikethrough";
+    isDuplicate?: boolean;
+    /** Position of this row in the caller's underlying (unfiltered) order — required when `onReorder` is provided. */
+    underlyingIndex?: number;
+  }
+</script>
+
+<script lang="ts">
+  import { collectionStore } from "../stores/collection.svelte";
+  import { playerStore } from "../stores/player.svelte";
+  import { i18n } from "../stores/i18n.svelte";
+  import { formatDate, formatFileSize, formatSampleRate, formatBitDepth, formatChannels, formatDuration } from "../utils/formatters";
+  import { formatDateAdded } from "../utils/date";
+  import { formatTrackNumber } from "../utils/artist";
+  import { parseMultiValue } from "../utils/multiValue";
+  import { SONG_TABLE_COLUMNS } from "../utils/songColumns";
+  import { columnResize } from "../utils/columnResize";
+  import type { VisibleColumns } from "../stores/collection.svelte";
+  import SortableHeader from "./SortableHeader.svelte";
+  import SongRating from "./SongRating.svelte";
+  import GenreChips from "./GenreChips.svelte";
+  import LinkButton from "./LinkButton.svelte";
+  import NowPlayingBars from "./NowPlayingBars.svelte";
+  import EmptyState from "./EmptyState.svelte";
+  import { Play, Plus, Edit3, Trash2, GripVertical, AlertTriangle, Music, Clock } from "lucide-svelte";
+  import { VirtualList } from "svelte-virtual-list-ts";
+  import type { Snippet } from "svelte";
+
+  const POINTER_DRAG_THRESHOLD_PX = 4;
+
+  interface Props {
+    rows: SongTableRow[];
+    /** "track" shows a disc-aware track number (album/artist/collection/auto-playlist views); "position" shows 1-based position + a play button, optionally with a drag handle when `onReorder` is set (playlist views). */
+    mode: "track" | "position";
+    discCount?: number;
+    leadingColumnWidth: string;
+    colDefaults: Partial<Record<keyof VisibleColumns, string>>;
+    /** `keyof Song`, or "track"/"position" for the leading column's natural order. */
+    sortField: string;
+    sortAsc: boolean;
+    onToggleSort: (field: string) => void;
+    selectedKeys?: Set<string>;
+    /**
+     * Row order to use for shift-click range selection. Defaults to `rows`.
+     * Pass the caller's natural (pre-sort) order to match the existing quirk
+     * where range-select operates on natural order even when the table is
+     * currently displayed sorted by a column.
+     */
+    rangeSelectionOrder?: SongTableRow[];
+    loading?: boolean;
+    emptyState?: Snippet;
+    onRowDoubleClick: (row: SongTableRow) => void;
+    onRowContextMenu: (event: MouseEvent, row: SongTableRow) => void;
+    onRate: (song: Song, rating: number) => void;
+    onAddToPlaylist?: (song: Song) => void;
+    onRemoveFromPlaylist?: (row: SongTableRow) => void;
+    onEditTags: (song: Song) => void;
+    /** When set, position rows show a drag handle and pointer-based reorder is enabled (PlaylistView only). */
+    onReorder?: (fromIndex: number, toIndex: number, selectedKeys: string[]) => void;
+    virtualized?: boolean;
+  }
+
+  let {
+    rows,
+    mode,
+    discCount = 1,
+    leadingColumnWidth,
+    colDefaults,
+    sortField,
+    sortAsc,
+    onToggleSort,
+    selectedKeys = $bindable(new Set()),
+    rangeSelectionOrder,
+    loading = false,
+    emptyState,
+    onRowDoubleClick,
+    onRowContextMenu,
+    onRate,
+    onAddToPlaylist,
+    onRemoveFromPlaylist,
+    onEditTags,
+    onReorder,
+    virtualized = false,
+  }: Props = $props();
+
+  let lastSelectedKey = $state<string | null>(null);
+  let keyIndex = $derived.by(() => {
+    const m = new Map<string, number>();
+    rows.forEach((r, i) => m.set(r.key, i));
+    return m;
+  });
+
+  let orderForRange = $derived(rangeSelectionOrder ?? rows);
+
+  function handleRowClick(e: MouseEvent, row: SongTableRow) {
+    const order = orderForRange;
+    if (e.shiftKey && lastSelectedKey !== null) {
+      const idx1 = order.findIndex((r) => r.key === lastSelectedKey);
+      const idx2 = order.findIndex((r) => r.key === row.key);
+      if (idx1 !== -1 && idx2 !== -1) {
+        const start = Math.min(idx1, idx2);
+        const end = Math.max(idx1, idx2);
+        const newSet = new Set(e.ctrlKey || e.metaKey ? selectedKeys : []);
+        for (let i = start; i <= end; i++) newSet.add(order[i].key);
+        selectedKeys = newSet;
+      }
+    } else if (e.ctrlKey || e.metaKey) {
+      const newSet = new Set(selectedKeys);
+      if (newSet.has(row.key)) newSet.delete(row.key);
+      else newSet.add(row.key);
+      selectedKeys = newSet;
+      lastSelectedKey = row.key;
+    } else if (selectedKeys.size === 1 && selectedKeys.has(row.key)) {
+      selectedKeys = new Set();
+      lastSelectedKey = null;
+    } else {
+      selectedKeys = new Set([row.key]);
+      lastSelectedKey = row.key;
+    }
+  }
+
+  function handleRowContextMenu(e: MouseEvent, row: SongTableRow) {
+    e.preventDefault();
+    if (!selectedKeys.has(row.key)) {
+      selectedKeys = new Set([row.key]);
+      lastSelectedKey = row.key;
+    }
+    onRowContextMenu(e, row);
+  }
+
+  function handleKeydown(e: KeyboardEvent) {
+    if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === "a") {
+      const target = e.target as HTMLElement;
+      if (target && (target.tagName === "INPUT" || target.tagName === "TEXTAREA")) return;
+      e.preventDefault();
+      selectedKeys = new Set(rows.map((r) => r.key));
+    } else if (e.key === "Escape") {
+      selectedKeys = new Set();
+    }
+  }
+
+  function handleWindowMouseDown(e: MouseEvent) {
+    if (selectedKeys.size === 0) return;
+    const target = e.target as HTMLElement;
+    if (!target) return;
+    if (
+      target.closest("[data-song-row]") ||
+      target.closest("[role='menu']") ||
+      target.closest("[data-floating-toolbar]") ||
+      target.closest("button") ||
+      target.closest("input")
+    ) {
+      return;
+    }
+    selectedKeys = new Set();
+  }
+
+  // --- Pointer-based drag reorder (only active when onReorder is provided) ---
+  // Native HTML5 drag events are swallowed by Tauri's dragDropEnabled window
+  // option (needed for OS file-drop import), so reordering uses pointer
+  // events instead.
+  let draggedIndex = $state<number | null>(null);
+  let dragOverIndex = $state<number | null>(null);
+  let pointerDragArmed = false;
+  let pointerDragStartX = 0;
+  let pointerDragStartY = 0;
+
+  function commitReorder(targetIndex: number) {
+    if (draggedIndex === null || targetIndex === draggedIndex) return;
+    const keys =
+      selectedKeys.size > 1 && selectedKeys.has(rows.find((r) => r.underlyingIndex === draggedIndex)?.key ?? "")
+        ? Array.from(selectedKeys)
+        : [rows.find((r) => r.underlyingIndex === draggedIndex)?.key ?? ""];
+    onReorder?.(draggedIndex, targetIndex, keys);
+  }
+
+  function handleRowPointerDown(e: PointerEvent, row: SongTableRow) {
+    if (!onReorder || row.underlyingIndex === undefined) return;
+    const target = e.target as HTMLElement;
+    if (target.closest("button, a, input, select, textarea, [data-interactive]")) return;
+    if (e.button !== 0) return;
+    pointerDragArmed = false;
+    pointerDragStartX = e.clientX;
+    pointerDragStartY = e.clientY;
+    draggedIndex = row.underlyingIndex;
+    (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+  }
+
+  function handlePointerDragMove(e: PointerEvent) {
+    if (draggedIndex === null) return;
+    if (!pointerDragArmed) {
+      const dx = e.clientX - pointerDragStartX;
+      const dy = e.clientY - pointerDragStartY;
+      if (Math.hypot(dx, dy) < POINTER_DRAG_THRESHOLD_PX) return;
+      pointerDragArmed = true;
+    }
+    const el = document.elementFromPoint(e.clientX, e.clientY)?.closest("[data-song-row]") as HTMLElement | null;
+    const idx = el?.dataset.index;
+    dragOverIndex = idx !== undefined ? Number(idx) : null;
+  }
+
+  function handlePointerDragUp() {
+    if (pointerDragArmed && dragOverIndex !== null) {
+      commitReorder(dragOverIndex);
+    }
+    draggedIndex = null;
+    dragOverIndex = null;
+    pointerDragArmed = false;
+  }
+
+  // --- Grid column template ---
+  let gridColsStyle = $derived.by(() => {
+    const vc = collectionStore.visibleColumns;
+    const cw = collectionStore.columnWidths;
+    const cols: string[] = [leadingColumnWidth];
+    for (const { key } of SONG_TABLE_COLUMNS) {
+      if (mode === "position" && key === "track") continue;
+      if (!vc[key]) continue;
+      const saved = cw[key];
+      cols.push(saved !== undefined ? `${saved}px` : (colDefaults[key] ?? "80px"));
+    }
+    return `grid-template-columns: ${cols.join(" ")}`;
+  });
+
+  interface HeaderMeta {
+    i18nKey: string;
+    className: string;
+    truncateClass?: string;
+  }
+  const HEADER_META: Partial<Record<string, HeaderMeta>> = {
+    track: { i18nKey: "collection.tableHeaderTrack", className: "text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full", truncateClass: "max-w-[calc(100%-1rem)]" },
+    title: { i18nKey: "collection.tableHeaderTitle", className: "text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full", truncateClass: "max-w-[calc(100%-1rem)]" },
+    artist: { i18nKey: "collection.tableHeaderArtist", className: "text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full", truncateClass: "max-w-[calc(100%-1rem)]" },
+    album: { i18nKey: "collection.tableHeaderAlbum", className: "text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full", truncateClass: "max-w-[calc(100%-1rem)]" },
+    composer: { i18nKey: "collection.tableHeaderComposer", className: "text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full", truncateClass: "max-w-[calc(100%-0.5rem)]" },
+    album_artist: { i18nKey: "collection.tableHeaderAlbumArtist", className: "text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full", truncateClass: "max-w-[calc(100%-0.5rem)]" },
+    format: { i18nKey: "collection.tableHeaderFormat", className: "text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full", truncateClass: "max-w-[calc(100%-0.5rem)]" },
+    year: { i18nKey: "collection.tableHeaderYear", className: "text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full", truncateClass: "max-w-[calc(100%-0.5rem)]" },
+    genre: { i18nKey: "collection.tableHeaderGenre", className: "text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full", truncateClass: "max-w-[calc(100%-0.5rem)]" },
+    grouping: { i18nKey: "collection.tableHeaderGrouping", className: "text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full", truncateClass: "max-w-[calc(100%-0.5rem)]" },
+    bpm: { i18nKey: "collection.tableHeaderBpm", className: "text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full", truncateClass: "max-w-[calc(100%-0.5rem)]" },
+    initial_key: { i18nKey: "collection.tableHeaderInitialKey", className: "text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full", truncateClass: "max-w-[calc(100%-0.5rem)]" },
+    bitrate: { i18nKey: "collection.tableHeaderBitrate", className: "text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full", truncateClass: "max-w-[calc(100%-0.5rem)]" },
+    samplerate: { i18nKey: "collection.tableHeaderSampleRate", className: "text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full", truncateClass: "max-w-[calc(100%-0.5rem)]" },
+    bitdepth: { i18nKey: "collection.tableHeaderBitDepth", className: "text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full", truncateClass: "max-w-[calc(100%-0.5rem)]" },
+    channels: { i18nKey: "collection.tableHeaderChannels", className: "text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full", truncateClass: "max-w-[calc(100%-0.5rem)]" },
+    filesize: { i18nKey: "collection.tableHeaderFileSize", className: "text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full", truncateClass: "max-w-[calc(100%-0.5rem)]" },
+    rating: { i18nKey: "collection.tableHeaderRating", className: "flex items-center justify-center hover:text-brand-text-primary transition-colors font-semibold uppercase tracking-wider min-w-0 w-full" },
+    playcount: { i18nKey: "collection.tableHeaderPlays", className: "text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full" },
+    skipcount: { i18nKey: "collection.tableHeaderSkips", className: "text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full" },
+    lastplayed: { i18nKey: "collection.tableHeaderLastPlayed", className: "text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full" },
+    added: { i18nKey: "collection.tableHeaderAdded", className: "text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full" },
+    duration: { i18nKey: "", className: "flex items-center justify-center hover:text-brand-text-primary transition-colors font-semibold uppercase tracking-wider min-w-0 w-full" },
+    path: { i18nKey: "collection.tableHeaderPath", className: "text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full", truncateClass: "max-w-[calc(100%-0.5rem)]" },
+  };
+
+  function headerActiveField(col: (typeof SONG_TABLE_COLUMNS)[number]): string {
+    return col.field ?? col.key;
+  }
+
+  function bindResize(key: keyof VisibleColumns) {
+    return { column: key, onResize: collectionStore.setColumnWidth.bind(collectionStore), onReset: collectionStore.resetColumnWidth.bind(collectionStore) };
+  }
+
+  function rowDisabled(row: SongTableRow): boolean {
+    return !!row.disabled;
+  }
+</script>
+
+{#snippet headerCell(col: (typeof SONG_TABLE_COLUMNS)[number])}
+  {@const meta = HEADER_META[col.key]}
+  {#if col.key === "actions"}
+    <div use:columnResize={bindResize(col.key)} class="relative overflow-hidden text-center">{i18n.t("collection.tableHeaderActions")}</div>
+  {:else if meta}
+    <div use:columnResize={bindResize(col.key)} class="relative overflow-hidden">
+      <SortableHeader
+        active={sortField === headerActiveField(col)}
+        {sortAsc}
+        onclick={() => onToggleSort(headerActiveField(col))}
+        class={meta.className}
+      >
+        {#snippet label(arrow)}
+          {#if col.key === "duration"}
+            <Clock class="w-3.5 h-3.5 shrink-0" /> {arrow}
+          {:else}
+            <span class="truncate {meta.truncateClass ?? ''}">{i18n.t(meta.i18nKey)} {arrow}</span>
+          {/if}
+        {/snippet}
+      </SortableHeader>
+    </div>
+  {/if}
+{/snippet}
+
+{#snippet bodyCell(col: (typeof SONG_TABLE_COLUMNS)[number], song: Song, row: SongTableRow)}
+  {#if col.key === "track"}
+    <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium">
+      {formatTrackNumber(song.track, song.disc, discCount, keyIndex.get(row.key) ?? 0)}
+    </div>
+  {:else if col.key === "title"}
+    <div class="font-medium truncate pr-4 flex items-center gap-2 min-w-0">
+      <span class="truncate {playerStore.currentSong && playerStore.currentSong.id === song.id ? 'text-brand-accent-text-hover' : 'text-brand-text-primary'} {row.disabledVariant === 'strikethrough' && rowDisabled(row) ? 'line-through' : ''}">
+        {song.title || i18n.t("collection.unknownSong")}
+      </span>
+      {#if row.disabledVariant === "strikethrough" && rowDisabled(row)}
+        <AlertTriangle class="w-3.5 h-3.5 shrink-0 text-amber-500" />
+      {/if}
+    </div>
+  {:else if col.key === "artist"}
+    <div class="text-brand-text-primary truncate pr-4 flex items-center min-w-0">
+      {#if song.artist}
+        {#each parseMultiValue(song.artist) as name, i (name)}
+          {#if i > 0}<span class="text-brand-text-primary/50 shrink-0">,&nbsp;</span>{/if}
+          <LinkButton
+            onclick={(e) => { e.stopPropagation(); collectionStore.viewArtist(name); }}
+            class="text-brand-text-primary truncate min-w-0"
+            title={i18n.t("collection.filterByArtist", { artist: name })}
+          >
+            {name}
+          </LinkButton>
+        {/each}
+      {:else}
+        <span class="text-brand-text-primary truncate min-w-0">{i18n.t("collection.unknownArtist")}</span>
+      {/if}
+    </div>
+  {:else if col.key === "album"}
+    <div class="text-brand-text-primary truncate pr-4 min-w-0 text-xs font-medium">
+      {song.album || i18n.t("collection.unknownAlbum")}
+    </div>
+  {:else if col.key === "composer"}
+    <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium" title={song.composer}>
+      {song.composer || "—"}
+    </div>
+  {:else if col.key === "album_artist"}
+    <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium" title={song.album_artist}>
+      {song.album_artist || "—"}
+    </div>
+  {:else if col.key === "format"}
+    <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-semibold uppercase">
+      {song.filetype ? song.filetype.toUpperCase() : "—"}
+    </div>
+  {:else if col.key === "year"}
+    <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium">
+      {song.year || "—"}
+    </div>
+  {:else if col.key === "genre"}
+    <div class="truncate pr-2 min-w-0" title={song.genre}>
+      {#if song.genre}
+        <GenreChips genre={song.genre} />
+      {:else}
+        <span class="text-brand-text-secondary text-xs font-medium">—</span>
+      {/if}
+    </div>
+  {:else if col.key === "grouping"}
+    <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium" title={song.grouping}>
+      {song.grouping || "—"}
+    </div>
+  {:else if col.key === "bpm"}
+    <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium">
+      {song.bpm || "—"}
+    </div>
+  {:else if col.key === "initial_key"}
+    <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium">
+      {song.initial_key || "—"}
+    </div>
+  {:else if col.key === "bitrate"}
+    <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium">
+      {song.bitrate ? `${song.bitrate}k` : "—"}
+    </div>
+  {:else if col.key === "samplerate"}
+    <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium">
+      {formatSampleRate(song.samplerate)}
+    </div>
+  {:else if col.key === "bitdepth"}
+    <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium">
+      {formatBitDepth(song.bitdepth)}
+    </div>
+  {:else if col.key === "channels"}
+    <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium">
+      {formatChannels(song.channels)}
+    </div>
+  {:else if col.key === "filesize"}
+    <div class="text-brand-text-primary truncate pr-2 min-w-0 text-xs font-medium">
+      {formatFileSize(song.filesize)}
+    </div>
+  {:else if col.key === "rating"}
+    <div class="flex justify-center">
+      <SongRating rating={song.rating} onRate={(r) => onRate(song, r)} />
+    </div>
+  {:else if col.key === "playcount"}
+    <div class="text-center text-brand-text-primary font-medium">
+      {song.playcount ?? 0}
+    </div>
+  {:else if col.key === "skipcount"}
+    <div class="text-center text-brand-text-primary font-medium text-xs">
+      {song.skipcount ?? 0}
+    </div>
+  {:else if col.key === "lastplayed"}
+    <div class="text-center text-brand-text-primary text-xs whitespace-nowrap">
+      {formatDate(song.lastplayed)}
+    </div>
+  {:else if col.key === "added"}
+    <div class="text-center text-brand-text-primary text-xs whitespace-nowrap">
+      {formatDateAdded(song.added)}
+    </div>
+  {:else if col.key === "duration"}
+    <div class="text-center text-brand-text-primary text-xs font-medium">
+      {formatDuration(song.length_nanosec)}
+    </div>
+  {:else if col.key === "path"}
+    <div class="text-brand-text-primary truncate pr-4 min-w-0 text-xs font-medium" title={song.path}>
+      {song.path || "—"}
+    </div>
+  {:else if col.key === "actions"}
+    <div class="flex items-center justify-center gap-2.5">
+      {#if onAddToPlaylist}
+        <button
+          onclick={() => onAddToPlaylist?.(song)}
+          class="text-brand-text-primary hover:text-brand-accent-text transition-colors"
+          title={i18n.t("collection.addPlaylistTooltipDefault")}
+        >
+          <Plus class="w-4 h-4" />
+        </button>
+      {/if}
+      <button
+        onclick={() => onEditTags(song)}
+        class="text-brand-text-primary hover:text-brand-accent-text transition-colors"
+        title={i18n.t("collection.editTagsTooltip")}
+      >
+        <Edit3 class="w-4 h-4" />
+      </button>
+      {#if onRemoveFromPlaylist}
+        <button
+          onclick={() => onRemoveFromPlaylist?.(row)}
+          class="text-brand-text-primary hover:text-red-400 transition-colors"
+          title={i18n.t("playlists.removeFromPlaylist")}
+        >
+          <Trash2 class="w-4 h-4" />
+        </button>
+      {/if}
+    </div>
+  {/if}
+{/snippet}
+
+{#snippet leadingCell(row: SongTableRow, displayIndex: number)}
+  {@const song = row.song}
+  <div class="text-center flex justify-center relative w-9 h-6 items-center">
+    {#if song && playerStore.currentSong && playerStore.currentSong.id === song.id && playerStore.state === "playing"}
+      <div class="flex items-center justify-center gap-0.5 h-3.5 w-3.5 absolute group-hover:opacity-0 transition-opacity">
+        <NowPlayingBars />
+      </div>
+    {/if}
+    {#if mode === "position"}
+      <span class="absolute text-xs font-medium text-brand-text-secondary group-hover:opacity-0 transition-opacity">{displayIndex + 1}</span>
+    {/if}
+    {#if song}
+      <button
+        onclick={(e) => { e.stopPropagation(); if (!rowDisabled(row)) onRowDoubleClick(row); }}
+        class="absolute flex items-center justify-center opacity-0 group-hover:opacity-100 text-brand-accent-text hover:text-brand-accent-text-hover transition-all duration-150 disabled:opacity-0 disabled:cursor-not-allowed"
+        disabled={rowDisabled(row)}
+        title={row.disabledTooltip ?? i18n.t("collection.playSong")}
+      >
+        <Play class="w-3.5 h-3.5 fill-current" />
+      </button>
+    {/if}
+    {#if onReorder}
+      <GripVertical class="absolute right-0 w-3.5 h-3.5 text-brand-text-secondary/60 opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none" />
+    {/if}
+  </div>
+{/snippet}
+
+{#snippet row_(row: SongTableRow, displayIndex: number)}
+  {@const song = row.song}
+  {@const disabled = rowDisabled(row)}
+  <!-- svelte-ignore a11y_no_static_element_interactions -->
+  <div
+    data-song-row="true"
+    data-index={row.underlyingIndex}
+    role="row"
+    tabindex="0"
+    onclick={(e) => song && !disabled && handleRowClick(e, row)}
+    ondblclick={() => song && !disabled && onRowDoubleClick(row)}
+    oncontextmenu={(e) => song && !disabled && handleRowContextMenu(e, row)}
+    onkeydown={(e) => { if (e.key === "Enter" && song && !disabled) onRowDoubleClick(row); }}
+    onpointerdown={(e) => handleRowPointerDown(e, row)}
+    style={gridColsStyle}
+    title={row.disabledTooltip}
+    class="grid items-center hover:bg-brand-sidebar/40 group transition-colors py-2 px-4 text-sm
+      {disabled ? 'opacity-50 cursor-not-allowed' : ''}
+      {onReorder ? 'cursor-grab active:cursor-grabbing' : ''}
+      {draggedIndex !== null && dragOverIndex === row.underlyingIndex ? 'border-t-2! border-brand-accent' : ''}
+      {selectedKeys.has(row.key) ? 'bg-brand-accent/20 border-l-2 border-brand-accent text-brand-accent-text-hover' : (song && playerStore.currentSong && playerStore.currentSong.id === song.id ? 'bg-brand-accent/10 text-brand-accent-text-hover' : '')}"
+  >
+    {@render leadingCell(row, displayIndex)}
+    {#if song}
+      {#each SONG_TABLE_COLUMNS as col (col.key)}
+        {#if !(mode === "position" && col.key === "track") && collectionStore.visibleColumns[col.key]}
+          {@render bodyCell(col, song, row)}
+        {/if}
+      {/each}
+    {/if}
+  </div>
+{/snippet}
+
+<div class="sticky top-0 z-10 flex flex-col rounded-t-lg bg-brand-sidebar/80 backdrop-blur-md border-b border-brand-border text-[10px] text-brand-text-primary uppercase tracking-wider font-semibold select-none">
+  <div class="grid items-center py-2.5 px-4" style={gridColsStyle}>
+    <div class="text-center w-9"></div>
+    {#each SONG_TABLE_COLUMNS as col (col.key)}
+      {#if !(mode === "position" && col.key === "track") && collectionStore.visibleColumns[col.key]}
+        {@render headerCell(col)}
+      {/if}
+    {/each}
+  </div>
+</div>
+
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div
+  class="divide-y divide-brand-border/40 rounded-b-lg overflow-hidden"
+  onpointermove={handlePointerDragMove}
+  onpointerup={handlePointerDragUp}
+>
+  {#if loading}
+    <div class="flex items-center justify-center py-16">
+      <div class="text-brand-text-primary text-sm">{i18n.t("home.loading")}</div>
+    </div>
+  {:else if rows.length === 0}
+    <div class="py-16 text-center select-none">
+      {#if emptyState}
+        {@render emptyState()}
+      {:else}
+        <EmptyState icon={Music} title={i18n.t("collection.noSongsTitle")} />
+      {/if}
+    </div>
+  {:else if virtualized}
+    {#key gridColsStyle}
+      <VirtualList items={rows} itemHeight={41}>
+        {#snippet children({ item }: { item: SongTableRow })}
+          {@render row_(item, keyIndex.get(item.key) ?? 0)}
+        {/snippet}
+      </VirtualList>
+    {/key}
+  {:else}
+    {#each rows as row, index (row.key)}
+      {@render row_(row, index)}
+    {/each}
+  {/if}
+</div>
+
+<svelte:window onkeydown={handleKeydown} onmousedown={handleWindowMouseDown} />

--- a/src/lib/utils/songSort.ts
+++ b/src/lib/utils/songSort.ts
@@ -1,0 +1,39 @@
+import type { Song } from "../types";
+
+/**
+ * Comparator for sorting songs by an arbitrary `Song` field, matching the
+ * table's sort-header semantics: title/artist/composer/genre prefer their
+ * `*sort` field when present, strings compare via localeCompare, numbers
+ * compare numerically, and missing values always sort to the end regardless
+ * of direction.
+ */
+export function compareSongs(a: Song, b: Song, field: keyof Song, asc: boolean): number {
+  let valA: unknown = a[field];
+  let valB: unknown = b[field];
+
+  if (field === "title") {
+    valA = a.titlesort?.trim() || a.title;
+    valB = b.titlesort?.trim() || b.title;
+  } else if (field === "artist") {
+    valA = a.album_artist_sort?.trim() || a.artistsort?.trim() || a.album_artist || a.artist;
+    valB = b.album_artist_sort?.trim() || b.artistsort?.trim() || b.album_artist || b.artist;
+  } else if (field === "composer") {
+    valA = a.composersort?.trim() || a.composer;
+    valB = b.composersort?.trim() || b.composer;
+  } else if (field === "genre") {
+    valA = a.genresort?.trim() || a.genre;
+    valB = b.genresort?.trim() || b.genre;
+  }
+
+  if (valA === undefined || valA === null) return asc ? 1 : -1;
+  if (valB === undefined || valB === null) return asc ? -1 : 1;
+
+  if (typeof valA === "string" && typeof valB === "string") {
+    const cmp = valA.localeCompare(valB);
+    return asc ? cmp : -cmp;
+  }
+  if (typeof valA === "number" && typeof valB === "number") {
+    return asc ? valA - valB : valB - valA;
+  }
+  return 0;
+}


### PR DESCRIPTION
## 📋 Summary
Addresses item 4 of #577: extracts a shared `SongTable.svelte` component and migrates all 5 song-table call sites (`AlbumDetailView`, `CollectionView`, `ArtistDetailView`, `AutoPlaylistDetailView`, `PlaylistView`) to use it, eliminating ~2,000 lines of duplicated table markup.

## 🔍 Implementation Notes
- `SongTable.svelte` is data-driven off the existing `SONG_TABLE_COLUMNS` config and covers the variance between call sites via props: `mode` (`"track"` disc-aware numbering vs `"position"` for ordered lists), `virtualized`/`scrollMemoryKey` (CollectionView), `onReorder` + pointer-based drag-to-reorder (PlaylistView), `isRowPlaying` override (needed so PlaylistView can disambiguate duplicate songs via `playlistItemUuid` rather than song id), `interactiveWhenDisabled`/`disabledPlaceholder` (PlaylistView's unavailable-track handling), and `positionSortField` (sortable position header for AutoPlaylistDetailView/PlaylistView).
- Also extracted the shared sort comparator into `src/lib/utils/songSort.ts`, used by all 5 views.
- Selection (click/shift/ctrl-click, Ctrl+A, Escape, click-outside-to-clear) and pointer-based drag-reorder logic now live once in `SongTable.svelte` instead of being duplicated per view.
- Beyond pure dedup, two intentional (user-approved mid-implementation) changes:
  - Row styling normalized to one consistent look across all 5 views (thumbnail, primary-colored text throughout, clickable album link) rather than preserving each view's previously-inconsistent styling.
  - `ArtistDetailView`'s singles table gained multi-select (it previously had none), for consistency with every other table now offering the same interactions.
- No backend changes; no intended change to playback, drag-reorder, or dynamic-playlist behavior.

## 🧪 Test Plan
- [x] `bun run check` (svelte-check) — 0 errors, 0 warnings
- [x] `bun run test -- --run` (frontend) — 481/481 passed, 52/52 files
- [ ] `cargo test` (src-tauri, if Rust changed) — N/A, no Rust changes
- [ ] Manually verified in the app — pending; will be checked via `bun run tauri dev` before merge

## 📸 Screenshots
N/A for this PR body — verified interactively with the requester across several rounds of screenshots during development (row styling contrast, now-playing indicator placement, virtualized Collection view rendering).

## ✅ Checklist
- [x] No unrelated changes bundled in
- [ ] Docs/screenshots updated if user-facing behavior changed — no user-facing screenshots in `docs/` reference this table styling; none needed
