### PR TITLE
fix(equalizer): prevent volume normalization toggle from wrapping onto next line (#627)

### DIFF
--- a/src/lib/components/Equalizer.svelte
+++ b/src/lib/components/Equalizer.svelte
@@ -357,8 +357,8 @@
 <div class="flex flex-col gap-6 text-brand-text-primary">
   <div class="bg-brand-sidebar border border-brand-border rounded-xl p-6 flex flex-col gap-6">
     <div class="flex flex-col gap-4">
-    <div class="flex items-start justify-between">
-      <div class="flex items-center gap-3">
+    <div class="flex items-start justify-between gap-4">
+      <div class="flex items-center gap-3 min-w-0">
         <div class="p-2 rounded-xl bg-brand-accent/15 text-brand-accent-text shrink-0">
           <Sliders class="w-5 h-5" />
         </div>
@@ -567,8 +567,8 @@
 
     <!-- Loudness Normalization (#77) -->
     <div class="flex flex-col gap-6 bg-brand-sidebar border border-brand-border rounded-xl p-6">
-      <div class="flex items-center justify-between gap-4 flex-wrap mb-2">
-        <div class="flex items-center gap-3">
+      <div class="flex items-start justify-between gap-4 mb-2">
+        <div class="flex items-center gap-3 min-w-0">
           <div class="p-2 rounded-xl bg-brand-accent/15 text-brand-accent-text shrink-0">
             <Activity class="w-5 h-5" />
           </div>

--- a/src/lib/components/Equalizer.test.ts
+++ b/src/lib/components/Equalizer.test.ts
@@ -114,4 +114,16 @@ describe("Equalizer.svelte", () => {
       settings: { enabled: true, target_lufs: -18.0, mode: "track", fallback_gain_db: -6.0 },
     });
   });
+
+  it("does not wrap loudness toggle to a new line and uses items-start layout", async () => {
+    const { getByText } = render(Equalizer);
+    await waitFor(() => {
+      expect(getByText(/loudness normalization/i)).toBeInTheDocument();
+    });
+
+    const titleEl = getByText(/loudness normalization/i);
+    const headerContainer = titleEl.closest("div.flex.items-start.justify-between");
+    expect(headerContainer).not.toBeNull();
+    expect(headerContainer).not.toHaveClass("flex-wrap");
+  });
 });


### PR DESCRIPTION
## 📋 Summary
Fixes #627

This PR fixes a layout defect in the Equalizer view where the Volume Normalization (Loudness) section header's toggle button was bumped to a new row beneath the title and description when long localized text (e.g. in French) or narrower viewport widths were displayed.

## 🔍 Implementation Notes
- Updated `src/lib/components/Equalizer.svelte`: removed `flex-wrap` from the Volume Normalization header container and updated layout to `flex items-start justify-between gap-4 mb-2`.
- Added `min-w-0` to the header title/description column to ensure subtitles wrap neatly within the left column rather than forcing flex item wrapping.
- Applied matching `gap-4` and `min-w-0` classes to the Equalizer section header for consistent layout behavior across sections.
- Added a unit test in `src/lib/components/Equalizer.test.ts` to assert that the loudness header maintains `items-start` layout without `flex-wrap`.

## 🧪 Test Plan
- [x] `bun run check` (svelte-check) — 0 errors, 0 warnings
- [x] `bun run test -- --run` (frontend) — all tests passing (including `Equalizer.test.ts`)
- [x] Manually verified in the app (verified Equalizer layout with long localized description text)

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed
