### PR TITLE
ci: auto-close linked issues when a PR merges into next

### DIFF
--- a/.github/workflows/close-linked-issues.yml
+++ b/.github/workflows/close-linked-issues.yml
@@ -1,0 +1,72 @@
+name: Close Linked Issues
+
+# GitHub's own "Fixes #N"/"Closes #N" auto-close only fires when a PR merges
+# into the repository's default branch (main). This repo also merges 2.0 work
+# into `next` (see the Branching Model in AGENTS.md), so PRs merged there need
+# the same closing-keyword handling done explicitly.
+on:
+  pull_request:
+    types: [closed]
+    branches: [ "next" ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  issues: write
+  pull-requests: read
+
+jobs:
+  close-linked-issues:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close issues referenced by closing keywords
+        uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
+        with:
+          script: |
+            const keywordPattern = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s*:?\s*#(\d+)/gi;
+            const text = `${context.payload.pull_request.title}\n${context.payload.pull_request.body ?? ""}`;
+            const issueNumbers = [...new Set([...text.matchAll(keywordPattern)].map(m => Number(m[1])))];
+
+            if (issueNumbers.length === 0) {
+              core.info("No closing keywords found in PR title/body.");
+              return;
+            }
+
+            for (const issueNumber of issueNumbers) {
+              try {
+                const { data: issue } = await github.rest.issues.get({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                });
+
+                if (issue.pull_request) {
+                  core.info(`#${issueNumber} is a pull request, not an issue — skipping.`);
+                  continue;
+                }
+                if (issue.state === "closed") {
+                  core.info(`#${issueNumber} is already closed.`);
+                  continue;
+                }
+
+                await github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                  state: "closed",
+                  state_reason: "completed",
+                });
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                  body: `Closed by #${context.payload.pull_request.number}.`,
+                });
+                core.info(`Closed #${issueNumber}.`);
+              } catch (err) {
+                core.warning(`Could not close #${issueNumber}: ${err.message}`);
+              }
+            }


### PR DESCRIPTION
## 📋 Summary
GitHub's native "Fixes #N"/"Closes #N" auto-close only fires when a PR merges into the repository's default branch (`main`). This repo also merges 2.0-milestone work into `next`, so PRs merged there leave their linked issues open — e.g. #408 had to be closed by hand after #658 merged. This adds a workflow that replicates the same closing-keyword handling for PRs merged into `next`.

## 🔍 Implementation Notes
- New `.github/workflows/close-linked-issues.yml`, triggered on `pull_request: types: [closed]` scoped to `branches: ["next"]` only — `main` already gets GitHub's native behavior, so this avoids a redundant run there.
- Guarded by `if: github.event.pull_request.merged == true` so a closed-without-merge PR is a no-op.
- Scans the PR title + body for `close(s|d)`, `fix(es|ed)`, `resolve(s|d)` followed by `#N` (same set of keywords GitHub's own linking recognizes), then closes each matched issue via the REST API with a comment linking back to the PR. Skips anything already closed or that turns out to be a PR, not an issue.
- Checked for trigger overlap with the other four `pull_request`-triggered workflows (`audit.yml`, `ci.yml`, `codeql.yml`, `flatpak.yml`) — none use `types: [closed]`, so there's no double-fire.
- `actions/github-script` pinned by commit SHA (v9.0.0), matching this repo's existing pinned-action convention.

## 🧪 Test Plan
- [x] YAML validated (`bunx js-yaml`) — no syntax errors.
- [ ] No unit tests apply (CI workflow, not application code) — first real signal will be the next PR merged into `next` after this lands; happy to do a manual dry run against a scratch issue/PR if you'd like before relying on it.

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed — n/a, not user-facing
