### PR TITLE
feat: capture Rust panics to a log file (#684)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -481,6 +481,40 @@ fn register_media_shortcuts(app: &tauri::App) {
     }
 }
 
+/// Installs a panic hook that appends the panic message, location, and a
+/// backtrace to `panic.log` in `log_dir`, then falls through to the default
+/// hook so the message still reaches stderr as before. Without this, a
+/// panic in a non-terminal launch (the normal desktop case) leaves no trace
+/// anywhere — the process just dies (#684).
+fn install_panic_hook(log_dir: std::path::PathBuf) {
+    let default_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        default_hook(info);
+
+        if let Err(e) = std::fs::create_dir_all(&log_dir) {
+            log::error!("Failed to create log dir for panic log: {e}");
+            return;
+        }
+
+        let backtrace = std::backtrace::Backtrace::force_capture();
+        let entry = format!(
+            "[{}] {}\n{}\n\n",
+            chrono::Local::now().to_rfc3339(),
+            info,
+            backtrace
+        );
+
+        if let Err(e) = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(log_dir.join("panic.log"))
+            .and_then(|mut f| std::io::Write::write_all(&mut f, entry.as_bytes()))
+        {
+            log::error!("Failed to write panic log: {e}");
+        }
+    }));
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     // Without this, every log::info!/warn!/error! call across the backend
@@ -626,6 +660,10 @@ pub fn run() {
             }
         }))
         .setup(|app| {
+            if let Ok(log_dir) = app.path().app_log_dir() {
+                install_panic_hook(log_dir);
+            }
+
             let db = Arc::new(
                 Database::new(app.path().app_data_dir().expect("no app data dir"))
                     .expect("failed to initialize database"),


### PR DESCRIPTION
## Summary

Installs a panic hook in `run()`'s `.setup()` closure that appends the panic message, location, and a backtrace to `panic.log` under the app's log dir, then falls through to the default hook so stderr output is unchanged. Previously a Rust panic was only visible when Luminous was launched from a terminal — a normal desktop launch left no trace anywhere.

This is the Rust panic-capture piece of #684 (Crash/panic diagnostics capture and export). Frontend error capture and the diagnostics export command are tracked as follow-up work on that issue and are not part of this PR.

## Changes

- `src-tauri/src/lib.rs`: adds `install_panic_hook(log_dir)` and wires it in as the first step of `.setup()`, using `app.path().app_log_dir()`.

## Test Plan

- [x] `cargo check --lib`
- [x] `cargo fmt -- --check src/lib.rs`

Part of #684