### PR TITLE
fix(collection): exclude blank album tags from the Albums grid

### DIFF
--- a/src-tauri/src/collection/query.rs
+++ b/src-tauri/src/collection/query.rs
@@ -268,7 +268,7 @@ impl CollectionScanner {
                 MAX(added) AS added,
                 COALESCE(SUM(length_nanosec), 0) AS total_duration_nanosec
              FROM songs
-             WHERE source IN (1, 2) AND unavailable = 0 AND album IS NOT NULL
+             WHERE source IN (1, 2) AND unavailable = 0 AND album IS NOT NULL AND album != ''
                AND album IN (
                  SELECT album FROM songs s2
                  WHERE s2.source IN (1, 2) AND s2.unavailable = 0 AND {}
@@ -557,7 +557,7 @@ impl CollectionScanner {
                 COALESCE(MAX(NULLIF(album_artist_sort, '')), MAX(NULLIF(artistsort, ''))) AS artist_sort,
                 MAX(NULLIF(albumsort, '')) AS albumsort
              FROM songs
-             WHERE source IN (1, 2) AND album IS NOT NULL AND unavailable = 0
+             WHERE source IN (1, 2) AND album IS NOT NULL AND album != '' AND unavailable = 0
              GROUP BY album
              ORDER BY COALESCE(MAX(album_artist_sort), MAX(artistsort), MAX(album_artist), MAX(artist)), COALESCE(MAX(albumsort), album)",
         )?;
@@ -600,7 +600,7 @@ impl CollectionScanner {
             "WITH album_counts AS (
                 SELECT album, COUNT(*) AS track_count
                 FROM songs
-                WHERE source IN (1, 2) AND album IS NOT NULL AND unavailable = 0
+                WHERE source IN (1, 2) AND album IS NOT NULL AND album != '' AND unavailable = 0
                 GROUP BY album
              ),
              base AS (
@@ -665,7 +665,7 @@ impl CollectionScanner {
             "WITH album_counts AS (
                 SELECT album, COUNT(*) AS track_count
                 FROM songs
-                WHERE source IN (1, 2) AND album IS NOT NULL AND unavailable = 0
+                WHERE source IN (1, 2) AND album IS NOT NULL AND album != '' AND unavailable = 0
                 GROUP BY album
              ),
              base AS (
@@ -1477,6 +1477,59 @@ mod tests {
         let album_four = find_album("Album Four");
         assert_eq!(album_four["artist"].as_str(), None);
         assert_eq!(album_four["track_count"].as_i64(), Some(2));
+
+        let _ = std::fs::remove_dir_all(temp_dir);
+    }
+
+    #[test]
+    fn test_get_albums_excludes_empty_string_album() {
+        // A present-but-blank album tag (as opposed to a missing one, which
+        // is NULL) must not surface as a pseudo-album — otherwise untagged
+        // singles from unrelated artists collapse into one bogus "Unknown
+        // Album" / "Various Artists" card (#issue: singles without an album
+        // title showing up in the Albums grid).
+        let temp_dir = std::env::temp_dir().join(format!(
+            "luminous_empty_album_test_{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let db = Arc::new(Database::new(temp_dir.clone()).unwrap());
+        let scanner = CollectionScanner::new(db.clone());
+        let conn = db.pool.get().unwrap();
+
+        let insert_song = |path: &str, title: &str, artist: &str, album: Option<&str>| {
+            let song = Song {
+                path: Some(path.to_string()),
+                title: Some(title.to_string()),
+                artist: Some(artist.to_string()),
+                album: album.map(|s| s.to_string()),
+                source: SongSource::LocalFile,
+                filetype: FileType::Mp3,
+                unavailable: false,
+                ..Default::default()
+            };
+            upsert_song(&conn, &song).unwrap();
+        };
+
+        insert_song("path/1.mp3", "Single One", "Artist A", Some(""));
+        insert_song("path/2.mp3", "Single Two", "Artist B", Some(""));
+        insert_song(
+            "path/3.mp3",
+            "Track In Album",
+            "Artist C",
+            Some("Real Album"),
+        );
+
+        let albums = scanner.get_albums().unwrap();
+
+        assert!(
+            albums.iter().all(|a| a["album"].as_str() != Some("")),
+            "empty-string album should not produce a pseudo-album entry: {albums:?}"
+        );
+        assert_eq!(albums.len(), 1);
+        assert_eq!(albums[0]["album"].as_str(), Some("Real Album"));
 
         let _ = std::fs::remove_dir_all(temp_dir);
     }


### PR DESCRIPTION
## 📋 Summary
Fixes a bug reported by the user: an "Unknown Album" / "Various Artists" card was showing up in the Albums grid, combining unrelated singles from different artists into one fake album.

## 🔍 Implementation Notes
`get_albums()` and three related queries in `src-tauri/src/collection/query.rs` filtered out album tags that were `NULL`, but not tags that are present-but-empty (`""`) — a distinct case a scanned file's ID3/Vorbis tags can produce. Since `GROUP BY album` treats every empty-string row as the same group, this merged every untagged single across every artist in the library into one pseudo-album, which the UI then rendered as "Unknown Album" / "Various Artists" with combined genres.

This never affected the Artist Detail view's discography tabs (which use `classifyRelease`'s single/EP/album split) — that pseudo-album's `artist` field comes back `NULL`, so it never matched a specific artist filter and only ever surfaced in the main Collection → Albums grid.

Fixed by also excluding `album != ''` in:
- `get_albums` — feeds the main Albums grid
- `get_compilations_by_artist`
- `get_artists` / `get_top_artists`'s `album_counts` CTE — this also had a latent bug where an artist with any untagged track could get their `album_count` bumped by the merged bucket once it crossed the 7-track threshold

## 🧪 Test Plan
- [x] `cargo test` (src-tauri) — all 226 tests pass, including a new regression test `test_get_albums_excludes_empty_string_album`
- [ ] `bun run check` (no frontend changes)
- [ ] `bun run test -- --run` (no frontend changes)
- [x] Manually verified in the app — confirmed the "Unknown Album" card no longer appears in the Albums grid

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed — n/a (removes an erroneous card, no new UI)
