### PR TITLE
docs: unwrap v1.5.0 release notes

### DIFF
--- a/docs/release-notes/v1.5.0.md
+++ b/docs/release-notes/v1.5.0.md
@@ -1,86 +1,34 @@
 # v1.5.0
 
-This release adds native Genres & Tags management, richer artist profiles, multi-value
-tags, custom sort overrides, system tray integration, and drag-and-drop playback.
+This release adds native Genres & Tags management, richer artist profiles, multi-value tags, custom sort overrides, system tray integration, and drag-and-drop playback.
 
 ### ✨ Genres, Tags & Artist Profiles
-- **Genres & Tags browsing**: a new Genres view groups your library's tags into cards you
-  arrange yourself — drag a tag onto a card to file it as a sub-genre, right-click for
-  Rename/Promote/Delete, and songs with no genre tag land in their own "No Genre" group. Genre
-  chips are now clickable and consistent everywhere they appear in the app
-  ([#224](https://github.com/esoltys/luminous/issues/224)).
-- **Enhanced Artist Profiles**: add a bio, official website, and links to Bandcamp, Spotify,
-  Instagram, and other platforms from an artist's page — they show up as a clickable About panel
-  ([#473](https://github.com/esoltys/luminous/issues/473),
-  [#474](https://github.com/esoltys/luminous/issues/474)).
-- **Multi-value tags**: Artist, Album Artist, Composer, and Genre now accept multiple
-  semicolon-separated values, kept as distinct searchable tags instead of one long string
-  ([#143](https://github.com/esoltys/luminous/issues/143),
-  [#458](https://github.com/esoltys/luminous/issues/458),
-  [#470](https://github.com/esoltys/luminous/issues/470)).
-- **Custom Sort Tags ("Sort As")**: set custom sort values for Title, Artist, Album, Album
-  Artist, Composer, and Genre so your library sorts the way you want without changing the
-  tag itself ([#151](https://github.com/esoltys/luminous/issues/151)).
-- **ID3v1 tag reading** for older MP3s, and a one-click **Clear Artwork** action to remove
-  embedded cover art from a track
-  ([#507](https://github.com/esoltys/luminous/issues/507),
-  [#449](https://github.com/esoltys/luminous/issues/449)).
-- **Artist tag in Smart Playlists**: the Artist tag is now available when building Smart
-  Playlists and auto-playlists, and as a song-table column
-  ([#639](https://github.com/esoltys/luminous/issues/639)).
+- **Genres & Tags browsing**: a new Genres view groups your library's tags into cards you arrange yourself — drag a tag onto a card to file it as a sub-genre, right-click for Rename/Promote/Delete, and songs with no genre tag land in their own "No Genre" group. Genre chips are now clickable and consistent everywhere they appear in the app ([#224](https://github.com/esoltys/luminous/issues/224)).
+- **Enhanced Artist Profiles**: add a bio, official website, and links to Bandcamp, Spotify, Instagram, and other platforms from an artist's page — they show up as a clickable About panel ([#473](https://github.com/esoltys/luminous/issues/473), [#474](https://github.com/esoltys/luminous/issues/474)).
+- **Multi-value tags**: Artist, Album Artist, Composer, and Genre now accept multiple semicolon-separated values, kept as distinct searchable tags instead of one long string ([#143](https://github.com/esoltys/luminous/issues/143), [#458](https://github.com/esoltys/luminous/issues/458), [#470](https://github.com/esoltys/luminous/issues/470)).
+- **Custom Sort Tags ("Sort As")**: set custom sort values for Title, Artist, Album, Album Artist, Composer, and Genre so your library sorts the way you want without changing the tag itself ([#151](https://github.com/esoltys/luminous/issues/151)).
+- **ID3v1 tag reading** for older MP3s, and a one-click **Clear Artwork** action to remove embedded cover art from a track ([#507](https://github.com/esoltys/luminous/issues/507), [#449](https://github.com/esoltys/luminous/issues/449)).
+- **Artist tag in Smart Playlists**: the Artist tag is now available when building Smart Playlists and auto-playlists, and as a song-table column ([#639](https://github.com/esoltys/luminous/issues/639)).
 
 ### 🎧 Playback & Desktop Integration
-- **System tray integration**: a "Minimize to tray" setting keeps Luminous running in the
-  background instead of quitting on window close, with play/pause and track navigation right
-  from the tray icon's context menu ([#439](https://github.com/esoltys/luminous/issues/439)).
-- **Drag & drop playback**: drop audio files or a whole folder onto the Luminous window to play
-  or queue them instantly — hold Shift while dropping to append instead of replacing the Queue
-  ([#389](https://github.com/esoltys/luminous/issues/389),
-  [#430](https://github.com/esoltys/luminous/issues/430)).
-- **Playbar cover art navigation**: click the player bar's album art to toggle Immersive Mode,
-  or jump straight to the Queue
-  ([#448](https://github.com/esoltys/luminous/issues/448),
-  [#450](https://github.com/esoltys/luminous/issues/450),
-  [#523](https://github.com/esoltys/luminous/issues/523)).
-- **Queue timestamp display**: show a Date Added column in the Queue and playlists via the
-  column picker ([#508](https://github.com/esoltys/luminous/issues/508)).
-- **Smoother playlist reordering** via pointer-based drag events, fixing fluidity issues with
-  the previous drag implementation
-  ([#517](https://github.com/esoltys/luminous/issues/517)).
+- **System tray integration**: a "Minimize to tray" setting keeps Luminous running in the background instead of quitting on window close, with play/pause and track navigation right from the tray icon's context menu ([#439](https://github.com/esoltys/luminous/issues/439)).
+- **Drag & drop playback**: drop audio files or a whole folder onto the Luminous window to play or queue them instantly — hold Shift while dropping to append instead of replacing the Queue ([#389](https://github.com/esoltys/luminous/issues/389), [#430](https://github.com/esoltys/luminous/issues/430)).
+- **Playbar cover art navigation**: click the player bar's album art to toggle Immersive Mode, or jump straight to the Queue ([#448](https://github.com/esoltys/luminous/issues/448), [#450](https://github.com/esoltys/luminous/issues/450), [#523](https://github.com/esoltys/luminous/issues/523)).
+- **Queue timestamp display**: show a Date Added column in the Queue and playlists via the column picker ([#508](https://github.com/esoltys/luminous/issues/508)).
+- **Smoother playlist reordering** via pointer-based drag events, fixing fluidity issues with the previous drag implementation ([#517](https://github.com/esoltys/luminous/issues/517)).
 
 ### 🐛 Fixes
-- **Cover art no longer goes stale after moving files**: when a song's file moved to a
-  different folder or watched root, its folder-derived cover art now re-scans the new
-  location instead of pointing at the old one
-  ([#626](https://github.com/esoltys/luminous/issues/626)).
-- **Queue now fully empties when playback completes naturally**, instead of leaving the
-  last-played song behind ([#631](https://github.com/esoltys/luminous/issues/631)).
-- **Shuffle Play no longer drops unplayed songs or re-shuffles the Queue mid-playback** on
-  track advance, item removal, or library updates
-  ([#633](https://github.com/esoltys/luminous/issues/633),
-  [#638](https://github.com/esoltys/luminous/issues/638)).
-- **Edit Artist Details dialog** no longer renders behind the player bar and is responsive
-  at compact window sizes
-  ([#634](https://github.com/esoltys/luminous/issues/634)).
-- **Genre chips now render on Artist cards**, matching the rest of the app
-  ([#642](https://github.com/esoltys/luminous/issues/642)).
-- **Untagged singles from different artists no longer merge into a fake "Unknown Album"
-  card** in the Albums grid
-  ([#646](https://github.com/esoltys/luminous/issues/646)).
-- **Genres view no longer hides its bottom row behind the player bar** when a song is
-  playing ([#648](https://github.com/esoltys/luminous/issues/648)).
+- **Cover art no longer goes stale after moving files**: when a song's file moved to a different folder or watched root, its folder-derived cover art now re-scans the new location instead of pointing at the old one ([#626](https://github.com/esoltys/luminous/issues/626)).
+- **Queue now fully empties when playback completes naturally**, instead of leaving the last-played song behind ([#631](https://github.com/esoltys/luminous/issues/631)).
+- **Shuffle Play no longer drops unplayed songs or re-shuffles the Queue mid-playback** on track advance, item removal, or library updates ([#633](https://github.com/esoltys/luminous/issues/633), [#638](https://github.com/esoltys/luminous/issues/638)).
+- **Edit Artist Details dialog** no longer renders behind the player bar and is responsive at compact window sizes ([#634](https://github.com/esoltys/luminous/issues/634)).
+- **Genre chips now render on Artist cards**, matching the rest of the app ([#642](https://github.com/esoltys/luminous/issues/642)).
+- **Untagged singles from different artists no longer merge into a fake "Unknown Album" card** in the Albums grid ([#646](https://github.com/esoltys/luminous/issues/646)).
+- **Genres view no longer hides its bottom row behind the player bar** when a song is playing ([#648](https://github.com/esoltys/luminous/issues/648)).
 
 ### 🛠️ Internal
-- Flatpak packaging for Flathub, with CI build caching
-  ([#419](https://github.com/esoltys/luminous/issues/419),
-  [#475](https://github.com/esoltys/luminous/issues/475)).
-- Automated Winget manifest generation and validation
-  ([#477](https://github.com/esoltys/luminous/issues/477),
-  [#493](https://github.com/esoltys/luminous/issues/493),
-  [#505](https://github.com/esoltys/luminous/issues/505)).
-- Installer-aware updater panel messaging for externally-managed install formats
-  ([#491](https://github.com/esoltys/luminous/issues/491)).
-- Startup crash prevention when Linux D-Bus/MPRIS is unavailable
-  ([#537](https://github.com/esoltys/luminous/issues/537)).
-- Automated PR quality gates in CI
-  ([#521](https://github.com/esoltys/luminous/issues/521)).
+- Flatpak packaging for Flathub, with CI build caching ([#419](https://github.com/esoltys/luminous/issues/419), [#475](https://github.com/esoltys/luminous/issues/475)).
+- Automated Winget manifest generation and validation ([#477](https://github.com/esoltys/luminous/issues/477), [#493](https://github.com/esoltys/luminous/issues/493), [#505](https://github.com/esoltys/luminous/issues/505)).
+- Installer-aware updater panel messaging for externally-managed install formats ([#491](https://github.com/esoltys/luminous/issues/491)).
+- Startup crash prevention when Linux D-Bus/MPRIS is unavailable ([#537](https://github.com/esoltys/luminous/issues/537)).
+- Automated PR quality gates in CI ([#521](https://github.com/esoltys/luminous/issues/521)).


### PR DESCRIPTION
Reflows `docs/release-notes/v1.5.0.md` so each paragraph and bullet is a single unwrapped line. GitHub renders a hand-wrapped `\n` inside a paragraph as a hard line break rather than a soft wrap, so the previous ~90-col wrapping showed spurious mid-sentence breaks wherever this file is rendered (e.g. pasted into the GitHub release body). Content unchanged.