### PR TITLE
fix: close watcher-pause timing race that fires spurious "songs updated" toast

### DIFF
--- a/src-tauri/src/collection.rs
+++ b/src-tauri/src/collection.rs
@@ -47,7 +47,7 @@ mod query;
 mod reconcile;
 mod watcher;
 pub(crate) use reconcile::resolve_case_insensitive_path;
-pub use watcher::{start_watcher, WatcherPauseGuard};
+pub use watcher::{start_watcher, SelfWriteTracker, WatcherPauseGuard};
 
 #[derive(Debug)]
 pub struct CollectionScanner {

--- a/src-tauri/src/collection/watcher.rs
+++ b/src-tauri/src/collection/watcher.rs
@@ -12,11 +12,13 @@ use anyhow::Result;
 use notify::Watcher;
 use rusqlite::params;
 use std::{
-    path::PathBuf,
+    collections::HashMap,
+    path::{Path, PathBuf},
     sync::{
         atomic::{AtomicU32, AtomicU64, Ordering},
         Arc,
     },
+    time::Instant,
 };
 use tauri::{AppHandle, Emitter, Manager};
 
@@ -59,6 +61,66 @@ impl Drop for WatcherPauseGuard {
             std::thread::sleep(WATCHER_UNPAUSE_GRACE);
             flag.fetch_sub(1, Ordering::Relaxed);
         });
+    }
+}
+
+/// How long a path stays "recently self-written" after [`SelfWriteTracker::mark_written`].
+/// Generous relative to `WATCHER_UNPAUSE_GRACE` on purpose: this is the
+/// fallback for when the OS's own change notification arrives *later* than
+/// that grace window already covers (#514) — 30s comfortably covers even a
+/// heavily loaded disk/AV scan without risking suppressing a genuine external
+/// edit to the same file made shortly after Luminous's own write.
+const SELF_WRITE_TTL: std::time::Duration = std::time::Duration::from_secs(30);
+
+/// Tracks paths Luminous itself just wrote, independent of and in addition to
+/// [`WatcherPauseGuard`]. The guard's pause window is purely time-based and
+/// covers the whole watcher regardless of path — if the OS's own change
+/// notification for a self-inflicted write is delayed past that window
+/// (plausible under disk/AV/cloud-sync load, more likely the more files one
+/// guarded operation touches), the watcher can't tell it apart from a
+/// genuine external change and re-reports it, producing a spurious
+/// "songs updated" toast for an edit the user already knows about (#514).
+///
+/// Callers that know the exact path(s) they're about to write should call
+/// [`Self::mark_written`] once they've resolved them (typically right after
+/// acquiring a `WatcherPauseGuard`, once the path is read from the DB); the
+/// watcher thread then skips any event for a tracked path regardless of how
+/// late it arrives, until the entry expires after [`SELF_WRITE_TTL`].
+#[derive(Default)]
+pub struct SelfWriteTracker {
+    inner: parking_lot::Mutex<HashMap<PathBuf, Instant>>,
+}
+
+impl SelfWriteTracker {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Records `paths` as just-written and sweeps out any previously tracked
+    /// path that's aged past [`SELF_WRITE_TTL`], keeping the map from growing
+    /// unbounded without needing a separate background sweep thread.
+    pub fn mark_written(&self, paths: impl IntoIterator<Item = PathBuf>) {
+        self.mark_written_at(paths, Instant::now());
+    }
+
+    fn mark_written_at(&self, paths: impl IntoIterator<Item = PathBuf>, now: Instant) {
+        let mut map = self.inner.lock();
+        for path in paths {
+            map.insert(path, now);
+        }
+        map.retain(|_, marked_at| now.duration_since(*marked_at) < SELF_WRITE_TTL);
+    }
+
+    /// Whether `path` was marked written within the last [`SELF_WRITE_TTL`].
+    pub fn contains_recent(&self, path: &Path) -> bool {
+        self.contains_recent_at(path, Instant::now())
+    }
+
+    fn contains_recent_at(&self, path: &Path, now: Instant) -> bool {
+        self.inner
+            .lock()
+            .get(path)
+            .is_some_and(|marked_at| now.duration_since(*marked_at) < SELF_WRITE_TTL)
     }
 }
 
@@ -298,6 +360,7 @@ pub fn start_watcher(app: AppHandle, state: &crate::AppState) {
     // Spawn the background thread to handle watcher events
     let db_for_thread = Arc::clone(&db);
     let watcher_paused = Arc::clone(&state.watcher_paused);
+    let self_writes = Arc::clone(&state.self_writes);
     std::thread::Builder::new()
         .name("luminous-watcher".to_string())
         .spawn(move || {
@@ -384,6 +447,15 @@ pub fn start_watcher(app: AppHandle, state: &crate::AppState) {
                         continue;
                     };
                     for path in event.paths {
+                        // A late-arriving OS notification for a path Luminous
+                        // itself just wrote (tag edit, cover art, organize
+                        // move, ...) — skip it regardless of whether the
+                        // coarse `watcher_paused` window above has already
+                        // elapsed, since that's exactly the race this exists
+                        // to close (#514).
+                        if self_writes.contains_recent(&path) {
+                            continue;
+                        }
                         if !path.exists() {
                             removed_paths.insert(path);
                         } else if path.is_file() && super::is_audio_file(&path) {
@@ -618,6 +690,47 @@ mod tests {
             RemoveKind::File
         )));
         assert!(is_mutating_watcher_event(&EventKind::Any));
+    }
+
+    #[test]
+    fn test_self_write_tracker_suppresses_recent_path() {
+        let tracker = SelfWriteTracker::new();
+        let path = PathBuf::from("/music/song.mp3");
+        tracker.mark_written(std::iter::once(path.clone()));
+        assert!(tracker.contains_recent(&path));
+    }
+
+    #[test]
+    fn test_self_write_tracker_ignores_unmarked_path() {
+        let tracker = SelfWriteTracker::new();
+        tracker.mark_written(std::iter::once(PathBuf::from("/music/a.mp3")));
+        assert!(!tracker.contains_recent(&PathBuf::from("/music/b.mp3")));
+    }
+
+    #[test]
+    fn test_self_write_tracker_expires_after_ttl() {
+        let tracker = SelfWriteTracker::new();
+        let path = PathBuf::from("/music/song.mp3");
+        let now = Instant::now();
+        let marked_at = now - (SELF_WRITE_TTL + std::time::Duration::from_secs(1));
+        tracker.mark_written_at(std::iter::once(path.clone()), marked_at);
+        assert!(!tracker.contains_recent_at(&path, now));
+    }
+
+    #[test]
+    fn test_self_write_tracker_mark_written_sweeps_expired_entries() {
+        let tracker = SelfWriteTracker::new();
+        let stale_path = PathBuf::from("/music/stale.mp3");
+        let fresh_path = PathBuf::from("/music/fresh.mp3");
+        let now = Instant::now();
+        let stale_at = now - (SELF_WRITE_TTL + std::time::Duration::from_secs(1));
+        tracker.mark_written_at(std::iter::once(stale_path.clone()), stale_at);
+
+        // A later mark_written call should sweep the stale entry out.
+        tracker.mark_written_at(std::iter::once(fresh_path.clone()), now);
+
+        assert!(!tracker.contains_recent_at(&stale_path, now));
+        assert!(tracker.contains_recent_at(&fresh_path, now));
     }
 
     #[test]

--- a/src-tauri/src/commands/organizer.rs
+++ b/src-tauri/src/commands/organizer.rs
@@ -27,10 +27,12 @@ pub async fn apply_organize(
 ) -> Result<OrganizeResult, String> {
     let db = &state.db;
     let watcher_paused = &state.watcher_paused;
+    let self_writes = &state.self_writes;
 
     let res = organizer::execute_apply(
         db,
         watcher_paused,
+        self_writes,
         &items,
         clean_empty_dirs,
         move_extra_files,

--- a/src-tauri/src/commands/tageditor.rs
+++ b/src-tauri/src/commands/tageditor.rs
@@ -163,6 +163,12 @@ pub async fn save_song_tags(
         .map_err(|_| "Song not found in library".to_string())?;
 
     let path = std::path::PathBuf::from(path_str);
+    // Close the timing race the coarse guard above can't (#514): the OS's own
+    // change notification for this write may arrive after the guard's grace
+    // window elapses, so track the exact path too.
+    state
+        .self_writes
+        .mark_written(std::iter::once(path.clone()));
 
     // 2. Write metadata back to disk (blocking lofty write in threadpool)
     // The single-song tag editor has no compilation toggle (that's an
@@ -336,6 +342,12 @@ pub async fn save_album_tags(
         }
     }
 
+    // See save_song_tags — close the timing race the coarse guard above can't
+    // (#514) by tracking every path this batch is about to write.
+    state
+        .self_writes
+        .mark_written(songs_data.iter().map(|m| std::path::PathBuf::from(&m.path)));
+
     let album_c = album.clone();
     let albumsort_c = albumsort.clone();
     // Normalize to the canonical `; `-delimited, trimmed, deduped form
@@ -438,6 +450,10 @@ pub async fn clear_song_cover_art(state: State<'_, AppState>, song_id: i64) -> R
         .map_err(|_| "Song not found in library".to_string())?;
 
     let path = std::path::PathBuf::from(path_str);
+    // See save_song_tags — close the timing race the coarse guard above can't (#514).
+    state
+        .self_writes
+        .mark_written(std::iter::once(path.clone()));
     let path_clone = path.clone();
     tauri::async_runtime::spawn_blocking(move || crate::tageditor::clear_embedded_art(&path_clone))
         .await
@@ -484,6 +500,11 @@ pub async fn clear_album_cover_art(
             paths.push((song_id, std::path::PathBuf::from(path_str)));
         }
     }
+
+    // See save_song_tags — close the timing race the coarse guard above can't (#514).
+    state
+        .self_writes
+        .mark_written(paths.iter().map(|(_, p)| p.clone()));
 
     let cleared: Vec<(i64, std::path::PathBuf)> = tauri::async_runtime::spawn_blocking(move || {
         paths

--- a/src-tauri/src/commands/tags.rs
+++ b/src-tauri/src/commands/tags.rs
@@ -1,5 +1,5 @@
 use crate::{
-    collection::WatcherPauseGuard,
+    collection::{SelfWriteTracker, WatcherPauseGuard},
     models::{GenreGroup, QueuePopulationMode, Song, Tag, TagGroup},
     tags::TagManager,
     AppState,
@@ -218,10 +218,16 @@ fn load_full_metadata(conn: &rusqlite::Connection, song_ids: &[i64]) -> Vec<Song
 /// whose on-disk write succeeded.
 async fn rewrite_genre_and_persist(
     conn: r2d2::PooledConnection<r2d2_sqlite::SqliteConnectionManager>,
+    self_writes: &Arc<SelfWriteTracker>,
     song_ids: &[i64],
     rewrite_genre: impl Fn(&str) -> String + Send + 'static,
 ) -> Result<u32, String> {
     let metas = load_full_metadata(&conn, song_ids);
+
+    // See tageditor's save_song_tags — close the timing race the coarse
+    // watcher-pause guard can't (#514) by tracking every path about to be
+    // rewritten.
+    self_writes.mark_written(metas.iter().map(|m| std::path::PathBuf::from(&m.path)));
 
     let (updated_count, writes): (u32, Vec<(i64, String)>) =
         tauri::async_runtime::spawn_blocking(move || {
@@ -301,10 +307,11 @@ pub async fn merge_tags(
 
     let from_c = from.clone();
     let into_c = into.clone();
-    let updated_count = rewrite_genre_and_persist(conn, &song_ids, move |genre| {
-        TagManager::rewrite_genre_for_merge(genre, &from_c, &into_c)
-    })
-    .await?;
+    let updated_count =
+        rewrite_genre_and_persist(conn, &state.self_writes, &song_ids, move |genre| {
+            TagManager::rewrite_genre_for_merge(genre, &from_c, &into_c)
+        })
+        .await?;
 
     manager
         .apply_merge_hierarchy(&from, &into)
@@ -339,10 +346,11 @@ pub async fn delete_tags(
     let song_ids: Vec<i64> = affected.iter().map(|(id, _, _)| *id).collect();
 
     let names_c = names.clone();
-    let updated_count = rewrite_genre_and_persist(conn, &song_ids, move |genre| {
-        TagManager::rewrite_genre_for_delete(genre, &names_c)
-    })
-    .await?;
+    let updated_count =
+        rewrite_genre_and_persist(conn, &state.self_writes, &song_ids, move |genre| {
+            TagManager::rewrite_genre_for_delete(genre, &names_c)
+        })
+        .await?;
 
     manager
         .apply_delete_hierarchy(&names)

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -60,6 +60,8 @@ pub struct AppState {
     /// without one's release re-arming the watcher while the other is still
     /// writing.
     pub watcher_paused: Arc<std::sync::atomic::AtomicU32>,
+    /// Path-aware companion to `watcher_paused` — see `collection::SelfWriteTracker` (#514).
+    pub self_writes: Arc<collection::SelfWriteTracker>,
     pub startup_file: Mutex<Option<String>>,
     /// OS "Now Playing" integration handle (#80) — `None` when the platform
     /// integration failed to initialize (unsupported desktop, no session
@@ -718,6 +720,7 @@ pub fn run() {
             }
 
             let watcher_paused = Arc::new(std::sync::atomic::AtomicU32::new(0));
+            let self_writes = Arc::new(collection::SelfWriteTracker::new());
 
             let state = AppState {
                 db,
@@ -728,6 +731,7 @@ pub fn run() {
                 cover_manager,
                 watcher,
                 watcher_paused,
+                self_writes,
                 startup_file: Mutex::new(startup_path),
                 media_session,
                 minimize_to_tray,

--- a/src-tauri/src/organizer.rs
+++ b/src-tauri/src/organizer.rs
@@ -918,6 +918,7 @@ fn verify_case_on_disk(path: &Path) -> io::Result<bool> {
 pub fn execute_apply(
     db: &Database,
     watcher_paused: &Arc<AtomicU32>,
+    self_writes: &Arc<crate::collection::SelfWriteTracker>,
     items: &[OrganizeApplyItem],
     clean_empty_dirs: bool,
     move_extra_files: bool,
@@ -925,6 +926,15 @@ pub fn execute_apply(
 ) -> Result<OrganizeResult> {
     let _watcher_pause_guard =
         crate::collection::WatcherPauseGuard::new(Arc::clone(watcher_paused));
+
+    // See tageditor's save_song_tags — close the timing race the coarse guard
+    // above can't (#514) by tracking both halves of every move: the source
+    // path (about to disappear) and the destination path (about to appear).
+    self_writes.mark_written(
+        items
+            .iter()
+            .flat_map(|item| [PathBuf::from(&item.from_path), PathBuf::from(&item.to_path)]),
+    );
 
     let mut moved_count = 0;
     let mut skipped_count = 0;
@@ -1645,7 +1655,9 @@ mod tests {
         }];
 
         let watcher_paused = Arc::new(AtomicU32::new(0));
-        let result = execute_apply(&db, &watcher_paused, &items, true, true, None).unwrap();
+        let self_writes = Arc::new(crate::collection::SelfWriteTracker::new());
+        let result =
+            execute_apply(&db, &watcher_paused, &self_writes, &items, true, true, None).unwrap();
         assert_eq!(result.moved_count, 1);
         assert!(result.errors.is_empty());
 
@@ -1725,7 +1737,17 @@ mod tests {
         }];
 
         let watcher_paused = Arc::new(AtomicU32::new(0));
-        let result = execute_apply(&db, &watcher_paused, &items, false, false, None).unwrap();
+        let self_writes = Arc::new(crate::collection::SelfWriteTracker::new());
+        let result = execute_apply(
+            &db,
+            &watcher_paused,
+            &self_writes,
+            &items,
+            false,
+            false,
+            None,
+        )
+        .unwrap();
         assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
         assert_eq!(result.moved_count, 1);
 
@@ -1856,7 +1878,17 @@ mod tests {
             .collect();
 
         let watcher_paused = Arc::new(AtomicU32::new(0));
-        let result = execute_apply(&db, &watcher_paused, &apply_items, false, false, None).unwrap();
+        let self_writes = Arc::new(crate::collection::SelfWriteTracker::new());
+        let result = execute_apply(
+            &db,
+            &watcher_paused,
+            &self_writes,
+            &apply_items,
+            false,
+            false,
+            None,
+        )
+        .unwrap();
         assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
 
         // Re-running preview after Apply must show every song as Unchanged now —


### PR DESCRIPTION
## 📋 Summary
Fixes #514. `WatcherPauseGuard` pauses the realtime file watcher for a self-inflicted write plus a fixed 1500ms grace period to absorb OS notification latency, but the pause check is purely time-based and applies to the whole watcher regardless of path. If the OS's own change notification for a self-inflicted write (tag edit, cover art clear, organizer move, bulk tag merge/delete) arrives after that window closes — plausible on Windows under AV scanning/cloud sync/slow disk, more likely the more files one operation touches — the watcher misreads it as an external change and fires the same `batch-processing-*` events used for real changes, producing a spurious "N songs updated" toast for an edit the user already made.

## 🔍 Implementation Notes
Added `SelfWriteTracker` (`src-tauri/src/collection/watcher.rs`) — a `parking_lot::Mutex<HashMap<PathBuf, Instant>>` with a 30s TTL, exposed as `AppState.self_writes`. Each write call site marks its exact path(s) as soon as it resolves them; the watcher thread's per-path classification loop skips any path still tracked, independent of the coarse `watcher_paused` counter's state, so a late-arriving notification is dropped no matter how long it takes.

`WatcherPauseGuard`/`WATCHER_UNPAUSE_GRACE` are left unchanged — they remain the first-line defense for the pre-path-resolution window and for pathless callers (`scan_all`), which are out of scope here.

Call sites wired up: `save_song_tags`, `save_album_tags`, `clear_song_cover_art`, `clear_album_cover_art` (`commands/tageditor.rs`); `execute_apply` file moves (`organizer.rs` / `commands/organizer.rs`); `merge_tags`/`delete_tags` via the shared `rewrite_genre_and_persist` (`commands/tags.rs`).

A second contributing mechanism surfaced during triage (Genre-view DB scan contention letting a delayed-event backlog flush in a burst) turned out to already be fixed on `next` — `get_tags_overview` already does a single combined scan — so it's out of scope for this PR; see the issue comments for details.

## 🧪 Test Plan
- [x] `bun run check` (svelte-check) — 0 errors
- [ ] `bun run test -- --run` (frontend) — no frontend changes in this PR
- [x] `cargo test` (src-tauri) — 249 passed, 1 ignored (pre-existing), 0 failed; includes 4 new `SelfWriteTracker` unit tests (suppress-recent, ignore-unmarked, expire-after-ttl, sweep-on-mark)
- [x] `cargo clippy --lib` — clean
- [x] Manually verified in the app: edited a single song's genre tag and a whole album's genre tags in `bun run tauri dev`; no spurious "songs updated" toast appeared afterward while idle/browsing

## 📸 Screenshots
Not applicable — no UI change; this is a backend timing-race fix, and no success toast is expected on tag save either way (see issue discussion).

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed — not applicable, no user-facing behavior changed (a spurious toast is being removed, not added)
