### PR TITLE
Feature: Pin to Home (#222)

### DIFF
--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -4,6 +4,7 @@ pub mod equalizer;
 pub mod loudness;
 pub mod lyrics;
 pub mod organizer;
+pub mod pins;
 pub mod player;
 pub mod playlist;
 pub mod settings;

--- a/src-tauri/src/commands/pins.rs
+++ b/src-tauri/src/commands/pins.rs
@@ -1,0 +1,137 @@
+//! Commands backing the user-curated "Pinned" shelf on Home (#222). A pin is
+//! stored as a lightweight `(item_type, ref_key)` reference — `get_pinned_items`
+//! resolves each reference against the live song/album/artist/playlist tables
+//! on every read, so a pinned item always reflects current data (artwork,
+//! rating, track count, ...) rather than a stale snapshot. A reference that no
+//! longer resolves (e.g. a pinned song was deleted) is silently omitted from
+//! the result rather than treated as an error — the orphan `pinned_items` row
+//! is left in place and self-heals if the item reappears. The DB/query logic
+//! itself lives in `crate::pins`; this file is just the Tauri wiring.
+
+use crate::{collection::CollectionScanner, models::PinnedItem, pins, AppState};
+use tauri::{AppHandle, Emitter, State};
+
+#[tauri::command]
+pub async fn pin_item(
+    item_type: String,
+    ref_key: String,
+    app: AppHandle,
+    state: State<'_, AppState>,
+) -> Result<(), String> {
+    let conn = state.db.pool.get().map_err(|e| e.to_string())?;
+    pins::pin(&conn, &item_type, &ref_key).map_err(|e| e.to_string())?;
+    let _ = app.emit("pinned-items-changed", ());
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn unpin_item(
+    item_type: String,
+    ref_key: String,
+    app: AppHandle,
+    state: State<'_, AppState>,
+) -> Result<(), String> {
+    let conn = state.db.pool.get().map_err(|e| e.to_string())?;
+    pins::unpin(&conn, &item_type, &ref_key).map_err(|e| e.to_string())?;
+    let _ = app.emit("pinned-items-changed", ());
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn reorder_pinned_items(
+    order: Vec<(String, String)>,
+    app: AppHandle,
+    state: State<'_, AppState>,
+) -> Result<(), String> {
+    let conn = state.db.pool.get().map_err(|e| e.to_string())?;
+    pins::reorder(&conn, &order).map_err(|e| e.to_string())?;
+    let _ = app.emit("pinned-items-changed", ());
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn get_pinned_items(state: State<'_, AppState>) -> Result<Vec<PinnedItem>, String> {
+    let refs = {
+        let conn = state.db.pool.get().map_err(|e| e.to_string())?;
+        pins::pinned_refs(&conn).map_err(|e| e.to_string())?
+    };
+    if refs.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let scanner = CollectionScanner::new(state.db.clone());
+    let mut albums_cache: Option<Vec<serde_json::Value>> = None;
+    let mut artists_cache: Option<Vec<serde_json::Value>> = None;
+    let mut playlists_cache: Option<Vec<crate::models::Playlist>> = None;
+
+    let mut items = Vec::with_capacity(refs.len());
+    for (item_type, ref_key) in refs {
+        match item_type.as_str() {
+            "song" => {
+                let conn = state.db.pool.get().map_err(|e| e.to_string())?;
+                if let Some(song) =
+                    pins::resolve_song(&conn, &ref_key).map_err(|e| e.to_string())?
+                {
+                    items.push(PinnedItem::Song {
+                        song: Box::new(song),
+                    });
+                }
+            }
+            "album" => {
+                let albums = match &albums_cache {
+                    Some(a) => a,
+                    None => {
+                        albums_cache = Some(pins::all_albums(&scanner).map_err(|e| e.to_string())?);
+                        albums_cache.as_ref().unwrap()
+                    }
+                };
+                if let Some(value) = pins::find_album(albums, &ref_key) {
+                    items.push(PinnedItem::Album {
+                        album: pins::album_item_from_json(value),
+                    });
+                }
+            }
+            "artist" => {
+                let artists = match &artists_cache {
+                    Some(a) => a,
+                    None => {
+                        artists_cache =
+                            Some(pins::all_artists(&scanner).map_err(|e| e.to_string())?);
+                        artists_cache.as_ref().unwrap()
+                    }
+                };
+                if let Some(value) = pins::find_artist(artists, &ref_key) {
+                    if let Ok(artist) = pins::artist_item_from_json(value) {
+                        items.push(PinnedItem::Artist { artist });
+                    }
+                }
+            }
+            "playlist" => {
+                let Ok(playlist_id) = ref_key.parse::<i64>() else {
+                    continue;
+                };
+                let playlists = match &playlists_cache {
+                    Some(p) => p,
+                    None => {
+                        let p = state
+                            .playlists
+                            .lock()
+                            .await
+                            .get_playlists()
+                            .map_err(|e| e.to_string())?;
+                        playlists_cache = Some(p);
+                        playlists_cache.as_ref().unwrap()
+                    }
+                };
+                if let Some(playlist) = playlists.iter().find(|p| p.id == playlist_id) {
+                    items.push(PinnedItem::Playlist {
+                        playlist: playlist.clone(),
+                    });
+                }
+            }
+            _ => {}
+        }
+    }
+
+    Ok(items)
+}

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 pub type DbPool = Pool<SqliteConnectionManager>;
 
 /// Current schema version. Increment when adding migrations.
-pub const CURRENT_SCHEMA_VERSION: i32 = 20;
+pub const CURRENT_SCHEMA_VERSION: i32 = 21;
 
 struct Migration {
     version: i32,
@@ -133,6 +133,11 @@ const MIGRATIONS: &[Migration] = &[
             }
             Ok(())
         },
+    },
+    Migration {
+        version: 21,
+        description: "pinned_items table for user-curated Home shelf (#222)",
+        apply: |conn| Ok(conn.execute_batch(MIGRATION_21)?),
     },
 ];
 
@@ -621,6 +626,16 @@ WHERE dynamic_enabled = 1
 // ---------------------------------------------------------------------------
 const MIGRATION_20: &str = "
 ALTER TABLE songs ADD COLUMN genresort TEXT;
+";
+
+const MIGRATION_21: &str = "
+CREATE TABLE IF NOT EXISTS pinned_items (
+    item_type TEXT NOT NULL,
+    ref_key   TEXT NOT NULL,
+    position  INTEGER NOT NULL DEFAULT 0,
+    pinned_at INTEGER NOT NULL,
+    PRIMARY KEY (item_type, ref_key)
+);
 ";
 
 // ---------------------------------------------------------------------------

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -24,6 +24,7 @@ pub mod lyrics;
 pub mod media_session;
 pub mod models;
 pub mod organizer;
+pub mod pins;
 pub mod player;
 pub mod playlist;
 pub mod playlist_parsers;
@@ -847,6 +848,11 @@ pub fn run() {
             commands::player::refresh_playback_queue,
             commands::player::set_shuffle_mode,
             commands::player::set_repeat_mode,
+            // Pinned Home shelf commands (#222)
+            commands::pins::pin_item,
+            commands::pins::unpin_item,
+            commands::pins::get_pinned_items,
+            commands::pins::reorder_pinned_items,
             // Playlist commands
             commands::playlist::validate_playlist_name,
             commands::playlist::create_playlist,

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -767,6 +767,31 @@ pub enum HomeItem {
     Playlist { playlist: Playlist },
 }
 
+/// Represents an artist summary, typed equivalent of the ad-hoc JSON shape
+/// returned by `CollectionScanner::get_artists`/`get_top_artists` — used here
+/// so a pinned artist (see `PinnedItem`) has a concrete Rust type.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ArtistItem {
+    pub name: Option<String>,
+    pub sort_artist: Option<String>,
+    pub album_count: i32,
+    pub song_count: i32,
+    pub total_playcount: Option<i32>,
+    pub genre: Option<String>,
+}
+
+/// A user-pinned Home-shelf entry (#222) — a superset of `HomeItem` that also
+/// allows Artist, since pins (unlike the system-curated rank/added rows) are
+/// explicitly user-curated across all four browsable entity types.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "camelCase")]
+pub enum PinnedItem {
+    Song { song: Box<Song> },
+    Album { album: AlbumItem },
+    Artist { artist: ArtistItem },
+    Playlist { playlist: Playlist },
+}
+
 /// A social media or external platform link associated with an artist (#473).
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
 pub struct ArtistSocialLink {

--- a/src-tauri/src/pins.rs
+++ b/src-tauri/src/pins.rs
@@ -1,0 +1,397 @@
+//! Pure DB/query logic backing the user-curated "Pinned" Home shelf (#222).
+//! Kept separate from the `#[tauri::command]` wrappers in `commands::pins`
+//! so it's unit-testable against a plain `Connection`/`CollectionScanner`
+//! rather than a full Tauri `AppState` — mirrors the `stats.rs` /
+//! `commands::stats` split.
+
+use crate::collection::{row_to_song, CollectionScanner, SONG_SELECT_COLS};
+use crate::models::{AlbumItem, ArtistItem, Song};
+use anyhow::Result;
+use rusqlite::{params, Connection};
+
+/// Pins `(item_type, ref_key)` at the front of the list (position 0),
+/// shifting every existing pin back by one — a newly pinned item is the one
+/// the user just acted on, so it should be the most reachable, not buried at
+/// the end of a long row. Re-pinning an already-pinned item is a no-op
+/// (its existing position is left alone).
+pub fn pin(conn: &Connection, item_type: &str, ref_key: &str) -> Result<()> {
+    let already_pinned: bool = conn
+        .query_row(
+            "SELECT 1 FROM pinned_items WHERE item_type = ?1 AND ref_key = ?2",
+            params![item_type, ref_key],
+            |_| Ok(()),
+        )
+        .is_ok();
+    if already_pinned {
+        return Ok(());
+    }
+
+    let pinned_at = chrono::Utc::now().timestamp();
+    conn.execute("UPDATE pinned_items SET position = position + 1", [])?;
+    conn.execute(
+        "INSERT INTO pinned_items (item_type, ref_key, position, pinned_at) VALUES (?1, ?2, 0, ?3)",
+        params![item_type, ref_key, pinned_at],
+    )?;
+    Ok(())
+}
+
+pub fn unpin(conn: &Connection, item_type: &str, ref_key: &str) -> Result<()> {
+    conn.execute(
+        "DELETE FROM pinned_items WHERE item_type = ?1 AND ref_key = ?2",
+        params![item_type, ref_key],
+    )?;
+    Ok(())
+}
+
+/// Every pinned `(item_type, ref_key)`, in display order.
+pub fn pinned_refs(conn: &Connection) -> Result<Vec<(String, String)>> {
+    let mut stmt =
+        conn.prepare("SELECT item_type, ref_key FROM pinned_items ORDER BY position ASC")?;
+    let rows = stmt
+        .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))?
+        .filter_map(|r| r.ok())
+        .collect();
+    Ok(rows)
+}
+
+/// Persists `order` (the full new pin sequence) by diffing it against the
+/// current `position` values and updating only the rows that moved —
+/// mirrors `reorder_playlist_items_batch`'s load/diff/update style.
+pub fn reorder(conn: &Connection, order: &[(String, String)]) -> Result<()> {
+    let current: Vec<(String, String, i64)> = {
+        let mut stmt = conn.prepare("SELECT item_type, ref_key, position FROM pinned_items")?;
+        let rows: Vec<(String, String, i64)> = stmt
+            .query_map([], |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)))?
+            .filter_map(|r| r.ok())
+            .collect();
+        rows
+    };
+
+    for (new_pos, (item_type, ref_key)) in order.iter().enumerate() {
+        let new_pos = new_pos as i64;
+        let changed = current
+            .iter()
+            .find(|(t, k, _)| t == item_type && k == ref_key)
+            .map(|(_, _, old_pos)| *old_pos != new_pos)
+            .unwrap_or(false);
+        if changed {
+            conn.execute(
+                "UPDATE pinned_items SET position = ?1 WHERE item_type = ?2 AND ref_key = ?3",
+                params![new_pos, item_type, ref_key],
+            )?;
+        }
+    }
+    Ok(())
+}
+
+/// Resolves a pinned song reference against live data — `None` (not an
+/// error) when the id doesn't parse or the song no longer exists/is
+/// unavailable, so a stale pin is silently dropped by the caller.
+pub fn resolve_song(conn: &Connection, ref_key: &str) -> Result<Option<Song>> {
+    let Ok(song_id) = ref_key.parse::<i64>() else {
+        return Ok(None);
+    };
+    let sql = format!("SELECT {SONG_SELECT_COLS} FROM songs WHERE id = ?1 AND unavailable = 0");
+    Ok(conn.query_row(&sql, params![song_id], row_to_song).ok())
+}
+
+/// Builds an `AlbumItem` from one entry of `CollectionScanner::get_albums()`'s
+/// JSON output. Built field-by-field rather than via `serde_json::from_value`:
+/// that JSON shape carries extra fields (added, artist_sort, albumsort) and
+/// omits `sample_song_id` (which `AlbumItem` declares as a plain,
+/// non-defaulted `Option`), so a blanket deserialize would fail on the
+/// missing key.
+pub fn album_item_from_json(value: &serde_json::Value) -> AlbumItem {
+    AlbumItem {
+        artist: value
+            .get("artist")
+            .and_then(|v| v.as_str())
+            .map(String::from),
+        album: value
+            .get("album")
+            .and_then(|v| v.as_str())
+            .map(String::from),
+        year: value.get("year").and_then(|v| v.as_i64()).map(|n| n as i32),
+        track_count: value
+            .get("track_count")
+            .and_then(|v| v.as_i64())
+            .unwrap_or(0) as i32,
+        disc_count: value
+            .get("disc_count")
+            .and_then(|v| v.as_i64())
+            .unwrap_or(1) as i32,
+        art_embedded: value
+            .get("art_embedded")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false),
+        art_automatic: value
+            .get("art_automatic")
+            .and_then(|v| v.as_str())
+            .map(String::from),
+        art_manual: value
+            .get("art_manual")
+            .and_then(|v| v.as_str())
+            .map(String::from),
+        genre: value
+            .get("genre")
+            .and_then(|v| v.as_str())
+            .map(String::from),
+        sample_song_id: None,
+        rating: value.get("rating").and_then(|v| v.as_f64()).unwrap_or(-1.0) as f32,
+        total_duration_nanosec: value
+            .get("total_duration_nanosec")
+            .and_then(|v| v.as_i64())
+            .unwrap_or(0),
+    }
+}
+
+/// Finds the album entry (from `get_albums()`'s output) matching `ref_key`
+/// (the bare album title, same key convention as `album_ratings`).
+pub fn find_album<'a>(
+    albums: &'a [serde_json::Value],
+    ref_key: &str,
+) -> Option<&'a serde_json::Value> {
+    albums
+        .iter()
+        .find(|a| a.get("album").and_then(|v| v.as_str()) == Some(ref_key))
+}
+
+/// Finds the artist entry (from `get_artists()`'s output) matching `ref_key`,
+/// case-insensitively — `get_artists` groups artists `COLLATE NOCASE` (#295),
+/// so an exact-case match could miss a pin whose stored casing drifted from
+/// the group's chosen display casing.
+pub fn find_artist<'a>(
+    artists: &'a [serde_json::Value],
+    ref_key: &str,
+) -> Option<&'a serde_json::Value> {
+    artists.iter().find(|a| {
+        a.get("name")
+            .and_then(|v| v.as_str())
+            .is_some_and(|name| name.eq_ignore_ascii_case(ref_key))
+    })
+}
+
+pub fn artist_item_from_json(value: &serde_json::Value) -> Result<ArtistItem> {
+    Ok(serde_json::from_value(value.clone())?)
+}
+
+/// Fetches every current album summary — a thin pass-through kept here so
+/// `commands::pins::get_pinned_items` doesn't need to import
+/// `CollectionScanner` directly.
+pub fn all_albums(scanner: &CollectionScanner) -> Result<Vec<serde_json::Value>> {
+    scanner.get_albums()
+}
+
+pub fn all_artists(scanner: &CollectionScanner) -> Result<Vec<serde_json::Value>> {
+    scanner.get_artists()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::Database;
+
+    fn test_db() -> (Database, std::path::PathBuf) {
+        let temp_dir = std::env::temp_dir().join(format!(
+            "luminous_pins_test_{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        (Database::new(temp_dir.clone()).unwrap(), temp_dir)
+    }
+
+    fn insert_song(conn: &Connection, path: &str) -> i64 {
+        conn.execute(
+            "INSERT INTO songs (path, title, unavailable) VALUES (?1, ?2, 0)",
+            params![path, "Test Song"],
+        )
+        .unwrap();
+        conn.last_insert_rowid()
+    }
+
+    #[test]
+    fn pinned_items_table_has_expected_columns() {
+        let (db, dir) = test_db();
+        let conn = db.pool.get().unwrap();
+        let mut stmt = conn.prepare("PRAGMA table_info('pinned_items')").unwrap();
+        let cols: Vec<String> = stmt
+            .query_map([], |row| row.get::<_, String>(1))
+            .unwrap()
+            .filter_map(|r| r.ok())
+            .collect();
+        for expected in ["item_type", "ref_key", "position", "pinned_at"] {
+            assert!(
+                cols.contains(&expected.to_string()),
+                "missing column {expected}"
+            );
+        }
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn pin_unpin_round_trip_for_each_item_type() {
+        let (db, dir) = test_db();
+        let conn = db.pool.get().unwrap();
+
+        for item_type in ["song", "album", "artist", "playlist"] {
+            pin(&conn, item_type, "ref-1").unwrap();
+            assert!(pinned_refs(&conn)
+                .unwrap()
+                .contains(&(item_type.to_string(), "ref-1".to_string())));
+
+            unpin(&conn, item_type, "ref-1").unwrap();
+            assert!(!pinned_refs(&conn)
+                .unwrap()
+                .contains(&(item_type.to_string(), "ref-1".to_string())));
+        }
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn pinning_inserts_at_the_front_and_shifts_existing_pins_back() {
+        let (db, dir) = test_db();
+        let conn = db.pool.get().unwrap();
+
+        pin(&conn, "song", "1").unwrap();
+        pin(&conn, "song", "2").unwrap();
+        pin(&conn, "song", "3").unwrap();
+
+        // Most recently pinned first.
+        assert_eq!(
+            pinned_refs(&conn).unwrap(),
+            vec![
+                ("song".into(), "3".into()),
+                ("song".into(), "2".into()),
+                ("song".into(), "1".into()),
+            ]
+        );
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn re_pinning_is_idempotent_and_keeps_original_position() {
+        let (db, dir) = test_db();
+        let conn = db.pool.get().unwrap();
+
+        pin(&conn, "song", "1").unwrap();
+        pin(&conn, "song", "2").unwrap();
+        pin(&conn, "song", "1").unwrap(); // re-pin, should be a no-op
+
+        let refs = pinned_refs(&conn).unwrap();
+        assert_eq!(refs.len(), 2, "re-pinning must not create a duplicate row");
+        assert_eq!(refs[0], ("song".to_string(), "2".to_string()));
+        assert_eq!(refs[1], ("song".to_string(), "1".to_string()));
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn reorder_updates_positions_for_a_partial_reorder() {
+        let (db, dir) = test_db();
+        let conn = db.pool.get().unwrap();
+
+        pin(&conn, "song", "1").unwrap();
+        pin(&conn, "song", "2").unwrap();
+        pin(&conn, "song", "3").unwrap();
+        assert_eq!(
+            pinned_refs(&conn).unwrap(),
+            vec![
+                ("song".into(), "3".into()),
+                ("song".into(), "2".into()),
+                ("song".into(), "1".into()),
+            ]
+        );
+
+        // Explicitly reorder to "3", "1", "2" regardless of the pin order above.
+        reorder(
+            &conn,
+            &[
+                ("song".to_string(), "3".to_string()),
+                ("song".to_string(), "1".to_string()),
+                ("song".to_string(), "2".to_string()),
+            ],
+        )
+        .unwrap();
+
+        assert_eq!(
+            pinned_refs(&conn).unwrap(),
+            vec![
+                ("song".into(), "3".into()),
+                ("song".into(), "1".into()),
+                ("song".into(), "2".into()),
+            ]
+        );
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn resolve_song_returns_live_data_and_none_for_missing_or_unavailable() {
+        let (db, dir) = test_db();
+        let conn = db.pool.get().unwrap();
+        let id = insert_song(&conn, "/tmp/pinned_song.flac");
+
+        let resolved = resolve_song(&conn, &id.to_string()).unwrap();
+        assert!(resolved.is_some());
+        assert_eq!(resolved.unwrap().id, id);
+
+        // A ref that no longer parses or doesn't exist resolves to None, not an error.
+        assert!(resolve_song(&conn, "not-a-number").unwrap().is_none());
+        assert!(resolve_song(&conn, "999999").unwrap().is_none());
+
+        // Marking the song unavailable (soft-deleted) also drops it from resolution.
+        conn.execute(
+            "UPDATE songs SET unavailable = 1 WHERE id = ?1",
+            params![id],
+        )
+        .unwrap();
+        assert!(resolve_song(&conn, &id.to_string()).unwrap().is_none());
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn album_item_from_json_maps_fields_and_defaults_missing_sample_song_id() {
+        let value = serde_json::json!({
+            "artist": "Test Artist",
+            "album": "Test Album",
+            "year": 2020,
+            "track_count": 10,
+            "disc_count": 1,
+            "art_embedded": true,
+            "art_automatic": null,
+            "art_manual": null,
+            "genre": "Rock",
+            "rating": 4.5,
+            "added": 1234,
+            "total_duration_nanosec": 999,
+            "artist_sort": "Artist, Test",
+            "albumsort": null,
+        });
+        let album = album_item_from_json(&value);
+        assert_eq!(album.album.as_deref(), Some("Test Album"));
+        assert_eq!(album.artist.as_deref(), Some("Test Artist"));
+        assert_eq!(album.track_count, 10);
+        assert_eq!(album.rating, 4.5);
+        assert_eq!(album.sample_song_id, None);
+    }
+
+    #[test]
+    fn find_artist_matches_case_insensitively() {
+        let artists = vec![serde_json::json!({
+            "name": "The War On Drugs",
+            "album_count": 3,
+            "song_count": 20,
+            "genre": null,
+            "sort_artist": "War On Drugs, The",
+            "total_playcount": 5,
+        })];
+        assert!(find_artist(&artists, "the war on drugs").is_some());
+        assert!(find_artist(&artists, "THE WAR ON DRUGS").is_some());
+        assert!(find_artist(&artists, "Someone Else").is_none());
+    }
+}

--- a/src/lib/components/AlbumContextMenu.svelte
+++ b/src/lib/components/AlbumContextMenu.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
-  import { Play, Plus, ListPlus, Mic2, Layers } from "lucide-svelte";
+  import { Play, Plus, ListPlus, Mic2, Layers, Pin, PinOff } from "lucide-svelte";
   import { i18n } from "../stores/i18n.svelte";
   import { playlistsStore } from "../stores/playlists.svelte";
+  import { pinnedStore } from "../stores/pinned.svelte";
   import { toastStore } from "../stores/toast.svelte";
   import { invoke } from "@tauri-apps/api/core";
   import type { Song } from "../types";
@@ -85,6 +86,19 @@
       icon={Mic2}
       label={i18n.t("playlists.contextMenuGoArtist")}
       onclick={() => { onGoToArtist?.(); onClose(); }}
+    />
+  {/if}
+
+  {#if albumName}
+    {#if !(onGoToArtist && artistName)}
+      <ContextMenuDivider />
+    {/if}
+    <ContextMenuItem
+      icon={pinnedStore.isPinned("album", albumName) ? PinOff : Pin}
+      label={pinnedStore.isPinned("album", albumName)
+        ? i18n.t("playlists.contextMenuUnpinHome")
+        : i18n.t("playlists.contextMenuPinHome")}
+      onclick={() => { pinnedStore.toggle("album", albumName); onClose(); }}
     />
   {/if}
 </ContextMenu>

--- a/src/lib/components/AlbumDetailView.svelte
+++ b/src/lib/components/AlbumDetailView.svelte
@@ -7,6 +7,7 @@
   import { windowLayoutStore } from "../stores/windowLayout.svelte";
   import { playerStore } from "../stores/player.svelte";
   import { playlistsStore } from "../stores/playlists.svelte";
+  import { pinnedStore } from "../stores/pinned.svelte";
   import { shuffleArray } from "../utils/shuffle";
   import CoverArt from "./CoverArt.svelte";
   import SongRating from "./SongRating.svelte";
@@ -23,7 +24,7 @@
   import LinkButton from "./LinkButton.svelte";
   import ColumnSelector from "./ColumnSelector.svelte";
   import SongTable, { type SongTableRow } from "./SongTable.svelte";
-  import { Plus, Edit3, RefreshCw } from "lucide-svelte";
+  import { Plus, Edit3, RefreshCw, Pin, PinOff } from "lucide-svelte";
   import type { Song, AlbumItem, PlayContext } from "../types";
   import { getCoverArtUrl, resolveArtUrl } from "../types";
   import { i18n } from "../stores/i18n.svelte";
@@ -423,6 +424,20 @@
             title={i18n.t('albumDetail.refreshTooltip')}
           >
             {#snippet icon()}<RefreshCw class="w-4 h-4 {refreshing || collectionStore.isScanning ? 'animate-spin' : ''}" />{/snippet}
+          </IconActionButton>
+          <IconActionButton
+            onclick={() => pinnedStore.toggle("album", albumName)}
+            title={pinnedStore.isPinned("album", albumName)
+              ? i18n.t("playlists.contextMenuUnpinHome")
+              : i18n.t("playlists.contextMenuPinHome")}
+          >
+            {#snippet icon()}
+              {#if pinnedStore.isPinned("album", albumName)}
+                <PinOff class="w-4 h-4" />
+              {:else}
+                <Pin class="w-4 h-4" />
+              {/if}
+            {/snippet}
           </IconActionButton>
           <ColumnSelector align="left" iconOnly />
         </div>

--- a/src/lib/components/ArtistCard.svelte
+++ b/src/lib/components/ArtistCard.svelte
@@ -33,7 +33,7 @@
   tabindex="0"
   onclick={(e) => customClick?.(e)}
   onkeydown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); customClick?.(e as unknown as MouseEvent); } }}
-  class="artist-card group bg-brand-sidebar border border-brand-border/60 rounded-xl p-4 flex flex-col items-center text-center outline-2 -outline-offset-2 outline-transparent hover:outline-brand-accent transition-[outline-color,border-color] duration-200 select-none"
+  class="artist-card group bg-brand-sidebar border border-brand-border/60 rounded-xl p-4 flex flex-col items-start text-left outline-2 -outline-offset-2 outline-transparent hover:outline-brand-accent transition-[outline-color,border-color] duration-200 select-none"
 >
   <div class="aspect-square w-full mb-3 bg-brand-main relative flex items-center justify-center">
     <CoverStack
@@ -44,23 +44,23 @@
   </div>
 
   <span
-    class="font-semibold text-sm text-brand-text-primary group-hover:text-brand-accent-text group-hover:underline transition-all duration-150 text-center truncate w-full"
+    class="font-semibold text-sm text-brand-text-primary group-hover:text-brand-accent-text group-hover:underline transition-all duration-150 text-left truncate w-full"
     title={i18n.t('collection.filterByArtist', { artist: artist.name || i18n.t('collection.unknownArtist') })}
   >
     {artist.name || i18n.t('collection.unknownArtist')}
   </span>
-  <div class="w-full mt-1.5 flex justify-center">
+  <span class="text-xs text-brand-text-secondary font-medium truncate w-full mt-0.5 text-left">
+    {i18n.t('playlists.songsCount', { count: artist.song_count })}
+  </span>
+  <div class="w-full mt-1.5 flex justify-start">
     {#if hasGenre}
       <GenreChips genre={artist.genre} />
     {:else}
-      <span class="text-xs text-brand-text-secondary font-medium truncate text-center">
+      <span class="text-xs text-brand-text-secondary font-medium truncate text-left">
         {i18n.t('artistDetail.unknownGenre')}
       </span>
     {/if}
   </div>
-  <span class="text-xs text-brand-text-secondary font-medium truncate w-full mt-0.5 text-center">
-    {i18n.t('playlists.songsCount', { count: artist.song_count })}
-  </span>
 </div>
 
 <style>

--- a/src/lib/components/ArtistDetailView.svelte
+++ b/src/lib/components/ArtistDetailView.svelte
@@ -5,6 +5,7 @@
   import { windowLayoutStore } from "../stores/windowLayout.svelte";
   import { playerStore } from "../stores/player.svelte";
   import { playlistsStore } from "../stores/playlists.svelte";
+  import { pinnedStore } from "../stores/pinned.svelte";
   import { shuffleArray } from "../utils/shuffle";
   import { formatDuration } from "../utils/formatters";
   import CoverArt from "./CoverArt.svelte";
@@ -17,13 +18,14 @@
   import { tagsStore } from "../stores/tags.svelte";
   import TagEditor from "./TagEditor.svelte";
   import ColumnSelector from "./ColumnSelector.svelte";
+  import IconActionButton from "./IconActionButton.svelte";
   import HorizontalScrollRow from "./HorizontalScrollRow.svelte";
   import PlayShuffleButtons from "./PlayShuffleButtons.svelte";
   import ArtistProfileEditor from "./ArtistProfileEditor.svelte";
   import SocialIcon from "./SocialIcon.svelte";
   import SongSelectionToolbar from "./SongSelectionToolbar.svelte";
   import SongTable, { type SongTableRow } from "./SongTable.svelte";
-  import { Edit3, ExternalLink } from "lucide-svelte";
+  import { Edit3, ExternalLink, Pin, PinOff } from "lucide-svelte";
   import type { Song, Playlist, AlbumItem, PlayContext, ArtistProfile } from "../types";
   import { resolveSocialUrl, formatDisplayLabel } from "../utils/artistSocials";
   import { getArtistAlbums, classifyRelease } from "../utils/artist";
@@ -357,15 +359,26 @@
             onShufflePlay={handleShufflePlay}
             disabled={loading || songs.length === 0}
           />
-          <button
-            type="button"
+          <IconActionButton
             onclick={() => { isEditorOpen = true; }}
-            class="px-3.5 py-1.5 rounded-full text-xs font-semibold bg-brand-sidebar/80 hover:bg-brand-sidebar text-brand-text-primary border border-brand-border hover:border-brand-accent/40 shadow-xs flex items-center gap-1.5 transition-all cursor-pointer"
             title={i18n.t("artistDetail.editArtistTooltip", {}, "Edit artist details, website, tags, and links")}
           >
-            <Edit3 class="w-3.5 h-3.5 text-brand-accent" />
-            <span>{i18n.t("artistDetail.editArtist", {}, "Edit")}</span>
-          </button>
+            {#snippet icon()}<Edit3 class="w-4 h-4" />{/snippet}
+          </IconActionButton>
+          <IconActionButton
+            onclick={() => pinnedStore.toggle("artist", artistName)}
+            title={pinnedStore.isPinned("artist", artistName)
+              ? i18n.t("artistDetail.unpinHome")
+              : i18n.t("artistDetail.pinHome")}
+          >
+            {#snippet icon()}
+              {#if pinnedStore.isPinned("artist", artistName)}
+                <PinOff class="w-4 h-4" />
+              {:else}
+                <Pin class="w-4 h-4" />
+              {/if}
+            {/snippet}
+          </IconActionButton>
           {#if singleSongs.length > 0}
             <ColumnSelector align="left" iconOnly />
           {/if}

--- a/src/lib/components/ArtistRowCard.svelte
+++ b/src/lib/components/ArtistRowCard.svelte
@@ -27,9 +27,9 @@
   tabindex="0"
   onclick={(e) => customClick?.(e)}
   onkeydown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); customClick?.(e as unknown as MouseEvent); } }}
-  class="group flex items-center gap-3 px-3 py-2.5 rounded-lg bg-brand-sidebar border border-brand-border/60 outline-2 -outline-offset-2 outline-transparent hover:outline-brand-accent transition-[outline-color,border-color] duration-200 select-none"
+  class="group grid grid-cols-[auto_1fr_auto] grid-rows-[auto_auto] items-center gap-x-3 gap-y-0.5 px-3 py-2.5 rounded-lg bg-brand-sidebar border border-brand-border/60 outline-2 -outline-offset-2 outline-transparent hover:outline-brand-accent transition-[outline-color,border-color] duration-200 select-none"
 >
-  <div class="relative shrink-0 overflow-hidden">
+  <div class="row-span-2 relative overflow-hidden">
     <CoverArt
       songId={frontCover?.songId}
       artEmbedded={frontCover?.artEmbedded ?? false}
@@ -39,16 +39,15 @@
     />
   </div>
 
-  <div class="min-w-0 flex-1">
-    <p class="truncate text-sm font-semibold text-brand-text-primary">{artist.name || i18n.t('collection.unknownArtist')}</p>
+  <p class="col-span-2 min-w-0 truncate text-sm font-semibold text-brand-text-primary">{artist.name || i18n.t('collection.unknownArtist')}</p>
+
+  <div class="min-w-0">
     {#if hasGenre}
-      <div class="min-w-0 mt-0.5"><GenreChips genre={artist.genre} /></div>
+      <GenreChips genre={artist.genre} />
     {:else}
       <p class="truncate text-xs text-brand-text-secondary font-medium">{i18n.t('artistDetail.unknownGenre')}</p>
     {/if}
   </div>
 
-  <div class="shrink-0 max-w-40 text-right">
-    <p class="text-xs text-brand-text-secondary font-medium tabular-nums truncate">{i18n.t('playlists.songsCount', { count: artist.song_count })}</p>
-  </div>
+  <p class="text-xs text-brand-text-secondary font-medium tabular-nums truncate text-right">{i18n.t('playlists.songsCount', { count: artist.song_count })}</p>
 </div>

--- a/src/lib/components/CollectionView.svelte
+++ b/src/lib/components/CollectionView.svelte
@@ -511,7 +511,7 @@
       <div class="pt-2">
         {#if navigationStore.activeSubTab === "albums"}
         {#if activeViewMode === "rows"}
-          <div class="grid grid-cols-[repeat(auto-fill,minmax(280px,1fr))] gap-2">
+          <div class="grid grid-cols-[repeat(auto-fit,minmax(280px,1fr))] gap-2">
             {#each sortedAlbums as album}
               <AlbumRowCard
                 {album}
@@ -534,7 +534,7 @@
         {/if}
         {:else if navigationStore.activeSubTab === "artists"}
         {#if activeViewMode === "rows"}
-          <div class="grid grid-cols-[repeat(auto-fill,minmax(280px,1fr))] gap-2">
+          <div class="grid grid-cols-[repeat(auto-fit,minmax(280px,1fr))] gap-2">
             {#each sortedArtists as artist}
               {@const artistAlbums = getArtistAlbumsFor(artist.name)}
               {@const artistSongs = getArtistSongsFor(artist.name)}

--- a/src/lib/components/HomeView.svelte
+++ b/src/lib/components/HomeView.svelte
@@ -10,6 +10,7 @@
   import HorizontalScrollRow from "./HorizontalScrollRow.svelte";
   import ArtistCard from "./ArtistCard.svelte";
   import HomeRowList from "./HomeRowList.svelte";
+  import PinnedRow from "./PinnedRow.svelte";
   import LibraryWelcome from "./LibraryWelcome.svelte";
   import { i18n } from "../stores/i18n.svelte";
   import { rememberScroll } from "../utils/scrollMemory";
@@ -112,6 +113,8 @@
         <div class="text-brand-text-secondary">{i18n.t('home.loading')}</div>
       </div>
     {:else}
+      <PinnedRow />
+
       {#if topArtists.length > 0}
         <HorizontalScrollRow title={i18n.t('home.topArtists')} onHeaderClick={viewTopArtists}>
           {#each topArtists as artist (artist.name)}

--- a/src/lib/components/PinnedRow.svelte
+++ b/src/lib/components/PinnedRow.svelte
@@ -1,0 +1,152 @@
+<script lang="ts">
+  import type { PinnedItem, PinnedItemType } from "../types";
+  import { pinnedRefKeyFor } from "../types";
+  import { pinnedStore } from "../stores/pinned.svelte";
+  import { playerStore } from "../stores/player.svelte";
+  import { navigationStore } from "../stores/navigation.svelte";
+  import { i18n } from "../stores/i18n.svelte";
+  import { getArtistAlbums, getArtistSongs } from "../utils/artist";
+  import { collectionStore } from "../stores/collection.svelte";
+  import HorizontalScrollRow from "./HorizontalScrollRow.svelte";
+  import AlbumCard from "./AlbumCard.svelte";
+  import ArtistCard from "./ArtistCard.svelte";
+  import PlaylistCard from "./PlaylistCard.svelte";
+  import PinnedSongCard from "./PinnedSongCard.svelte";
+
+  function keyFor(item: PinnedItem): string {
+    return `${item.type}:${pinnedRefKeyFor(item)}`;
+  }
+
+  function openItem(item: PinnedItem) {
+    switch (item.type) {
+      case "song":
+        playerStore.playSong(item.song.id);
+        break;
+      case "album":
+        navigationStore.viewAlbum(item.album.album || "");
+        break;
+      case "artist":
+        navigationStore.viewArtist(item.artist.name || "");
+        break;
+      case "playlist":
+        navigationStore.viewPlaylist(item.playlist.id);
+        break;
+    }
+  }
+
+  // Pointer-based drag reorder — native HTML5 drag events are swallowed by
+  // Tauri's dragDropEnabled window option (needed for OS file-drop import
+  // into the queue), so reordering uses pointer events instead, mirroring
+  // SongTable.svelte's pointer-drag reorder. Unlike SongTable's row (whose
+  // own onclick lives on the exact element that takes pointer capture),
+  // each pinned card's click handler lives on a nested child element
+  // (AlbumCard/ArtistCard/etc.'s own root), so capture is deferred until a
+  // drag is actually armed — capturing eagerly on every pointerdown, as
+  // SongTable does, retargets the *click* event to this wrapper too and
+  // silently swallows every nested card's click.
+  const POINTER_DRAG_THRESHOLD_PX = 4;
+
+  let draggedIndex = $state<number | null>(null);
+  let dragOverIndex = $state<number | null>(null);
+  let pointerDragArmed = false;
+  let pointerDragStartX = 0;
+  let pointerDragStartY = 0;
+  let pointerDragPointerId: number | null = null;
+  let pointerDragEl: HTMLElement | null = null;
+
+  function commitReorder(targetIndex: number) {
+    if (draggedIndex === null || targetIndex === draggedIndex) return;
+    const items = [...pinnedStore.items];
+    const [moved] = items.splice(draggedIndex, 1);
+    items.splice(targetIndex, 0, moved);
+    const order: Array<[PinnedItemType, string]> = items.map((item) => [item.type, pinnedRefKeyFor(item)]);
+    pinnedStore.reorder(order);
+  }
+
+  // Eats the single click that follows a committed drag, so releasing the
+  // pointer over a different card doesn't also open that card.
+  function suppressOneClick(e: MouseEvent) {
+    e.preventDefault();
+    e.stopPropagation();
+  }
+
+  function handleCardPointerDown(e: PointerEvent, index: number) {
+    if (e.button !== 0) return;
+    const target = e.target as HTMLElement;
+    if (target.closest("button, a, input, select, textarea, [data-interactive]")) return;
+    pointerDragArmed = false;
+    pointerDragStartX = e.clientX;
+    pointerDragStartY = e.clientY;
+    pointerDragPointerId = e.pointerId;
+    pointerDragEl = e.currentTarget as HTMLElement;
+    draggedIndex = index;
+    window.addEventListener("pointermove", handlePointerDragMove);
+    window.addEventListener("pointerup", handlePointerDragUp);
+  }
+
+  function handlePointerDragMove(e: PointerEvent) {
+    if (draggedIndex === null) return;
+    if (!pointerDragArmed) {
+      const dx = e.clientX - pointerDragStartX;
+      const dy = e.clientY - pointerDragStartY;
+      if (Math.hypot(dx, dy) < POINTER_DRAG_THRESHOLD_PX) return;
+      pointerDragArmed = true;
+      // Only once an actual drag is confirmed: pin subsequent pointer events
+      // to this element/JS loop so WebView2 can't hijack the in-progress
+      // gesture into a native OS drag (which — with dragDropEnabled on —
+      // would otherwise surface the "drop files to queue" overlay).
+      if (pointerDragEl && pointerDragPointerId !== null) {
+        pointerDragEl.setPointerCapture?.(pointerDragPointerId);
+      }
+    }
+    const el = document.elementFromPoint(e.clientX, e.clientY)?.closest("[data-pinned-index]") as HTMLElement | null;
+    const idx = el?.dataset.pinnedIndex;
+    dragOverIndex = idx !== undefined ? Number(idx) : null;
+  }
+
+  function handlePointerDragUp() {
+    window.removeEventListener("pointermove", handlePointerDragMove);
+    window.removeEventListener("pointerup", handlePointerDragUp);
+    if (pointerDragArmed && dragOverIndex !== null) {
+      commitReorder(dragOverIndex);
+      window.addEventListener("click", suppressOneClick, { capture: true, once: true });
+    }
+    draggedIndex = null;
+    dragOverIndex = null;
+    pointerDragArmed = false;
+    pointerDragPointerId = null;
+    pointerDragEl = null;
+  }
+</script>
+
+{#if pinnedStore.items.length > 0}
+  <HorizontalScrollRow title={i18n.t('home.pinned')}>
+    {#each pinnedStore.items as item, index (keyFor(item))}
+      <!-- svelte-ignore a11y_no_static_element_interactions -->
+      <div
+        data-pinned-index={index}
+        onpointerdown={(e) => handleCardPointerDown(e, index)}
+        ondragstart={(e) => e.preventDefault()}
+        class="relative w-44 shrink-0 snap-start transition-opacity rounded-xl cursor-grab active:cursor-grabbing {draggedIndex === index ? 'opacity-40' : ''}"
+      >
+        {#if item.type === "album"}
+          <AlbumCard album={item.album} onclick={() => openItem(item)} />
+        {:else if item.type === "artist"}
+          <ArtistCard
+            artist={item.artist}
+            artistAlbums={getArtistAlbums(collectionStore.albums, item.artist.name)}
+            artistSongs={getArtistSongs(collectionStore.songs, item.artist.name)}
+            onclick={() => openItem(item)}
+          />
+        {:else if item.type === "playlist"}
+          <PlaylistCard playlist={item.playlist} onClick={() => openItem(item)} />
+        {:else}
+          <PinnedSongCard song={item.song} onclick={() => openItem(item)} />
+        {/if}
+        {#if dragOverIndex === index && draggedIndex !== null && draggedIndex !== index}
+          <div class="absolute inset-0 bg-brand-accent/30 rounded-xl pointer-events-none"></div>
+        {/if}
+      </div>
+    {/each}
+  </HorizontalScrollRow>
+{/if}

--- a/src/lib/components/PinnedSongCard.svelte
+++ b/src/lib/components/PinnedSongCard.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+  import type { Song } from "../types";
+  import { i18n } from "../stores/i18n.svelte";
+  import CoverArt from "./CoverArt.svelte";
+
+  interface Props {
+    song: Song;
+    widthClass?: string;
+    onclick?: (e: MouseEvent) => void;
+  }
+
+  let { song, widthClass = "w-full", onclick }: Props = $props();
+</script>
+
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<!-- svelte-ignore a11y_click_events_have_key_events -->
+<div
+  {onclick}
+  class="{widthClass} bg-brand-sidebar border border-brand-border/60 rounded-b-xl overflow-hidden flex flex-col group hover:border-brand-accent/40 transition-all duration-200 select-none cursor-pointer"
+>
+  <div class="aspect-square bg-brand-main flex items-center justify-center text-brand-accent-text relative overflow-hidden w-full">
+    <CoverArt
+      songId={song.id}
+      artEmbedded={song.art_embedded}
+      artAutomatic={song.art_automatic}
+      artManual={song.art_manual}
+      sizeClass="w-full h-full"
+    />
+  </div>
+  <div class="p-3.5 flex flex-col flex-1">
+    <p class="font-semibold text-sm text-brand-text-primary truncate w-full">
+      {song.title || i18n.t('collection.unknownSong')}
+    </p>
+    <p class="text-xs text-brand-text-secondary truncate mt-0.5 font-medium">
+      {song.artist || i18n.t('collection.unknownArtist')}
+    </p>
+  </div>
+</div>

--- a/src/lib/components/PlaylistView.svelte
+++ b/src/lib/components/PlaylistView.svelte
@@ -2,6 +2,7 @@
   import { onMount } from "svelte";
   import { fade } from "svelte/transition";
   import { playlistsStore } from "../stores/playlists.svelte";
+  import { pinnedStore } from "../stores/pinned.svelte";
   import { playerStore } from "../stores/player.svelte";
   import { collectionStore } from "../stores/collection.svelte";
   import { navigationStore } from "../stores/navigation.svelte";
@@ -28,7 +29,9 @@
     MoreHorizontal,
     Eraser,
     Sparkles,
-    FolderPlus
+    FolderPlus,
+    Pin,
+    PinOff
   } from "lucide-svelte";
   import { resolveArtUrl } from "../types";
   import { i18n } from "../stores/i18n.svelte";
@@ -725,6 +728,23 @@
                 <Radio class="w-4 h-4" />
                 <span>{i18n.t("playlists.makeActiveBtn")}</span>
               </Button>
+            {/if}
+            {#if !isQueue && activePlaylist}
+              <IconActionButton
+                onclick={() => pinnedStore.toggle("playlist", String(activePlaylist!.id))}
+                title={pinnedStore.isPinned("playlist", String(activePlaylist.id))
+                  ? i18n.t("playlists.contextMenuUnpinHome")
+                  : i18n.t("playlists.contextMenuPinHome")}
+                class="shrink-0"
+              >
+                {#snippet icon()}
+                  {#if pinnedStore.isPinned("playlist", String(activePlaylist.id))}
+                    <PinOff class="w-4 h-4" />
+                  {:else}
+                    <Pin class="w-4 h-4" />
+                  {/if}
+                {/snippet}
+              </IconActionButton>
             {/if}
             <ColumnSelector align="left" iconOnly />
           </div>

--- a/src/lib/components/SongContextMenu.svelte
+++ b/src/lib/components/SongContextMenu.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
-  import { Play, Plus, ListPlus, Mic2, DiscAlbum, Edit3, Folder, Layers } from "lucide-svelte";
+  import { Play, Plus, ListPlus, Mic2, DiscAlbum, Edit3, Folder, Layers, Pin, PinOff } from "lucide-svelte";
   import { invoke } from "@tauri-apps/api/core";
   import { i18n } from "../stores/i18n.svelte";
   import { playlistsStore } from "../stores/playlists.svelte";
+  import { pinnedStore } from "../stores/pinned.svelte";
   import { toastStore } from "../stores/toast.svelte";
   import type { Song } from "../types";
   import ContextMenu from "./ContextMenu.svelte";
@@ -106,6 +107,14 @@
         onclick={() => { onGoToAlbum?.(); onClose(); }}
       />
     {/if}
+
+    <ContextMenuItem
+      icon={pinnedStore.isPinned("song", String(song.id)) ? PinOff : Pin}
+      label={pinnedStore.isPinned("song", String(song.id))
+        ? i18n.t("playlists.contextMenuUnpinHome")
+        : i18n.t("playlists.contextMenuPinHome")}
+      onclick={() => { pinnedStore.toggle("song", String(song.id)); onClose(); }}
+    />
   {/if}
 
   <ContextMenuDivider />

--- a/src/lib/components/SongTable.svelte
+++ b/src/lib/components/SongTable.svelte
@@ -630,8 +630,8 @@
     class="grid items-center border-b border-brand-border/40 hover:bg-brand-sidebar/40 group transition-colors py-2.5 px-4 text-sm
       {disabled ? 'opacity-50 cursor-not-allowed' : ''}
       {onReorder ? 'cursor-grab active:cursor-grabbing' : ''}
-      {draggedIndex !== null && dragOverIndex === row.underlyingIndex ? 'border-t-2! border-brand-accent' : ''}
-      {selectedKeys.has(row.key) ? 'bg-brand-accent/20 border-l-2 border-brand-accent text-brand-accent-text-hover' : (song && rowIsPlaying(row) ? 'bg-brand-accent/10' : '')}"
+      {selectedKeys.has(row.key) ? 'bg-brand-accent/20 border-l-2 border-brand-accent text-brand-accent-text-hover' : (song && rowIsPlaying(row) ? 'bg-brand-accent/10' : '')}
+      {draggedIndex !== null && dragOverIndex === row.underlyingIndex ? 'bg-brand-accent/30!' : ''}"
   >
     {@render leadingCell(row, displayIndex)}
     {#if song}

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -57,8 +57,9 @@ export const en = {
     topArtists: "Top Artists",
     mostPlayed: "Top 5 Most Played",
     recentlyAdded: "Recently Added",
+    pinned: "Pinned",
     exploreLibrary: "Explore Your Library",
-    libraryOverview: "Explore your music collection: {songs} Songs • {albums} Albums • {artists} Artists",
+    libraryOverview: "Explore your music collection: {artists} Artists • {albums} Albums • {songs} Songs",
     emptyState: "Start adding music to see your personalized collections"
   },
   emptyLibrary: {
@@ -526,6 +527,8 @@ export const en = {
     contextMenuGoArtist: "Go to Artist",
     contextMenuGoAlbum: "Go to Album",
     contextMenuEditTags: "Edit Tags",
+    contextMenuPinHome: "Pin to Home",
+    contextMenuUnpinHome: "Unpin from Home",
     noFilterResults: "No songs match \"{query}\"",
     editSmartPlaylistBtn: "Edit Rules",
     smartRulePlaylistLabel: "Smart Rule Playlist",
@@ -803,6 +806,8 @@ export const en = {
     shuffleAndPlay: "Shuffle Play",
     editArtist: "Edit",
     editArtistTooltip: "Edit artist details, website, tags, and links",
+    pinHome: "Pin to Home",
+    unpinHome: "Unpin from Home",
     about: "About",
     links: "LINKS",
     showMore: "Show more",

--- a/src/lib/locales/fr.ts
+++ b/src/lib/locales/fr.ts
@@ -57,8 +57,9 @@ export const fr = {
     topArtists: "Artistes populaires",
     mostPlayed: "Top 5 des plus écoutés",
     recentlyAdded: "Ajoutés récemment",
+    pinned: "Épinglé",
     exploreLibrary: "Explorez votre bibliothèque",
-    libraryOverview: "Explorez votre collection musicale : {songs} titres • {albums} albums • {artists} artistes",
+    libraryOverview: "Explorez votre collection musicale : {artists} artistes • {albums} albums • {songs} titres",
     emptyState: "Commencez à ajouter de la musique pour voir vos collections personnalisées"
   },
   emptyLibrary: {
@@ -525,6 +526,8 @@ export const fr = {
     contextMenuGoArtist: "Aller à l'artiste",
     contextMenuGoAlbum: "Aller à l'album",
     contextMenuEditTags: "Éditer les étiquettes",
+    contextMenuPinHome: "Épingler à l'accueil",
+    contextMenuUnpinHome: "Détacher de l'accueil",
     noFilterResults: "Aucune chanson ne correspond à \"{query}\"",
     editSmartPlaylistBtn: "Modifier les règles",
     smartRulePlaylistLabel: "Liste intelligente",
@@ -835,6 +838,8 @@ export const fr = {
     shuffleAndPlay: "Lecture aléatoire",
     editArtist: "Modifier",
     editArtistTooltip: "Modifier les détails de l'artiste, site web, tags et liens",
+    pinHome: "Épingler à l'accueil",
+    unpinHome: "Détacher de l'accueil",
     about: "À propos",
     links: "LIENS",
     showMore: "Afficher plus",

--- a/src/lib/stores/pinned.svelte.ts
+++ b/src/lib/stores/pinned.svelte.ts
@@ -1,0 +1,72 @@
+import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
+import type { PinnedItem, PinnedItemType } from "../types";
+import { pinnedRefKeyFor } from "../types";
+
+class PinnedStore {
+  items = $state<PinnedItem[]>([]);
+  private keys = $state<Set<string>>(new Set());
+  private libraryChangedDebounce: ReturnType<typeof setTimeout> | undefined;
+
+  constructor() {
+    this.init();
+  }
+
+  private async init() {
+    try {
+      await listen("pinned-items-changed", () => this.refresh());
+      // Pins resolve against live song/album/artist/playlist data (see
+      // get_pinned_items), so a tag edit, rescan, etc. elsewhere in the app
+      // should refresh what's shown here too — debounced to match
+      // HomeView's own library-changed handling.
+      await listen("library-changed", () => {
+        clearTimeout(this.libraryChangedDebounce);
+        this.libraryChangedDebounce = setTimeout(() => this.refresh(), 500);
+      });
+      await this.refresh();
+    } catch (err) {
+      console.error("Failed to initialize PinnedStore:", err);
+    }
+  }
+
+  async refresh() {
+    const items = await invoke<PinnedItem[]>("get_pinned_items");
+    this.items = Array.isArray(items) ? items : [];
+    this.keys = new Set(this.items.map((item) => `${item.type}:${pinnedRefKeyFor(item)}`));
+  }
+
+  isPinned(itemType: PinnedItemType, refKey: string): boolean {
+    return this.keys.has(`${itemType}:${refKey}`);
+  }
+
+  async pin(itemType: PinnedItemType, refKey: string) {
+    await invoke("pin_item", { itemType, refKey });
+    await this.refresh();
+  }
+
+  async unpin(itemType: PinnedItemType, refKey: string) {
+    await invoke("unpin_item", { itemType, refKey });
+    await this.refresh();
+  }
+
+  async toggle(itemType: PinnedItemType, refKey: string) {
+    if (this.isPinned(itemType, refKey)) {
+      await this.unpin(itemType, refKey);
+    } else {
+      await this.pin(itemType, refKey);
+    }
+  }
+
+  async reorder(order: Array<[PinnedItemType, string]>) {
+    const positionOf = new Map(order.map(([type, refKey], idx) => [`${type}:${refKey}`, idx]));
+    this.items = [...this.items].sort((a, b) => {
+      const posA = positionOf.get(`${a.type}:${pinnedRefKeyFor(a)}`) ?? 0;
+      const posB = positionOf.get(`${b.type}:${pinnedRefKeyFor(b)}`) ?? 0;
+      return posA - posB;
+    });
+    await invoke("reorder_pinned_items", { order });
+    await this.refresh();
+  }
+}
+
+export const pinnedStore = new PinnedStore();

--- a/src/lib/stores/pinned.test.ts
+++ b/src/lib/stores/pinned.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
+import type { PinnedItem } from "../types";
+
+import { pinnedStore } from "./pinned.svelte";
+
+describe("PinnedStore", () => {
+  let eventCallbacks: Record<string, Function> = {};
+
+  const mockItems: PinnedItem[] = [
+    { type: "song", song: { id: 10, title: "Song A" } as any },
+    { type: "album", album: { album: "Album A", artist: "Artist A" } as any },
+    { type: "artist", artist: { name: "Artist A" } as any },
+    { type: "playlist", playlist: { id: 5, name: "Playlist A" } as any },
+  ];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    eventCallbacks = {};
+
+    vi.mocked(listen).mockImplementation(async (event: string, callback: any) => {
+      eventCallbacks[event] = callback;
+      return () => {};
+    });
+
+    vi.mocked(invoke).mockImplementation(async (cmd: string) => {
+      switch (cmd) {
+        case "get_pinned_items":
+          return mockItems;
+        default:
+          return null;
+      }
+    });
+  });
+
+  it("loads pinned items on refresh and reports isPinned per type/refKey", async () => {
+    await pinnedStore.refresh();
+    expect(pinnedStore.items).toHaveLength(4);
+    expect(pinnedStore.isPinned("song", "10")).toBe(true);
+    expect(pinnedStore.isPinned("album", "Album A")).toBe(true);
+    expect(pinnedStore.isPinned("artist", "Artist A")).toBe(true);
+    expect(pinnedStore.isPinned("playlist", "5")).toBe(true);
+    expect(pinnedStore.isPinned("song", "999")).toBe(false);
+  });
+
+  it("pin() invokes pin_item with itemType/refKey and refreshes", async () => {
+    await pinnedStore.pin("song", "42");
+    expect(invoke).toHaveBeenCalledWith("pin_item", { itemType: "song", refKey: "42" });
+    expect(invoke).toHaveBeenCalledWith("get_pinned_items");
+  });
+
+  it("unpin() invokes unpin_item with itemType/refKey and refreshes", async () => {
+    await pinnedStore.unpin("song", "42");
+    expect(invoke).toHaveBeenCalledWith("unpin_item", { itemType: "song", refKey: "42" });
+    expect(invoke).toHaveBeenCalledWith("get_pinned_items");
+  });
+
+  it("toggle() unpins an already-pinned item and pins one that isn't", async () => {
+    await pinnedStore.refresh();
+
+    await pinnedStore.toggle("song", "10");
+    expect(invoke).toHaveBeenCalledWith("unpin_item", { itemType: "song", refKey: "10" });
+
+    await pinnedStore.toggle("song", "999");
+    expect(invoke).toHaveBeenCalledWith("pin_item", { itemType: "song", refKey: "999" });
+  });
+
+  it("reorder() invokes reorder_pinned_items with the given order and refreshes", async () => {
+    const order: Array<["song", string]> = [["song", "2"], ["song", "1"]];
+    await pinnedStore.reorder(order);
+    expect(invoke).toHaveBeenCalledWith("reorder_pinned_items", { order });
+    expect(invoke).toHaveBeenCalledWith("get_pinned_items");
+  });
+});

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -376,6 +376,34 @@ export type HomeItem =
   | { type: "album"; album: AlbumItem }
   | { type: "playlist"; playlist: Playlist };
 
+/** A user-pinned Home-shelf entry (#222) — a superset of {@link HomeItem} that
+ * also allows Artist, since pins are explicitly user-curated across all four
+ * browsable entity types. */
+export type PinnedItemType = "song" | "album" | "artist" | "playlist";
+
+export type PinnedItem =
+  | { type: "song"; song: Song }
+  | { type: "album"; album: AlbumItem }
+  | { type: "artist"; artist: ArtistItem }
+  | { type: "playlist"; playlist: Playlist };
+
+/** The `(item_type, ref_key)` identity Luminous stores for a pin — song/playlist
+ * id as a string, bare album title, or effective-artist name. Shared by the
+ * pinned store and every pin/unpin entry point so they agree on how to key
+ * each item type. */
+export function pinnedRefKeyFor(item: PinnedItem): string {
+  switch (item.type) {
+    case "song":
+      return String(item.song.id);
+    case "album":
+      return item.album.album ?? "";
+    case "artist":
+      return item.artist.name ?? "";
+    case "playlist":
+      return String(item.playlist.id);
+  }
+}
+
 // What the user was inside when a play started — lets "Recently Played"
 // show an Album/Playlist card instead of always collapsing to a Song.
 export type PlayContext =


### PR DESCRIPTION
## 📋 Summary
Fixes #222. Adds a user-curated "Pinned" shelf to Home, alongside the existing system-curated rows (Top Artists, Most Played, Recently Added). Users can pin any song, album, artist, or playlist for persistent quick access, reorder pins by drag-and-drop, and unpin from the same entry points.

## 🔍 Implementation Notes
**Backend**
- New `pinned_items` table (migration 21, [db.rs](../blob/next/src-tauri/src/db.rs)) storing `(item_type, ref_key, position, pinned_at)`. Keys: song/playlist id, bare album title (same convention as `album_ratings`), effective-artist name (same convention as `artist_profiles`).
- New `PinnedItem` enum and `ArtistItem` struct in `models.rs`.
- Pin/unpin/reorder logic lives in a pure `pins.rs` module (unit-testable against a plain `Connection`), with thin `#[tauri::command]` wrappers in `commands/pins.rs`. `get_pinned_items` always resolves against live data (current artwork/rating/genre/etc.) and silently drops a pin whose target no longer exists, rather than erroring — so pins self-heal and never surface stale data.
- Newly pinned items are inserted at the front of the list, not appended to the end.

**Frontend**
- New `pinnedStore` (mirrors `playlists.svelte.ts`'s pattern), a `PinnedRow` on Home (horizontal, drag-reorderable, mixed item types), and pin/unpin entry points: `SongContextMenu`, `AlbumContextMenu`, the Playlist/Artist/Album detail headers (icon buttons — those three have no context menu of their own for the entity itself).
- Drag reordering uses pointer events rather than native HTML5 drag, because Tauri's `dragDropEnabled` window option (needed for OS file-drop-to-queue import) hijacks native drag gestures. This also uncovered and fixed the same latent issue in `SongTable`'s playlist-track reorder; both now share the same background-tint drop-target indicator for consistency.
- New i18n keys added to both `en.ts` and `fr.ts`.

**Incidental fixes surfaced while building/reviewing this** (small, same files already touched):
- `ArtistCard`: left-aligned text, reordered to name → song count → genre.
- `ArtistRowCard`/`AlbumRowCard`: the row-view grid used `auto-fill`, which reserves phantom empty columns instead of letting populated cards stretch to fill the panel — switched to `auto-fit`.
- `ArtistRowCard`: rebuilt as an explicit CSS grid so the artist name spans the full row width on its own line instead of being boxed into a narrow flex column that wasn't picking up available space.
- Home's library-overview stat line reordered to Artists → Albums → Songs.

## 🧪 Test Plan
- [x] `bun run check` (svelte-check) — 0 errors
- [x] `bun run test -- --run` (frontend) — 535+ passed, including new `pinned.test.ts`
- [x] `cargo test` (src-tauri) — 238 passed, including 8 new tests in `pins.rs` (pin/unpin round-trip per item type, idempotent re-pin, front-insertion ordering, partial reorder, live-vs-stale song resolution, album JSON→struct mapping, case-insensitive artist matching, migration column check)
- [x] Manually verified in the app by the repo owner: pinned/unpinned song/album/artist/playlist from every entry point, drag-reorder, live-refresh on tag edits, and the row-view layout fixes.

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed — N/A, no screenshot harness entries for this view exist yet
