### PR TITLE
fix: clone from the correct base branch in Flathub submission script

### DIFF
--- a/scripts/submit-flathub.ts
+++ b/scripts/submit-flathub.ts
@@ -46,6 +46,11 @@ async function main() {
   console.log(`Resolved ${tagArg} -> ${commit}`);
 
   const branchName = REPO === "flathub/flathub" ? APP_ID : "master";
+  // New-app submissions branch off flathub/flathub's `new-pr` branch, not its
+  // `master` — see https://github.com/flathub/flathub/blob/master/CONTRIBUTING.md.
+  // Post-acceptance updates against flathub/org.luminous.music branch off its
+  // normal `master`.
+  const baseBranch = REPO === "flathub/flathub" ? "new-pr" : "master";
 
   // Build the submission manifest: same as the in-repo one, but with the
   // `type: dir` local-checkout source swapped for a pinned `type: git` source
@@ -91,10 +96,15 @@ async function main() {
     console.log("Fork already exists or succeeded with notice.");
   }
 
-  console.log(`Cloning esoltys/${REPO_NAME} (shallow)...`);
-  execSync(`git clone --depth=1 https://github.com/esoltys/${REPO_NAME}.git "${tmpDir}"`, {
-    stdio: "inherit",
-  });
+  // Clone directly at baseBranch (not the fork's default branch) — a plain
+  // `git clone --depth=1` grabs the default branch (master), and master has
+  // no shared history with new-pr on flathub/flathub, which makes GitHub
+  // reject the PR later ("no history in common").
+  console.log(`Cloning esoltys/${REPO_NAME} (shallow, base: ${baseBranch})...`);
+  execSync(
+    `git clone --depth=1 --branch ${baseBranch} https://github.com/esoltys/${REPO_NAME}.git "${tmpDir}"`,
+    { stdio: "inherit" },
+  );
 
   try {
     execSync(`git checkout -b ${branchName}`, { cwd: tmpDir, stdio: "inherit" });
@@ -116,12 +126,6 @@ async function main() {
 
   console.log(`Pushing branch ${branchName}...`);
   execSync(`git push -u origin ${branchName} --force`, { cwd: tmpDir, stdio: "inherit" });
-
-  // New-app submissions land on flathub/flathub's `new-pr` branch, not
-  // `master` — see https://github.com/flathub/flathub/blob/master/CONTRIBUTING.md.
-  // Post-acceptance updates against flathub/org.luminous.music use its normal
-  // `master` branch, matching `branchName` above.
-  const baseBranch = REPO === "flathub/flathub" ? "new-pr" : "master";
 
   console.log(`Creating Pull Request to ${REPO} (base: ${baseBranch})...`);
   const prCmd = `gh pr create --repo ${REPO} --head esoltys:${branchName} --base ${baseBranch} --title "${APP_ID}: ${tagArg}" --body "Update Luminous Flatpak manifest to ${tagArg}."`;


### PR DESCRIPTION
## 📋 Summary
Follow-up to #478/#693. The real initial submission ([flathub/flathub#10022](https://github.com/flathub/flathub/pull/10022)) surfaced one more bug in `scripts/submit-flathub.ts`: `git clone --depth=1` without `--branch` grabs the fork's *default* branch (`master`), so the submission branch was created off `master` instead of `new-pr`. Since those two branches share no history on `flathub/flathub`, GitHub rejected the PR creation with "no history in common" on the first real attempt. Fixed by cloning directly at the intended base branch.

## 🔍 Implementation Notes
- `baseBranch` (`new-pr` for new submissions, `master` for post-acceptance updates) is now computed once near the top and reused for both the clone and the `gh pr create --base` call.
- Verified against the real target: after the fix, re-running the script produced a submission branch with correct shared history, and the PR was created successfully.

## 🧪 Test Plan
- [x] `bun run check` (svelte-check) — clean
- [ ] `bun run test -- --run` (frontend) — not applicable
- [ ] `cargo test` (src-tauri) — not applicable
- [x] Manually verified in the app: this is the fix that unblocked the actual real-world submission — flathub/flathub#10022 was successfully opened using this corrected script

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed — not applicable
