### PR TITLE
fix: stop logging partial AcoustID API key in cleartext

### DIFF
--- a/src-tauri/src/tageditor.rs
+++ b/src-tauri/src/tageditor.rs
@@ -410,19 +410,8 @@ pub async fn lookup_acoustid(
         _ => return Err(anyhow!("NO_API_KEY")),
     };
 
-    let masked_key = if client_key.len() > 4 {
-        format!(
-            "{}***{}",
-            &client_key[..2],
-            &client_key[client_key.len() - 2..]
-        )
-    } else {
-        "***".to_string()
-    };
-
     eprintln!(
-        "[Luminous Backend] AcoustID: Querying API lookup service via POST (client key: {}, duration: {}s)...",
-        masked_key,
+        "[Luminous Backend] AcoustID: Querying API lookup service via POST (duration: {}s)...",
         duration_sec
     );
 


### PR DESCRIPTION
## 📋 Summary
Fixes #656. GitHub code scanning ([alert #13](https://github.com/esoltys/luminous/security/code-scanning/13), `rust/cleartext-logging`) flagged that `lookup_acoustid` logs part of the AcoustID API key. The existing `masked_key` still spliced in real characters from `client_key`, so CodeQL's taint tracking correctly treated it as cleartext logging of sensitive data. This drops the key from the log line entirely.

## 🔍 Implementation Notes
`src-tauri/src/tageditor.rs` — removed the `masked_key` construction and the key from the `eprintln!` in `lookup_acoustid`; the log line now only reports the lookup duration.

## 🧪 Test Plan
- [x] `cargo check` (src-tauri)
- [ ] `bun run check` (svelte-check) — no frontend changes
- [ ] `bun run test -- --run` (frontend) — no frontend changes
- [ ] `cargo test` (src-tauri) — not run, backend logging-only change
- [x] Manually verified in the app

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed — not applicable (log-only change)
