### PR TITLE
docs: add opendesktop.org listing update to release checklist

### DIFF
--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -105,5 +105,9 @@ manual.
 - [ ] Verify the in-app updater picks up the new release from an older installed version
       (the app checks for updates on launch — confirm the prompt/flow actually works end
       to end, not just that the build has `createUpdaterArtifacts` set).
+- [ ] Update the [opendesktop.org listing](https://www.opendesktop.org/c/2370163/) with the
+      new `.deb`/`.rpm` (via "Add URL" pointing at the GitHub release assets, not a
+      re-upload) and a changelog entry. This is a manual listing with no automated sync —
+      it'll silently go stale the same way the winget manifest did (#476) if skipped.
 - [ ] Close/link the GitHub issues resolved by this release; update the milestone if one's
       in use.

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -108,6 +108,6 @@ manual.
 - [ ] Update the [opendesktop.org listing](https://www.opendesktop.org/c/2370163/) with the
       new `.deb`/`.rpm` (via "Add URL" pointing at the GitHub release assets, not a
       re-upload) and a changelog entry. This is a manual listing with no automated sync —
-      it'll silently go stale the same way the winget manifest did (#476) if skipped.
+      easy to let it silently go stale if skipped.
 - [ ] Close/link the GitHub issues resolved by this release; update the milestone if one's
       in use.


### PR DESCRIPTION
## 📋 Summary
Adds a reminder to `docs/RELEASE_CHECKLIST.md` to update the [opendesktop.org listing](https://www.opendesktop.org/c/2370163/) (new `.deb`/`.rpm` links + changelog) on every release.

## 🔍 Implementation Notes
This listing has no automated sync back to GitHub releases — it's a manual upload/URL-link step on opendesktop.org itself. Without a checklist reminder it's exactly the kind of thing that silently drifts, the same way the winget manifest went stale for months unnoticed (#476).

## 🧪 Test Plan
- [x] Docs-only change, no build/test impact

## ✅ Checklist
- [x] No unrelated changes bundled in
