### PR TITLE
fix(collection): render genre chips on artist cards

### DIFF
--- a/src/lib/components/ArtistCard.svelte
+++ b/src/lib/components/ArtistCard.svelte
@@ -2,6 +2,7 @@
   import type { ArtistItem, AlbumItem, Song } from "../types";
   import { i18n } from "../stores/i18n.svelte";
   import CoverStack from "./CoverStack.svelte";
+  import GenreChips from "./GenreChips.svelte";
   import { getArtistCoverStack } from "../utils/covers";
 
   interface Props {
@@ -22,7 +23,7 @@
 
   let covers = $derived(getArtistCoverStack(artistAlbums, artistSongs));
 
-  let genreLabel = $derived(artist.genre?.trim() || i18n.t('artistDetail.unknownGenre'));
+  let hasGenre = $derived(!!artist.genre?.trim());
 </script>
 
 <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
@@ -48,12 +49,15 @@
   >
     {artist.name || i18n.t('collection.unknownArtist')}
   </span>
-  <span
-    class="text-xs text-brand-text-secondary font-medium truncate w-full mt-1.5 text-center"
-    title={genreLabel}
-  >
-    {genreLabel}
-  </span>
+  <div class="w-full mt-1.5 flex justify-center">
+    {#if hasGenre}
+      <GenreChips genre={artist.genre} />
+    {:else}
+      <span class="text-xs text-brand-text-secondary font-medium truncate text-center">
+        {i18n.t('artistDetail.unknownGenre')}
+      </span>
+    {/if}
+  </div>
   <span class="text-xs text-brand-text-secondary font-medium truncate w-full mt-0.5 text-center">
     {i18n.t('playlists.songsCount', { count: artist.song_count })}
   </span>

--- a/src/lib/components/ArtistCard.test.ts
+++ b/src/lib/components/ArtistCard.test.ts
@@ -52,17 +52,24 @@ describe("ArtistCard.svelte", () => {
     vi.clearAllMocks();
   });
 
-  it("renders artist name, genre, and song count", () => {
-    const { getByText } = render(ArtistCard, {
+  it("renders artist name, genre chip, and song count", () => {
+    const { getByText, getByRole } = render(ArtistCard, {
       props: { artist: mockArtist, artistAlbums: [] },
     });
 
     expect(getByText("Dave Hawkins")).toBeInTheDocument();
-    const genreEl = getByText("Rock");
-    expect(genreEl).toBeInTheDocument();
-    expect(genreEl).toHaveAttribute("title", "Rock");
-    expect(genreEl.className).toContain("truncate");
+    const genreChip = getByRole("button", { name: "Rock" });
+    expect(genreChip).toBeInTheDocument();
+    expect(getByText("Rock")).toBeInTheDocument();
     expect(getByText("6 songs")).toBeInTheDocument();
+  });
+
+  it("falls back to unknown genre text when artist has no genre", () => {
+    const { getByText } = render(ArtistCard, {
+      props: { artist: { ...mockArtist, genre: undefined }, artistAlbums: [] },
+    });
+
+    expect(getByText("Unknown genre")).toBeInTheDocument();
   });
 
   it("renders cover artwork from artistAlbums when albums exist", () => {

--- a/src/lib/components/ArtistRowCard.svelte
+++ b/src/lib/components/ArtistRowCard.svelte
@@ -2,6 +2,7 @@
   import type { ArtistItem, AlbumItem, Song } from "../types";
   import { i18n } from "../stores/i18n.svelte";
   import CoverArt from "./CoverArt.svelte";
+  import GenreChips from "./GenreChips.svelte";
   import { getArtistCoverStack } from "../utils/covers";
 
   interface Props {
@@ -16,7 +17,7 @@
   // Same front-cover selection ArtistCard uses for its CoverStack (index 0 is
   // the front/topmost tile), so the row's single cover always matches it.
   let frontCover = $derived(getArtistCoverStack(artistAlbums, artistSongs, 1)[0]);
-  let genreLabel = $derived(artist.genre?.trim() || i18n.t('artistDetail.unknownGenre'));
+  let hasGenre = $derived(!!artist.genre?.trim());
 </script>
 
 <!-- svelte-ignore a11y_click_events_have_key_events -->
@@ -40,7 +41,11 @@
 
   <div class="min-w-0 flex-1">
     <p class="truncate text-sm font-semibold text-brand-text-primary">{artist.name || i18n.t('collection.unknownArtist')}</p>
-    <p class="truncate text-xs text-brand-text-secondary font-medium">{genreLabel}</p>
+    {#if hasGenre}
+      <div class="min-w-0 mt-0.5"><GenreChips genre={artist.genre} /></div>
+    {:else}
+      <p class="truncate text-xs text-brand-text-secondary font-medium">{i18n.t('artistDetail.unknownGenre')}</p>
+    {/if}
   </div>
 
   <div class="shrink-0 max-w-40 text-right">

--- a/src/lib/components/ArtistRowCard.test.ts
+++ b/src/lib/components/ArtistRowCard.test.ts
@@ -33,14 +33,23 @@ describe("ArtistRowCard.svelte", () => {
     vi.clearAllMocks();
   });
 
-  it("renders artist name, genre, and song count", () => {
-    const { getByText } = render(ArtistRowCard, {
+  it("renders artist name, genre chip, and song count", () => {
+    const { getByText, getByRole } = render(ArtistRowCard, {
       props: { artist: mockArtist, artistAlbums: [mockAlbum] },
     });
 
     expect(getByText("Dave Hawkins")).toBeInTheDocument();
+    expect(getByRole("button", { name: "Rock" })).toBeInTheDocument();
     expect(getByText("Rock")).toBeInTheDocument();
     expect(getByText("6 songs")).toBeInTheDocument();
+  });
+
+  it("falls back to unknown genre text when artist has no genre", () => {
+    const { getByText } = render(ArtistRowCard, {
+      props: { artist: { ...mockArtist, genre: undefined }, artistAlbums: [mockAlbum] },
+    });
+
+    expect(getByText("Unknown genre")).toBeInTheDocument();
   });
 
   it("renders cover art from the artist's front album, matching CoverStack's front tile", () => {


### PR DESCRIPTION
## 📋 Summary
Fixes #642. `ArtistCard` (full grid card) and `ArtistRowCard` (compact row card) rendered genre as plain truncated text instead of the pill-shaped `GenreChips` component used by `AlbumCard` and the artist/album detail views, so genre display was inconsistent between artist cards and everything else in the app.

## 🔍 Implementation Notes
- Both cards now render `<GenreChips genre={artist.genre} />` when the artist has a genre, matching `AlbumCard`'s pattern.
- Kept the existing "Unknown genre" fallback text (as plain text, matching `GenreChips`'s own convention of rendering nothing when there's no genre) for artists with no genre set.
- No shared artist card component exists across the app — `ArtistCard.svelte` and `ArtistRowCard.svelte` are separate components, both updated.
- Updated `ArtistCard.test.ts` / `ArtistRowCard.test.ts` for the new chip-based genre rendering and added a fallback-text test for each.

## 🧪 Test Plan
- [x] `bun run check` (svelte-check)
- [x] `bun run test:run` (frontend, full suite — 523 passed)
- [ ] `cargo test` (src-tauri, if Rust changed) — no Rust changes
- [x] Manually verified in the app (Home "Top Artists" row and Artists collection view, both grid and list layouts)

## 📸 Screenshots
Home "Top Artists" row, Artists list view, and Artists grid view all now show genre chips (e.g. "Ambient +1", "Rock +5") instead of plain semicolon-separated text.

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed — not applicable, no docs reference this rendering
