### PR TITLE
refactor: dedup merge_tags/delete_tags (#577 item 7)

### DIFF
--- a/src-tauri/src/commands/tags.rs
+++ b/src-tauri/src/commands/tags.rs
@@ -211,39 +211,25 @@ fn load_full_metadata(conn: &rusqlite::Connection, song_ids: &[i64]) -> Vec<Song
     out
 }
 
-/// Merges `from` into `into`: rewrites every affected song's embedded genre
-/// tag on disk and in the DB (same dual-write as the regular tag editor —
-/// see `tags.rs`'s module doc comment), then folds `from`'s curated
-/// hierarchy position into `into`'s. Returns the number of songs updated.
-#[tauri::command]
-pub async fn merge_tags(
-    app: AppHandle,
-    state: State<'_, AppState>,
-    from: String,
-    into: String,
+/// Shared by [`merge_tags`]/[`delete_tags`]: rewrites every affected song's
+/// embedded genre tag on disk and in the DB (same dual-write as the regular
+/// tag editor — see `tags.rs`'s module doc comment). `rewrite_genre` computes
+/// each song's new genre string from its current one; callers supply
+/// merge-into or delete-these-names logic. Returns the number of songs
+/// whose on-disk write succeeded.
+async fn rewrite_genre_and_persist(
+    conn: r2d2::PooledConnection<r2d2_sqlite::SqliteConnectionManager>,
+    song_ids: &[i64],
+    rewrite_genre: impl Fn(&str) -> String + Send + 'static,
 ) -> Result<u32, String> {
-    if from.trim().is_empty() || into.trim().is_empty() || from.eq_ignore_ascii_case(&into) {
-        return Ok(0);
-    }
+    let metas = load_full_metadata(&conn, song_ids);
 
-    let _watcher_pause_guard = WatcherPauseGuard::new(Arc::clone(&state.watcher_paused));
-
-    let manager = TagManager::new(state.db.clone());
-    let conn = state.db.pool.get().map_err(|e| e.to_string())?;
-    let affected = manager
-        .songs_containing_any(std::slice::from_ref(&from))
-        .map_err(|e| e.to_string())?;
-    let song_ids: Vec<i64> = affected.iter().map(|(id, _, _)| *id).collect();
-    let metas = load_full_metadata(&conn, &song_ids);
-
-    let from_c = from.clone();
-    let into_c = into.clone();
     let (updated_count, writes): (u32, Vec<(i64, String)>) =
         tauri::async_runtime::spawn_blocking(move || {
             let mut count = 0u32;
             let mut writes = Vec::with_capacity(metas.len());
             for item in &metas {
-                let new_genre = TagManager::rewrite_genre_for_merge(&item.genre, &from_c, &into_c);
+                let new_genre = rewrite_genre(&item.genre);
                 let path = std::path::PathBuf::from(&item.path);
                 let write_res = crate::tageditor::write_tags(
                     &path,
@@ -286,6 +272,39 @@ pub async fn merge_tags(
         .map_err(|e| e.to_string())?;
     }
     tx.commit().map_err(|e| e.to_string())?;
+
+    Ok(updated_count)
+}
+
+/// Merges `from` into `into`: rewrites every affected song's embedded genre
+/// tag on disk and in the DB, then folds `from`'s curated hierarchy position
+/// into `into`'s. Returns the number of songs updated.
+#[tauri::command]
+pub async fn merge_tags(
+    app: AppHandle,
+    state: State<'_, AppState>,
+    from: String,
+    into: String,
+) -> Result<u32, String> {
+    if from.trim().is_empty() || into.trim().is_empty() || from.eq_ignore_ascii_case(&into) {
+        return Ok(0);
+    }
+
+    let _watcher_pause_guard = WatcherPauseGuard::new(Arc::clone(&state.watcher_paused));
+
+    let manager = TagManager::new(state.db.clone());
+    let conn = state.db.pool.get().map_err(|e| e.to_string())?;
+    let affected = manager
+        .songs_containing_any(std::slice::from_ref(&from))
+        .map_err(|e| e.to_string())?;
+    let song_ids: Vec<i64> = affected.iter().map(|(id, _, _)| *id).collect();
+
+    let from_c = from.clone();
+    let into_c = into.clone();
+    let updated_count = rewrite_genre_and_persist(conn, &song_ids, move |genre| {
+        TagManager::rewrite_genre_for_merge(genre, &from_c, &into_c)
+    })
+    .await?;
 
     manager
         .apply_merge_hierarchy(&from, &into)
@@ -318,57 +337,13 @@ pub async fn delete_tags(
         .songs_containing_any(&names)
         .map_err(|e| e.to_string())?;
     let song_ids: Vec<i64> = affected.iter().map(|(id, _, _)| *id).collect();
-    let metas = load_full_metadata(&conn, &song_ids);
 
     let names_c = names.clone();
-    let (updated_count, writes): (u32, Vec<(i64, String)>) =
-        tauri::async_runtime::spawn_blocking(move || {
-            let mut count = 0u32;
-            let mut writes = Vec::with_capacity(metas.len());
-            for item in &metas {
-                let new_genre = TagManager::rewrite_genre_for_delete(&item.genre, &names_c);
-                let path = std::path::PathBuf::from(&item.path);
-                let write_res = crate::tageditor::write_tags(
-                    &path,
-                    &item.title,
-                    item.titlesort.as_deref(),
-                    &item.artist,
-                    item.artistsort.as_deref(),
-                    &item.album,
-                    item.albumsort.as_deref(),
-                    &item.album_artist,
-                    item.album_artist_sort.as_deref(),
-                    &item.composer,
-                    item.composersort.as_deref(),
-                    &new_genre,
-                    item.genresort.as_deref(),
-                    item.track,
-                    item.disc,
-                    item.year,
-                    &item.grouping,
-                    item.bpm,
-                    &item.initial_key,
-                    item.compilation,
-                );
-                if write_res.is_ok() {
-                    count += 1;
-                }
-                writes.push((item.id, new_genre));
-            }
-            (count, writes)
+    let updated_count =
+        rewrite_genre_and_persist(conn, &song_ids, move |genre| {
+            TagManager::rewrite_genre_for_delete(genre, &names_c)
         })
-        .await
-        .map_err(|e| e.to_string())?;
-
-    let tx = conn.unchecked_transaction().map_err(|e| e.to_string())?;
-    for (song_id, new_genre) in &writes {
-        tx.execute(
-            "UPDATE songs SET genre = ?1 WHERE id = ?2",
-            rusqlite::params![new_genre, song_id],
-        )
-        .map_err(|e| e.to_string())?;
-    }
-    tx.commit().map_err(|e| e.to_string())?;
+        .await?;
 
     manager
         .apply_delete_hierarchy(&names)


### PR DESCRIPTION
## 📋 Summary
Addresses item 7 of #577: extracts the shared `rewrite_genre_and_persist` helper out of `merge_tags`/`delete_tags` in `src-tauri/src/commands/tags.rs`, which had ~75 lines of near-total duplication (load-metadata → `spawn_blocking` write-loop → DB transaction), differing only in how each computes a song's new genre string.

## 🔍 Implementation Notes
- `rewrite_genre_and_persist(conn, song_ids, rewrite_genre)` owns the full sequence: loads each song's full tag metadata, rewrites every file's embedded genre via `crate::tageditor::write_tags` off the async runtime (`spawn_blocking`), then persists the new genre column to the DB in one transaction. `rewrite_genre` is a per-caller closure (`Fn(&str) -> String`) — `merge_tags` passes `TagManager::rewrite_genre_for_merge`, `delete_tags` passes `TagManager::rewrite_genre_for_delete`.
- Had to change the connection parameter from `&rusqlite::Connection` to an owned `r2d2::PooledConnection<SqliteConnectionManager>`: a borrowed connection isn't `Send` (rusqlite's `Connection` isn't `Sync`), so holding `&Connection` across the `spawn_blocking().await` inside a separate async fn broke Tauri's `Send`-future requirement for commands. Passing the pooled connection by value (as the original single-function version implicitly did by keeping it in scope) resolves it.
- `merge_tags`/`delete_tags` now just: resolve affected song ids, call the shared helper with their own genre-rewrite closure, then run their own hierarchy op (`apply_merge_hierarchy` / `apply_delete_hierarchy`) and emit `library-changed` — the part where they genuinely differ.
- Left `TagWriteRequest` (item 8/12's job, since it also touches `tageditor::write_tags`'s 19-arg signature) out of scope here — this item only removes the duplication *between* `merge_tags` and `delete_tags` themselves.
- No behavior change intended.

## 🧪 Test Plan
- [x] `cargo build` (src-tauri) — clean
- [x] `cargo test` (src-tauri) — all passing, including the 24 `tags::` unit tests and the `tag_editor_bdd`/`playlists_bdd` scenarios
- [x] `cargo clippy --lib` — no new warnings (3 pre-existing warnings elsewhere in `tags.rs`, unrelated to this change)
- [ ] Manually verified in the app — pending, via `bun run tauri dev` (merge two genres, delete a genre, confirm file tags + hierarchy update correctly)

## 📸 Screenshots
N/A — pure backend refactor, no UI changes.

## ✅ Checklist
- [x] No unrelated changes bundled in
- [ ] Docs/screenshots updated if user-facing behavior changed — no user-facing behavior change
