### PR TITLE
fix: hard-filter Familiar queue mode to playcount > 0

### DIFF
--- a/src-tauri/src/collection.rs
+++ b/src-tauri/src/collection.rs
@@ -2446,7 +2446,7 @@ pub(crate) fn mode_query_fragments(mode: QueuePopulationMode) -> (&'static str, 
         QueuePopulationMode::Favourites => (" AND rating >= 4", "RANDOM()"),
         QueuePopulationMode::DeepCuts => (" AND (playcount = 0 OR lastplayed IS NULL)", "RANDOM()"),
         QueuePopulationMode::Familiar => (
-            "",
+            " AND playcount > 0",
             "((ABS(RANDOM()) % 1000000) / 1000000.0) * (playcount + 1) DESC",
         ),
         QueuePopulationMode::Discover => (
@@ -4652,8 +4652,9 @@ mod tests {
             .unwrap();
         assert_eq!(
             titles(familiar),
-            vec!["DeepCut", "Discover", "Familiar", "Fav", "Neutral"],
-            "Familiar biases order via weighting, not filtering"
+            vec!["Discover", "Familiar", "Neutral"],
+            "Familiar excludes never-played songs (playcount > 0), then biases order by \
+             playcount among the rest"
         );
 
         let favourites = tag_manager


### PR DESCRIPTION
## 📋 Summary
Follow-up from [#593's review discussion](https://github.com/esoltys/luminous/pull/593#issuecomment-5429707453): the "Essentials" (`Familiar`) queue population mode was including never-played songs. This was by design (a weighting bias, not a filter) but the user asked to hard-filter it instead, matching `Discover` mode's existing `playcount > 0` filter.

## 🔍 Implementation Notes
- `mode_query_fragments`'s `Familiar` arm now adds `" AND playcount > 0"` alongside its existing `RANDOM() * (playcount + 1)` weighted ordering — same filter `Discover` already uses, so a never-played song can no longer surface under either biased-toward-plays mode.
- Updated `test_get_songs_by_tag_population_modes` to assert the new filtered set (`["Discover", "Familiar", "Neutral"]`, excluding the two 0-play seed songs) instead of the old "no filtering, only weighting" assertion.

## 🧪 Test Plan
- [x] `cargo build` (src-tauri) — clean
- [x] `cargo test` (src-tauri) — full suite passing (218 lib unit tests + BDD suites), including the updated `test_get_songs_by_tag_population_modes`
- [x] `cargo clippy --lib --tests` — no new warnings (pre-existing warnings elsewhere, unrelated)
- [x] `cargo fmt --check -- src/collection.rs` — clean

## 📸 Screenshots
N/A — backend query filter change, no UI changes.

## ✅ Checklist
- [x] No unrelated changes bundled in
- [ ] Docs/screenshots updated if user-facing behavior changed — behavior change is the point of this PR (Essentials/Familiar no longer surfaces never-played songs), but no docs reference the old weighting-only behavior
