### PR TITLE
fix: don't force Various Artists pill on compilations with a real album artist

### DIFF
--- a/src/lib/components/AlbumTagEditor.svelte
+++ b/src/lib/components/AlbumTagEditor.svelte
@@ -204,7 +204,7 @@
           </FormField>
 
           <FormField label={i18n.t('albumTagEditor.albumArtistField')} for="album-tag-albumartist" span2>
-            {#if compilation}
+            {#if compilation && albumArtist === VARIOUS_ARTISTS}
               <div class="flex items-center h-9">
                 <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full border border-brand-border bg-brand-main text-xs font-semibold text-brand-text-primary">
                   {VARIOUS_ARTISTS}

--- a/src/lib/components/AlbumTagEditor.test.ts
+++ b/src/lib/components/AlbumTagEditor.test.ts
@@ -333,6 +333,21 @@ describe("AlbumTagEditor.svelte", () => {
     });
   });
 
+  it("shows the real Album Artist as an editable field for a compilation-flagged album whose artist isn't literally Various Artists", async () => {
+    const onClose = vi.fn();
+    const { getByLabelText, getByText, queryByText } = render(AlbumTagEditor, {
+      songIds: [101],
+      initialAlbum: "Greatest Hits",
+      initialAlbumArtist: "Artist A",
+      initialCompilation: true,
+      onClose,
+    });
+
+    expect(getByLabelText("Album Artist")).toBeInTheDocument();
+    expect(getByText("Artist A")).toBeInTheDocument();
+    expect(queryByText("Various Artists")).not.toBeInTheDocument();
+  });
+
   it("disables Clear Embedded Artwork when no track in the album has embedded art", async () => {
     const onClose = vi.fn();
     const { getByRole } = render(AlbumTagEditor, {

--- a/src/lib/components/TagEditor.svelte
+++ b/src/lib/components/TagEditor.svelte
@@ -414,7 +414,7 @@
               {#if compilation}
                 <div class="flex items-center h-9">
                   <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full border border-brand-border bg-brand-main text-xs font-semibold text-brand-text-primary">
-                    Various Artists
+                    {albumArtist}
                     <Lock class="w-3 h-3 text-brand-text-secondary shrink-0" />
                   </span>
                 </div>

--- a/src/lib/components/TagEditor.test.ts
+++ b/src/lib/components/TagEditor.test.ts
@@ -89,6 +89,25 @@ describe("TagEditor.svelte", () => {
     expect(queryByLabelText("Album Artist")).not.toBeInTheDocument();
   });
 
+  it("shows the real Album Artist in the read-only pill for a compilation-flagged track whose artist isn't literally Various Artists", async () => {
+    vi.mocked(invoke).mockImplementation(async (cmd: string) => {
+      if (cmd === "get_song_details") {
+        return { ...mockSongDetails, album_artist: "Artist A", compilation: true };
+      }
+      if (cmd === "get_library_snapshot") return { songs: [], albums: [], artists: [] };
+      return null;
+    });
+
+    const onClose = vi.fn();
+    const { getByText, queryByText, queryByLabelText } = render(TagEditor, { songId: 10, onClose });
+
+    await waitFor(() => {
+      expect(getByText("Artist A")).toBeInTheDocument();
+    });
+    expect(queryByText("Various Artists")).not.toBeInTheDocument();
+    expect(queryByLabelText("Album Artist")).not.toBeInTheDocument();
+  });
+
   it("calls onClose when cancel button is clicked", async () => {
     const onClose = vi.fn();
     const { getByRole } = render(TagEditor, { songId: 10, onClose });


### PR DESCRIPTION
## 📋 Summary
Fixes #690. Editing a compilation-flagged album (or track) whose Album Artist was a real name — not literally "Various Artists" — showed a locked "Various Artists" pill in the tag editor, hiding the actual value.

## 🔍 Implementation Notes
- `AlbumTagEditor.svelte`: the Album Artist field now only renders the locked "Various Artists" pill when `compilation` is true **and** the album artist genuinely is "Various Artists"; otherwise it falls through to the normal editable field showing the real value.
- `TagEditor.svelte`: the read-only pill (album-level compilation is edited via `AlbumTagEditor`, so this view stays read-only) now renders the actual `albumArtist` value instead of a hardcoded "Various Artists" string.

## 🧪 Test Plan
- [x] `bun run check` (svelte-check) — 0 errors
- [x] `bun run test -- --run` (frontend) — `AlbumTagEditor.test.ts` and `TagEditor.test.ts` pass (22/22), including two new regression tests for a compilation-flagged album/track with a real artist name
- [ ] `cargo test` (src-tauri, if Rust changed) — no Rust changes
- [x] Manually verified in the app by the user

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed — not applicable (bugfix, no new feature/screenshot)
