### PR TITLE
refactor: introduce TagWriteRequest (#577 items 8+12)

### DIFF
--- a/src-tauri/src/collection.rs
+++ b/src-tauri/src/collection.rs
@@ -3457,25 +3457,13 @@ mod tests {
 
         crate::tageditor::write_tags(
             &path,
-            "Title",
-            None,
-            "Artist",
-            None,
-            "Album",
-            None,
-            "",
-            None,
-            "",
-            None,
-            "Rock; Jazz Fusion; Live",
-            None,
-            None,
-            None,
-            None,
-            "",
-            None,
-            "",
-            false,
+            &crate::tageditor::TagWriteRequest {
+                title: "Title",
+                artist: "Artist",
+                album: "Album",
+                genre: "Rock; Jazz Fusion; Live",
+                ..Default::default()
+            },
         )
         .expect("write_tags should succeed");
 
@@ -3491,25 +3479,14 @@ mod tests {
 
         crate::tageditor::write_tags(
             &path,
-            "Title",
-            None,
-            "Artist A; Artist B",
-            None,
-            "Album",
-            None,
-            "Album Artist A; Album Artist B",
-            None,
-            "Composer A; Composer B",
-            None,
-            "",
-            None,
-            None,
-            None,
-            None,
-            "",
-            None,
-            "",
-            false,
+            &crate::tageditor::TagWriteRequest {
+                title: "Title",
+                artist: "Artist A; Artist B",
+                album: "Album",
+                album_artist: "Album Artist A; Album Artist B",
+                composer: "Composer A; Composer B",
+                ..Default::default()
+            },
         )
         .expect("write_tags should succeed");
 
@@ -3538,25 +3515,13 @@ mod tests {
 
         crate::tageditor::write_tags(
             &path,
-            "Title",
-            None,
-            "Artist",
-            None,
-            "Album",
-            None,
-            "",
-            None,
-            "",
-            None,
-            "",
-            None,
-            None,
-            None,
-            Some(1995),
-            "",
-            None,
-            "",
-            false,
+            &crate::tageditor::TagWriteRequest {
+                title: "Title",
+                artist: "Artist",
+                album: "Album",
+                year: Some(1995),
+                ..Default::default()
+            },
         )
         .expect("write_tags should succeed");
 
@@ -3580,30 +3545,23 @@ mod tests {
 
         crate::tageditor::write_tags(
             &path,
-            "Title",
-            None,
-            "Artist",
-            None,
-            "Album",
-            None,
-            "",
-            None,
-            "",
-            None,
-            "",
-            None,
-            None,
-            None,
-            Some(1995),
-            "",
-            None,
-            "",
-            false,
+            &crate::tageditor::TagWriteRequest {
+                title: "Title",
+                artist: "Artist",
+                album: "Album",
+                year: Some(1995),
+                ..Default::default()
+            },
         )
         .expect("write_tags should succeed");
         crate::tageditor::write_tags(
-            &path, "Title", None, "Artist", None, "Album", None, "", None, "", None, "", None,
-            None, None, None, "", None, "", false,
+            &path,
+            &crate::tageditor::TagWriteRequest {
+                title: "Title",
+                artist: "Artist",
+                album: "Album",
+                ..Default::default()
+            },
         )
         .expect("second write_tags (clearing year) should succeed");
 

--- a/src-tauri/src/commands/tageditor.rs
+++ b/src-tauri/src/commands/tageditor.rs
@@ -188,32 +188,32 @@ pub async fn save_song_tags(
     let genre_str =
         models::join_multi_value(&models::parse_multi_value(&genre.unwrap_or_default()));
     let genre_c = genre_str.clone();
-    let genresort_c = genresort.clone();
     let grouping_c = grouping.clone();
     let initial_key_c = initial_key.clone();
 
     tauri::async_runtime::spawn_blocking(move || {
         crate::tageditor::write_tags(
             &path_clone,
-            &title_c,
-            titlesort_c.as_deref(),
-            &artist_c,
-            artistsort_c.as_deref(),
-            &album_c,
-            albumsort_c.as_deref(),
-            &album_artist_c,
-            album_artist_sort_c.as_deref(),
-            &composer_c,
-            composersort_c.as_deref(),
-            &genre_c,
-            genresort_c.as_deref(),
-            track,
-            disc,
-            year,
-            &grouping_c,
-            bpm,
-            &initial_key_c,
-            compilation,
+            &crate::tageditor::TagWriteRequest {
+                title: &title_c,
+                titlesort: titlesort_c.as_deref(),
+                artist: &artist_c,
+                artistsort: artistsort_c.as_deref(),
+                album: &album_c,
+                albumsort: albumsort_c.as_deref(),
+                album_artist: &album_artist_c,
+                album_artist_sort: album_artist_sort_c.as_deref(),
+                composer: &composer_c,
+                composersort: composersort_c.as_deref(),
+                genre: &genre_c,
+                track,
+                disc,
+                year,
+                grouping: &grouping_c,
+                bpm,
+                initial_key: &initial_key_c,
+                compilation,
+            },
         )
     })
     .await
@@ -347,7 +347,6 @@ pub async fn save_album_tags(
     let genre_str =
         models::join_multi_value(&models::parse_multi_value(&genre.unwrap_or_default()));
     let genre_c = genre_str.clone();
-    let genresort_c = genresort.clone();
 
     let updated_count = tauri::async_runtime::spawn_blocking(move || {
         let mut count = 0u32;
@@ -355,25 +354,26 @@ pub async fn save_album_tags(
             let path = std::path::PathBuf::from(&item.path);
             let write_res = crate::tageditor::write_tags(
                 &path,
-                &item.title,
-                item.titlesort.as_deref(),
-                &item.artist,
-                item.artistsort.as_deref(),
-                &album_c,
-                albumsort_c.as_deref(),
-                &album_artist_c,
-                album_artist_sort_c.as_deref(),
-                &item.composer,
-                item.composersort.as_deref(),
-                &genre_c,
-                genresort_c.as_deref(),
-                item.track,
-                disc,
-                year,
-                &item.grouping,
-                item.bpm,
-                &item.initial_key,
-                compilation,
+                &crate::tageditor::TagWriteRequest {
+                    title: &item.title,
+                    titlesort: item.titlesort.as_deref(),
+                    artist: &item.artist,
+                    artistsort: item.artistsort.as_deref(),
+                    album: &album_c,
+                    albumsort: albumsort_c.as_deref(),
+                    album_artist: &album_artist_c,
+                    album_artist_sort: album_artist_sort_c.as_deref(),
+                    composer: &item.composer,
+                    composersort: item.composersort.as_deref(),
+                    genre: &genre_c,
+                    track: item.track,
+                    disc,
+                    year,
+                    grouping: &item.grouping,
+                    bpm: item.bpm,
+                    initial_key: &item.initial_key,
+                    compilation,
+                },
             );
             if write_res.is_ok() {
                 count += 1;

--- a/src-tauri/src/commands/tags.rs
+++ b/src-tauri/src/commands/tags.rs
@@ -161,7 +161,6 @@ struct SongFullMetadata {
     composer: String,
     composersort: Option<String>,
     genre: String,
-    genresort: Option<String>,
     track: Option<u32>,
     disc: Option<u32>,
     year: Option<u32>,
@@ -175,7 +174,7 @@ fn load_full_metadata(conn: &rusqlite::Connection, song_ids: &[i64]) -> Vec<Song
     let mut out = Vec::with_capacity(song_ids.len());
     for &id in song_ids {
         let res = conn.query_row(
-            "SELECT path, title, titlesort, artist, artistsort, album, albumsort, album_artist, album_artist_sort, composer, composersort, genre, genresort, track, disc, year, grouping, bpm, initial_key, compilation
+            "SELECT path, title, titlesort, artist, artistsort, album, albumsort, album_artist, album_artist_sort, composer, composersort, genre, track, disc, year, grouping, bpm, initial_key, compilation
              FROM songs WHERE id = ?1",
             rusqlite::params![id],
             |row| {
@@ -193,14 +192,13 @@ fn load_full_metadata(conn: &rusqlite::Connection, song_ids: &[i64]) -> Vec<Song
                     composer: row.get(9).unwrap_or_default(),
                     composersort: row.get(10).ok(),
                     genre: row.get(11).unwrap_or_default(),
-                    genresort: row.get(12).ok(),
-                    track: row.get(13).ok(),
-                    disc: row.get(14).ok(),
-                    year: row.get(15).ok(),
-                    grouping: row.get(16).unwrap_or_default(),
-                    bpm: row.get(17).ok(),
-                    initial_key: row.get(18).unwrap_or_default(),
-                    compilation: row.get(19).unwrap_or(false),
+                    track: row.get(12).ok(),
+                    disc: row.get(13).ok(),
+                    year: row.get(14).ok(),
+                    grouping: row.get(15).unwrap_or_default(),
+                    bpm: row.get(16).ok(),
+                    initial_key: row.get(17).unwrap_or_default(),
+                    compilation: row.get(18).unwrap_or(false),
                 })
             },
         );
@@ -233,25 +231,26 @@ async fn rewrite_genre_and_persist(
                 let path = std::path::PathBuf::from(&item.path);
                 let write_res = crate::tageditor::write_tags(
                     &path,
-                    &item.title,
-                    item.titlesort.as_deref(),
-                    &item.artist,
-                    item.artistsort.as_deref(),
-                    &item.album,
-                    item.albumsort.as_deref(),
-                    &item.album_artist,
-                    item.album_artist_sort.as_deref(),
-                    &item.composer,
-                    item.composersort.as_deref(),
-                    &new_genre,
-                    item.genresort.as_deref(),
-                    item.track,
-                    item.disc,
-                    item.year,
-                    &item.grouping,
-                    item.bpm,
-                    &item.initial_key,
-                    item.compilation,
+                    &crate::tageditor::TagWriteRequest {
+                        title: &item.title,
+                        titlesort: item.titlesort.as_deref(),
+                        artist: &item.artist,
+                        artistsort: item.artistsort.as_deref(),
+                        album: &item.album,
+                        albumsort: item.albumsort.as_deref(),
+                        album_artist: &item.album_artist,
+                        album_artist_sort: item.album_artist_sort.as_deref(),
+                        composer: &item.composer,
+                        composersort: item.composersort.as_deref(),
+                        genre: &new_genre,
+                        track: item.track,
+                        disc: item.disc,
+                        year: item.year,
+                        grouping: &item.grouping,
+                        bpm: item.bpm,
+                        initial_key: &item.initial_key,
+                        compilation: item.compilation,
+                    },
                 );
                 if write_res.is_ok() {
                     count += 1;

--- a/src-tauri/src/commands/tags.rs
+++ b/src-tauri/src/commands/tags.rs
@@ -211,39 +211,25 @@ fn load_full_metadata(conn: &rusqlite::Connection, song_ids: &[i64]) -> Vec<Song
     out
 }
 
-/// Merges `from` into `into`: rewrites every affected song's embedded genre
-/// tag on disk and in the DB (same dual-write as the regular tag editor —
-/// see `tags.rs`'s module doc comment), then folds `from`'s curated
-/// hierarchy position into `into`'s. Returns the number of songs updated.
-#[tauri::command]
-pub async fn merge_tags(
-    app: AppHandle,
-    state: State<'_, AppState>,
-    from: String,
-    into: String,
+/// Shared by [`merge_tags`]/[`delete_tags`]: rewrites every affected song's
+/// embedded genre tag on disk and in the DB (same dual-write as the regular
+/// tag editor — see `tags.rs`'s module doc comment). `rewrite_genre` computes
+/// each song's new genre string from its current one; callers supply
+/// merge-into or delete-these-names logic. Returns the number of songs
+/// whose on-disk write succeeded.
+async fn rewrite_genre_and_persist(
+    conn: r2d2::PooledConnection<r2d2_sqlite::SqliteConnectionManager>,
+    song_ids: &[i64],
+    rewrite_genre: impl Fn(&str) -> String + Send + 'static,
 ) -> Result<u32, String> {
-    if from.trim().is_empty() || into.trim().is_empty() || from.eq_ignore_ascii_case(&into) {
-        return Ok(0);
-    }
+    let metas = load_full_metadata(&conn, song_ids);
 
-    let _watcher_pause_guard = WatcherPauseGuard::new(Arc::clone(&state.watcher_paused));
-
-    let manager = TagManager::new(state.db.clone());
-    let conn = state.db.pool.get().map_err(|e| e.to_string())?;
-    let affected = manager
-        .songs_containing_any(std::slice::from_ref(&from))
-        .map_err(|e| e.to_string())?;
-    let song_ids: Vec<i64> = affected.iter().map(|(id, _, _)| *id).collect();
-    let metas = load_full_metadata(&conn, &song_ids);
-
-    let from_c = from.clone();
-    let into_c = into.clone();
     let (updated_count, writes): (u32, Vec<(i64, String)>) =
         tauri::async_runtime::spawn_blocking(move || {
             let mut count = 0u32;
             let mut writes = Vec::with_capacity(metas.len());
             for item in &metas {
-                let new_genre = TagManager::rewrite_genre_for_merge(&item.genre, &from_c, &into_c);
+                let new_genre = rewrite_genre(&item.genre);
                 let path = std::path::PathBuf::from(&item.path);
                 let write_res = crate::tageditor::write_tags(
                     &path,
@@ -286,6 +272,39 @@ pub async fn merge_tags(
         .map_err(|e| e.to_string())?;
     }
     tx.commit().map_err(|e| e.to_string())?;
+
+    Ok(updated_count)
+}
+
+/// Merges `from` into `into`: rewrites every affected song's embedded genre
+/// tag on disk and in the DB, then folds `from`'s curated hierarchy position
+/// into `into`'s. Returns the number of songs updated.
+#[tauri::command]
+pub async fn merge_tags(
+    app: AppHandle,
+    state: State<'_, AppState>,
+    from: String,
+    into: String,
+) -> Result<u32, String> {
+    if from.trim().is_empty() || into.trim().is_empty() || from.eq_ignore_ascii_case(&into) {
+        return Ok(0);
+    }
+
+    let _watcher_pause_guard = WatcherPauseGuard::new(Arc::clone(&state.watcher_paused));
+
+    let manager = TagManager::new(state.db.clone());
+    let conn = state.db.pool.get().map_err(|e| e.to_string())?;
+    let affected = manager
+        .songs_containing_any(std::slice::from_ref(&from))
+        .map_err(|e| e.to_string())?;
+    let song_ids: Vec<i64> = affected.iter().map(|(id, _, _)| *id).collect();
+
+    let from_c = from.clone();
+    let into_c = into.clone();
+    let updated_count = rewrite_genre_and_persist(conn, &song_ids, move |genre| {
+        TagManager::rewrite_genre_for_merge(genre, &from_c, &into_c)
+    })
+    .await?;
 
     manager
         .apply_merge_hierarchy(&from, &into)
@@ -318,57 +337,13 @@ pub async fn delete_tags(
         .songs_containing_any(&names)
         .map_err(|e| e.to_string())?;
     let song_ids: Vec<i64> = affected.iter().map(|(id, _, _)| *id).collect();
-    let metas = load_full_metadata(&conn, &song_ids);
 
     let names_c = names.clone();
-    let (updated_count, writes): (u32, Vec<(i64, String)>) =
-        tauri::async_runtime::spawn_blocking(move || {
-            let mut count = 0u32;
-            let mut writes = Vec::with_capacity(metas.len());
-            for item in &metas {
-                let new_genre = TagManager::rewrite_genre_for_delete(&item.genre, &names_c);
-                let path = std::path::PathBuf::from(&item.path);
-                let write_res = crate::tageditor::write_tags(
-                    &path,
-                    &item.title,
-                    item.titlesort.as_deref(),
-                    &item.artist,
-                    item.artistsort.as_deref(),
-                    &item.album,
-                    item.albumsort.as_deref(),
-                    &item.album_artist,
-                    item.album_artist_sort.as_deref(),
-                    &item.composer,
-                    item.composersort.as_deref(),
-                    &new_genre,
-                    item.genresort.as_deref(),
-                    item.track,
-                    item.disc,
-                    item.year,
-                    &item.grouping,
-                    item.bpm,
-                    &item.initial_key,
-                    item.compilation,
-                );
-                if write_res.is_ok() {
-                    count += 1;
-                }
-                writes.push((item.id, new_genre));
-            }
-            (count, writes)
+    let updated_count =
+        rewrite_genre_and_persist(conn, &song_ids, move |genre| {
+            TagManager::rewrite_genre_for_delete(genre, &names_c)
         })
-        .await
-        .map_err(|e| e.to_string())?;
-
-    let tx = conn.unchecked_transaction().map_err(|e| e.to_string())?;
-    for (song_id, new_genre) in &writes {
-        tx.execute(
-            "UPDATE songs SET genre = ?1 WHERE id = ?2",
-            rusqlite::params![new_genre, song_id],
-        )
-        .map_err(|e| e.to_string())?;
-    }
-    tx.commit().map_err(|e| e.to_string())?;
+        .await?;
 
     manager
         .apply_delete_hierarchy(&names)

--- a/src-tauri/src/tageditor.rs
+++ b/src-tauri/src/tageditor.rs
@@ -84,6 +84,34 @@ struct AcoustIdResponse {
 // Tag Editor File Writer
 // ---------------------------------------------------------------------------
 
+/// Every field [`write_tags`] needs to persist a song's tags to disk,
+/// grouped into one request instead of a long positional argument list.
+/// Borrows rather than owns its string fields — callers already hold the
+/// owned data (loaded from the DB or a genre-rewrite result) and just need
+/// to name it once per write. Has no `genresort` field: `genresort` has no
+/// on-disk tag mapping and was never used by `write_tags`.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct TagWriteRequest<'a> {
+    pub title: &'a str,
+    pub titlesort: Option<&'a str>,
+    pub artist: &'a str,
+    pub artistsort: Option<&'a str>,
+    pub album: &'a str,
+    pub albumsort: Option<&'a str>,
+    pub album_artist: &'a str,
+    pub album_artist_sort: Option<&'a str>,
+    pub composer: &'a str,
+    pub composersort: Option<&'a str>,
+    pub genre: &'a str,
+    pub track: Option<u32>,
+    pub disc: Option<u32>,
+    pub year: Option<u32>,
+    pub grouping: &'a str,
+    pub bpm: Option<f32>,
+    pub initial_key: &'a str,
+    pub compilation: bool,
+}
+
 /// Write the given tag fields to `path`'s primary tag, creating one if the
 /// file has none yet. Every field is written unconditionally — `Option`
 /// fields (`track`, `disc`, `year`, `bpm`) are cleared from the file when
@@ -93,29 +121,28 @@ struct AcoustIdResponse {
 /// Retries the on-disk save up to 5 times with a short delay, since it can
 /// transiently fail if another process (e.g. an antivirus scanner) has the
 /// file open.
-#[allow(clippy::too_many_arguments)]
-pub fn write_tags(
-    path: &Path,
-    title: &str,
-    titlesort: Option<&str>,
-    artist: &str,
-    artistsort: Option<&str>,
-    album: &str,
-    albumsort: Option<&str>,
-    album_artist: &str,
-    album_artist_sort: Option<&str>,
-    composer: &str,
-    composersort: Option<&str>,
-    genre: &str,
-    _genresort: Option<&str>,
-    track: Option<u32>,
-    disc: Option<u32>,
-    year: Option<u32>,
-    grouping: &str,
-    bpm: Option<f32>,
-    initial_key: &str,
-    compilation: bool,
-) -> Result<()> {
+pub fn write_tags(path: &Path, req: &TagWriteRequest) -> Result<()> {
+    let TagWriteRequest {
+        title,
+        titlesort,
+        artist,
+        artistsort,
+        album,
+        albumsort,
+        album_artist,
+        album_artist_sort,
+        composer,
+        composersort,
+        genre,
+        track,
+        disc,
+        year,
+        grouping,
+        bpm,
+        initial_key,
+        compilation,
+    } = *req;
+
     let mut tagged_file = Probe::open(path)
         .context("failed to open audio file for tag writing")?
         .read()
@@ -592,25 +619,15 @@ mod tests {
 
         write_tags(
             &path,
-            "Title",
-            None,
-            "Artist",
-            None,
-            "Album",
-            None,
-            "Album Artist",
-            None,
-            "Composer",
-            None,
-            "Rock; Jazz Fusion; Live",
-            None,
-            None,
-            None,
-            None,
-            "",
-            None,
-            "",
-            false,
+            &TagWriteRequest {
+                title: "Title",
+                artist: "Artist",
+                album: "Album",
+                album_artist: "Album Artist",
+                composer: "Composer",
+                genre: "Rock; Jazz Fusion; Live",
+                ..Default::default()
+            },
         )
         .expect("write_tags should succeed");
 
@@ -632,8 +649,14 @@ mod tests {
         write_test_wav(&path);
 
         write_tags(
-            &path, "Title", None, "Artist", None, "Album", None, "", None, "", None, "Metal", None,
-            None, None, None, "", None, "", false,
+            &path,
+            &TagWriteRequest {
+                title: "Title",
+                artist: "Artist",
+                album: "Album",
+                genre: "Metal",
+                ..Default::default()
+            },
         )
         .expect("write_tags should succeed");
 
@@ -650,13 +673,24 @@ mod tests {
         write_test_wav(&path);
 
         write_tags(
-            &path, "Title", None, "Artist", None, "Album", None, "", None, "", None, "Metal", None,
-            None, None, None, "", None, "", false,
+            &path,
+            &TagWriteRequest {
+                title: "Title",
+                artist: "Artist",
+                album: "Album",
+                genre: "Metal",
+                ..Default::default()
+            },
         )
         .expect("write_tags should succeed");
         write_tags(
-            &path, "Title", None, "Artist", None, "Album", None, "", None, "", None, "", None,
-            None, None, None, "", None, "", false,
+            &path,
+            &TagWriteRequest {
+                title: "Title",
+                artist: "Artist",
+                album: "Album",
+                ..Default::default()
+            },
         )
         .expect("write_tags with empty genre should succeed");
 
@@ -673,25 +707,14 @@ mod tests {
 
         write_tags(
             &path,
-            "Title",
-            None,
-            "Artist A; Artist B",
-            None,
-            "Album",
-            None,
-            "Album Artist A; Album Artist B",
-            None,
-            "Composer A; Composer B",
-            None,
-            "",
-            None,
-            None,
-            None,
-            None,
-            "",
-            None,
-            "",
-            false,
+            &TagWriteRequest {
+                title: "Title",
+                artist: "Artist A; Artist B",
+                album: "Album",
+                album_artist: "Album Artist A; Album Artist B",
+                composer: "Composer A; Composer B",
+                ..Default::default()
+            },
         )
         .expect("write_tags should succeed");
 
@@ -725,30 +748,23 @@ mod tests {
 
         write_tags(
             &path,
-            "Title",
-            None,
-            "Artist",
-            None,
-            "Album",
-            None,
-            "Album Artist",
-            None,
-            "Composer",
-            None,
-            "",
-            None,
-            None,
-            None,
-            None,
-            "",
-            None,
-            "",
-            false,
+            &TagWriteRequest {
+                title: "Title",
+                artist: "Artist",
+                album: "Album",
+                album_artist: "Album Artist",
+                composer: "Composer",
+                ..Default::default()
+            },
         )
         .expect("write_tags should succeed");
         write_tags(
-            &path, "Title", None, "", None, "Album", None, "", None, "", None, "", None, None,
-            None, None, "", None, "", false,
+            &path,
+            &TagWriteRequest {
+                title: "Title",
+                album: "Album",
+                ..Default::default()
+            },
         )
         .expect("write_tags with empty artist/album_artist/composer should succeed");
 
@@ -767,25 +783,20 @@ mod tests {
 
         write_tags(
             &path,
-            "The Beatles",
-            Some("Beatles, The"),
-            "The Beatles",
-            Some("Beatles, The"),
-            "Abbey Road",
-            Some("Abbey Road Sort"),
-            "The Beatles",
-            Some("Beatles, The"),
-            "McCartney",
-            Some("McCartney, Paul"),
-            "Rock",
-            Some("Rock, Classic"),
-            None,
-            None,
-            None,
-            "",
-            None,
-            "",
-            false,
+            &TagWriteRequest {
+                title: "The Beatles",
+                titlesort: Some("Beatles, The"),
+                artist: "The Beatles",
+                artistsort: Some("Beatles, The"),
+                album: "Abbey Road",
+                albumsort: Some("Abbey Road Sort"),
+                album_artist: "The Beatles",
+                album_artist_sort: Some("Beatles, The"),
+                composer: "McCartney",
+                composersort: Some("McCartney, Paul"),
+                genre: "Rock",
+                ..Default::default()
+            },
         )
         .expect("write_tags should succeed");
 

--- a/src-tauri/tests/smoke_test.rs
+++ b/src-tauri/tests/smoke_test.rs
@@ -67,25 +67,12 @@ async fn smoke_full_pipeline() {
     // --- Tag writing (real lofty write to a real file on disk) ---
     tageditor::write_tags(
         &song_path,
-        "Smoke Test Tone",
-        None,
-        "Smoke Test Artist",
-        None,
-        "Smoke Test Album",
-        None,
-        "",
-        None,
-        "",
-        None,
-        "",
-        None,
-        None,
-        None,
-        None,
-        "",
-        None,
-        "",
-        false,
+        &tageditor::TagWriteRequest {
+            title: "Smoke Test Tone",
+            artist: "Smoke Test Artist",
+            album: "Smoke Test Album",
+            ..Default::default()
+        },
     )
     .expect("write_tags should succeed against a real audio file");
     println!("[ok] tag writing (lofty)");


### PR DESCRIPTION
## 📋 Summary
Addresses items 8 and 12 of #577 together, as the plan called for (they share the same field set): introduces `tageditor::TagWriteRequest<'a>` and migrates `write_tags` and every caller (`save_song_tags`, `save_album_tags`, `rewrite_genre_and_persist`, plus all unit tests) off `write_tags`'s 19-positional-argument signature.

## 🔍 Implementation Notes
- `write_tags(path: &Path, req: &TagWriteRequest)` replaces the 19-positional-arg signature. `TagWriteRequest<'a>` borrows its string fields (no extra cloning beyond what callers already needed) and derives `Default`, so tests only name the fields they actually care about (`TagWriteRequest { title: "Title", artist: "Artist", album: "Album", ..Default::default() }`).
- Dropped the dead `_genresort` parameter entirely — it has no on-disk tag mapping and was never read by `write_tags`. Also removed `genresort` from `commands/tags.rs`'s `SongFullMetadata` (and the corresponding SQL column/clone) now that nothing reads it, and removed the now-dead `genresort_c` clones in `save_song_tags`/`save_album_tags` (the DB `UPDATE`s still write the original `genresort` value — only the extra clone-for-write_tags was dead).
- Named-field struct literals replace positional argument lists at every call site, so a misordered field is a compile error pointing at the field name instead of a silent off-by-one in a 19-argument call.
- Updated every call site: `save_song_tags`, `save_album_tags` (`commands/tageditor.rs`), `rewrite_genre_and_persist` (`commands/tags.rs`, from item 7/#586), `smoke_test.rs`, and all `write_tags` unit tests in `tageditor.rs` and `collection.rs`.
- No behavior change intended.

## 🧪 Test Plan
- [x] `cargo build` (src-tauri) — clean
- [x] `cargo test` (src-tauri) — full suite passing (BDD scenarios, unit tests, `smoke_test.rs`)
- [x] `cargo clippy --lib --tests` — no new warnings (3 pre-existing warnings elsewhere in `tags.rs`, unrelated)
- [x] Manually verified in the app — pending, via `bun run tauri dev` (edit a song's tags, edit an album's tags, confirm file + DB both update correctly)

## 📸 Screenshots
N/A — pure backend refactor, no UI changes.

## ✅ Checklist
- [x] No unrelated changes bundled in
- [ ] Docs/screenshots updated if user-facing behavior changed — no user-facing behavior change
