### PR TITLE
fix: issue skill worktree step doesn't match shell sandbox reality

### DIFF
--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: issue
-description: Look up a GitHub issue, confirm its milestone-derived base branch, and set up a dedicated worktree to start work on it
+description: Look up a GitHub issue, confirm its milestone-derived base branch, and prep the session's worktree to start work on it
 ---
 
 Start work on issue $ARGUMENTS.
@@ -13,10 +13,18 @@ Start work on issue $ARGUMENTS.
 3. **Confirm before doing anything**: show the user the issue title, milestone, and the base
    branch you determined, and get an explicit go-ahead. Don't skip this even when the milestone
    makes the base obvious — this confirmation is the whole point of the skill.
-4. **Set up the worktree**: `git fetch origin`, then create a new worktree under
-   `.claude/worktrees/<short-issue-slug>` branched from `origin/<base>` (never reuse an existing
-   worktree folder from a prior task — always create a fresh one). `cd` into it and run `pwd` to
-   verify you're actually there before touching any files.
+4. **Set up the worktree**: `git fetch origin`.
+   - **This session's shell is sandboxed to the worktree it started in**: `cd` into any other
+     worktree only holds for the rest of that same command — the next tool call's `cwd` silently
+     resets back to the original worktree, regardless of `cd`. Verified by direct test (`cd ../x
+     && pwd` shows the new path, but the very next command reports "Shell cwd was reset to ...").
+     So creating a fresh worktree under `.claude/worktrees/<short-issue-slug>` would just be
+     unusable dead weight — skip it.
+   - Instead, reuse the worktree this session is already running from: confirm it's clean
+     (`git status --porcelain --ignored`), then repoint its existing branch onto the correct base
+     with `git reset --hard origin/<base>`. Tell the user you're reusing the current worktree
+     (naming it) and why, rather than creating a fresh `.claude/worktrees/` one as AGENTS.md's
+     Version Control section normally calls for.
 5. **Mark it in progress**: set the issue's Status to "In Progress" on the "Luminous Music Player"
    Project board (`gh project item-edit` — see docs/ISSUE_PRIORITY.md for the field/option IDs).
 6. **Report back**: summarize the issue (what it's asking for, root cause if it's a bug, relevant


### PR DESCRIPTION
## Summary
The `/issue` skill's worktree step always failed silently: it tried to `cd` into a freshly created worktree under `.claude/worktrees/<slug>`, but this session's shell is sandboxed to the worktree it started in — a `cd` only persists for the rest of that same command, and the next tool call's `cwd` resets back. Verified directly by creating a test worktree, `cd`-ing into it, confirming `pwd` showed the new path, then observing the very next command report the cwd reset back.

## Changes
- Removed the dead "create a fresh worktree and cd into it" step.
- The skill now reuses the session's current worktree instead: confirms it's clean, then hard-resets its branch onto the correct base (`main` or `next` per the issue's milestone).
- Updated the skill's frontmatter description to match ("prep the session's worktree" instead of "set up a dedicated worktree").

## Test plan
- [x] Reproduced the failure directly: created a worktree, `cd`'d into it, confirmed the shell cwd reset on the next command.
- [x] Manually walked through the updated skill steps in this session to confirm the reuse-and-reset flow works as written.
