### PR TITLE
fix: merge Home screen subtitle and library stats into one line

### DIFF
--- a/src/lib/components/HomeView.svelte
+++ b/src/lib/components/HomeView.svelte
@@ -76,17 +76,14 @@
         {getTimeOfDayGreeting()}
       </h1>
       <p class="text-sm text-brand-text-secondary mt-1">
-        {i18n.t('home.exploreSub')}
+        {collectionStore.stats.total_songs > 0
+          ? i18n.t('home.libraryOverview', {
+              songs: collectionStore.stats.total_songs,
+              albums: collectionStore.stats.total_albums,
+              artists: collectionStore.stats.total_artists
+            })
+          : i18n.t('home.exploreSub')}
       </p>
-      {#if collectionStore.stats.total_songs > 0}
-        <p class="text-sm text-brand-text-secondary mt-1">
-          {i18n.t('home.libraryOverview', {
-            songs: collectionStore.stats.total_songs,
-            albums: collectionStore.stats.total_albums,
-            artists: collectionStore.stats.total_artists
-          })}
-        </p>
-      {/if}
     </div>
 
     <div class="px-6 pt-4 space-y-12">

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -58,7 +58,7 @@ export const en = {
     mostPlayed: "Top 5 Most Played",
     recentlyAdded: "Recently Added",
     exploreLibrary: "Explore Your Library",
-    libraryOverview: "{songs} Songs • {albums} Albums • {artists} Artists",
+    libraryOverview: "Explore your music collection: {songs} Songs • {albums} Albums • {artists} Artists",
     emptyState: "Start adding music to see your personalized collections"
   },
   emptyLibrary: {

--- a/src/lib/locales/fr.ts
+++ b/src/lib/locales/fr.ts
@@ -58,7 +58,7 @@ export const fr = {
     mostPlayed: "Top 5 des plus écoutés",
     recentlyAdded: "Ajoutés récemment",
     exploreLibrary: "Explorez votre bibliothèque",
-    libraryOverview: "{songs} titres • {albums} albums • {artists} artistes",
+    libraryOverview: "Explorez votre collection musicale : {songs} titres • {albums} albums • {artists} artistes",
     emptyState: "Commencez à ajouter de la musique pour voir vos collections personnalisées"
   },
   emptyLibrary: {


### PR DESCRIPTION
## 📋 Summary
Merges the Home screen's greeting subtitle and library stats line into a single line, e.g. "Explore your music collection: 2371 Songs • 219 Albums • 134 Artists" instead of two stacked lines.

## 🔍 Implementation Notes
- `home.libraryOverview` now includes the "Explore your music collection" prefix (and its French equivalent), and is shown in place of `home.exploreSub` once the library has songs.
- `home.exploreSub` is still shown on its own when the library is empty (`total_songs === 0`).

## 🧪 Test Plan
- [x] `bun run check` (svelte-check) — 0 errors, 0 warnings
- [ ] `bun run test -- --run` (frontend)
- [ ] `cargo test` (src-tauri, if Rust changed) — no Rust changes
- [ ] Manually verified in the app (describe what you did)

## 📸 Screenshots
Before/after not attached — verify visually via `bun run tauri dev` on the Home screen.

## ✅ Checklist
- [x] No unrelated changes bundled in
- [ ] Docs/screenshots updated if user-facing behavior changed (see `.claude/CLAUDE.md` for the screenshot harness)
