### PR TITLE
docs: clarify PR review, CI check wait, and no-assistant-merge rules in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,7 @@ into Picard's territory; it's a different, complementary axis Picard was never m
 ## Branching & PR Rules
 
 - NEVER commit or push directly to `main`. All changes ship via PR, even release version bumps and docs-only edits.
+- NEVER merge PRs yourself. Open the PR, ensure all CI checks pass, and let the user review and merge the PR on GitHub.
 - PR base branch depends on the target issue's milestone — see Branching Model below (2.0-milestone work targets `next`; everything else targets `main`).
 - Before creating a branch, confirm the base: `git fetch origin && git switch -c <branch> origin/<base>`.
 
@@ -235,10 +236,12 @@ punt either to the user.
 - Use conventional commit messages: `feat:`, `fix:`, `chore:`, `refactor:`, `docs:`, `test:`.
 - Stage all relevant files with `git add -A` before committing unless selective staging is needed.
 - Proactively search and view GitHub issues using the `gh` command tool (e.g., `gh issue list` and `gh issue view <id>`) when asked to "fix a bug" or "work on a feature".
-- When working on a bug or feature, always work in a dedicated git worktree. Note that Claude uses its own worktree flow in `.claude/worktrees/`, while all other AI assistants and agents must place their dedicated worktree in the `.worktrees/` directory (e.g., `.worktrees/<feature-or-bug-name>`). Do not merge the temporary branch or delete the worktree until the user has approved the changes.
+- When working on a bug or feature, always work in a dedicated git worktree. Note that Claude uses its own worktree flow in `.claude/worktrees/`, while all other AI assistants and agents must place their dedicated worktree in the `.worktrees/` directory (e.g., `.worktrees/<feature-or-bug-name>`). Do not delete the worktree until the changes have been reviewed, merged, and approved for cleanup by the user.
 - As soon as you start working a tracked issue, set its Status to "In Progress" on the Project board (see [docs/ISSUE_PRIORITY.md](docs/ISSUE_PRIORITY.md) for the `gh project item-edit` command) — don't leave it sitting at "Todo" while work is underway.
-- Present the Walkthrough (`walkthrough.md`) to the user and wait for their explicit feedback and approval before merging. Do NOT run `bun run tauri dev` as a background task (it does not work as expected). Ask the user to run the dev server (`bun run tauri dev`) and check manually.
-- Only after the user has reviewed the Walkthrough and approved the changes may you merge the temporary branch, clean up (remove) the worktree, and update/comment on and close the relevant GitHub issues using the `gh` CLI tool — and set each issue's Status to "Done" on the Project board at the same time, so it doesn't stay stuck at "In Progress" after closing. Note that an issue must not be closed until the corresponding changes have been successfully merged into the target branch. On Windows, `git worktree remove` fails with "Permission denied" on the worktree the current session is running from (open file handles keep it locked) — hand the `git worktree remove`/`git branch -d` commands to the user to run themselves in that case instead of retrying.
+- Present the Walkthrough (`walkthrough.md`) to the user and wait for their explicit feedback and approval before opening or finalizing a PR. Do NOT run `bun run tauri dev` as a background task (it does not work as expected). Ask the user to run the dev server (`bun run tauri dev`) and check manually.
+- **NEVER merge pull requests yourself.** The assistant must never execute `gh pr merge`, `git merge`, or auto-merge PRs. Pull requests must be reviewed and merged exclusively by the user on GitHub after all CI checks have passed.
+- After creating a PR, monitor the CI check status (`gh pr checks <id>`). Once checks pass, provide the PR link to the user for final review and merge.
+- Only after the user has reviewed and merged the PR on GitHub should the corresponding issues be confirmed closed and their Status set to "Done" on the Project board. On Windows, `git worktree remove` fails with "Permission denied" on the worktree the current session is running from (open file handles keep it locked) — hand the `git worktree remove`/`git branch -d` commands to the user to run themselves in that case instead of retrying.
 - **Creating Issues & Pull Requests**:
   1. Inspect the relevant templates under `.github/ISSUE_TEMPLATE/` (e.g., `bug_report.md`, `feature_request.md`) when creating issues.
   2. Inspect `.github/PULL_REQUEST_TEMPLATE.md` when preparing or creating Pull Requests.


### PR DESCRIPTION
## 📋 Summary
Updates `AGENTS.md` to make the PR review and merge workflow explicit: assistants must never merge PRs themselves, must monitor and wait for CI checks to pass, and must leave PR review and merging entirely to the user.

## 🔍 Implementation Notes
- Added explicit prohibition against assistants merging PRs directly in `Branching & PR Rules` and `Version Control`.
- Clarified that assistants should monitor `gh pr checks` and hand off the PR to the user for review and merge once CI is green.
- Clarified that issue closure and worktree cleanup instructions should only happen after the user has merged the PR on GitHub.

## 🧪 Test Plan
- Docs only change.

## ✅ Checklist
- [x] No unrelated changes bundled in
