### PR TITLE
docs: update Epic template and instructions for sub-issues and related section

### DIFF
--- a/.github/ISSUE_TEMPLATE/epic.md
+++ b/.github/ISSUE_TEMPLATE/epic.md
@@ -10,10 +10,9 @@ labels: []
 
 This issue tracks the overall effort at a glance. Implementation detail lives in the sub-issues below, not here.
 
-## Sub-issues
-<!-- Checklist of the issues that make up this epic. Check off closed ones; leave open ones unchecked. -->
+<!-- Note: Do NOT list sub-issues in the description body — GitHub automatically displays them below the description if they are properly added as sub-issues (e.g. `gh issue edit <epic-id> --add-sub-issue <id1>,<id2>...` or via the GitHub web UI). -->
 
-- [ ] #0 — <!-- short description -->
-
+<!-- Optional: If there are adjacent issues that inform or overlap with this epic but aren't part of its scope, include a ## Related section below. If there are no related issues, leave the section out entirely.
 ## Related
-<!-- Optional: adjacent issues that inform or overlap with this epic but aren't part of its scope. -->
+- #0 — short description
+-->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -219,6 +219,7 @@ verify with the user, not a reason to skip telling them.
 
 - Never hand-wrap lines in GitHub issue/PR bodies — GitHub renders single newlines as hard breaks. Write paragraphs as one long line.
 - Always use the repo PR template and the Epic/issue templates in `.github/`.
+- For Epic issues: do not list sub-issues in the description body — GitHub automatically shows them below the description if they are properly added as sub-issues (e.g. `gh issue edit <epic-id> --add-sub-issue <ids>`). If there are no related issues, leave the `## Related` section out entirely.
 - Do NOT apply priority labels to issues. Priority lives in the Project board only.
 
 ## Issue Priority
@@ -243,13 +244,14 @@ punt either to the user.
 - After creating a PR, provide the PR link directly to the user for review and merge. You do not need to monitor or wait for CI checks — the user will make sure the checks complete before merging.
 - Only after the user has reviewed and merged the PR on GitHub should the corresponding issues be confirmed closed and their Status set to "Done" on the Project board. On Windows, `git worktree remove` fails with "Permission denied" on the worktree the current session is running from (open file handles keep it locked) — hand the `git worktree remove`/`git branch -d` commands to the user to run themselves in that case instead of retrying.
 - **Creating Issues & Pull Requests**:
-  1. Inspect the relevant templates under `.github/ISSUE_TEMPLATE/` (e.g., `bug_report.md`, `feature_request.md`) when creating issues.
+  1. Inspect the relevant templates under `.github/ISSUE_TEMPLATE/` (e.g., `bug_report.md`, `feature_request.md`, `epic.md`) when creating issues.
   2. Inspect `.github/PULL_REQUEST_TEMPLATE.md` when preparing or creating Pull Requests.
   3. Perform a codebase search or analysis to fill out the template's sections (Description, Root Cause Analysis, Affected Components & Code Locations, Proposed Solution) accurately.
   4. Write the issue or PR body to a temporary scratch file in the workspace or the artifacts scratch directory.
   5. Create the issue using the GitHub CLI:
      - For bugs: `gh issue create --title "<Title>" --body-file "<PathToScratchFile>" --label "bug" --milestone "<Milestone>"`
      - For features: `gh issue create --title "<Title>" --body-file "<PathToScratchFile>" --milestone "<Milestone>"` (no label needed)
+     - For epics: `gh issue create --title "Epic: <Title>" --body-file "<PathToScratchFile>" --milestone "<Milestone>"` (no label needed). After creating the epic, link its sub-issues with `gh issue edit <epic-id> --add-sub-issue <id1>,<id2>...`. Never list sub-issues in the issue description body (GitHub automatically shows them below the description when added as sub-issues). If there are no related issues, leave the `## Related` section out entirely.
      - Never add `--label P1`/`P2`/`P3`/`P4` (see Issue Priority above) — priority is a Project
        field, not a label.
   6. Verify the created issue by running `gh issue view <id>`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,7 @@ A release is only complete when **all three** of the following hold. Never repor
 
 ## GitHub issue/PR body formatting
 - GitHub renders a single `\n` within a paragraph as a hard line break (not CommonMark's soft-wrap-to-space behavior). Never hand-wrap prose paragraphs in an issue/PR body at ~80-100 cols like source code — write each paragraph and each bullet as one unwrapped line, or the rendered body shows spurious mid-sentence line breaks.
+- Epic issues: do not list sub-issues in the description body — GitHub automatically shows them below the description if they are properly added as sub-issues (`gh issue edit <epic-id> --add-sub-issue <ids>`). If there are no related issues, leave the `## Related` section out entirely.
 
 ## Claude Code specifics
 


### PR DESCRIPTION
## 📋 Summary
Updates the Epic issue template and canonical instructions to align with GitHub's native sub-issues feature: sub-issues are not manually listed in the issue body since GitHub displays them automatically below the description when linked, and the Related section is omitted if there are no related issues.

## 🔍 Implementation Notes
- `.github/ISSUE_TEMPLATE/epic.md`: Removed the manual `## Sub-issues` checklist section and commented out the optional `## Related` section with a reminder to omit it if there are no related issues. Added a note explaining how native sub-issues work.
- `AGENTS.md`: Added Epic guidance to `## Issue & PR Formatting` and updated step 1 & 5 in `Creating Issues & Pull Requests` to cover `epic.md`, `gh issue edit --add-sub-issue`, and omitting the Related section when empty.
- `CLAUDE.md`: Added matching Epic formatting instruction under `## GitHub issue/PR body formatting`.

## 🧪 Test Plan
- [x] Verified template rendering and markdown comments in `.github/ISSUE_TEMPLATE/epic.md`
- [x] Verified formatting across `AGENTS.md` and `CLAUDE.md`

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed (see `.claude/CLAUDE.md` for the screenshot harness)
