### PR TITLE
docs: update README module tree for post-refactor layout (#577 item 23)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ luminous/
 │   ├── lib/
 │   │   ├── components/       # PlayerBar, Visualizers, Equalizer, LyricsView, TagEditor, etc.
 │   │   ├── locales/          # English & French translation strings
-│   │   ├── stores/           # Global stores (player, collection, playlists, theme, i18n, prefs)
+│   │   ├── stores/           # Global stores (player, collection, navigation, windowLayout, playlists, theme, i18n, prefs)
 │   │   ├── types/            # Frontend interfaces
 │   │   └── utils/            # Shared utilities (color parsing, filter parsing, lyrics, stats, etc.)
 │   └── routes/               # Layouts and navigation views
@@ -56,7 +56,7 @@ luminous/
     │   ├── analyzer.rs       # Real-time FFT spectrum processing
     │   ├── audio.rs          # Symphonia decoding thread & CPAL playback loop with gapless double-buffering
     │   ├── band_waveform.rs  # Layered low/mid/high frequency-band waveform analysis scanner
-    │   ├── collection.rs     # Lofty scanner & folder watcher
+    │   ├── collection.rs     # Lofty scanner & folder watcher (query/reconcile/watcher split into collection/)
     │   ├── covermanager.rs   # Cover art extractor and iTunes search API fallback
     │   ├── db.rs             # SQLite schema migration & connection pool
     │   ├── equalizer.rs      # Biquad DSP: 10-band graphic & 20-band parametric filters
@@ -70,10 +70,12 @@ luminous/
     │   ├── models.rs         # Shared structs and types
     │   ├── organizer.rs      # Tag-based file/folder reorganizer
     │   ├── player.rs         # Playback controller (Shuffle, Repeat, Next/Prev)
-    │   ├── playlist.rs       # Playlist manager, Queue abstraction, dynamic-playlist reconciler & undo/redo stack
+    │   ├── playlist.rs       # Playlist manager & Queue abstraction (auto-sync/dynamic/import-export/undo split into playlist/)
     │   ├── playlist_parsers.rs # M3U, M3U8, PLS, and XSPF import/export
     │   ├── stats.rs          # Play counts, ratings, and history tracking
     │   ├── tageditor.rs      # lofty tag writer & AcoustID fingerprint generator
+    │   ├── tags.rs           # Genre/tag browsing over the existing songs.genre column
+    │   ├── tray.rs           # System tray icon, menu, and minimize-to-tray behavior
     │   ├── waveform.rs       # Background audio peak analyzer
     │   └── commands/         # Tauri IPC command handlers
     └── Cargo.toml            # Rust dependencies (cpal, symphonia, rusqlite, lofty, rustfft)


### PR DESCRIPTION
## 📋 Summary
Fixes #613. Updates README.md's module tree to match the post-refactor layout from the #577 Stage 3 module splits.

- Notes the `collection.rs`/`playlist.rs` submodule splits (#577 items 17–18): `collection/query.rs,reconcile.rs,watcher.rs` and `playlist/auto_sync.rs,dynamic.rs,import_export.rs,mutation_undo.rs`.
- Adds `tags.rs` and `tray.rs` to the tree — these already existed in the codebase but had never been listed in the README (a pre-existing gap, fixed while auditing the tree for accuracy).
- Updates the stores line to include `navigation` and `windowLayout`, split out of `collection.svelte.ts` in #611.

## 🔍 Implementation Notes
`docs/architecture.svg` was intentionally left unchanged: it describes the architecture at the "Frontend / IPC / Audio / DB / Scan / Media" conceptual layer rather than by individual file name, so none of the #577 splits (which reorganized code within existing modules, not across the diagram's zones) made it stale. `FoldersView.svelte`'s rename to `SettingsView`/`SettingsFolders` (#612) also required no doc changes since it was never named in either doc.

`lib.rs::run()` (#577 item 19) and `audio.rs::decode_thread` (#610) were split into named internal functions rather than new files/modules, so their existing one-line README descriptions still hold.

## 🧪 Test Plan
Docs-only change — no build/test impact.
- [x] Diffed the README tree against the actual `src-tauri/src/` and `src/lib/stores/` directory listings to confirm accuracy.

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed (docs-only change; no screenshots needed)
