### PR TITLE
fix: use Flathub's required PR title format for new submissions

### DIFF
--- a/scripts/submit-flathub.ts
+++ b/scripts/submit-flathub.ts
@@ -134,8 +134,14 @@ async function main() {
   console.log(`Pushing branch ${branchName}...`);
   execSync(`git push -u origin ${branchName} --force`, { cwd: tmpDir, stdio: "inherit" });
 
+  // Flathub's submission-checker bot hard-requires this exact title format
+  // for a NEW submission ("Add $FLATPAK_ID") — confirmed by a real rejection
+  // ("PR title is 'Add $FLATPAK_ID'"). Post-acceptance updates aren't new
+  // submissions, so they keep the old descriptive title.
+  const prTitle = REPO === "flathub/flathub" ? `Add ${APP_ID}` : `${APP_ID}: ${tagArg}`;
+
   console.log(`Creating Pull Request to ${REPO} (base: ${baseBranch})...`);
-  const prCmd = `gh pr create --repo ${REPO} --head esoltys:${branchName} --base ${baseBranch} --title "${APP_ID}: ${tagArg}" --body "Update Luminous Flatpak manifest to ${tagArg}."`;
+  const prCmd = `gh pr create --repo ${REPO} --head esoltys:${branchName} --base ${baseBranch} --title "${prTitle}" --body "Update Luminous Flatpak manifest to ${tagArg}."`;
   execSync(prCmd, { cwd: tmpDir, stdio: "inherit" });
 
   fs.rmSync(tmpDir, { recursive: true, force: true });


### PR DESCRIPTION
## 📋 Summary
Follow-up to #478. Flathub's `submission-checker` bot rejected the real new-app submission ([flathub/flathub#10024](https://github.com/flathub/flathub/pull/10024)) as "blocked" because the PR title didn't match its required format: `Add $FLATPAK_ID`. `scripts/submit-flathub.ts` was titling every submission `"${APP_ID}: ${tagArg}"`, which only fits a post-acceptance update, not the initial submission.

## 🔍 Implementation Notes
- New-app submissions to `flathub/flathub` now get the title `Add ${APP_ID}`.
- Post-acceptance updates (against `flathub/io.github.esoltys.Luminous` once accepted) keep the previous descriptive title, since that requirement is specific to new submissions.

## 🧪 Test Plan
- [x] `bun run check` (svelte-check) — clean
- [ ] `bun run test -- --run` (frontend) — not applicable
- [ ] `cargo test` (src-tauri) — not applicable
- [x] Manually verified: fixed the real PR's title (`gh pr edit`) to match, confirming the exact required format, then applied the same logic in the script for future runs

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed — not applicable
