### PR TITLE
fix: scope pre-commit hook formatting to staged files only

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -4,8 +4,8 @@ set -euo pipefail
 repo_root="$(git rev-parse --show-toplevel)"
 cd "$repo_root"
 
-if ! command -v cargo >/dev/null 2>&1; then
-  echo "error: cargo is not installed or not on PATH." >&2
+if ! command -v rustfmt >/dev/null 2>&1; then
+  echo "error: rustfmt is not installed or not on PATH." >&2
   exit 1
 fi
 
@@ -20,14 +20,10 @@ if [ ${#rust_files[@]} -eq 0 ]; then
   exit 0
 fi
 
-echo "Formatting staged Rust files in src-tauri with cargo fmt..."
-cargo fmt --manifest-path src-tauri/Cargo.toml
+echo "Formatting staged Rust files in src-tauri with rustfmt..."
+rustfmt --edition 2021 "${rust_files[@]}"
 
 echo "Re-adding formatted Rust files to the index..."
-while IFS= read -r -d '' file; do
-  case "$file" in
-    *.rs) git add -- "$file" ;;
-  esac
-done < <(git diff --name-only -z --diff-filter=AM -- src-tauri)
+git add -- "${rust_files[@]}"
 
-echo "cargo fmt completed and rust files in src-tauri have been re-staged."
+echo "rustfmt completed and staged rust files in src-tauri have been re-staged."


### PR DESCRIPTION
## 📋 Summary
Scopes `.githooks/pre-commit`'s Rust auto-formatting to only the files actually staged for commit. Previously it ran `cargo fmt` across the whole `src-tauri` crate and re-staged *every* modified `.rs` file, silently sweeping unrelated pre-existing formatting drift into unrelated commits (this happened concretely in PR #534 / issue #524). Fixes #535.

## 🔍 Implementation Notes
The hook already computed a `rust_files` array from `git diff --cached` (the actually-staged files) but never used it — formatting and re-staging both ran off broader, unscoped `git diff`/whole-crate calls instead. Replaced whole-crate `cargo fmt --manifest-path src-tauri/Cargo.toml` with `rustfmt --edition 2021 "${rust_files[@]}"`, and replaced the broad re-add loop with `git add -- "${rust_files[@]}"`, so both steps are scoped to `rust_files`.

## 🧪 Test Plan
- [x] Manually verified in a worktree: added an unstaged badly-formatted line to `lib.rs` (simulating pre-existing drift) and a staged badly-formatted line to `audio.rs` (simulating an actual commit), then ran `bash .githooks/pre-commit` directly. Confirmed `audio.rs` was formatted and re-staged while `lib.rs` was left completely untouched.
- [ ] `bun run check` (svelte-check) — not applicable, no frontend changes
- [ ] `bun run test -- --run` (frontend) — not applicable
- [ ] `cargo test` (src-tauri) — not applicable, no Rust source changed

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed — not applicable (dev-tooling only)
