### PR TITLE
Feature: pin auto playlists to Home (#667)

### DIFF
--- a/src-tauri/src/commands/pins.rs
+++ b/src-tauri/src/commands/pins.rs
@@ -129,6 +129,27 @@ pub async fn get_pinned_items(state: State<'_, AppState>) -> Result<Vec<PinnedIt
                     });
                 }
             }
+            "auto_playlist" => {
+                let playlists = match &playlists_cache {
+                    Some(p) => p,
+                    None => {
+                        let p = state
+                            .playlists
+                            .lock()
+                            .await
+                            .get_playlists()
+                            .map_err(|e| e.to_string())?;
+                        playlists_cache = Some(p);
+                        playlists_cache.as_ref().unwrap()
+                    }
+                };
+                if let Some(auto_playlist) =
+                    pins::resolve_auto_playlist(&scanner, playlists, &ref_key)
+                        .map_err(|e| e.to_string())?
+                {
+                    items.push(PinnedItem::AutoPlaylist { auto_playlist });
+                }
+            }
             _ => {}
         }
     }

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -819,6 +819,7 @@ pub enum PinnedItem {
     },
     #[serde(rename = "auto_playlist")]
     AutoPlaylist {
+        #[serde(rename = "autoPlaylist")]
         auto_playlist: AutoPlaylistItem,
     },
 }
@@ -982,5 +983,34 @@ mod tests {
         };
 
         assert!(s1.is_same_album_or_cue_sibling(&s2));
+    }
+
+    // Regression test for a real bug: `#[serde(rename_all = "camelCase")]` on
+    // the `PinnedItem` enum only renames the variant tag, not the fields
+    // *inside* a struct variant — so `auto_playlist: AutoPlaylistItem` would
+    // silently serialize its key as `"auto_playlist"` while the frontend
+    // (types/index.ts) reads `item.autoPlaylist`, leaving it `undefined` and
+    // crashing `PinnedRow.svelte` on the very first render.
+    #[test]
+    fn pinned_item_auto_playlist_serializes_with_camel_case_type_and_field() {
+        let item = PinnedItem::AutoPlaylist {
+            auto_playlist: AutoPlaylistItem {
+                kind: "favourites".to_string(),
+                genre: None,
+                artist_tag: None,
+                decade: None,
+                bpm: None,
+                playlist_id: None,
+                updated: None,
+                track_count: 3,
+            },
+        };
+        let value = serde_json::to_value(&item).unwrap();
+        assert_eq!(value["type"], "auto_playlist");
+        assert!(
+            value.get("autoPlaylist").is_some(),
+            "expected a camelCase \"autoPlaylist\" key, got: {value}"
+        );
+        assert_eq!(value["autoPlaylist"]["trackCount"], 3);
     }
 }

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -780,16 +780,47 @@ pub struct ArtistItem {
     pub genre: Option<String>,
 }
 
+/// A materialized or virtual auto-playlist referenced by a Home pin — mirrors
+/// the frontend's `AutoPlaylistRef` shape so `AutoPlaylistCard` can render a
+/// pinned auto-playlist without a second code path. Favourites/Recently
+/// Added/Most Played/History have no backing playlist row (`playlist_id`/
+/// `updated` are `None`); genre/decade/bpm/artist_tag are materialized rows,
+/// so those are populated from the matching `Playlist`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AutoPlaylistItem {
+    pub kind: String,
+    pub genre: Option<String>,
+    pub artist_tag: Option<String>,
+    pub decade: Option<String>,
+    pub bpm: Option<String>,
+    pub playlist_id: Option<i64>,
+    pub updated: Option<i64>,
+    pub track_count: i32,
+}
+
 /// A user-pinned Home-shelf entry (#222) — a superset of `HomeItem` that also
 /// allows Artist, since pins (unlike the system-curated rank/added rows) are
 /// explicitly user-curated across all four browsable entity types.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "camelCase")]
 pub enum PinnedItem {
-    Song { song: Box<Song> },
-    Album { album: AlbumItem },
-    Artist { artist: ArtistItem },
-    Playlist { playlist: Playlist },
+    Song {
+        song: Box<Song>,
+    },
+    Album {
+        album: AlbumItem,
+    },
+    Artist {
+        artist: ArtistItem,
+    },
+    Playlist {
+        playlist: Playlist,
+    },
+    #[serde(rename = "auto_playlist")]
+    AutoPlaylist {
+        auto_playlist: AutoPlaylistItem,
+    },
 }
 
 /// A social media or external platform link associated with an artist (#473).

--- a/src-tauri/src/pins.rs
+++ b/src-tauri/src/pins.rs
@@ -5,7 +5,7 @@
 //! `commands::stats` split.
 
 use crate::collection::{row_to_song, CollectionScanner, SONG_SELECT_COLS};
-use crate::models::{AlbumItem, ArtistItem, Song};
+use crate::models::{AlbumItem, ArtistItem, AutoPlaylistItem, Playlist, Song};
 use anyhow::Result;
 use rusqlite::{params, Connection};
 
@@ -180,6 +180,94 @@ pub fn artist_item_from_json(value: &serde_json::Value) -> Result<ArtistItem> {
 /// `CollectionScanner` directly.
 pub fn all_albums(scanner: &CollectionScanner) -> Result<Vec<serde_json::Value>> {
     scanner.get_albums()
+}
+
+/// Splits an auto-playlist ref_key into its kind and (for genre/decade/bpm/
+/// artist_tag) selector — e.g. `"genre:Rock"` -> `("genre", Some("Rock"))`,
+/// `"favourites"` -> `("favourites", None)`. Split on the *first* colon only,
+/// so a selector value that itself contains a colon is preserved intact.
+fn parse_auto_playlist_ref(ref_key: &str) -> (&str, Option<&str>) {
+    match ref_key.split_once(':') {
+        Some((kind, selector)) => (kind, Some(selector)),
+        None => (ref_key, None),
+    }
+}
+
+/// Resolves a pinned auto-playlist reference against live data. Favourites/
+/// Recently Added/Most Played/History have no backing playlist row, so their
+/// resolution just recomputes the same song list the auto-playlist card/view
+/// would show and reports its length. Genre/decade/bpm/artist_tag are
+/// materialized (dynamic_enabled) playlist rows, keyed by their stable
+/// selector value rather than `Playlist.id` — the row can be dropped and
+/// recreated by a sync, but the selector (a genre name, decade, etc.) is what
+/// the user actually pinned. Returns `None` (not an error) when the kind is
+/// unknown or the auto-playlist currently has no songs — mirrors
+/// `resolve_song`'s silent-drop-on-stale-pin behavior.
+pub fn resolve_auto_playlist(
+    scanner: &CollectionScanner,
+    playlists: &[Playlist],
+    ref_key: &str,
+) -> Result<Option<AutoPlaylistItem>> {
+    let (kind, selector) = parse_auto_playlist_ref(ref_key);
+
+    let virtual_item = |kind: &str, track_count: i32| AutoPlaylistItem {
+        kind: kind.to_string(),
+        genre: None,
+        artist_tag: None,
+        decade: None,
+        bpm: None,
+        playlist_id: None,
+        updated: None,
+        track_count,
+    };
+
+    let item = match kind {
+        "favourites" => {
+            let count = scanner.get_favourite_songs()?.len() as i32;
+            (count > 0).then(|| virtual_item(kind, count))
+        }
+        "recently_added" => {
+            let count = scanner.get_recently_added_songs(50)?.len() as i32;
+            (count > 0).then(|| virtual_item(kind, count))
+        }
+        "most_played" => {
+            let count = scanner.get_most_played_songs(50)?.len() as i32;
+            (count > 0).then(|| virtual_item(kind, count))
+        }
+        "history" => {
+            let count = scanner.get_recently_played_songs(100)?.len() as i32;
+            (count > 0).then(|| virtual_item(kind, count))
+        }
+        "genre" | "decade" | "bpm" | "artist_tag" => {
+            let selector = selector.unwrap_or("").to_string();
+            let prefix = match kind {
+                "genre" => "tag:",
+                "decade" => "decade:",
+                "bpm" => "bpmrange:",
+                _ => "artisttag:",
+            };
+            let expected_spec = format!("{prefix}{selector}");
+            playlists
+                .iter()
+                .find(|p| {
+                    p.dynamic_enabled
+                        && p.track_count > 0
+                        && p.dynamic_spec.as_deref() == Some(expected_spec.as_str())
+                })
+                .map(|p| AutoPlaylistItem {
+                    kind: kind.to_string(),
+                    genre: (kind == "genre").then(|| selector.clone()),
+                    artist_tag: (kind == "artist_tag").then(|| selector.clone()),
+                    decade: (kind == "decade").then(|| selector.clone()),
+                    bpm: (kind == "bpm").then_some(selector),
+                    playlist_id: Some(p.id),
+                    updated: Some(p.updated),
+                    track_count: p.track_count,
+                })
+        }
+        _ => None,
+    };
+    Ok(item)
 }
 
 pub fn all_artists(scanner: &CollectionScanner) -> Result<Vec<serde_json::Value>> {
@@ -393,5 +481,118 @@ mod tests {
         assert!(find_artist(&artists, "the war on drugs").is_some());
         assert!(find_artist(&artists, "THE WAR ON DRUGS").is_some());
         assert!(find_artist(&artists, "Someone Else").is_none());
+    }
+
+    #[test]
+    fn parse_auto_playlist_ref_splits_on_first_colon_only() {
+        assert_eq!(parse_auto_playlist_ref("favourites"), ("favourites", None));
+        assert_eq!(
+            parse_auto_playlist_ref("genre:Rock"),
+            ("genre", Some("Rock"))
+        );
+        // A selector containing its own colon stays intact.
+        assert_eq!(
+            parse_auto_playlist_ref("bpm:60-90:extra"),
+            ("bpm", Some("60-90:extra"))
+        );
+    }
+
+    fn test_playlist(id: i64, dynamic_spec: &str, track_count: i32) -> Playlist {
+        Playlist {
+            id,
+            name: dynamic_spec.to_string(),
+            dynamic_enabled: true,
+            dynamic_spec: Some(dynamic_spec.to_string()),
+            population_mode: Default::default(),
+            last_played_row: None,
+            created: 0,
+            updated: 42,
+            track_count,
+            is_queue: false,
+        }
+    }
+
+    #[test]
+    fn resolve_auto_playlist_favourites_reflects_live_favourite_count() {
+        let (db, dir) = test_db();
+        {
+            let conn = db.pool.get().unwrap();
+            let id = insert_song(&conn, "/tmp/favourite.flac");
+            conn.execute(
+                "UPDATE songs SET rating = 5, source = 1 WHERE id = ?1",
+                params![id],
+            )
+            .unwrap();
+        }
+        let scanner = CollectionScanner::new(std::sync::Arc::new(db));
+
+        let resolved = resolve_auto_playlist(&scanner, &[], "favourites").unwrap();
+        let item = resolved.expect("favourites should resolve while a favourite exists");
+        assert_eq!(item.kind, "favourites");
+        assert_eq!(item.track_count, 1);
+        assert_eq!(item.playlist_id, None);
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn resolve_auto_playlist_virtual_kind_drops_when_empty() {
+        let (db, dir) = test_db();
+        let scanner = CollectionScanner::new(std::sync::Arc::new(db));
+
+        // No songs at all in the library — favourites/most_played/history all resolve to None.
+        assert!(resolve_auto_playlist(&scanner, &[], "favourites")
+            .unwrap()
+            .is_none());
+        assert!(resolve_auto_playlist(&scanner, &[], "most_played")
+            .unwrap()
+            .is_none());
+        assert!(resolve_auto_playlist(&scanner, &[], "history")
+            .unwrap()
+            .is_none());
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn resolve_auto_playlist_materialized_kind_matches_by_selector_not_id() {
+        let (db, dir) = test_db();
+        let scanner = CollectionScanner::new(std::sync::Arc::new(db));
+        let playlists = vec![
+            test_playlist(1, "tag:Rock", 12),
+            test_playlist(2, "decade:1980s", 4),
+            test_playlist(3, "bpmrange:60-90", 7),
+            test_playlist(4, "artisttag:Progressive Metal", 3),
+        ];
+
+        let genre = resolve_auto_playlist(&scanner, &playlists, "genre:Rock")
+            .unwrap()
+            .expect("genre:Rock should resolve against playlist id 1");
+        assert_eq!(genre.playlist_id, Some(1));
+        assert_eq!(genre.genre.as_deref(), Some("Rock"));
+        assert_eq!(genre.track_count, 12);
+
+        let decade = resolve_auto_playlist(&scanner, &playlists, "decade:1980s")
+            .unwrap()
+            .expect("decade:1980s should resolve");
+        assert_eq!(decade.decade.as_deref(), Some("1980s"));
+
+        let bpm = resolve_auto_playlist(&scanner, &playlists, "bpm:60-90")
+            .unwrap()
+            .expect("bpm:60-90 should resolve");
+        assert_eq!(bpm.bpm.as_deref(), Some("60-90"));
+
+        let artist_tag =
+            resolve_auto_playlist(&scanner, &playlists, "artist_tag:Progressive Metal")
+                .unwrap()
+                .expect("artist_tag:Progressive Metal should resolve");
+        assert_eq!(artist_tag.artist_tag.as_deref(), Some("Progressive Metal"));
+
+        // A selector that no longer matches any row (renamed/deleted) self-heals to None.
+        assert!(resolve_auto_playlist(&scanner, &playlists, "genre:Jazz")
+            .unwrap()
+            .is_none());
+
+        let _ = std::fs::remove_dir_all(dir);
     }
 }

--- a/src/lib/components/AutoPlaylistDetailView.svelte
+++ b/src/lib/components/AutoPlaylistDetailView.svelte
@@ -6,6 +6,8 @@
   import { navigationStore, type AutoPlaylistRef } from "../stores/navigation.svelte";
   import { playerStore } from "../stores/player.svelte";
   import { playlistsStore } from "../stores/playlists.svelte";
+  import { pinnedStore } from "../stores/pinned.svelte";
+  import { autoPlaylistRefKeyFor } from "../types";
   import { songsToCoverStack } from "../utils/covers";
   import CoverStack from "./CoverStack.svelte";
   import TagEditor from "./TagEditor.svelte";
@@ -22,7 +24,7 @@
   import ContextMenuItem from "./ContextMenuItem.svelte";
   import ContextMenuDivider from "./ContextMenuDivider.svelte";
   import SongTable, { type SongTableRow } from "./SongTable.svelte";
-  import { Clock, Plus, FolderPlus, Music, Gauge, RefreshCw, Heart, Calendar, Hourglass, Search, RotateCcw, RotateCw, MoreHorizontal, X, Eraser, Tag, TrendingUp } from "lucide-svelte";
+  import { Clock, Plus, FolderPlus, Music, Gauge, RefreshCw, Heart, Calendar, Hourglass, Search, RotateCcw, RotateCw, MoreHorizontal, X, Eraser, Tag, TrendingUp, Pin, PinOff } from "lucide-svelte";
   import { shuffleArray } from "../utils/shuffle";
   import type { PlaylistItem, QueuePopulationMode, Song } from "../types";
   import { i18n } from "../stores/i18n.svelte";
@@ -56,6 +58,7 @@
   let bpm = $derived(view.bpm);
   let playlistId = $derived(view.playlistId);
   let updated = $derived(view.updated);
+  let pinRefKey = $derived(autoPlaylistRefKeyFor(view));
 
   let songs = $state<Song[]>([]);
   let loading = $state(true);
@@ -472,6 +475,21 @@
             disabled={loading || songs.length === 0}
             class="shrink-0"
           />
+          <IconActionButton
+            onclick={() => pinnedStore.toggle("auto_playlist", pinRefKey)}
+            title={pinnedStore.isPinned("auto_playlist", pinRefKey)
+              ? i18n.t("playlists.contextMenuUnpinHome")
+              : i18n.t("playlists.contextMenuPinHome")}
+            class="shrink-0"
+          >
+            {#snippet icon()}
+              {#if pinnedStore.isPinned("auto_playlist", pinRefKey)}
+                <PinOff class="w-4 h-4" />
+              {:else}
+                <Pin class="w-4 h-4" />
+              {/if}
+            {/snippet}
+          </IconActionButton>
           <ColumnSelector align="left" iconOnly />
         </div>
 

--- a/src/lib/components/PinnedRow.svelte
+++ b/src/lib/components/PinnedRow.svelte
@@ -1,20 +1,44 @@
 <script lang="ts">
-  import type { PinnedItem, PinnedItemType } from "../types";
+  import type { AutoPlaylistItem, PinnedItem, PinnedItemType } from "../types";
   import { pinnedRefKeyFor } from "../types";
   import { pinnedStore } from "../stores/pinned.svelte";
   import { playerStore } from "../stores/player.svelte";
+  import { playlistsStore } from "../stores/playlists.svelte";
   import { navigationStore } from "../stores/navigation.svelte";
   import { i18n } from "../stores/i18n.svelte";
   import { getArtistAlbums, getArtistSongs } from "../utils/artist";
+  import { getPlaylistDisplayName } from "../utils/playlist";
   import { collectionStore } from "../stores/collection.svelte";
   import HorizontalScrollRow from "./HorizontalScrollRow.svelte";
   import AlbumCard from "./AlbumCard.svelte";
   import ArtistCard from "./ArtistCard.svelte";
   import PlaylistCard from "./PlaylistCard.svelte";
+  import AutoPlaylistCard from "./AutoPlaylistCard.svelte";
   import PinnedSongCard from "./PinnedSongCard.svelte";
 
   function keyFor(item: PinnedItem): string {
     return `${item.type}:${pinnedRefKeyFor(item)}`;
+  }
+
+  // Mirrors PlaylistsCollectionView's autoDefs label derivation — Favourites/
+  // Recently Added/Most Played/History use fixed i18n labels, while genre/
+  // decade/bpm/artist_tag defer to the materialized playlist's own display
+  // name (falling back to the raw selector if the row hasn't resolved yet).
+  function autoPlaylistLabel(ap: AutoPlaylistItem): string {
+    switch (ap.kind) {
+      case "favourites":
+        return i18n.t("playlists.autoFavourites");
+      case "recently_added":
+        return i18n.t("playlists.autoRecentlyAdded");
+      case "most_played":
+        return i18n.t("playlists.autoMostPlayed");
+      case "history":
+        return i18n.t("playlists.autoHistory");
+      default: {
+        const pl = playlistsStore.playlists.find((p) => p.id === ap.playlistId);
+        return pl ? getPlaylistDisplayName(pl) : (ap.genre ?? ap.decade ?? ap.bpm ?? ap.artistTag ?? ap.kind);
+      }
+    }
   }
 
   function openItem(item: PinnedItem) {
@@ -30,6 +54,17 @@
         break;
       case "playlist":
         navigationStore.viewPlaylist(item.playlist.id);
+        break;
+      case "auto_playlist":
+        navigationStore.viewAutoPlaylist({
+          kind: item.autoPlaylist.kind,
+          genre: item.autoPlaylist.genre,
+          artistTag: item.autoPlaylist.artistTag,
+          decade: item.autoPlaylist.decade,
+          bpm: item.autoPlaylist.bpm,
+          playlistId: item.autoPlaylist.playlistId,
+          updated: item.autoPlaylist.updated,
+        });
         break;
     }
   }
@@ -140,6 +175,19 @@
           />
         {:else if item.type === "playlist"}
           <PlaylistCard playlist={item.playlist} onClick={() => openItem(item)} />
+        {:else if item.type === "auto_playlist"}
+          <AutoPlaylistCard
+            label={autoPlaylistLabel(item.autoPlaylist)}
+            kind={item.autoPlaylist.kind}
+            genre={item.autoPlaylist.genre}
+            artistTag={item.autoPlaylist.artistTag}
+            decade={item.autoPlaylist.decade}
+            bpm={item.autoPlaylist.bpm}
+            playlistId={item.autoPlaylist.playlistId}
+            updated={item.autoPlaylist.updated}
+            trackCount={item.autoPlaylist.trackCount}
+            onClick={() => openItem(item)}
+          />
         {:else}
           <PinnedSongCard song={item.song} onclick={() => openItem(item)} />
         {/if}

--- a/src/lib/stores/pinned.test.ts
+++ b/src/lib/stores/pinned.test.ts
@@ -13,6 +13,7 @@ describe("PinnedStore", () => {
     { type: "album", album: { album: "Album A", artist: "Artist A" } as any },
     { type: "artist", artist: { name: "Artist A" } as any },
     { type: "playlist", playlist: { id: 5, name: "Playlist A" } as any },
+    { type: "auto_playlist", autoPlaylist: { kind: "favourites", trackCount: 12 } as any },
   ];
 
   beforeEach(() => {
@@ -36,11 +37,12 @@ describe("PinnedStore", () => {
 
   it("loads pinned items on refresh and reports isPinned per type/refKey", async () => {
     await pinnedStore.refresh();
-    expect(pinnedStore.items).toHaveLength(4);
+    expect(pinnedStore.items).toHaveLength(5);
     expect(pinnedStore.isPinned("song", "10")).toBe(true);
     expect(pinnedStore.isPinned("album", "Album A")).toBe(true);
     expect(pinnedStore.isPinned("artist", "Artist A")).toBe(true);
     expect(pinnedStore.isPinned("playlist", "5")).toBe(true);
+    expect(pinnedStore.isPinned("auto_playlist", "favourites")).toBe(true);
     expect(pinnedStore.isPinned("song", "999")).toBe(false);
   });
 

--- a/src/lib/types/index.test.ts
+++ b/src/lib/types/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { resolveArtUrl, getCoverArtUrl } from "./index";
+import { resolveArtUrl, getCoverArtUrl, pinnedRefKeyFor, autoPlaylistRefKeyFor, type PinnedItem } from "./index";
 
 describe("resolveArtUrl", () => {
   it("returns null for null, undefined, or empty string", () => {
@@ -29,5 +29,37 @@ describe("resolveArtUrl", () => {
   it("wraps Windows absolute local filesystem paths in luminous-art://local/", () => {
     const winPath = "C:\\Users\\User\\Music\\Album\\folder.jpg";
     expect(resolveArtUrl(winPath)).toBe(`luminous-art://local/${winPath}`);
+  });
+});
+
+describe("autoPlaylistRefKeyFor", () => {
+  it("uses the bare kind for auto-playlists with no backing playlist row", () => {
+    expect(autoPlaylistRefKeyFor({ kind: "favourites" })).toBe("favourites");
+    expect(autoPlaylistRefKeyFor({ kind: "recently_added" })).toBe("recently_added");
+    expect(autoPlaylistRefKeyFor({ kind: "most_played" })).toBe("most_played");
+    expect(autoPlaylistRefKeyFor({ kind: "history" })).toBe("history");
+  });
+
+  it("keys materialized kinds by their selector, not a playlist id", () => {
+    expect(autoPlaylistRefKeyFor({ kind: "genre", genre: "Rock" })).toBe("genre:Rock");
+    expect(autoPlaylistRefKeyFor({ kind: "decade", decade: "1980s" })).toBe("decade:1980s");
+    expect(autoPlaylistRefKeyFor({ kind: "bpm", bpm: "60-90" })).toBe("bpm:60-90");
+    expect(autoPlaylistRefKeyFor({ kind: "artist_tag", artistTag: "Progressive Metal" })).toBe(
+      "artist_tag:Progressive Metal"
+    );
+  });
+});
+
+describe("pinnedRefKeyFor", () => {
+  it("dispatches each PinnedItem type to its identifying key", () => {
+    expect(pinnedRefKeyFor({ type: "song", song: { id: 7 } as any })).toBe("7");
+    expect(pinnedRefKeyFor({ type: "album", album: { album: "Album A" } as any })).toBe("Album A");
+    expect(pinnedRefKeyFor({ type: "artist", artist: { name: "Artist A" } as any })).toBe("Artist A");
+    expect(pinnedRefKeyFor({ type: "playlist", playlist: { id: 3 } as any })).toBe("3");
+    const autoPlaylistItem: PinnedItem = {
+      type: "auto_playlist",
+      autoPlaylist: { kind: "genre", genre: "Jazz", trackCount: 5 } as any,
+    };
+    expect(pinnedRefKeyFor(autoPlaylistItem)).toBe("genre:Jazz");
   });
 });

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -379,13 +379,57 @@ export type HomeItem =
 /** A user-pinned Home-shelf entry (#222) — a superset of {@link HomeItem} that
  * also allows Artist, since pins are explicitly user-curated across all four
  * browsable entity types. */
-export type PinnedItemType = "song" | "album" | "artist" | "playlist";
+export type PinnedItemType = "song" | "album" | "artist" | "playlist" | "auto_playlist";
+
+/** A pinned auto-playlist (genre/decade/BPM/artist-tag/Favourites/Recently
+ * Added/Most Played/History) — enough of {@link AutoPlaylistRef}'s shape for
+ * `AutoPlaylistCard` to render it directly. Favourites/Recently Added/Most
+ * Played/History have no backing playlist row, so `playlistId`/`updated` are
+ * absent for those kinds. */
+export interface AutoPlaylistItem {
+  kind: "favourites" | "recently_added" | "most_played" | "history" | "genre" | "decade" | "bpm" | "artist_tag";
+  genre?: string;
+  artistTag?: string;
+  decade?: string;
+  bpm?: string;
+  playlistId?: number;
+  updated?: number;
+  trackCount: number;
+}
 
 export type PinnedItem =
   | { type: "song"; song: Song }
   | { type: "album"; album: AlbumItem }
   | { type: "artist"; artist: ArtistItem }
-  | { type: "playlist"; playlist: Playlist };
+  | { type: "playlist"; playlist: Playlist }
+  | { type: "auto_playlist"; autoPlaylist: AutoPlaylistItem };
+
+/** The stable ref_key for a pinned auto-playlist: the bare kind for
+ * Favourites/Recently Added/Most Played/History (no backing row to key on),
+ * or `kind:selector` for genre/decade/bpm/artist_tag — keyed by the selector
+ * value (genre name, decade, bpm spec, artist tag) rather than the
+ * materialized playlist's id, since that row can be dropped and recreated by
+ * a background sync while the selector stays stable. */
+export function autoPlaylistRefKeyFor(ref: {
+  kind: string;
+  genre?: string;
+  decade?: string;
+  bpm?: string;
+  artistTag?: string;
+}): string {
+  switch (ref.kind) {
+    case "genre":
+      return `genre:${ref.genre ?? ""}`;
+    case "decade":
+      return `decade:${ref.decade ?? ""}`;
+    case "bpm":
+      return `bpm:${ref.bpm ?? ""}`;
+    case "artist_tag":
+      return `artist_tag:${ref.artistTag ?? ""}`;
+    default:
+      return ref.kind;
+  }
+}
 
 /** The `(item_type, ref_key)` identity Luminous stores for a pin — song/playlist
  * id as a string, bare album title, or effective-artist name. Shared by the
@@ -401,6 +445,8 @@ export function pinnedRefKeyFor(item: PinnedItem): string {
       return item.artist.name ?? "";
     case "playlist":
       return String(item.playlist.id);
+    case "auto_playlist":
+      return autoPlaylistRefKeyFor(item.autoPlaylist);
   }
 }
 


### PR DESCRIPTION
## 📋 Summary
Fixes #667. PR #664 ("Pin to Home", closing #222) added a user-curated Pinned shelf to Home for songs, albums, artists, and custom playlists, but never wired auto playlists into it — this fills that gap for all eight auto-playlist kinds (Favourites, Recently Added, Most Played, History, Genre, Decade, BPM, Artist-Tag).

## 🔍 Implementation Notes
This is really two gaps in one:
- **Genre/Decade/BPM/Artist-Tag** are backed by real (materialized, `dynamic_enabled`) playlist rows, so they reuse the existing pin machinery — but keyed by their stable *selector* (genre name, decade, bpm spec, artist tag), not `Playlist.id`. That row can be dropped and recreated by the nightly auto-playlist sync; the selector can't.
- **Favourites/Recently Added/Most Played/History** have no backing playlist row at all — they're computed live from `songs`/`play_history`. These get a new `auto_playlist` pin type whose backend resolver ([pins.rs](../blob/next/src-tauri/src/pins.rs)) just recomputes the same live song count the auto-playlist card/view already shows, and self-heals (drops the pin) if that count hits zero — mirroring how a pinned song/album/artist already self-heals when its target disappears.

No DB migration needed — `pinned_items.item_type` is a free-text column, so `"auto_playlist"` is just a new value in it.

Added the same Pin/Unpin icon button `PlaylistView.svelte` already has to `AutoPlaylistDetailView.svelte`'s header, and wired `PinnedRow.svelte` to render a pinned auto playlist via the existing `AutoPlaylistCard` and open it via `navigationStore.viewAutoPlaylist(...)`.

**A real bug this surfaced:** the first version crashed the whole Home view as soon as any auto playlist was pinned. `#[serde(rename_all = "camelCase")]` on the `PinnedItem` enum only renames the *variant tag*, not fields inside a struct variant, so `auto_playlist` serialized verbatim instead of as `autoPlaylist` — leaving `item.autoPlaylist` `undefined` on the frontend and throwing inside `PinnedStore.init()`, which every page depends on. Fixed with an explicit `#[serde(rename = "autoPlaylist")]` on that field, plus a serialization regression test in `models.rs` so this can't silently reappear.

## 🧪 Test Plan
- [x] `bun run check` (svelte-check) — 0 errors
- [x] `bun run test -- --run` (frontend) — 538 passed, including new coverage in `types/index.test.ts` and `pinned.test.ts`
- [x] `cargo test` (src-tauri) — 243 passed, including 6 new tests in `pins.rs`/`models.rs` (favourites/most-played/recently-added/history live-count resolution, empty-drops-to-none, materialized-kind selector matching, stale-selector self-heal, serde field-naming regression)
- [x] Manually verified in the app by the repo owner: pinned a Decade auto playlist and Favourites, confirmed both render correctly on Home's Pinned shelf with the right cover art (real artwork for the materialized playlist, the heart icon for Favourites) and reproduced/confirmed the fix for the crash above.

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed — N/A, no screenshot harness entries for this view exist yet
