### PR TITLE
fix(audio): rebuild output stream on a fresh thread to avoid RPC_E_CHANGED_MODE

### DIFF
--- a/src-tauri/src/audio.rs
+++ b/src-tauri/src/audio.rs
@@ -684,6 +684,56 @@ fn build_output(
     })
 }
 
+/// Runs `build_output` on a brand-new, short-lived OS thread instead of the
+/// caller's own thread. Used only for stream *rebuilds* (device switch /
+/// stream error) — see #619: once `decode_thread`'s long-lived OS thread has
+/// built and torn down a WASAPI stream for one device, re-querying
+/// `default_output_config()` on that same thread for a *different* device can
+/// fail with `RPC_E_CHANGED_MODE`. A fresh thread has no such history, so its
+/// first COM touch (via cpal's own thread-local guard) starts clean.
+/// `cpal::Stream` is `Send + Sync`, so the built `AudioOutput` can safely be
+/// handed back to the caller. Bounded by a timeout so a wedged WASAPI call on
+/// the scratch thread can't hang `decode_thread` — see the wedge risk
+/// documented on `AudioOutput` above.
+#[allow(clippy::too_many_arguments)]
+fn build_output_on_fresh_thread(
+    position: &Arc<AtomicU64>,
+    volume: &Arc<Mutex<f32>>,
+    visualizer_buf: &Arc<crate::analyzer::AudioVisualizerBuffer>,
+    equalizer: &Arc<Mutex<crate::equalizer::Equalizer>>,
+    loudness_gain: &Arc<AtomicU32>,
+    fade_gain: &Arc<AtomicU32>,
+) -> Result<AudioOutput, String> {
+    let position = Arc::clone(position);
+    let volume = Arc::clone(volume);
+    let visualizer_buf = Arc::clone(visualizer_buf);
+    let equalizer = Arc::clone(equalizer);
+    let loudness_gain = Arc::clone(loudness_gain);
+    let fade_gain = Arc::clone(fade_gain);
+
+    let (tx, rx) = mpsc::channel();
+    let spawned = std::thread::Builder::new()
+        .name("luminous-audio-rebuild".into())
+        .spawn(move || {
+            let result = build_output(
+                &position,
+                &volume,
+                &visualizer_buf,
+                &equalizer,
+                &loudness_gain,
+                &fade_gain,
+            );
+            let _ = tx.send(result);
+        });
+
+    if let Err(e) = spawned {
+        return Err(format!("Failed to spawn audio rebuild thread: {e}"));
+    }
+
+    rx.recv_timeout(std::time::Duration::from_secs(5))
+        .unwrap_or_else(|_| Err("Timed out rebuilding audio output stream".to_string()))
+}
+
 /// Mutable state that lives for the duration of one track's inner `'decode`
 /// loop iteration in [`decode_thread`]. Kept separate from `output:
 /// Option<AudioOutput>` because the output stream is reassigned wholesale on
@@ -1044,7 +1094,7 @@ fn check_and_rebuild_output(
             }
             *output = None;
 
-            match build_output(
+            match build_output_on_fresh_thread(
                 position,
                 volume,
                 visualizer_buf,


### PR DESCRIPTION
## 📋 Summary
Fixes #619 — switching the OS default output device mid-playback on Windows could permanently break audio for the rest of the app session with a COM error (`RPC_E_CHANGED_MODE`).

## 🔍 Implementation Notes
`build_output` and its rebuild caller `check_and_rebuild_output` both ran on `decode_thread`, a single OS thread that lives for the entire app session. Once that long-lived thread had built and torn down a WASAPI stream for one device, re-querying `default_output_config()` on the same thread for a *different* device (after a device switch) could fail with `RPC_E_CHANGED_MODE` ("Cannot change thread mode after it is set"). cpal's own COM-init guard already tolerates that specific error on its own `CoInitializeEx` call, so the failure was coming from a deeper WASAPI call that only misbehaves once the thread has accumulated history from a prior device/stream.

Added `build_output_on_fresh_thread` in `src-tauri/src/audio.rs`, which runs the *rebuild* call into `build_output` on a brand-new, short-lived OS thread instead of `decode_thread` itself. A fresh thread has never touched COM, so its first touch (via cpal's own thread-local guard) starts clean with no leftover state from the just-torn-down old device's stream. `cpal::Stream` is `Send + Sync` (it owns its own internal WASAPI I/O thread), so the built `AudioOutput` can be safely handed back to `decode_thread`. Bounded by a 5s timeout so a wedged WASAPI call on the scratch thread can't hang playback.

Scope is intentionally narrow: only the rebuild call site in `check_and_rebuild_output` changed. The initial `build_output` call at track-open time (not reported as broken) is untouched.

## 🧪 Test Plan
- [x] `cargo check` / `cargo clippy --lib -- -D warnings` — clean
- [x] `cargo test --lib` — 218 passed, 0 failed, 1 ignored (pre-existing, unrelated)
- [x] Manually verified in the app — switched the OS default output device repeatedly (3 devices, back-and-forth) mid-playback via `bun run tauri dev`; playback recovered cleanly every time with no `RPC_E_CHANGED_MODE`/COM errors in the logs

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed — n/a, backend-only bug fix, no user-facing UI change
