### PR TITLE
refactor: dedup organizer collision resolution (#577 item 10)

### DIFF
--- a/src-tauri/src/organizer.rs
+++ b/src-tauri/src/organizer.rs
@@ -405,6 +405,58 @@ fn apply_dir_casing_map(parts: &mut [String], map: &DirCasingMap) {
     }
 }
 
+/// The folder collision-routing paths (destination and its "Duplicates"
+/// subfolder) are computed relative to: the explicit destination dir if
+/// set, else whichever library root `source_path` is under, else its own
+/// parent directory.
+fn resolve_dest_folder(
+    source_path: &Path,
+    options: &OrganizeOptions,
+    library_dirs: &[String],
+) -> PathBuf {
+    if let Some(ref dest) = options.destination_dir {
+        PathBuf::from(dest)
+    } else {
+        library_dirs
+            .iter()
+            .map(PathBuf::from)
+            .find(|dir| source_path.starts_with(dir))
+            .or_else(|| source_path.parent().map(|p| p.to_path_buf()))
+            .unwrap_or_else(|| PathBuf::from("."))
+    }
+}
+
+/// Appends a numeric " (N)" suffix to `dup_path`'s file stem, incrementing
+/// until it lands on a path that doesn't already exist on disk. If it lands
+/// on `source_path` itself, the file is already at its resolved target, so
+/// returns `is_unchanged = true` instead of a fresh suffix.
+fn resolve_duplicate_path(dup_path: &Path, source_path: &Path) -> (PathBuf, bool) {
+    let mut duplicate_counter = 1;
+    let mut final_dup_path = dup_path.to_path_buf();
+
+    while final_dup_path.exists() {
+        if final_dup_path == source_path {
+            return (final_dup_path, true);
+        }
+        if let Some(ext) = dup_path.extension().map(|s| s.to_owned()) {
+            if let Some(stem) = dup_path
+                .file_stem()
+                .map(|s| s.to_string_lossy().into_owned())
+            {
+                final_dup_path = dup_path.with_file_name(format!(
+                    "{} ({}).{}",
+                    stem,
+                    duplicate_counter,
+                    ext.to_string_lossy()
+                ));
+            }
+        }
+        duplicate_counter += 1;
+    }
+
+    (final_dup_path, false)
+}
+
 /// Compute dry-run preview items for given song IDs.
 pub fn compute_preview(
     db: &Database,
@@ -604,8 +656,6 @@ pub fn compute_preview(
                 }
             }
 
-            let mut duplicate_counter = 1;
-
             for &idx in &indices {
                 if idx == canonical_idx {
                     continue; // Canonical item gets to keep its target, but it might still have an external collision (checked below)
@@ -632,16 +682,7 @@ pub fn compute_preview(
                 let original_target = Path::new(&preview_items[idx].to_path);
                 let source_path = Path::new(&preview_items[idx].from_path);
 
-                let dest_folder: PathBuf = if let Some(ref dest) = options.destination_dir {
-                    PathBuf::from(dest)
-                } else {
-                    library_dirs
-                        .iter()
-                        .map(PathBuf::from)
-                        .find(|dir| source_path.starts_with(dir))
-                        .or_else(|| source_path.parent().map(|p| p.to_path_buf()))
-                        .unwrap_or_else(|| PathBuf::from("."))
-                };
+                let dest_folder = resolve_dest_folder(source_path, options, &library_dirs);
 
                 let rel_path = original_target
                     .strip_prefix(&dest_folder)
@@ -651,29 +692,8 @@ pub fn compute_preview(
                 dup_path.push("Duplicates");
                 dup_path.push(rel_path);
 
-                let mut final_dup_path = dup_path.clone();
-                let mut is_unchanged = false;
-
-                while final_dup_path.exists() {
-                    if final_dup_path == source_path {
-                        is_unchanged = true;
-                        break;
-                    }
-                    if let Some(ext) = dup_path.extension().map(|s| s.to_owned()) {
-                        if let Some(stem) = dup_path
-                            .file_stem()
-                            .map(|s| s.to_string_lossy().into_owned())
-                        {
-                            final_dup_path = dup_path.with_file_name(format!(
-                                "{} ({}).{}",
-                                stem,
-                                duplicate_counter,
-                                ext.to_string_lossy()
-                            ));
-                        }
-                    }
-                    duplicate_counter += 1;
-                }
+                let (final_dup_path, is_unchanged) =
+                    resolve_duplicate_path(&dup_path, source_path);
 
                 preview_items[idx].to_path = final_dup_path.to_string_lossy().to_string();
                 if is_unchanged {
@@ -716,16 +736,7 @@ pub fn compute_preview(
                 }
             }
 
-            let dest_folder: PathBuf = if let Some(ref dest) = options.destination_dir {
-                PathBuf::from(dest)
-            } else {
-                library_dirs
-                    .iter()
-                    .map(PathBuf::from)
-                    .find(|dir| source_path.starts_with(dir))
-                    .or_else(|| source_path.parent().map(|p| p.to_path_buf()))
-                    .unwrap_or_else(|| PathBuf::from("."))
-            };
+            let dest_folder = resolve_dest_folder(source_path, options, &library_dirs);
 
             let rel_path = current_target
                 .strip_prefix(&dest_folder)
@@ -735,30 +746,7 @@ pub fn compute_preview(
             dup_path.push("Duplicates");
             dup_path.push(rel_path);
 
-            let mut duplicate_counter = 1;
-            let mut final_dup_path = dup_path.clone();
-            let mut is_unchanged = false;
-
-            while final_dup_path.exists() {
-                if final_dup_path == source_path {
-                    is_unchanged = true;
-                    break;
-                }
-                if let Some(ext) = dup_path.extension().map(|s| s.to_owned()) {
-                    if let Some(stem) = dup_path
-                        .file_stem()
-                        .map(|s| s.to_string_lossy().into_owned())
-                    {
-                        final_dup_path = dup_path.with_file_name(format!(
-                            "{} ({}).{}",
-                            stem,
-                            duplicate_counter,
-                            ext.to_string_lossy()
-                        ));
-                    }
-                }
-                duplicate_counter += 1;
-            }
+            let (final_dup_path, is_unchanged) = resolve_duplicate_path(&dup_path, source_path);
 
             item.to_path = final_dup_path.to_string_lossy().to_string();
             if is_unchanged {


### PR DESCRIPTION
## 📋 Summary
Addresses item 10 of #577: extracts `resolve_dest_folder` and `resolve_duplicate_path` out of `compute_preview` (`src-tauri/src/organizer.rs`), which duplicated the same duplicate-path-resolution logic within one function — once for internal collisions (two songs mapping to the same target) and once for external collisions (target already exists on disk).

## 🔍 Implementation Notes
- `resolve_dest_folder(source_path, options, library_dirs)`: the explicit-destination-dir-or-library-root-or-parent-dir resolution, previously duplicated verbatim in both collision passes.
- `resolve_duplicate_path(dup_path, source_path)`: the "append a numeric ` (N)` suffix until the path is free on disk, or discover it's already `source_path` itself" loop, previously duplicated verbatim (including its own `duplicate_counter`) in both passes. Returns `(final_path, is_unchanged)`.
- Both `compute_preview` passes now just build `dup_path` and call the two helpers.
- No behavior change intended — same resolution order, same suffix format, same unchanged-detection.

## 🧪 Test Plan
- [x] `cargo build` (src-tauri) — clean
- [x] `cargo test` (src-tauri) — full suite passing, including the 15 `organizer::` unit tests
- [x] `cargo clippy --lib --tests` — no new warnings (3 pre-existing warnings elsewhere in `tags.rs`, unrelated)
- [ ] Manually verified in the app — pending, via `bun run tauri dev` (run Organize Library preview with an intentional collision, confirm it still routes to `Duplicates/` with the expected numeric suffix)

## 📸 Screenshots
N/A — pure backend refactor, no UI changes.

## ✅ Checklist
- [x] No unrelated changes bundled in
- [ ] Docs/screenshots updated if user-facing behavior changed — no user-facing behavior change
