### PR TITLE
style: fix rustfmt drift in commands/tags.rs and organizer.rs

### DIFF
--- a/src-tauri/src/commands/tags.rs
+++ b/src-tauri/src/commands/tags.rs
@@ -339,11 +339,10 @@ pub async fn delete_tags(
     let song_ids: Vec<i64> = affected.iter().map(|(id, _, _)| *id).collect();
 
     let names_c = names.clone();
-    let updated_count =
-        rewrite_genre_and_persist(conn, &song_ids, move |genre| {
-            TagManager::rewrite_genre_for_delete(genre, &names_c)
-        })
-        .await?;
+    let updated_count = rewrite_genre_and_persist(conn, &song_ids, move |genre| {
+        TagManager::rewrite_genre_for_delete(genre, &names_c)
+    })
+    .await?;
 
     manager
         .apply_delete_hierarchy(&names)

--- a/src-tauri/src/organizer.rs
+++ b/src-tauri/src/organizer.rs
@@ -692,8 +692,7 @@ pub fn compute_preview(
                 dup_path.push("Duplicates");
                 dup_path.push(rel_path);
 
-                let (final_dup_path, is_unchanged) =
-                    resolve_duplicate_path(&dup_path, source_path);
+                let (final_dup_path, is_unchanged) = resolve_duplicate_path(&dup_path, source_path);
 
                 preview_items[idx].to_path = final_dup_path.to_string_lossy().to_string();
                 if is_unchanged {


### PR DESCRIPTION
## 📋 Summary
`cargo fmt --check` has shown a diff in these two spots on every #577 PR since items 7 (#commands/tags.rs) and 10 (organizer.rs) landed unformatted — `rustfmt` wasn't run before those merges. Fixing it here so it stops recurring as noise in every subsequent PR's fmt check.

## 🔍 Implementation Notes
- `cargo fmt -- src/commands/tags.rs src/organizer.rs` — whitespace/line-wrapping only, no logic changes.
- `cargo fmt --check` on the full tree is now clean.

## 🧪 Test Plan
- [x] `cargo build` — clean
- [x] `cargo test --lib` — 218 passed, 0 failed, 1 ignored
- [x] `cargo clippy --lib --tests` — no new warnings
- [x] `cargo fmt --check` (full tree) — clean

## 📸 Screenshots
N/A — whitespace-only change.

## ✅ Checklist
- [x] No unrelated changes bundled in
- [ ] Docs/screenshots updated if user-facing behavior changed — no user-facing behavior change