### PR TITLE
fix: match immersive view typography to playbar order and mock

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -433,20 +433,20 @@
 
               <!-- Song Details Info: hidden below md, where it would stack
                    under the cover art instead of sitting beside it. -->
-              <div class="hidden md:flex flex-col text-center md:text-left space-y-4 max-w-md">
+              <div class="hidden md:flex flex-col text-center md:text-left w-full max-w-md">
                 <div>
                   <span class="px-3 py-1 text-xs font-semibold uppercase tracking-wider bg-brand-accent/15 text-brand-accent-text border border-brand-border rounded-full select-none">
                     {i18n.t('playerBar.nowPlaying')}
                   </span>
                 </div>
-                <h1 class="text-3xl md:text-5xl font-black text-brand-text-primary leading-tight tracking-tight select-text">
+                <h1 class="mt-3 text-4xl md:text-6xl font-black text-brand-text-primary leading-[0.95] tracking-tight select-text">
                   {playerStore.currentSong.title || i18n.t('collection.unknownSong')}
                 </h1>
-                <p class="text-lg md:text-xl text-brand-text-secondary select-text font-medium">
-                  {playerStore.currentSong.artist || i18n.t('collection.unknownArtist')}
-                </p>
-                <p class="text-sm text-brand-text-secondary/60 italic truncate select-text">
+                <p class="mt-3 text-lg md:text-xl text-brand-text-secondary select-text font-semibold">
                   {playerStore.currentSong.album || i18n.t('collection.unknownAlbum')}
+                </p>
+                <p class="mt-0.5 text-base md:text-lg text-brand-text-secondary/70 select-text font-medium">
+                  {playerStore.currentSong.artist || i18n.t('collection.unknownArtist')}
                 </p>
               </div>
             {:else}


### PR DESCRIPTION
## 📋 Summary
Cleans up the immersive (album-art) view's song typography.

## 🔍 Implementation Notes
Touches `src/routes/+layout.svelte` only, in the "BACK FACE: Immersive Dedicated Album Artwork Screen" section. Reordered the text stack to title/album/artist to match the order used in `PlayerBar.svelte`, tightened the title's line height and bumped its size, and gave album/artist distinct weights so the hierarchy reads more clearly. Also fixed the text column to a constant width (`w-full max-w-md` instead of `max-w-md`) so the flex row's total width — and therefore the cover art's centered position — no longer shifts depending on how long the title/album/artist text happens to be. Artist is now spaced tighter to album (`mt-0.5`) than the other lines (`mt-3`).

## 🧪 Test Plan
- [ ] `bun run check` (svelte-check)
- [ ] `bun run test -- --run` (frontend)
- [ ] `cargo test` (src-tauri, if Rust changed)
- [x] Manually verified in the app by the user against a reference mock

## 📸 Screenshots
N/A — verified live in the running app by the user.

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed (no screenshot harness entry needed — no new feature, just typography/layout tweak)

Fixes #701 (filed retroactively during 1.6 release scope review).