### PR TITLE
ci: authenticate close-linked-issues with a PAT to stop close-email notifications

### DIFF
--- a/.github/workflows/close-linked-issues.yml
+++ b/.github/workflows/close-linked-issues.yml
@@ -25,6 +25,12 @@ jobs:
       - name: Close issues referenced by closing keywords
         uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
         with:
+          # Authenticate as the repo owner (via a fine-grained PAT) rather than
+          # the default GITHUB_TOKEN, which attributes closes to github-actions[bot].
+          # GitHub suppresses notification emails for actions you perform yourself,
+          # but not for a bot acting on an issue you're subscribed to — a PAT-backed
+          # close is treated the same as the native "Fixes #N" auto-close on `main`.
+          github-token: ${{ secrets.ISSUE_CLOSE_PAT }}
           script: |
             const keywordPattern = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s*:?\s*#(\d+)/gi;
             const text = `${context.payload.pull_request.title}\n${context.payload.pull_request.body ?? ""}`;


### PR DESCRIPTION
## 📋 Summary
Fixes #704. Merging a PR into `next` that references "Fixes #N" closes the linked issue via `close-linked-issues.yml`, but the default `GITHUB_TOKEN` attributes that close to `github-actions[bot]` rather than the repo owner. GitHub only suppresses notification emails for actions you perform yourself, so every `next`-branch merge that closes an issue still emails the owner, even after #683 removed the "Closed by #N" comment. Merges into `main` don't have this problem because GitHub's native auto-close runs as the merging user.

## 🔍 Implementation Notes
- Added `github-token: ${{ secrets.ISSUE_CLOSE_PAT }}` to the `actions/github-script` step so the close is attributed to the repo owner (via a fine-grained PAT scoped to this repo, Issues: read/write), matching the native auto-close's self-action behavior.
- `ISSUE_CLOSE_PAT` has already been added as a repository secret.
- Left the workflow's `permissions:` block as-is; it's now unused by this step but harmless.

## 🧪 Test Plan
- [x] Validated `.github/workflows/close-linked-issues.yml` syntax with `bunx js-yaml`.
- [ ] Behavior itself is only verifiable by watching the next real merge into `next` and confirming no notification email arrives.

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed — not applicable (CI-only change)
