### PR TITLE
ci: stop close-linked-issues workflow from creating comments

### DIFF
--- a/.github/workflows/close-linked-issues.yml
+++ b/.github/workflows/close-linked-issues.yml
@@ -59,12 +59,6 @@ jobs:
                   state: "closed",
                   state_reason: "completed",
                 });
-                await github.rest.issues.createComment({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: issueNumber,
-                  body: `Closed by #${context.payload.pull_request.number}.`,
-                });
                 core.info(`Closed #${issueNumber}.`);
               } catch (err) {
                 core.warning(`Could not close #${issueNumber}: ${err.message}`);


### PR DESCRIPTION
## 📋 Summary
Removes comment creation (`Closed by #N.`) in `.github/workflows/close-linked-issues.yml` when auto-closing issues referenced by PRs merged into `next`. This stops GitHub from sending email notifications for closed issues while retaining automatic issue closure.

## 🔍 Implementation Notes
- Removed the `github.rest.issues.createComment` step in `.github/workflows/close-linked-issues.yml`.
- Retained `github.rest.issues.update({ state: "closed", state_reason: "completed" })` so linked issues are still properly closed with reason `completed`.

## 🧪 Test Plan
- [x] Validated `.github/workflows/close-linked-issues.yml` syntax with `bunx js-yaml`.

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed
