### PR TITLE
fix: remove unused isMac export flagged by knip

### DIFF
--- a/src/lib/platform.ts
+++ b/src/lib/platform.ts
@@ -8,4 +8,3 @@ const platform = typeof navigator !== "undefined" ? navigator.platform : "";
 
 export const isLinux = /linux/i.test(userAgent) || /linux/i.test(platform);
 export const isWindows = userAgent.includes("Windows") || platform.includes("Win");
-export const isMac = /mac/i.test(userAgent) || /mac/i.test(platform);


### PR DESCRIPTION
## 📋 Summary
CI on `next` is red: `bun run knip` fails with "Unused exports (1): isMac src/lib/platform.ts:11:14". `isMac` was added in the platform-detection consolidation (70e2b22) for symmetry with `isLinux`/`isWindows`, but no call site ever used it (only Linux/Windows sniffing had duplicated implementations to consolidate), and `knip` was added shortly after that commit, catching the dead export on the next push to `next`.

## 🔍 Implementation Notes
Removed the unused `isMac` export from `src/lib/platform.ts`. `isLinux` and `isWindows` are untouched and still used at their existing call sites.

## 🧪 Test Plan
- [x] `bun run check` (svelte-check + knip, now clean)

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed — n/a, no user-facing change
