### PR TITLE
fix(player): prevent queue clearing in shuffle mode and sync artist view on library changes (#633)

### DIFF
--- a/src/lib/components/ArtistDetailView.svelte
+++ b/src/lib/components/ArtistDetailView.svelte
@@ -156,6 +156,8 @@
 
   $effect(() => {
     const requested = artistName;
+    // Track collectionStore.songs so artist details update when the library changes (e.g. new albums added)
+    const _libraryVersion = collectionStore.songs;
     loading = true;
     Promise.all([
       invoke<Song[]>("get_songs_by_artist", { artist: requested }),

--- a/src/lib/stores/player.svelte.ts
+++ b/src/lib/stores/player.svelte.ts
@@ -323,6 +323,7 @@ export class PlayerStore {
   private async syncQueueTrackPosition() {
     if (!this.currentSong || !this.playlistId || !this.playlistItemUuid) return;
     if (this.repeatMode === "playlist") return;
+    if (this.shuffleMode !== "off") return;
     const pl = playlistsStore.playlists.find((p) => p.id === this.playlistId);
     if (pl?.is_queue || this.activeContextName === "Queue") {
       await playlistsStore.trimQueueBeforeUuid(this.playlistId, this.playlistItemUuid);

--- a/src/lib/stores/player.test.ts
+++ b/src/lib/stores/player.test.ts
@@ -272,4 +272,77 @@ describe("PlayerStore", () => {
 
     if (originalListenImpl) vi.mocked(listen).mockImplementation(originalListenImpl);
   });
+
+  it("should not trim queue tracks before uuid when shuffle_mode is enabled", async () => {
+    const originalListenImpl = vi.mocked(listen).getMockImplementation();
+    let playbackStateCallback: ((event: { payload: any }) => Promise<void>) | undefined;
+    vi.mocked(listen).mockImplementation(async (event: string, callback: any) => {
+      if (event === "playback-state") playbackStateCallback = callback;
+      return () => {};
+    });
+
+    store = new PlayerStore();
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    await playlistsStore.refreshPlaylists();
+    const queueId = playlistsStore.queuePlaylist!.id;
+    vi.mocked(invoke).mockClear();
+
+    // Trigger playback-state with shuffle_mode: "all"
+    await playbackStateCallback?.({
+      payload: {
+        state: "playing",
+        current_song: { id: 2, title: "Shuffled Track" },
+        playlist_id: queueId,
+        playlist_item_uuid: "uuid-shuffled-2",
+        remaining_playlist_items: 4,
+        position_nanosec: 500,
+        volume: 1,
+        shuffle_mode: "all",
+        repeat_mode: "off",
+      },
+    });
+
+    expect(invoke).not.toHaveBeenCalledWith("trim_playlist_before_uuid", expect.anything());
+
+    if (originalListenImpl) vi.mocked(listen).mockImplementation(originalListenImpl);
+  });
+
+  it("should trim queue tracks before uuid when shuffle_mode is off", async () => {
+    const originalListenImpl = vi.mocked(listen).getMockImplementation();
+    let playbackStateCallback: ((event: { payload: any }) => Promise<void>) | undefined;
+    vi.mocked(listen).mockImplementation(async (event: string, callback: any) => {
+      if (event === "playback-state") playbackStateCallback = callback;
+      return () => {};
+    });
+
+    store = new PlayerStore();
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    await playlistsStore.refreshPlaylists();
+    const queueId = playlistsStore.queuePlaylist!.id;
+    vi.mocked(invoke).mockClear();
+
+    // Trigger playback-state with shuffle_mode: "off"
+    await playbackStateCallback?.({
+      payload: {
+        state: "playing",
+        current_song: { id: 2, title: "Sequential Track" },
+        playlist_id: queueId,
+        playlist_item_uuid: "uuid-seq-2",
+        remaining_playlist_items: 4,
+        position_nanosec: 500,
+        volume: 1,
+        shuffle_mode: "off",
+        repeat_mode: "off",
+      },
+    });
+
+    expect(invoke).toHaveBeenCalledWith("trim_playlist_before_uuid", {
+      playlistId: queueId,
+      uuid: "uuid-seq-2",
+    });
+
+    if (originalListenImpl) vi.mocked(listen).mockImplementation(originalListenImpl);
+  });
 });


### PR DESCRIPTION
## 📋 Summary
Fixes #633

When playing the Queue in shuffle mode (e.g. via "Shuffle Play" on an Artist profile, Album, or Playlist), track transitions or library update events (`library-changed` from background scanner/watcher) triggered `syncQueueTrackPosition()`. Because `syncQueueTrackPosition()` invoked `trimQueueBeforeUuid` without checking `shuffleMode`, all playlist items preceding the current track in database order were deleted even if they had not yet been played in shuffle order. This wiped unplayed tracks and caused premature queue completion, stopping playback and clearing the entire Queue.

This PR guards `syncQueueTrackPosition()` to only run when `shuffleMode === "off"`, and adds reactive tracking in `ArtistDetailView.svelte` to refresh the artist's song list when `collectionStore.songs` updates on library changes.

## 🔍 Implementation Notes
- **`PlayerStore.syncQueueTrackPosition`**: Added an early return when `this.shuffleMode !== "off"`. Positional trimming (`trimQueueBeforeUuid`) is strictly sequential and should not be invoked when playback follows a non-linear shuffle order.
- **`ArtistDetailView.svelte`**: Read `collectionStore.songs` inside the artist loading `$effect` so that library rescans, additions, and edits automatically re-fetch the artist's songs and duration metadata.
- **`src/lib/stores/player.test.ts`**: Added unit tests ensuring `trim_playlist_before_uuid` is suppressed when `shuffle_mode` is enabled (`"all"`) and executed when `shuffle_mode` is `"off"`.

## 🧪 Test Plan
- [x] `bun run check` (svelte-check found 0 errors and 0 warnings)
- [x] `bun run test:run` (all 60 test files passed, 509 tests passed)
- [x] `cargo test` (all unit, integration, and BDD suites in src-tauri passed)

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed
