### PR TITLE
feat: reactive & inviting Home screen for fresh/unplayed libraries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3134,7 +3134,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "luminous"
-version = "1.5.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bs1770",

--- a/src-tauri/src/collection/query.rs
+++ b/src-tauri/src/collection/query.rs
@@ -655,9 +655,11 @@ impl CollectionScanner {
     }
 
     /// Artists ranked by total play count across their songs (ties broken
-    /// alphabetically). Artists with zero plays are excluded entirely —
-    /// this powers the Home "Top Artists" carousel, not a full artist
-    /// directory (see `get_artists` for that).
+    /// alphabetically). When the library has no play history at all (a
+    /// freshly scanned collection), falls back to ranking by song count
+    /// instead of excluding every artist — this powers the Home "Top
+    /// Artists" carousel, not a full artist directory (see `get_artists`
+    /// for that).
     pub fn get_top_artists(&self, limit: i64) -> Result<Vec<serde_json::Value>> {
         let conn = self.db.pool.get()?;
         // See get_artists() for why grouping is case-insensitive (issue #295).
@@ -675,6 +677,9 @@ impl CollectionScanner {
                 FROM songs s
                 WHERE s.source IN (1, 2) AND s.unavailable = 0
              ),
+             totals AS (
+                SELECT SUM(COALESCE(playcount, 0)) AS lib_total_playcount FROM base
+             ),
              grouped AS (
                 SELECT
                     MIN(effective_artist) AS effective_artist,
@@ -683,7 +688,6 @@ impl CollectionScanner {
                     SUM(COALESCE(playcount, 0)) AS total_playcount
                 FROM base
                 GROUP BY effective_artist COLLATE NOCASE
-                HAVING SUM(COALESCE(playcount, 0)) > 0
              )
              SELECT
                 g.effective_artist,
@@ -704,8 +708,11 @@ impl CollectionScanner {
                     ORDER BY COUNT(*) DESC, COALESCE(sg.genresort, sg.genre) ASC
                     LIMIT 1
                 ) AS genre
-             FROM grouped g
-             ORDER BY g.total_playcount DESC, g.sort_artist COLLATE NOCASE
+             FROM grouped g, totals t
+             ORDER BY
+                g.total_playcount DESC,
+                CASE WHEN t.lib_total_playcount = 0 THEN g.song_count END DESC,
+                g.sort_artist COLLATE NOCASE
              LIMIT ?1",
         )?;
         let artists: Vec<serde_json::Value> = stmt
@@ -959,6 +966,39 @@ impl CollectionScanner {
              FROM songs s
              WHERE s.source IN (1, 2) AND s.unavailable = 0 AND s.added IS NOT NULL
              ORDER BY s.added DESC
+             LIMIT ?1"
+        );
+        let mut stmt = conn.prepare(&sql)?;
+        let songs_with_counts: Vec<(Song, i64, i64)> = stmt
+            .query_map(params![query_limit], |row| {
+                let song = row_to_song(row)?;
+                let count: i64 = row.get(SONG_SELECT_COL_COUNT)?;
+                let disc_count: i64 = row.get(SONG_SELECT_COL_COUNT + 1)?;
+                Ok((song, count, disc_count))
+            })?
+            .filter_map(|r| r.ok())
+            .collect();
+        let mut items = group_songs_into_home_items(songs_with_counts, limit as usize);
+        attach_album_ratings(&conn, &mut items)?;
+        Ok(items)
+    }
+
+    /// A shuffled sample of full albums in the library, for users with
+    /// little or no play history yet. Reuses the same Album grouping as
+    /// `get_recently_added`; only the ordering (random) and the album-only
+    /// filter differ. Reshuffles on every call by design — freshness over
+    /// stability across refreshes.
+    pub fn get_featured_albums(&self, limit: i64) -> Result<Vec<HomeItem>> {
+        let conn = self.db.pool.get()?;
+        // See get_recently_played's identical overfetch-then-group comment.
+        let query_limit = limit * 20;
+        let home_item_select_cols = home_item_select_cols();
+        let sql = format!(
+            "SELECT {home_item_select_cols}
+             FROM songs s
+             WHERE s.source IN (1, 2) AND s.unavailable = 0
+               AND s.album IS NOT NULL AND s.album != ''
+             ORDER BY RANDOM()
              LIMIT ?1"
         );
         let mut stmt = conn.prepare(&sql)?;
@@ -1944,7 +1984,7 @@ mod tests {
     }
 
     #[test]
-    fn test_get_top_artists_ranks_by_playcount_and_excludes_zero_plays() {
+    fn test_get_top_artists_ranks_by_playcount_and_ranks_zero_plays_last() {
         let temp_dir = std::env::temp_dir().join(format!(
             "luminous_top_artists_test_{}",
             std::time::SystemTime::now()
@@ -1994,7 +2034,9 @@ mod tests {
             4,
         );
 
-        // Artist Unplayed: never played, must be excluded entirely.
+        // Artist Unplayed: never played. The library as a whole has play
+        // history (High/Low), so the zero-play fallback must NOT kick in —
+        // Unplayed is still included, but ranked last by total_playcount.
         seed(
             r"C:\Music\Artist Unplayed\track.mp3",
             "Artist Unplayed",
@@ -2009,10 +2051,58 @@ mod tests {
             .iter()
             .map(|a| a["name"].as_str().unwrap())
             .collect();
-        assert_eq!(names, vec!["Artist High", "Artist Low"]);
+        assert_eq!(names, vec!["Artist High", "Artist Low", "Artist Unplayed"]);
 
         let high = &top_artists[0];
         assert_eq!(high["song_count"].as_i64(), Some(2));
+
+        let _ = std::fs::remove_dir_all(temp_dir);
+    }
+
+    #[test]
+    fn test_get_top_artists_falls_back_to_song_count_when_library_has_no_plays() {
+        let temp_dir = std::env::temp_dir().join(format!(
+            "luminous_top_artists_fallback_test_{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let db = Arc::new(Database::new(temp_dir.clone()).unwrap());
+        let conn = db.pool.get().unwrap();
+
+        let seed = |path: &str, artist: &str, title: &str| {
+            upsert_song(
+                &conn,
+                &Song {
+                    artist: Some(artist.to_string()),
+                    title: Some(title.to_string()),
+                    source: SongSource::LocalFile,
+                    path: Some(path.to_string()),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        };
+
+        // A freshly-scanned library: no song anywhere has ever been played.
+        // Artist Big has more songs than Artist Small.
+        seed(r"C:\Music\Artist Big\a.mp3", "Artist Big", "Track A");
+        seed(r"C:\Music\Artist Big\b.mp3", "Artist Big", "Track B");
+        seed(r"C:\Music\Artist Small\a.mp3", "Artist Small", "Track A");
+
+        let scanner = CollectionScanner::new(db.clone());
+        let top_artists = scanner.get_top_artists(10).unwrap();
+
+        // Zero-play library: nothing gets excluded, and ranking falls back
+        // to song_count DESC instead of collapsing to alphabetical order.
+        let names: Vec<&str> = top_artists
+            .iter()
+            .map(|a| a["name"].as_str().unwrap())
+            .collect();
+        assert_eq!(names, vec!["Artist Big", "Artist Small"]);
+        assert_eq!(top_artists[0]["song_count"].as_i64(), Some(2));
+        assert_eq!(top_artists[1]["song_count"].as_i64(), Some(1));
 
         let _ = std::fs::remove_dir_all(temp_dir);
     }
@@ -2279,6 +2369,112 @@ mod tests {
             }
             other => panic!("expected Album item, got {other:?}"),
         }
+
+        let _ = std::fs::remove_dir_all(temp_dir);
+    }
+
+    #[test]
+    fn test_get_featured_albums_returns_albums_without_play_history() {
+        let temp_dir = std::env::temp_dir().join(format!(
+            "luminous_featured_albums_test_{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let db = Arc::new(Database::new(temp_dir.clone()).unwrap());
+        let scanner = CollectionScanner::new(db.clone());
+        let conn = db.pool.get().unwrap();
+
+        let insert_song = |path: &str, title: &str, artist: &str, album: Option<&str>| {
+            let song = Song {
+                source: SongSource::LocalFile,
+                path: Some(path.to_string()),
+                title: Some(title.to_string()),
+                artist: Some(artist.to_string()),
+                album: album.map(|a| a.to_string()),
+                added: Some(1000),
+                ..Default::default()
+            };
+            upsert_song(&conn, &song).unwrap();
+        };
+
+        // Two full albums (no play history — playcount defaults to 0/unset).
+        for i in 1..=3 {
+            insert_song(
+                &format!("path/album_a_{i}.mp3"),
+                &format!("A Track {i}"),
+                "Artist A",
+                Some("Album A"),
+            );
+        }
+        for i in 1..=3 {
+            insert_song(
+                &format!("path/album_b_{i}.mp3"),
+                &format!("B Track {i}"),
+                "Artist B",
+                Some("Album B"),
+            );
+        }
+        // A standalone single with no album tag — must be excluded.
+        insert_song("path/single.mp3", "Single Track", "Artist C", None);
+
+        let items = scanner.get_featured_albums(10).unwrap();
+        assert_eq!(items.len(), 2, "should surface both albums, no singles");
+        for item in &items {
+            match item {
+                HomeItem::Album { album } => {
+                    assert!(
+                        matches!(album.album.as_deref(), Some("Album A") | Some("Album B")),
+                        "unexpected album: {album:?}"
+                    );
+                }
+                other => panic!("expected Album item, got {other:?}"),
+            }
+        }
+
+        let _ = std::fs::remove_dir_all(temp_dir);
+    }
+
+    #[test]
+    fn test_get_featured_albums_respects_limit() {
+        let temp_dir = std::env::temp_dir().join(format!(
+            "luminous_featured_albums_limit_test_{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let db = Arc::new(Database::new(temp_dir.clone()).unwrap());
+        let scanner = CollectionScanner::new(db.clone());
+        let conn = db.pool.get().unwrap();
+
+        let insert_song = |path: &str, title: &str, artist: &str, album: &str| {
+            let song = Song {
+                source: SongSource::LocalFile,
+                path: Some(path.to_string()),
+                title: Some(title.to_string()),
+                artist: Some(artist.to_string()),
+                album: Some(album.to_string()),
+                added: Some(1000),
+                ..Default::default()
+            };
+            upsert_song(&conn, &song).unwrap();
+        };
+
+        for album_idx in 1..=5 {
+            for track_idx in 1..=2 {
+                insert_song(
+                    &format!("path/album_{album_idx}_track_{track_idx}.mp3"),
+                    &format!("Track {track_idx}"),
+                    "Various Artist",
+                    &format!("Album {album_idx}"),
+                );
+            }
+        }
+
+        let items = scanner.get_featured_albums(2).unwrap();
+        assert_eq!(items.len(), 2);
 
         let _ = std::fs::remove_dir_all(temp_dir);
     }

--- a/src-tauri/src/commands/collection.rs
+++ b/src-tauri/src/commands/collection.rs
@@ -234,6 +234,17 @@ pub async fn get_recently_added(
 }
 
 #[tauri::command]
+pub async fn get_featured_albums(
+    limit: Option<i64>,
+    state: State<'_, AppState>,
+) -> Result<Vec<HomeItem>, String> {
+    let scanner = CollectionScanner::new(state.db.clone());
+    scanner
+        .get_featured_albums(limit.unwrap_or(10))
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
 pub async fn get_artist_profile(
     artist: String,
     state: State<'_, AppState>,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -822,6 +822,7 @@ pub fn run() {
             commands::collection::clear_play_history,
             commands::collection::get_most_frequently_played,
             commands::collection::get_recently_added,
+            commands::collection::get_featured_albums,
             commands::collection::get_artist_profile,
             commands::collection::set_artist_profile,
             commands::collection::get_all_artist_profiles,

--- a/src/lib/components/HomeView.svelte
+++ b/src/lib/components/HomeView.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
   import { onMount } from "svelte";
   import { invoke } from "@tauri-apps/api/core";
+  import { listen } from "@tauri-apps/api/event";
   import { playerStore } from "../stores/player.svelte";
   import { collectionStore } from "../stores/collection.svelte";
   import { navigationStore } from "../stores/navigation.svelte";
-  import type { HomeItem, ArtistItem } from "../types";
+  import type { HomeItem, ArtistItem, ScanProgress } from "../types";
   import { getArtistAlbums, getArtistSongs } from "../utils/artist";
   import HorizontalScrollRow from "./HorizontalScrollRow.svelte";
   import ArtistCard from "./ArtistCard.svelte";
@@ -16,7 +17,9 @@
   let topArtists = $state<ArtistItem[]>([]);
   let frequentlyPlayed = $state<HomeItem[]>([]);
   let recentlyAdded = $state<HomeItem[]>([]);
+  let featuredAlbums = $state<HomeItem[]>([]);
   let isLoading = $state(true);
+  let libraryChangedDebounce: ReturnType<typeof setTimeout> | undefined;
 
   function getTimeOfDayGreeting(): string {
     const hour = new Date().getHours();
@@ -29,14 +32,16 @@
   async function loadCuratedData() {
     isLoading = true;
     try {
-      const [artists, frequent, added] = await Promise.all([
+      const [artists, frequent, added, featured] = await Promise.all([
         invoke<ArtistItem[]>("get_top_artists", { limit: 15 }),
         invoke<HomeItem[]>("get_most_frequently_played", { limit: 5 }),
         invoke<HomeItem[]>("get_recently_added", { limit: 5 }),
+        invoke<HomeItem[]>("get_featured_albums", { limit: 5 }),
       ]);
       topArtists = artists;
       frequentlyPlayed = frequent;
       recentlyAdded = added;
+      featuredAlbums = featured;
     } catch (err) {
       console.error("Failed to load curated data:", err);
     } finally {
@@ -46,6 +51,21 @@
 
   onMount(() => {
     loadCuratedData();
+
+    const unlistenScan = listen<ScanProgress>("scan-progress", (event) => {
+      if (event.payload.phase === "done") loadCuratedData();
+    });
+
+    const unlistenLibrary = listen("library-changed", () => {
+      clearTimeout(libraryChangedDebounce);
+      libraryChangedDebounce = setTimeout(loadCuratedData, 500);
+    });
+
+    return () => {
+      clearTimeout(libraryChangedDebounce);
+      unlistenScan.then((fn) => fn());
+      unlistenLibrary.then((fn) => fn());
+    };
   });
 </script>
 
@@ -58,6 +78,15 @@
       <p class="text-sm text-brand-text-secondary mt-1">
         {i18n.t('home.exploreSub')}
       </p>
+      {#if collectionStore.stats.total_songs > 0}
+        <p class="text-sm text-brand-text-secondary mt-1">
+          {i18n.t('home.libraryOverview', {
+            songs: collectionStore.stats.total_songs,
+            albums: collectionStore.stats.total_albums,
+            artists: collectionStore.stats.total_artists
+          })}
+        </p>
+      {/if}
     </div>
 
     <div class="px-6 pt-4 space-y-12">
@@ -81,10 +110,12 @@
         </HorizontalScrollRow>
       {/if}
 
-      {#if frequentlyPlayed.length > 0 || recentlyAdded.length > 0}
+      {#if frequentlyPlayed.length > 0 || featuredAlbums.length > 0 || recentlyAdded.length > 0}
         <div class="grid grid-cols-1 lg:grid-cols-2 gap-8">
           {#if frequentlyPlayed.length > 0}
             <HomeRowList title={i18n.t('home.mostPlayed')} items={frequentlyPlayed} variant="rank" />
+          {:else if featuredAlbums.length > 0}
+            <HomeRowList title={i18n.t('home.exploreLibrary')} items={featuredAlbums} variant="added" />
           {/if}
           {#if recentlyAdded.length > 0}
             <HomeRowList title={i18n.t('home.recentlyAdded')} items={recentlyAdded} variant="added" />

--- a/src/lib/components/HomeView.test.ts
+++ b/src/lib/components/HomeView.test.ts
@@ -1,0 +1,202 @@
+import "@testing-library/jest-dom";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/svelte";
+import HomeView from "./HomeView.svelte";
+import { collectionStore } from "../stores/collection.svelte";
+import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
+import type { HomeItem, ArtistItem, AlbumItem, Song, ScanProgress } from "../types";
+
+function makeArtist(overrides: Partial<ArtistItem> = {}): ArtistItem {
+  return {
+    name: "Tom Petty",
+    album_count: 2,
+    song_count: 12,
+    genre: "Rock",
+    ...overrides,
+  };
+}
+
+function makeAlbum(overrides: Partial<AlbumItem> = {}): AlbumItem {
+  return {
+    artist: "Tom Petty",
+    album: "Full Moon Fever",
+    year: 1989,
+    track_count: 12,
+    disc_count: 1,
+    art_embedded: false,
+    art_automatic: null,
+    art_manual: null,
+    genre: "Rock",
+    rating: -1,
+    total_duration_nanosec: 0,
+    ...overrides,
+  };
+}
+
+function makeSong(overrides: Partial<Song> = {}): Song {
+  return {
+    id: 1,
+    source: "local_file",
+    filetype: "MP3",
+    title: "Wildflowers",
+    artist: "Tom Petty",
+    album: "Wildflowers",
+    art_embedded: false,
+    art_unset: false,
+    compilation: false,
+    beginning_nanosec: 0,
+    end_nanosec: 0,
+    rating: -1,
+    playcount: 0,
+    skipcount: 0,
+    length_nanosec: 195_000_000_000,
+    added: 1_700_000_000,
+    unavailable: false,
+    ...overrides,
+  };
+}
+
+// Captures listen() callbacks by event name so tests can fire them directly,
+// mirroring how the real backend would emit scan-progress/library-changed.
+const listenCallbacks: Record<string, (event: { payload: unknown }) => void> = {};
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn((event: string, callback: (e: { payload: unknown }) => void) => {
+    listenCallbacks[event] = callback;
+    return Promise.resolve(() => {});
+  }),
+}));
+
+let mockTopArtists: ArtistItem[] = [];
+let mockFrequentlyPlayed: HomeItem[] = [];
+let mockRecentlyAdded: HomeItem[] = [];
+let mockFeaturedAlbums: HomeItem[] = [];
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn((cmd: string) => {
+    if (cmd === "get_top_artists") return Promise.resolve(mockTopArtists);
+    if (cmd === "get_most_frequently_played") return Promise.resolve(mockFrequentlyPlayed);
+    if (cmd === "get_recently_added") return Promise.resolve(mockRecentlyAdded);
+    if (cmd === "get_featured_albums") return Promise.resolve(mockFeaturedAlbums);
+    // collectionStore initializes itself on module load and expects this shape.
+    if (cmd === "get_library_snapshot") return Promise.resolve({ songs: [], albums: [], artists: [] });
+    return Promise.resolve([]);
+  }),
+}));
+
+describe("HomeView.svelte", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    for (const key of Object.keys(listenCallbacks)) delete listenCallbacks[key];
+    mockTopArtists = [];
+    mockFrequentlyPlayed = [];
+    mockRecentlyAdded = [];
+    mockFeaturedAlbums = [];
+    collectionStore.stats = {
+      total_songs: 0,
+      total_artists: 0,
+      total_albums: 0,
+      total_duration_nanosec: 0,
+      total_filesize_bytes: 0,
+    };
+    collectionStore.songs = [];
+    collectionStore.albums = [];
+  });
+
+  it("fetches all four curated home queries on mount", async () => {
+    render(HomeView);
+
+    await waitFor(() => {
+      expect(invoke).toHaveBeenCalledWith("get_top_artists", { limit: 15 });
+      expect(invoke).toHaveBeenCalledWith("get_most_frequently_played", { limit: 5 });
+      expect(invoke).toHaveBeenCalledWith("get_recently_added", { limit: 5 });
+      expect(invoke).toHaveBeenCalledWith("get_featured_albums", { limit: 5 });
+    });
+  });
+
+  it("shows LibraryWelcome when the library is genuinely empty", async () => {
+    render(HomeView);
+
+    await waitFor(() => {
+      expect(screen.getByText("Welcome to Luminous")).toBeInTheDocument();
+    });
+  });
+
+  it("does not show LibraryWelcome once recentlyAdded/topArtists have content, even with zero plays", async () => {
+    mockTopArtists = [makeArtist()];
+    mockRecentlyAdded = [{ type: "album", album: makeAlbum() }];
+
+    render(HomeView);
+
+    await waitFor(() => {
+      expect(screen.getAllByText("Tom Petty").length).toBeGreaterThan(0);
+    });
+    expect(screen.queryByText("Welcome to Luminous")).not.toBeInTheDocument();
+  });
+
+  it("shows the Explore Your Library row when there is no play history, and hides it once there is", async () => {
+    mockFeaturedAlbums = [{ type: "album", album: makeAlbum({ album: "Discover Me" }) }];
+
+    render(HomeView);
+
+    await waitFor(() => {
+      expect(screen.getByText("Explore Your Library")).toBeInTheDocument();
+    });
+  });
+
+  it("hides the Explore Your Library row in favor of Most Played once play history exists", async () => {
+    mockFrequentlyPlayed = [{ type: "song", song: makeSong({ title: "Most Played Song" }) }];
+    mockFeaturedAlbums = [{ type: "album", album: makeAlbum({ album: "Discover Me" }) }];
+
+    render(HomeView);
+
+    await waitFor(() => {
+      expect(screen.getByText("Top 5 Most Played")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("Explore Your Library")).not.toBeInTheDocument();
+  });
+
+  it("refreshes curated data when a scan-progress 'done' event fires", async () => {
+    render(HomeView);
+
+    await waitFor(() => {
+      expect(listenCallbacks["scan-progress"]).toBeDefined();
+    });
+    vi.mocked(invoke).mockClear();
+
+    const doneEvent: ScanProgress = { phase: "done", scanned: 10, total: 10, silent: false };
+    listenCallbacks["scan-progress"]({ payload: doneEvent });
+
+    await waitFor(() => {
+      expect(invoke).toHaveBeenCalledWith("get_top_artists", { limit: 15 });
+    });
+  });
+
+  it("debounces rapid library-changed events into a single refresh", async () => {
+    vi.useFakeTimers();
+    try {
+      render(HomeView);
+
+      await vi.waitFor(() => {
+        expect(listenCallbacks["library-changed"]).toBeDefined();
+      });
+      vi.mocked(invoke).mockClear();
+
+      // Simulate a burst of per-file library-changed events during a scan.
+      for (let i = 0; i < 20; i++) {
+        listenCallbacks["library-changed"]({ payload: undefined });
+      }
+      expect(invoke).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(500);
+
+      const topArtistsCalls = vi
+        .mocked(invoke)
+        .mock.calls.filter(([cmd]) => cmd === "get_top_artists");
+      expect(topArtistsCalls).toHaveLength(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -57,6 +57,8 @@ export const en = {
     topArtists: "Top Artists",
     mostPlayed: "Top 5 Most Played",
     recentlyAdded: "Recently Added",
+    exploreLibrary: "Explore Your Library",
+    libraryOverview: "{songs} Songs • {albums} Albums • {artists} Artists",
     emptyState: "Start adding music to see your personalized collections"
   },
   emptyLibrary: {

--- a/src/lib/locales/fr.ts
+++ b/src/lib/locales/fr.ts
@@ -57,6 +57,8 @@ export const fr = {
     topArtists: "Artistes populaires",
     mostPlayed: "Top 5 des plus écoutés",
     recentlyAdded: "Ajoutés récemment",
+    exploreLibrary: "Explorez votre bibliothèque",
+    libraryOverview: "{songs} titres • {albums} albums • {artists} artistes",
     emptyState: "Commencez à ajouter de la musique pour voir vos collections personnalisées"
   },
   emptyLibrary: {


### PR DESCRIPTION
## 📋 Summary
Fixes #408. The Home screen loaded curated data once on mount and never refreshed during/after a library scan, and `get_top_artists` excluded every artist when the library had zero play history — leaving new users with a stale, sparse Home screen even after a full scan completed.

## 🔍 Implementation Notes
- `HomeView.svelte` now listens for backend `scan-progress` (refreshes on `phase === "done"`) and `library-changed` (debounced 500ms, since it can fire once per file during a batch import) instead of only loading once in `onMount()`.
- `get_top_artists` (`src-tauri/src/collection/query.rs`) falls back to ranking by `song_count` instead of excluding zero-play artists — but only when the *entire* library has zero total playcount, so ranking is byte-for-byte unchanged for libraries that already have play history.
- New `get_featured_albums` backend command (query → Tauri command → registration) surfaces a shuffled sample of full albums. On Home, an "Explore Your Library" row takes the place of "Most Played" until the user has play history.
- Home now shows a compact "X Songs • Y Albums • Z Artists" overview line under the greeting, sourced from the already-reactive `collectionStore.stats` — no new backend call needed.
- Intentionally left out of scope (issue updated to reflect this): a separate "Featured Artists" section distinct from Top Artists, and Quick Start action buttons (Shuffle Library / Browse Collection) alongside the overview line — the above already resolves the sparseness without the extra surface area.

## 🧪 Test Plan
- [x] `bun run check` (svelte-check) — 0 errors
- [x] `bun run test:run` (frontend) — 530 passed, including new `HomeView.test.ts` (refresh-on-scan, debounce, row visibility, empty-state gating)
- [x] `cargo test` (src-tauri) — 228 passed, including new/updated `get_top_artists` and `get_featured_albums` coverage
- [x] Manually verified in the app — confirmed Top Artists (song-count ranked), Explore Your Library, Recently Added, and the library overview line all populate live as a scan completes, with no reload needed.

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed — n/a, no screenshot-harness entries needed for this change
