### PR TITLE
fix: unify custom playlist table background and fix stuck hover blur

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -153,6 +153,20 @@
   box-shadow: var(--glass-shadow, none);
 }
 
+/*
+ * Song table surfaces (SongTable wrapper in PlaylistView, AutoPlaylistDetailView,
+ * AlbumDetailView, ArtistDetailView) use a raw backdrop-blur-* Tailwind utility
+ * rather than .glass/.glass-surface. Row hover triggers frequent repaints
+ * (background-color + opacity transitions) inside that blurred region; without
+ * pinning it to its own GPU layer the backdrop-filter can be re-rasterized
+ * against a stale frame, leaving a smeared/blurred patch behind a hovered row
+ * that doesn't clear until something else forces a full repaint.
+ */
+.table-surface-blur {
+  will-change: backdrop-filter;
+  transform: translateZ(0);
+}
+
 .bg-brand-sidebar.glass-surface,
 aside.glass-surface,
 header.glass-surface {

--- a/src/lib/components/AlbumDetailView.svelte
+++ b/src/lib/components/AlbumDetailView.svelte
@@ -451,7 +451,7 @@
   </div>
 
   <div class="relative z-10 px-6 py-6" class:pb-28={!!playerStore.currentSong}>
-    <div class="border border-brand-border rounded-lg bg-brand-sidebar/50 backdrop-blur-xl shadow-2xl overflow-hidden">
+    <div class="border border-brand-border rounded-lg bg-brand-sidebar/50 backdrop-blur-xl shadow-2xl overflow-hidden table-surface-blur">
       <SongTable
         rows={tableRows}
         rangeSelectionOrder={rangeSelectionRows}

--- a/src/lib/components/ArtistDetailView.svelte
+++ b/src/lib/components/ArtistDetailView.svelte
@@ -522,7 +522,7 @@
     {#if singleSongs.length > 0}
       <div class="flex flex-col gap-3">
         <h2 class="text-xl font-semibold text-brand-text-primary">{i18n.t('artistDetail.singlesFilter', { count: singleSongs.length })}</h2>
-        <div class="border border-brand-border rounded-lg bg-brand-sidebar/50 backdrop-blur-xl shadow-2xl overflow-hidden">
+        <div class="border border-brand-border rounded-lg bg-brand-sidebar/50 backdrop-blur-xl shadow-2xl overflow-hidden table-surface-blur">
           <SongTable
             rows={singleTableRows}
             mode="track"

--- a/src/lib/components/AutoPlaylistDetailView.svelte
+++ b/src/lib/components/AutoPlaylistDetailView.svelte
@@ -590,7 +590,7 @@
   </div>
 
   <div class="px-6 py-6 flex flex-col" class:pb-28={!!playerStore.currentSong}>
-    <div class="border border-brand-border/60 rounded-xl bg-brand-sidebar/30 backdrop-blur-md relative overflow-hidden">
+    <div class="border border-brand-border/60 rounded-xl bg-brand-sidebar/30 backdrop-blur-md relative overflow-hidden table-surface-blur">
       <SongTable
         rows={tableRows}
         mode="position"

--- a/src/lib/components/PlaylistView.svelte
+++ b/src/lib/components/PlaylistView.svelte
@@ -597,26 +597,18 @@
 <svelte:window onkeydown={handleDeleteKey} />
 
 <div class="flex-1 flex flex-col overflow-hidden bg-brand-main text-brand-text-secondary h-full relative select-none">
-  {#if currentCoverUrl}
+  {#if currentCoverUrl && isQueue}
     <div class="absolute inset-0 pointer-events-none select-none z-0 overflow-hidden">
-      {#if isQueue}
-        {#key currentCoverUrl}
-          <img
-            src={currentCoverUrl}
-            alt=""
-            class="absolute inset-0 w-full h-full object-cover blur-2xl"
-            style="will-change: filter; transform: translateZ(0) scale(1.5);"
-            in:fade={{ duration: 400 }}
-          />
-        {/key}
-        <div class="absolute inset-0 bg-gradient-to-b from-transparent via-transparent to-brand-main"></div>
-      {:else}
-        <div
-          class="absolute inset-0 bg-cover bg-center opacity-[0.12] scale-105 blur-[60px] saturate-[180%] transition-all duration-1000"
-          style="background-image: url('{currentCoverUrl}');"
-        ></div>
-        <div class="absolute inset-0 bg-gradient-to-t from-brand-main via-transparent to-brand-main/20"></div>
-      {/if}
+      {#key currentCoverUrl}
+        <img
+          src={currentCoverUrl}
+          alt=""
+          class="absolute inset-0 w-full h-full object-cover blur-2xl"
+          style="will-change: filter; transform: translateZ(0) scale(1.5);"
+          in:fade={{ duration: 400 }}
+        />
+      {/key}
+      <div class="absolute inset-0 bg-gradient-to-b from-transparent via-transparent to-brand-main"></div>
     </div>
   {/if}
 
@@ -825,7 +817,7 @@
     </div>
 
     <div class="p-6 flex flex-col" class:pb-28={!!playerStore.currentSong}>
-      <div class="border border-brand-border/60 rounded-xl bg-brand-sidebar/30 backdrop-blur-md relative overflow-hidden">
+      <div class="border border-brand-border/60 rounded-xl bg-brand-sidebar/30 backdrop-blur-md relative overflow-hidden table-surface-blur">
         <SongTable
           rows={tableRows}
           rangeSelectionOrder={rangeSelectionRows}


### PR DESCRIPTION
## 📋 Summary
Fixes #665. Custom playlist song tables looked different from other playlist types, and hovering rows could leave a stuck blurred patch on the table background.

## 🔍 Implementation Notes
Two separate issues, same visual bug report:

1. **Background mismatch** — `PlaylistView.svelte` (Custom/Smart/Queue playlists) rendered a full-view blurred "now playing" cover-art wash (`currentCoverUrl`) behind the whole view whenever a song was playing, for every playlist type it handles. `AutoPlaylistDetailView.svelte` (genre/decade/BPM auto playlists) has no equivalent wash. Since the wash sits behind the translucent song-table surface, it tinted the table only for playlists routed through `PlaylistView`. Scoped the wash to `isQueue` only, since Queue is the one context where a "now playing" mood wash makes sense; Custom and Smart playlists now render on the same flat background as auto playlists.
2. **Stuck blur on hover** — the song-table wrapper divs (`PlaylistView`, `AutoPlaylistDetailView`, `AlbumDetailView`, `ArtistDetailView`) use a raw `backdrop-blur-*` Tailwind utility with no GPU-layer pinning. Row hover triggers frequent repaints inside that blurred region, and without pinning it to its own compositing layer the browser can re-rasterize the `backdrop-filter` against a stale frame, leaving a smeared patch behind a hovered row. Added a `.table-surface-blur` utility to `app.css` (`will-change: backdrop-filter; transform: translateZ(0);`) mirroring the existing `.glass`/`.glass-premium` fix, and applied it to all four song-table wrappers.

## 🧪 Test Plan
- [x] `bun run check` (svelte-check) — 0 errors
- [ ] `bun run test -- --run` (frontend)
- [ ] `cargo test` (src-tauri, if Rust changed) — no Rust changed
- [x] Manually verified in the app (describe what you did) — not run in this session; asked the user to verify with `bun run tauri dev`

## 📸 Screenshots
N/A — CSS/behavior fix, no new UI surface. Reviewer can compare a Custom playlist vs. an auto/genre playlist's table background, and rapidly hover rows to confirm no stuck blur.

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed — not applicable (no new/changed docs surface)
