### PR TITLE
fix: align artist header album stack flush right and render genre pills

### DIFF
--- a/src/lib/components/ArtistDetailView.svelte
+++ b/src/lib/components/ArtistDetailView.svelte
@@ -7,6 +7,7 @@
   import { formatDuration } from "../utils/formatters";
   import CoverArt from "./CoverArt.svelte";
   import CoverStack from "./CoverStack.svelte";
+  import GenreChips from "./GenreChips.svelte";
   import AlbumCard from "./AlbumCard.svelte";
   import PlaylistCard from "./PlaylistCard.svelte";
   import AlbumContextMenu from "./AlbumContextMenu.svelte";
@@ -25,6 +26,7 @@
   import { resolveSocialUrl, formatDisplayLabel } from "../utils/artistSocials";
   import { getArtistAlbums, classifyRelease } from "../utils/artist";
   import { songsToCoverStack } from "../utils/covers";
+  import { parseMultiValue, joinMultiValue } from "../utils/multiValue";
   import { isSmartPlaylistSpec } from "../utils/filterParser";
   import { i18n } from "../stores/i18n.svelte";
   import { toastStore } from "../stores/toast.svelte";
@@ -181,22 +183,26 @@
     collectionStore.activeSubTab = "artists";
   }
 
-  function deriveGenreLabel(list: Song[]): string {
+  function deriveArtistGenres(list: Song[]): string {
     const counts = new Map<string, number>();
     for (const s of list) {
-      const g = (s.genre ?? "").trim();
-      if (g !== "") counts.set(g, (counts.get(g) ?? 0) + 1);
+      if (!s.genre) continue;
+      for (const g of parseMultiValue(s.genre)) {
+        const trimmed = g.trim();
+        if (trimmed) {
+          counts.set(trimmed, (counts.get(trimmed) ?? 0) + 1);
+        }
+      }
     }
-    if (counts.size === 0) return i18n.t('artistDetail.unknownGenre');
-    const maxCount = Math.max(...counts.values());
-    const top = [...counts.entries()]
-      .filter(([, c]) => c === maxCount)
-      .map(([g]) => g)
-      .sort((a, b) => a.localeCompare(b));
-    return top.slice(0, 2).join(" / ");
+    if (counts.size === 0) return "";
+    const sorted = [...counts.entries()]
+      .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+      .map(([g]) => g);
+    return joinMultiValue(sorted);
   }
 
-  let genreLabel = $derived(deriveGenreLabel(songs));
+  let rawGenre = $derived(deriveArtistGenres(songs));
+  let genreLabel = $derived(rawGenre ? undefined : i18n.t('artistDetail.unknownGenre'));
 
   let totalDurationLabel = $derived.by(() => {
     const totalNs = songs.reduce((sum, s) => sum + (s.length_nanosec ?? 0), 0);
@@ -328,8 +334,16 @@
         {#if !collectionStore.isDetailHeaderCollapsed}
         <h1 class="text-3xl sm:text-4xl font-heading font-bold text-brand-text-primary leading-snug truncate py-0.5">{artistName}</h1>
 
-        <div class="flex items-center gap-3 text-xs text-brand-text-secondary font-medium">
-          <span>{i18n.t('artistDetail.statsLine', { genre: genreLabel, songs: songsText, duration: totalDurationLabel })}</span>
+        <div class="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-brand-text-secondary font-medium">
+          {#if rawGenre}
+            <GenreChips genre={rawGenre} variant="full" />
+          {:else}
+            <span>{genreLabel}</span>
+          {/if}
+          <span>•</span>
+          <span>{songsText}</span>
+          <span>•</span>
+          <span>{totalDurationLabel}</span>
         </div>
         {/if}
 

--- a/src/lib/components/ArtistDetailView.test.ts
+++ b/src/lib/components/ArtistDetailView.test.ts
@@ -99,10 +99,10 @@ describe("ArtistDetailView", () => {
     render(ArtistDetailView, { props: { artistName: "Shania Twain" } });
 
     // "Country", "Pop", "Rock" should be rendered as chips
-    const countryChip = await screen.findByRole("button", { name: /^Country$/i });
+    const countryChip = await screen.findByTitle("Browse Country");
     expect(countryChip).toBeTruthy();
-    expect(screen.getByRole("button", { name: /^Pop$/i })).toBeTruthy();
-    expect(screen.getByRole("button", { name: /^Rock$/i })).toBeTruthy();
+    expect(screen.getByTitle("Browse Pop")).toBeTruthy();
+    expect(screen.getByTitle("Browse Rock")).toBeTruthy();
 
     await fireEvent.click(countryChip);
     expect(collectionStore.selectedAutoPlaylist?.genre).toBe("Country");

--- a/src/lib/components/ArtistDetailView.test.ts
+++ b/src/lib/components/ArtistDetailView.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/svelte";
 import ArtistDetailView from "./ArtistDetailView.svelte";
 import { collectionStore } from "../stores/collection.svelte";
+import { invoke } from "@tauri-apps/api/core";
 
 vi.mock("@tauri-apps/api/core", () => ({
   invoke: vi.fn((cmd: string, args?: any) => {
@@ -78,5 +79,52 @@ describe("ArtistDetailView", () => {
     await fireEvent.click(editBtn);
 
     expect(screen.getByRole("dialog")).toBeTruthy();
+  });
+
+  it("renders genre chips when artist has songs with multi-value genres", async () => {
+    const invokeMock = vi.mocked(invoke);
+    invokeMock.mockImplementation((cmd: string, args?: any) => {
+      if (cmd === "get_songs_by_artist") {
+        return Promise.resolve([
+          { id: 1, title: "Song 1", artist: "Shania Twain", genre: "Country; Pop", length_nanosec: 180_000_000_000 } as any,
+          { id: 2, title: "Song 2", artist: "Shania Twain", genre: "Country; Rock", length_nanosec: 200_000_000_000 } as any,
+        ]);
+      }
+      if (cmd === "get_playlists_by_artist") return Promise.resolve([]);
+      if (cmd === "get_compilations_by_artist") return Promise.resolve([]);
+      if (cmd === "get_artist_profile") return Promise.resolve(null as any);
+      return Promise.resolve();
+    });
+
+    render(ArtistDetailView, { props: { artistName: "Shania Twain" } });
+
+    // "Country", "Pop", "Rock" should be rendered as chips
+    const countryChip = await screen.findByRole("button", { name: /^Country$/i });
+    expect(countryChip).toBeTruthy();
+    expect(screen.getByRole("button", { name: /^Pop$/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /^Rock$/i })).toBeTruthy();
+
+    await fireEvent.click(countryChip);
+    expect(collectionStore.selectedAutoPlaylist?.genre).toBe("Country");
+    expect(collectionStore.activeTab).toBe("playlists");
+  });
+
+  it("renders Unknown genre when artist songs have no genre", async () => {
+    const invokeMock = vi.mocked(invoke);
+    invokeMock.mockImplementation((cmd: string, args?: any) => {
+      if (cmd === "get_songs_by_artist") {
+        return Promise.resolve([
+          { id: 1, title: "Song 1", artist: "Shania Twain", genre: "", length_nanosec: 180_000_000_000 } as any,
+        ]);
+      }
+      if (cmd === "get_playlists_by_artist") return Promise.resolve([]);
+      if (cmd === "get_compilations_by_artist") return Promise.resolve([]);
+      if (cmd === "get_artist_profile") return Promise.resolve(null as any);
+      return Promise.resolve();
+    });
+
+    render(ArtistDetailView, { props: { artistName: "Shania Twain" } });
+
+    expect(await screen.findByText("Unknown genre")).toBeTruthy();
   });
 });

--- a/src/lib/components/CoverStack.svelte
+++ b/src/lib/components/CoverStack.svelte
@@ -64,7 +64,7 @@
   }
 </script>
 
-<div class="flex items-center justify-center w-full h-full my-auto select-none">
+<div class="flex items-center {direction === 'left' ? 'justify-end' : 'justify-center'} w-full h-full my-auto select-none">
   {#if activeCovers.length > 0}
     {#if activeCovers.length === 1}
       <div class="{sizeClass} overflow-hidden relative">
@@ -95,11 +95,11 @@
       </div>
     {/if}
   {:else if fallbackName}
-    <div class="w-24 h-24 bg-gradient-to-br {getArtistGradient(fallbackName)} rounded-full flex items-center justify-center text-white border border-brand-border/40 font-bold text-2xl shadow-md shrink-0 mx-auto">
+    <div class="w-24 h-24 bg-gradient-to-br {getArtistGradient(fallbackName)} rounded-full flex items-center justify-center text-white border border-brand-border/40 font-bold text-2xl shadow-md shrink-0 {direction === 'left' ? 'ml-auto' : 'mx-auto'}">
       {fallbackName ? fallbackName.charAt(0).toUpperCase() : "?"}
     </div>
   {:else}
-    <div class="{sizeClass} bg-brand-main flex items-center justify-center text-brand-accent-text border border-brand-border overflow-hidden relative mx-auto">
+    <div class="{sizeClass} bg-brand-main flex items-center justify-center text-brand-accent-text border border-brand-border overflow-hidden relative {direction === 'left' ? 'ml-auto' : 'mx-auto'}">
       <CoverArt
         songId={undefined}
         artEmbedded={false}

--- a/src/lib/components/CoverStack.test.ts
+++ b/src/lib/components/CoverStack.test.ts
@@ -1,0 +1,44 @@
+import "@testing-library/jest-dom";
+import { describe, it, expect, vi } from "vitest";
+import { render } from "@testing-library/svelte";
+import CoverStack from "./CoverStack.svelte";
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn().mockResolvedValue(""),
+}));
+
+describe("CoverStack.svelte", () => {
+  const mockCovers = [
+    { songId: 1, artAutomatic: "cover1.jpg" },
+    { songId: 2, artAutomatic: "cover2.jpg" },
+  ];
+
+  it("centers content by default when direction is right", () => {
+    const { container } = render(CoverStack, {
+      props: { covers: mockCovers, direction: "right" },
+    });
+
+    const rootDiv = container.firstElementChild as HTMLElement;
+    expect(rootDiv.className).toContain("justify-center");
+    expect(rootDiv.className).not.toContain("justify-end");
+  });
+
+  it("right-aligns content when direction is left", () => {
+    const { container } = render(CoverStack, {
+      props: { covers: mockCovers, direction: "left" },
+    });
+
+    const rootDiv = container.firstElementChild as HTMLElement;
+    expect(rootDiv.className).toContain("justify-end");
+    expect(rootDiv.className).not.toContain("justify-center");
+  });
+
+  it("renders single cover correctly with direction left", () => {
+    const { container } = render(CoverStack, {
+      props: { covers: [mockCovers[0]], direction: "left" },
+    });
+
+    const rootDiv = container.firstElementChild as HTMLElement;
+    expect(rootDiv.className).toContain("justify-end");
+  });
+});


### PR DESCRIPTION
## 📋 Summary
Fixes #606
Fixes #607

This PR resolves two header formatting and layout issues in the artist detail view:
1. **Flush Right Album Stack (#606)**: Ensures the hero header album cover stack aligns flush with the right container margin when `direction="left"`.
2. **Genre Pills Rendering (#607)**: Parses multi-value `; `-delimited genres from artist songs and renders them as clickable pills/chips using `<GenreChips variant="full" />` matching the layout of `AlbumDetailView`.

## 🔍 Implementation Notes
- **`CoverStack.svelte`**: Updated the outer flex wrapper from `justify-center` to `{direction === 'left' ? 'justify-end' : 'justify-center'}` and adjusted fallback initial avatar margins. In left-stacking mode, index 0 (the frontmost cover) now stays flush against the right margin at `translate(0, 0)` while subsequent covers fan out to the left.
- **`ArtistDetailView.svelte`**: Replaced the previous `deriveGenreLabel` implementation with `deriveArtistGenres` using `parseMultiValue` and `joinMultiValue`. It ranks unique genre tags by occurrence count across songs and renders them as separate pill chips using `<GenreChips variant="full" />` alongside track count and total duration separated by bullet delimiters.
- **Unit Tests**: Added `CoverStack.test.ts` to test left and right layout justifications, and expanded `ArtistDetailView.test.ts` to verify multi-value genre chip rendering and navigation.

## 🧪 Test Plan
- [x] `bun run check` (svelte-check) — 0 errors, 0 warnings
- [x] Unit tests added and verified for `CoverStack` and `ArtistDetailView`
- [x] Manually verified in the app by user

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed
