### PR TITLE
feat: copy error notification text to clipboard

### DIFF
--- a/src/lib/components/Toast.svelte
+++ b/src/lib/components/Toast.svelte
@@ -6,10 +6,17 @@
     InfoIcon as Info,
     ChecksIcon as CheckCheck,
     SparkleIcon as Sparkles,
-    XIcon as X
+    XIcon as X,
+    ClipboardIcon as Clipboard,
+    CheckIcon as Check
   } from "phosphor-svelte";
   import { toastStore } from "../stores/toast.svelte";
+  import { i18n } from "../stores/i18n.svelte";
   import { portal } from "../utils/portal";
+
+  const COPY_FEEDBACK_DURATION_MS = 1500;
+  let copiedToastId = $state<number | null>(null);
+  let copyTimeout: ReturnType<typeof setTimeout> | null = null;
 
   async function openExternalUrl(url: string) {
     try {
@@ -19,6 +26,38 @@
       window.open(url, "_blank");
     }
   }
+
+  async function copyToClipboard(id: number, text: string) {
+    try {
+      if (navigator?.clipboard?.writeText) {
+        await navigator.clipboard.writeText(text);
+      } else {
+        const textArea = document.createElement("textarea");
+        textArea.value = text;
+        textArea.style.position = "fixed";
+        textArea.style.left = "-999999px";
+        textArea.style.top = "-999999px";
+        document.body.appendChild(textArea);
+        textArea.focus();
+        textArea.select();
+        document.execCommand("copy");
+        textArea.remove();
+      }
+      if (copyTimeout) clearTimeout(copyTimeout);
+      copiedToastId = id;
+      copyTimeout = setTimeout(() => {
+        if (copiedToastId === id) copiedToastId = null;
+      }, COPY_FEEDBACK_DURATION_MS);
+    } catch (err) {
+      console.error("Failed to copy error to clipboard:", err);
+    }
+  }
+
+  $effect(() => {
+    return () => {
+      if (copyTimeout) clearTimeout(copyTimeout);
+    };
+  });
 </script>
 
 <div
@@ -64,12 +103,42 @@
       {:else}
         <span class="flex-1">{toast.text}</span>
       {/if}
-      <button
-        onclick={() => toastStore.dismiss(toast.id)}
-        class="shrink-0 opacity-60 hover:opacity-100 transition-opacity"
-      >
-        <X class="w-3.5 h-3.5" />
-      </button>
+      <div class="flex items-center gap-1 shrink-0">
+        {#if toast.variant === "error"}
+          <button
+            type="button"
+            onclick={() => copyToClipboard(toast.id, toast.text)}
+            class="opacity-60 hover:opacity-100 transition-opacity p-0.5 rounded cursor-pointer"
+            title={copiedToastId === toast.id
+              ? i18n.t('toast.copied', {}, 'Copied to clipboard')
+              : i18n.t('toast.copyError', {}, 'Copy error to clipboard')}
+            aria-label={copiedToastId === toast.id
+              ? i18n.t('toast.copied', {}, 'Copied to clipboard')
+              : i18n.t('toast.copyError', {}, 'Copy error to clipboard')}
+          >
+            {#if copiedToastId === toast.id}
+              <Check class="w-3.5 h-3.5 text-emerald-400" />
+            {:else}
+              <Clipboard class="w-3.5 h-3.5" />
+            {/if}
+          </button>
+        {/if}
+        <button
+          type="button"
+          onclick={() => {
+            if (copiedToastId === toast.id) {
+              if (copyTimeout) clearTimeout(copyTimeout);
+              copiedToastId = null;
+            }
+            toastStore.dismiss(toast.id);
+          }}
+          class="opacity-60 hover:opacity-100 transition-opacity p-0.5 rounded cursor-pointer"
+          title={i18n.t('toast.dismiss', {}, 'Dismiss notification')}
+          aria-label={i18n.t('toast.dismiss', {}, 'Dismiss notification')}
+        >
+          <X class="w-3.5 h-3.5" />
+        </button>
+      </div>
     </div>
   {/each}
 </div>

--- a/src/lib/components/Toast.test.ts
+++ b/src/lib/components/Toast.test.ts
@@ -1,0 +1,98 @@
+import "@testing-library/jest-dom";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/svelte";
+import Toast from "./Toast.svelte";
+import { toastStore } from "../stores/toast.svelte";
+import { i18n } from "../stores/i18n.svelte";
+
+vi.mock("@tauri-apps/plugin-opener", () => ({
+  openUrl: vi.fn().mockResolvedValue(undefined),
+}));
+
+describe("Toast.svelte", () => {
+  let writeTextMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    i18n.currentLocale = "en";
+    writeTextMock = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, {
+      clipboard: {
+        writeText: writeTextMock,
+      },
+    });
+    for (const m of [...toastStore.messages]) {
+      toastStore.dismiss(m.id);
+    }
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("renders an error toast with a copy button and copies text to clipboard on click", async () => {
+    toastStore.show("Failed to save tags: write error", "error");
+
+    render(Toast);
+
+    expect(screen.getByText("Failed to save tags: write error")).toBeInTheDocument();
+
+    const copyBtn = screen.queryByLabelText("Copy error to clipboard");
+    expect(copyBtn).toBeInTheDocument();
+    expect(copyBtn).toHaveAttribute("title", "Copy error to clipboard");
+
+    await fireEvent.click(copyBtn!);
+
+    expect(writeTextMock).toHaveBeenCalledWith("Failed to save tags: write error");
+
+    expect(screen.queryByLabelText("Copied to clipboard")).toBeInTheDocument();
+
+    await vi.advanceTimersByTimeAsync(1500);
+
+    expect(screen.queryByLabelText("Copy error to clipboard")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Copied to clipboard")).not.toBeInTheDocument();
+  });
+
+  it("does not render a copy button for non-error toasts", () => {
+    toastStore.show("Playlist saved", "success");
+    toastStore.show("Scanned 50 songs", "info");
+    toastStore.show("Playback warning", "warning");
+    toastStore.show("Milestone reached!", "milestone");
+
+    render(Toast);
+
+    expect(screen.queryByLabelText("Copy error to clipboard")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/copy/i)).not.toBeInTheDocument();
+  });
+
+  it("dismisses the toast when clicking the dismiss button", async () => {
+    const id = toastStore.show("Temporary error", "error");
+
+    render(Toast);
+
+    const dismissBtn = screen.getByLabelText("Dismiss notification");
+    expect(dismissBtn).toBeInTheDocument();
+
+    await fireEvent.click(dismissBtn);
+
+    expect(toastStore.messages.find((m) => m.id === id)).toBeUndefined();
+  });
+
+  it("renders localized labels in French", async () => {
+    i18n.currentLocale = "fr";
+    toastStore.show("Échec de l'enregistrement", "error");
+
+    render(Toast);
+
+    const copyBtn = screen.queryByLabelText("Copier l'erreur dans le presse-papiers");
+    expect(copyBtn).toBeInTheDocument();
+    expect(copyBtn).toHaveAttribute("title", "Copier l'erreur dans le presse-papiers");
+
+    const dismissBtn = screen.queryByLabelText("Fermer la notification");
+    expect(dismissBtn).toBeInTheDocument();
+
+    await fireEvent.click(copyBtn!);
+
+    expect(screen.queryByLabelText("Copié dans le presse-papiers")).toBeInTheDocument();
+  });
+});

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -871,6 +871,11 @@ export const en = {
     expand: "Expand",
     collapse: "Collapse"
   },
+  toast: {
+    copyError: "Copy error to clipboard",
+    copied: "Copied to clipboard",
+    dismiss: "Dismiss notification"
+  },
   songTags: {
     genresTabDescription: "Showing {count} genres",
     viewGenre: "Genre",

--- a/src/lib/locales/fr.ts
+++ b/src/lib/locales/fr.ts
@@ -903,6 +903,11 @@ export const fr = {
     expand: "Développer",
     collapse: "Réduire"
   },
+  toast: {
+    copyError: "Copier l'erreur dans le presse-papiers",
+    copied: "Copié dans le presse-papiers",
+    dismiss: "Fermer la notification"
+  },
   organizer: {
     title: "Organiser les fichiers",
     subtitle: "Renommer et réorganiser les fichiers selon un modèle de tags",


### PR DESCRIPTION
## 📋 Summary
Adds a "Copy to Clipboard" action button to error notifications (toasts), allowing users to easily copy diagnostic error text with a single click. Closes #727.

## 🔍 Implementation Notes
- In `src/lib/components/Toast.svelte`, rendered a copy button alongside the dismiss button specifically for error toasts (`toast.variant === 'error'`).
- Uses `ClipboardIcon` from `phosphor-svelte`, switching to `CheckIcon` with an emerald highlight for 1.5 seconds upon copying for visual confirmation.
- Writes to clipboard using `navigator.clipboard.writeText(text)` with a fallback for restricted environments.
- Added full bilingual localization (`toast.copyError`, `toast.copied`, `toast.dismiss`) across English (`src/lib/locales/en.ts`) and French (`src/lib/locales/fr.ts`).
- Added unit tests in `src/lib/components/Toast.test.ts` to verify copying, feedback icon swapping, non-error variant exclusion, dismissal, and French localization.

## 🧪 Test Plan
- [x] `bun run check` (svelte-check: 0 errors, 0 warnings)
- [x] `bun run test -- Toast.test.ts --run` (all 4 component tests + 5 store tests passing)
- [x] `bun run test:run` (all 62 test files / 527 tests passing)
- [x] Manually verified in the app (attempted to create a playlist named "Queue", verified the error toast rendered the clipboard icon, clicked to copy, confirmed the 1.5s checkmark state, and pasted the exact error message)

## ✅ Checklist
- [x] No unrelated changes bundled in
