### PR TITLE
Add Missing Metadata auto-playlist and MusicBrainz Picard bridge

### DIFF
--- a/src-tauri/src/collection/query.rs
+++ b/src-tauri/src/collection/query.rs
@@ -527,6 +527,40 @@ impl CollectionScanner {
         Ok(songs)
     }
 
+    /// Songs missing one or more core tags (title/artist/album — the minimum
+    /// set needed to identify a track), selected per `mode`'s bias, for the
+    /// "Missing Metadata" auto-playlist (#367). NULL and empty-string are
+    /// both treated as "missing" since tag reads/writes use either
+    /// convention depending on the column.
+    pub fn get_songs_missing_core_tags(
+        &self,
+        limit: i64,
+        mode: QueuePopulationMode,
+    ) -> Result<Vec<Song>> {
+        let conn = self.db.pool.get()?;
+        let (extra_where, order_by) = mode_query_fragments(mode);
+        let sql = format!(
+            "SELECT {} FROM songs
+             WHERE (
+                 title IS NULL OR TRIM(title) = ''
+                 OR artist IS NULL OR TRIM(artist) = ''
+                 OR album IS NULL OR TRIM(album) = ''
+             )
+               AND source IN (1, 2)
+               AND unavailable = 0
+               {extra_where}
+             ORDER BY {order_by}
+             LIMIT ?1",
+            SONG_SELECT_COLS
+        );
+        let mut stmt = conn.prepare(&sql)?;
+        let songs = stmt
+            .query_map(params![limit], row_to_song)?
+            .filter_map(|r| r.ok())
+            .collect();
+        Ok(songs)
+    }
+
     /// Distinct artist tags across all artist profiles in the library.
     pub fn get_library_artist_tags(&self) -> Result<Vec<String>> {
         let conn = self.db.pool.get()?;

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -4,6 +4,7 @@ pub mod equalizer;
 pub mod loudness;
 pub mod lyrics;
 pub mod organizer;
+pub mod picard;
 pub mod pins;
 pub mod player;
 pub mod playlist;

--- a/src-tauri/src/commands/picard.rs
+++ b/src-tauri/src/commands/picard.rs
@@ -46,10 +46,13 @@ pub async fn open_in_picard(state: State<'_, AppState>, song_ids: Vec<i64>) -> R
     picard::launch_picard(&exe, &paths).map_err(|e| e.to_string())
 }
 
-/// Cheap existence check so the frontend can hide/grey the "Open in Picard"
-/// action instead of always showing it and failing on click.
+/// Resolves the Picard executable's current path, if found — `None` means
+/// not installed/not locatable. Serves both the cheap "is it available"
+/// check the frontend uses to disable "Open in Picard" actions, and the
+/// Settings page's integration status display (which also wants the actual
+/// path, not just a bool).
 #[tauri::command]
-pub async fn is_picard_available(state: State<'_, AppState>) -> Result<bool, String> {
+pub async fn get_picard_path(state: State<'_, AppState>) -> Result<Option<String>, String> {
     let custom_path = read_custom_picard_path(&state)?;
-    Ok(picard::find_picard(custom_path.as_deref()).is_some())
+    Ok(picard::find_picard(custom_path.as_deref()).map(|p| p.to_string_lossy().to_string()))
 }

--- a/src-tauri/src/commands/picard.rs
+++ b/src-tauri/src/commands/picard.rs
@@ -1,0 +1,55 @@
+use crate::picard;
+use crate::AppState;
+use tauri::State;
+
+fn read_custom_picard_path(state: &State<'_, AppState>) -> Result<Option<String>, String> {
+    let conn = state.db.pool.get().map_err(|e| e.to_string())?;
+    Ok(conn
+        .query_row(
+            "SELECT value FROM app_state WHERE key = 'picard_path'",
+            [],
+            |row| row.get(0),
+        )
+        .ok()
+        .filter(|s: &String| !s.trim().is_empty()))
+}
+
+/// Launches MusicBrainz Picard with the given songs' file paths (#367) — a
+/// one-way handoff, see `crate::picard` for details. Takes song IDs rather
+/// than raw paths so only real library songs can be handed to an external
+/// process, and paths are resolved server-side.
+#[tauri::command]
+pub async fn open_in_picard(state: State<'_, AppState>, song_ids: Vec<i64>) -> Result<(), String> {
+    let conn = state.db.pool.get().map_err(|e| e.to_string())?;
+    let mut paths = Vec::new();
+    for id in song_ids {
+        let path: Option<String> = conn
+            .query_row("SELECT path FROM songs WHERE id = ?1", [id], |row| {
+                row.get(0)
+            })
+            .ok();
+        if let Some(path) = path {
+            paths.push(std::path::PathBuf::from(path));
+        }
+    }
+    drop(conn);
+
+    if paths.is_empty() {
+        return Err("No local files found for the selected songs".to_string());
+    }
+
+    let custom_path = read_custom_picard_path(&state)?;
+    let exe = picard::find_picard(custom_path.as_deref()).ok_or_else(|| {
+        "MusicBrainz Picard not found. Install it from picard.musicbrainz.org, or set a custom path in Settings.".to_string()
+    })?;
+
+    picard::launch_picard(&exe, &paths).map_err(|e| e.to_string())
+}
+
+/// Cheap existence check so the frontend can hide/grey the "Open in Picard"
+/// action instead of always showing it and failing on click.
+#[tauri::command]
+pub async fn is_picard_available(state: State<'_, AppState>) -> Result<bool, String> {
+    let custom_path = read_custom_picard_path(&state)?;
+    Ok(picard::find_picard(custom_path.as_deref()).is_some())
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -24,6 +24,7 @@ pub mod lyrics;
 pub mod media_session;
 pub mod models;
 pub mod organizer;
+pub mod picard;
 pub mod pins;
 pub mod player;
 pub mod playlist;
@@ -953,6 +954,9 @@ pub fn run() {
             commands::tageditor::save_album_tags,
             commands::tageditor::clear_song_cover_art,
             commands::tageditor::clear_album_cover_art,
+            // MusicBrainz Picard bridge commands (#367)
+            commands::picard::open_in_picard,
+            commands::picard::is_picard_available,
             // Genre/tag browsing commands (#224) — read the existing
             // songs.genre column above; editing goes through save_song_tags.
             commands::tags::get_songs_by_tag,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -956,7 +956,7 @@ pub fn run() {
             commands::tageditor::clear_album_cover_art,
             // MusicBrainz Picard bridge commands (#367)
             commands::picard::open_in_picard,
-            commands::picard::is_picard_available,
+            commands::picard::get_picard_path,
             // Genre/tag browsing commands (#224) — read the existing
             // songs.genre column above; editing goes through save_song_tags.
             commands::tags::get_songs_by_tag,

--- a/src-tauri/src/picard.rs
+++ b/src-tauri/src/picard.rs
@@ -1,0 +1,125 @@
+//! Bridge to the external MusicBrainz Picard application (#367). A one-way
+//! handoff only: Luminous discovers and launches Picard with a list of file
+//! paths so the user can tag them there; Luminous never calls the
+//! MusicBrainz API itself (see AGENTS.md's "not best-of-all-worlds" product
+//! scope — canonical tag lookup is Picard's job) and does not watch the
+//! Picard process for completion. Tag edits made in Picard are picked up
+//! later by the existing file-watcher/incremental scanner, same as any
+//! other out-of-band edit.
+//!
+//! Deliberately scoped to process discovery/launch only, and kept separate
+//! from any future MusicBrainz *API* integration (e.g. a Details Pane
+//! pulling artist bios/images, tracked loosely under epic #677) — that is a
+//! different kind of integration and should live in its own module rather
+//! than being bolted onto this one.
+
+use anyhow::{anyhow, Context, Result};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Locates the Picard executable: an optional caller-supplied custom path
+/// (persisted via `set_app_setting("picard_path", ...)`) takes priority,
+/// then the `PICARD_PATH` env var (dev/packaging override), then a bare
+/// `picard`/`picard.exe` lookup on `PATH`, then a short list of common
+/// per-OS install locations. Returns `None` if nothing is found — callers
+/// turn that into a "Picard not found" message rather than a raw spawn
+/// failure. macOS is not a Luminous build target, so no macOS-specific
+/// discovery is included.
+pub fn find_picard(custom_path: Option<&str>) -> Option<PathBuf> {
+    if let Some(p) = custom_path.filter(|p| !p.trim().is_empty()) {
+        let path = PathBuf::from(p);
+        if path.is_file() {
+            return Some(path);
+        }
+    }
+
+    if let Ok(env_path) = std::env::var("PICARD_PATH") {
+        if !env_path.trim().is_empty() {
+            let path = PathBuf::from(&env_path);
+            if path.is_file() {
+                return Some(path);
+            }
+        }
+    }
+
+    #[cfg(windows)]
+    {
+        if let Some(p) = which_on_path("picard.exe") {
+            return Some(p);
+        }
+        let candidates = [
+            PathBuf::from(r"C:\Program Files\MusicBrainz Picard\picard.exe"),
+            PathBuf::from(r"C:\Program Files (x86)\MusicBrainz Picard\picard.exe"),
+        ];
+        for candidate in candidates {
+            if candidate.is_file() {
+                return Some(candidate);
+            }
+        }
+        if let Ok(local) = std::env::var("LOCALAPPDATA") {
+            let candidate = PathBuf::from(local).join(r"Programs\MusicBrainz Picard\picard.exe");
+            if candidate.is_file() {
+                return Some(candidate);
+            }
+        }
+        None
+    }
+
+    #[cfg(not(windows))]
+    {
+        which_on_path("picard")
+    }
+}
+
+/// Bare-name `PATH` lookup without shelling out — the cross-platform
+/// equivalent of `which`/`where`.
+fn which_on_path(name: &str) -> Option<PathBuf> {
+    let path_var = std::env::var_os("PATH")?;
+    std::env::split_paths(&path_var)
+        .map(|dir| dir.join(name))
+        .find(|full| full.is_file())
+}
+
+/// Launches Picard with the given file/folder paths (Picard's CLI accepts
+/// one or more absolute paths as trailing arguments). Fire-and-forget —
+/// Picard is a long-lived GUI app; Luminous doesn't wait on it or read its
+/// output.
+pub fn launch_picard(exe: &Path, paths: &[PathBuf]) -> Result<()> {
+    if paths.is_empty() {
+        return Err(anyhow!("No files to open in Picard"));
+    }
+    let mut cmd = Command::new(exe);
+    cmd.args(paths);
+    cmd.spawn().context("failed to launch MusicBrainz Picard")?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn find_picard_prefers_custom_path_when_it_exists() {
+        let exe = std::env::current_exe().unwrap();
+        let found = find_picard(Some(exe.to_str().unwrap()));
+        assert_eq!(found.as_deref(), Some(exe.as_path()));
+    }
+
+    #[test]
+    fn find_picard_ignores_custom_path_that_does_not_exist() {
+        let found = find_picard(Some("/definitely/not/a/real/path/picard"));
+        // Falls through to PICARD_PATH/PATH lookup, neither of which should
+        // resolve in a clean test environment.
+        assert_ne!(
+            found.as_deref().map(|p| p.to_string_lossy().to_string()),
+            Some("/definitely/not/a/real/path/picard".to_string())
+        );
+    }
+
+    #[test]
+    fn launch_picard_rejects_empty_path_list() {
+        let exe = std::env::current_exe().unwrap();
+        let result = launch_picard(&exe, &[]);
+        assert!(result.is_err());
+    }
+}

--- a/src-tauri/src/pins.rs
+++ b/src-tauri/src/pins.rs
@@ -238,6 +238,28 @@ pub fn resolve_auto_playlist(
             let count = scanner.get_recently_played_songs(100)?.len() as i32;
             (count > 0).then(|| virtual_item(kind, count))
         }
+        "missing_metadata" => {
+            // Materialized like genre/decade/bpm/artist_tag (a real
+            // dynamic_enabled row), but a fixed singleton spec rather than
+            // one keyed by a selector value (#367).
+            playlists
+                .iter()
+                .find(|p| {
+                    p.dynamic_enabled
+                        && p.track_count > 0
+                        && p.dynamic_spec.as_deref() == Some("missingmeta")
+                })
+                .map(|p| AutoPlaylistItem {
+                    kind: kind.to_string(),
+                    genre: None,
+                    artist_tag: None,
+                    decade: None,
+                    bpm: None,
+                    playlist_id: Some(p.id),
+                    updated: Some(p.updated),
+                    track_count: p.track_count,
+                })
+        }
         "genre" | "decade" | "bpm" | "artist_tag" => {
             let selector = selector.unwrap_or("").to_string();
             let prefix = match kind {
@@ -592,6 +614,35 @@ mod tests {
         assert!(resolve_auto_playlist(&scanner, &playlists, "genre:Jazz")
             .unwrap()
             .is_none());
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn resolve_auto_playlist_missing_metadata_matches_fixed_spec_with_no_selector() {
+        let (db, dir) = test_db();
+        let scanner = CollectionScanner::new(std::sync::Arc::new(db));
+        let playlists = vec![test_playlist(1, "missingmeta", 3)];
+
+        let item = resolve_auto_playlist(&scanner, &playlists, "missing_metadata")
+            .unwrap()
+            .expect("missing_metadata should resolve against the singleton row");
+        assert_eq!(item.playlist_id, Some(1));
+        assert_eq!(item.track_count, 3);
+        assert!(
+            item.genre.is_none()
+                && item.decade.is_none()
+                && item.bpm.is_none()
+                && item.artist_tag.is_none()
+        );
+
+        // Dropped to 0 songs (or the row deleted) self-heals to None.
+        let empty_playlists = vec![test_playlist(1, "missingmeta", 0)];
+        assert!(
+            resolve_auto_playlist(&scanner, &empty_playlists, "missing_metadata")
+                .unwrap()
+                .is_none()
+        );
 
         let _ = std::fs::remove_dir_all(dir);
     }

--- a/src-tauri/src/playlist/auto_sync.rs
+++ b/src-tauri/src/playlist/auto_sync.rs
@@ -47,6 +47,7 @@ impl PlaylistManager {
         self.sync_decade_auto_playlists()?;
         self.sync_bpm_auto_playlists()?;
         self.sync_artist_tag_auto_playlists()?;
+        self.sync_missing_metadata_auto_playlist()?;
         Ok(())
     }
 
@@ -503,6 +504,79 @@ impl PlaylistManager {
                     params![playlist_id, song.id, position as i32, Uuid::new_v4().to_string()],
                 )?;
             }
+        }
+
+        Ok(())
+    }
+
+    /// Regenerates the single "Missing Metadata" auto-playlist (#367) — a
+    /// system-managed `playlists` row with `dynamic_enabled = 1` and
+    /// `dynamic_spec = "missingmeta"` — if missing or its `updated`
+    /// timestamp is more than 24h old. Unlike genre/decade/BPM/artist-tag
+    /// auto-playlists there is exactly one row and no
+    /// `MIN_LIBRARY_SONGS_FOR_AUTO_PLAYLIST` gate: the point is to surface
+    /// library health issues even when only one song is affected. The row
+    /// is created unconditionally (even at 0 matches) so it never has to
+    /// wait for a first offending song; the frontend hides the card when
+    /// `track_count == 0`, the same convention used for genre/decade/BPM at
+    /// 0 songs.
+    pub fn sync_missing_metadata_auto_playlist(&self) -> Result<()> {
+        const STALE_AFTER_SECS: i64 = 24 * 60 * 60;
+        const SPEC: &str = "missingmeta";
+        const NAME: &str = "Missing Metadata";
+
+        let scanner = CollectionScanner::new(self.db.clone());
+        let conn = self.db.pool.get()?;
+        let now = chrono::Utc::now().timestamp();
+
+        let existing_row: Option<(i64, i64, String)> = conn
+            .query_row(
+                "SELECT id, COALESCE(updated, 0), COALESCE(population_mode, 'all') FROM playlists WHERE dynamic_enabled = 1 AND dynamic_spec = ?1",
+                params![SPEC],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .ok();
+        let mode = existing_row
+            .as_ref()
+            .map(|(_, _, m)| QueuePopulationMode::from(m.as_str()))
+            .unwrap_or_default();
+
+        let needs_generation = match existing_row {
+            None => true,
+            Some((_, updated, _)) => now - updated > STALE_AFTER_SECS,
+        };
+        if !needs_generation {
+            return Ok(());
+        }
+
+        let songs = scanner.get_songs_missing_core_tags(NO_SONG_LIMIT, mode)?;
+
+        let playlist_id = match existing_row {
+            Some((id, _, _)) => {
+                conn.execute(
+                    "UPDATE playlists SET updated = ?1 WHERE id = ?2",
+                    params![now, id],
+                )?;
+                conn.execute(
+                    "DELETE FROM playlist_items WHERE playlist_id = ?1",
+                    params![id],
+                )?;
+                id
+            }
+            None => {
+                conn.execute(
+                    "INSERT INTO playlists (name, dynamic_enabled, dynamic_spec, created, updated) VALUES (?1, 1, ?2, ?3, ?3)",
+                    params![NAME, SPEC, now],
+                )?;
+                conn.last_insert_rowid()
+            }
+        };
+
+        for (position, song) in songs.iter().enumerate() {
+            conn.execute(
+                "INSERT INTO playlist_items (playlist_id, song_id, position, uuid, type) VALUES (?1, ?2, ?3, ?4, 0)",
+                params![playlist_id, song.id, position as i32, Uuid::new_v4().to_string()],
+            )?;
         }
 
         Ok(())
@@ -986,6 +1060,78 @@ mod tests {
                 .iter()
                 .any(|p| p.dynamic_spec.as_deref() == Some("artisttag:canadian")),
             "artisttag:canadian must be pruned when 0 songs remain"
+        );
+
+        let _ = std::fs::remove_dir_all(temp_dir);
+    }
+
+    #[test]
+    fn test_sync_missing_metadata_auto_playlist() {
+        let (db, temp_dir) = setup_test_db();
+        let db_arc = std::sync::Arc::new(db);
+
+        {
+            let conn = db_arc.pool.get().unwrap();
+            // Complete — should not appear.
+            conn.execute(
+                "INSERT INTO songs (title, artist, album, source, unavailable) VALUES ('Complete Song', 'Artist', 'Album', 1, 0)",
+                [],
+            )
+            .unwrap();
+            // Missing artist (empty string, not NULL).
+            conn.execute(
+                "INSERT INTO songs (title, artist, album, source, unavailable) VALUES ('No Artist', '', 'Album', 1, 0)",
+                [],
+            )
+            .unwrap();
+            // Missing album (NULL).
+            conn.execute(
+                "INSERT INTO songs (title, artist, source, unavailable) VALUES ('No Album', 'Artist', 1, 0)",
+                [],
+            )
+            .unwrap();
+        }
+
+        let manager = PlaylistManager::new(db_arc.clone()).unwrap();
+        // Unlike genre/decade/BPM/artist-tag, this must be created even with
+        // only a couple of matching songs — no 25-song threshold gate.
+        manager.sync_missing_metadata_auto_playlist().unwrap();
+
+        let playlists = manager.get_playlists().unwrap();
+        let pl = playlists
+            .iter()
+            .find(|p| p.dynamic_spec.as_deref() == Some("missingmeta"))
+            .expect("Missing Metadata auto-playlist should always be created, even below any song-count threshold");
+        assert_eq!(pl.name, "Missing Metadata");
+
+        let tracks = manager.get_playlist_tracks(pl.id).unwrap();
+        let titles: Vec<_> = tracks
+            .iter()
+            .map(|t| t.song.as_ref().unwrap().title.clone().unwrap())
+            .collect();
+        assert_eq!(titles.len(), 2);
+        assert!(titles.contains(&"No Artist".to_string()));
+        assert!(titles.contains(&"No Album".to_string()));
+        assert!(!titles.contains(&"Complete Song".to_string()));
+
+        // Fixing the tags and reconciling should drop the songs out again.
+        db_arc
+            .pool
+            .get()
+            .unwrap()
+            .execute(
+                "UPDATE songs SET artist = 'Artist' WHERE title = 'No Artist'",
+                [],
+            )
+            .unwrap();
+        let mut manager = manager;
+        let deltas = manager.reconcile_dynamic_playlists().unwrap();
+        assert!(deltas.iter().any(|d| d.playlist_id == pl.id));
+        let tracks = manager.get_playlist_tracks(pl.id).unwrap();
+        assert_eq!(tracks.len(), 1);
+        assert_eq!(
+            tracks[0].song.as_ref().unwrap().title.as_deref(),
+            Some("No Album")
         );
 
         let _ = std::fs::remove_dir_all(temp_dir);

--- a/src-tauri/src/playlist/dynamic.rs
+++ b/src-tauri/src/playlist/dynamic.rs
@@ -78,8 +78,9 @@ impl PlaylistManager {
     }
 
     /// Every library song matching a dynamic spec, in the order the spec's
-    /// population mode dictates. The single dispatch point for all four spec
-    /// kinds (decade:, bpmrange:, tag:, smart-rule query).
+    /// population mode dictates. The single dispatch point for all spec
+    /// kinds (decade:, bpmrange:, artisttag:, missingmeta, tag:, smart-rule
+    /// query).
     fn songs_for_spec(&self, spec: &str, mode: QueuePopulationMode) -> Result<Vec<Song>> {
         let scanner = CollectionScanner::new(self.db.clone());
         if let Some(decade) = spec.strip_prefix("decade:") {
@@ -91,6 +92,8 @@ impl PlaylistManager {
             scanner.get_songs_by_bpm_range(min, max, NO_SONG_LIMIT, mode)
         } else if let Some(tag) = spec.strip_prefix("artisttag:") {
             scanner.get_songs_by_artist_tag(tag, NO_SONG_LIMIT, mode)
+        } else if spec == "missingmeta" {
+            scanner.get_songs_missing_core_tags(NO_SONG_LIMIT, mode)
         } else if let Some(name) = spec.strip_prefix("tag:") {
             // A system genre auto-playlist, keyed on a curated tag name
             // (#548) rather than a Smart Playlist rule spec (which always

--- a/src/lib/components/AlbumDetailView.svelte
+++ b/src/lib/components/AlbumDetailView.svelte
@@ -31,6 +31,7 @@
   import { toastStore } from "../stores/toast.svelte";
   import { compareSongs } from "../utils/songSort";
   import { rememberScroll } from "../utils/scrollMemory";
+  import { openInPicard } from "../utils/picard";
 
   let { albumName }: { albumName: string } = $props();
 
@@ -484,6 +485,7 @@
         onRate={rateSong}
         onAddToPlaylist={(song) => handleAddSongToPlaylist(song.id)}
         onEditTags={(song) => openTagEditor(song.id)}
+        onOpenInPicard={(song) => openInPicard([song.id])}
       />
     </div>
   </div>
@@ -542,6 +544,7 @@
     onGoToArtist={() => navigationStore.viewArtist(song.album_artist?.trim() || song.artist || "")}
     onGoToAlbum={() => navigationStore.viewAlbum(song.album || "")}
     onEditTags={() => openTagEditor(song.id)}
+    onOpenInPicard={() => openInPicard(selectedKeys.size > 1 ? Array.from(selectedKeys, Number) : [song.id])}
     onClose={() => { contextMenuState = null; }}
   />
 {/if}

--- a/src/lib/components/ArtistDetailView.svelte
+++ b/src/lib/components/ArtistDetailView.svelte
@@ -35,6 +35,7 @@
   import { i18n } from "../stores/i18n.svelte";
   import { toastStore } from "../stores/toast.svelte";
   import { rememberScroll } from "../utils/scrollMemory";
+  import { openInPicard } from "../utils/picard";
   import { compareSongs } from "../utils/songSort";
 
   let { artistName }: { artistName: string } = $props();
@@ -551,6 +552,7 @@
             onRate={rateSingle}
             onAddToPlaylist={(song) => handleAddSingleToPlaylist(song.id)}
             onEditTags={(song) => openTagEditor(song.id)}
+            onOpenInPicard={(song) => openInPicard([song.id])}
           />
         </div>
       </div>
@@ -640,6 +642,7 @@
       }
     }}
     onEditTags={() => openTagEditor(song.id)}
+    onOpenInPicard={() => openInPicard(selectedKeys.size > 1 ? Array.from(selectedKeys, Number) : [song.id])}
     onClose={() => { singleContextMenuState = null; }}
   />
 {/if}

--- a/src/lib/components/ArtistDetailView.svelte
+++ b/src/lib/components/ArtistDetailView.svelte
@@ -232,25 +232,25 @@
     songs.length === 1 ? i18n.t("playlists.oneSong") : i18n.t("playlists.songsCount", { count: songs.length })
   );
 
-  // Some artists have no proper album releases at all (every track is a loose
-  // single with no album tag), so getArtistAlbums() returns nothing and the
-  // Albums/Singles/Popular filters all end up empty. Fall back to showing the
-  // artist's individual songs directly rather than an empty "no releases" state.
-  // Mutually exclusive with `singles` (albums.length is 0 whenever this is
-  // populated), so combining the two counts is safe.
+  // Songs with no album tag at all are excluded from get_albums() entirely
+  // (it requires a non-empty album), so they'd never surface via `albums`/
+  // `singles`. Surface each such song individually as its own "loose
+  // single" — computed directly from this artist's songs rather than gated
+  // on "this artist has zero proper albums", which used to make every
+  // blank-album song vanish the moment the artist had even one real album
+  // elsewhere (its `albums.length` going from 0 to 1 turned this fallback
+  // off entirely, even though the loose songs and real albums are disjoint
+  // sets and can coexist).
   let looseSongs = $derived(
-    albums.length === 0 ? [...songs].sort((a, b) => (a.title || "").localeCompare(b.title || "")) : []
+    songs.filter((s) => !s.album).sort((a, b) => (a.title || "").localeCompare(b.title || ""))
   );
 
   // Grouped singles are AlbumItems (track_count === 1), but they render as a
   // song table alongside loose singles — resolve each back to its one song.
-  let singleSongs = $derived(
-    singles.length > 0
-      ? singles
-          .map((a) => songs.find((s) => s.album === a.album))
-          .filter((s): s is Song => s !== undefined)
-      : looseSongs
-  );
+  let singleSongs = $derived([
+    ...singles.map((a) => songs.find((s) => s.album === a.album)).filter((s): s is Song => s !== undefined),
+    ...looseSongs,
+  ]);
 
   let sortedSingleSongs = $derived.by(() => {
     if (singleSortField === "track") {

--- a/src/lib/components/AutoPlaylistCard.svelte
+++ b/src/lib/components/AutoPlaylistCard.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { invoke } from "@tauri-apps/api/core";
-  import { ListMusic, Heart, Clock, Hourglass, Calendar, Music, Gauge, Tag, TrendingUp } from "lucide-svelte";
+  import { ListMusic, Heart, Clock, Hourglass, Calendar, Music, Gauge, Tag, TrendingUp, AlertTriangle } from "lucide-svelte";
   import CardBadge from "./CardBadge.svelte";
   import type { PlaylistItem, Song } from "../types";
   import { songsToCoverStack } from "../utils/covers";
@@ -13,7 +13,7 @@
 
   interface Props {
     label: string;
-    kind: "favourites" | "recently_added" | "most_played" | "history" | "genre" | "decade" | "bpm" | "artist_tag";
+    kind: "favourites" | "recently_added" | "most_played" | "history" | "genre" | "decade" | "bpm" | "artist_tag" | "missing_metadata";
     genre?: string;
     artistTag?: string;
     decade?: string;
@@ -31,7 +31,7 @@
   let { label, kind, genre, artistTag, decade, bpm, playlistId, updated, trackCount, onClick, widthClass = "w-full" }: Props = $props();
 
   let displayLabel = $derived.by(() => {
-    if ((kind === "genre" || kind === "decade" || kind === "bpm" || kind === "artist_tag") && playlistId !== undefined) {
+    if ((kind === "genre" || kind === "decade" || kind === "bpm" || kind === "artist_tag" || kind === "missing_metadata") && playlistId !== undefined) {
       const pl = playlistsStore.playlists.find((p) => p.id === playlistId);
       if (pl) return getPlaylistDisplayName(pl);
     }
@@ -39,6 +39,7 @@
   });
 
   let subtitleLabel = $derived.by(() => {
+    if (kind === "missing_metadata") return i18n.t("playlists.missingMetadataAutoPlaylist");
     if (kind === "decade" || decade) return i18n.t("playlists.decadeAutoPlaylist");
     if (kind === "bpm") return i18n.t("playlists.bpmAutoPlaylist");
     if (kind === "artist_tag" || artistTag) return i18n.t("playlists.artistTagAutoPlaylist");
@@ -61,7 +62,7 @@
     const pid = playlistId;
 
     const request =
-      (k === "genre" || k === "decade" || k === "bpm" || k === "artist_tag") && pid !== undefined
+      (k === "genre" || k === "decade" || k === "bpm" || k === "artist_tag" || k === "missing_metadata") && pid !== undefined
         ? invoke<PlaylistItem[]>("get_playlist_tracks", { playlistId: pid }).then((items) =>
             items.filter((item) => !!item.song).map((item) => item.song as Song)
           )
@@ -108,11 +109,12 @@
       case "recently_added": return "bg-[#CA8A04] text-white";
       case "most_played": return "bg-[#DC2626] text-white";
       case "history": return "bg-[#8B5CF6] text-white";
+      case "missing_metadata": return "bg-amber-600 text-white";
     }
   });
 
   let updatedLabel = $derived.by(() => {
-    if ((kind !== "genre" && kind !== "decade" && kind !== "bpm" && kind !== "artist_tag") || updated === undefined) return null;
+    if ((kind !== "genre" && kind !== "decade" && kind !== "bpm" && kind !== "artist_tag" && kind !== "missing_metadata") || updated === undefined) return null;
     return formatRelativeDate(updated);
   });
 </script>
@@ -159,6 +161,10 @@
     {:else if kind === "bpm"}
       <div class="w-full h-full bg-brand-main bg-gradient-to-br from-[#C026D3]/25 to-[#E879F9]/15 flex items-center justify-center overflow-hidden border border-[#E879F9]/30 shadow-[0_0_20px_2px_rgba(232,121,249,0.35)]">
         <Gauge class="w-10 h-10 text-[#E879F9]" />
+      </div>
+    {:else if kind === "missing_metadata"}
+      <div class="w-full h-full bg-brand-main bg-gradient-to-br from-amber-600/25 to-amber-400/15 flex items-center justify-center overflow-hidden border border-amber-400/30 shadow-[0_0_20px_2px_rgba(245,158,11,0.35)]">
+        <AlertTriangle class="w-10 h-10 text-amber-500" />
       </div>
     {:else}
       <div class="w-full h-full bg-brand-main bg-gradient-to-br from-slate-700/40 to-slate-900/30 flex items-center justify-center overflow-hidden border border-slate-400/20 shadow-[0_0_20px_2px_rgba(100,116,139,0.25)]">

--- a/src/lib/components/AutoPlaylistDetailView.svelte
+++ b/src/lib/components/AutoPlaylistDetailView.svelte
@@ -33,6 +33,7 @@
   import { genreColorHsl, resolveGenreColorIndex } from "../utils/genrePalette";
   import { rememberScroll } from "../utils/scrollMemory";
   import { openInPicard } from "../utils/picard";
+  import { picardStore } from "../stores/picard.svelte";
   import { compareSongs } from "../utils/songSort";
   import { toTitleCase } from "../utils/formatters";
   import Modal from "./Modal.svelte";
@@ -761,7 +762,8 @@
           ? i18n.t("picard.openSelectedInPicard", { count: selectedKeys.size })
           : i18n.t("picard.openAllInPicard")}
         onclick={() => { handleOpenAllInPicard(); overflowMenuPos = null; }}
-        disabled={loading || songs.length === 0}
+        disabled={loading || songs.length === 0 || !picardStore.available}
+        title={picardStore.available ? undefined : i18n.t("picard.notFoundTooltip")}
       />
     {/if}
 

--- a/src/lib/components/AutoPlaylistDetailView.svelte
+++ b/src/lib/components/AutoPlaylistDetailView.svelte
@@ -24,7 +24,7 @@
   import ContextMenuItem from "./ContextMenuItem.svelte";
   import ContextMenuDivider from "./ContextMenuDivider.svelte";
   import SongTable, { type SongTableRow } from "./SongTable.svelte";
-  import { Clock, Plus, FolderPlus, Music, Gauge, RefreshCw, Heart, Calendar, Hourglass, Search, RotateCcw, RotateCw, MoreHorizontal, X, Eraser, Tag, TrendingUp, Pin, PinOff, AlertTriangle } from "lucide-svelte";
+  import { Clock, Plus, FolderPlus, Music, Gauge, RefreshCw, Heart, Calendar, Hourglass, Search, RotateCcw, RotateCw, MoreHorizontal, X, Eraser, Tag, TrendingUp, Pin, PinOff, AlertTriangle, Disc3 } from "lucide-svelte";
   import { shuffleArray } from "../utils/shuffle";
   import type { PlaylistItem, QueuePopulationMode, Song } from "../types";
   import { i18n } from "../stores/i18n.svelte";
@@ -247,6 +247,15 @@
   async function handleAddSongToPlaylist(songId: number) {
     const songObj = songs.find((s) => s.id === songId);
     await playlistsStore.addSongsToActiveTarget([songId], songObj?.title || "Song");
+  }
+
+  /** Bulk "Open in Picard" from the Missing Metadata playlist's overflow menu
+   * (#367) — the primary entry point for handing everything in the list off
+   * to Picard at once. Opens just the current selection if any songs are
+   * selected, otherwise every song in the list. */
+  function handleOpenAllInPicard() {
+    const ids = selectedKeys.size > 0 ? Array.from(selectedKeys, Number) : songs.map((s) => s.id);
+    openInPicard(ids);
   }
 
   async function handleAddAllToPlaylist() {
@@ -741,6 +750,18 @@
         label={i18n.t("playlists.refreshPlaylistBtn", {}, "Refresh Playlist")}
         onclick={() => { handleRefreshAutoPlaylist(); overflowMenuPos = null; }}
         disabled={loading || isRefreshing}
+      />
+    {/if}
+
+    {#if kind === "missing_metadata"}
+      <ContextMenuDivider />
+      <ContextMenuItem
+        icon={Disc3}
+        label={selectedKeys.size > 0
+          ? i18n.t("picard.openSelectedInPicard", { count: selectedKeys.size })
+          : i18n.t("picard.openAllInPicard")}
+        onclick={() => { handleOpenAllInPicard(); overflowMenuPos = null; }}
+        disabled={loading || songs.length === 0}
       />
     {/if}
 

--- a/src/lib/components/AutoPlaylistDetailView.svelte
+++ b/src/lib/components/AutoPlaylistDetailView.svelte
@@ -24,7 +24,7 @@
   import ContextMenuItem from "./ContextMenuItem.svelte";
   import ContextMenuDivider from "./ContextMenuDivider.svelte";
   import SongTable, { type SongTableRow } from "./SongTable.svelte";
-  import { Clock, Plus, FolderPlus, Music, Gauge, RefreshCw, Heart, Calendar, Hourglass, Search, RotateCcw, RotateCw, MoreHorizontal, X, Eraser, Tag, TrendingUp, Pin, PinOff } from "lucide-svelte";
+  import { Clock, Plus, FolderPlus, Music, Gauge, RefreshCw, Heart, Calendar, Hourglass, Search, RotateCcw, RotateCw, MoreHorizontal, X, Eraser, Tag, TrendingUp, Pin, PinOff, AlertTriangle } from "lucide-svelte";
   import { shuffleArray } from "../utils/shuffle";
   import type { PlaylistItem, QueuePopulationMode, Song } from "../types";
   import { i18n } from "../stores/i18n.svelte";
@@ -32,6 +32,7 @@
   import { getPopulationModeSuffix, getBpmBucketLabel } from "../utils/playlist";
   import { genreColorHsl, resolveGenreColorIndex } from "../utils/genrePalette";
   import { rememberScroll } from "../utils/scrollMemory";
+  import { openInPicard } from "../utils/picard";
   import { compareSongs } from "../utils/songSort";
   import { toTitleCase } from "../utils/formatters";
   import Modal from "./Modal.svelte";
@@ -106,6 +107,10 @@
     if (kind === "recently_added") return i18n.t("playlists.autoRecentlyAdded");
     if (kind === "most_played") return i18n.t("playlists.autoMostPlayed");
     if (kind === "history") return i18n.t("playlists.autoHistory");
+    // Missing Metadata (#367) is a diagnostic singleton — always bare, no
+    // population-mode suffix (population mode has no meaning here: the
+    // point is to surface every affected song, not bias toward favourites).
+    if (kind === "missing_metadata") return i18n.t("playlists.autoMissingMetadata");
     const base = kind === "decade"
       ? (decade || i18n.t("artistDetail.unknownYear"))
       : kind === "bpm"
@@ -145,7 +150,7 @@
   });
 
   let updatedLabel = $derived.by(() => {
-    if ((kind !== "genre" && kind !== "decade" && kind !== "bpm" && kind !== "artist_tag") || updated === undefined) return null;
+    if ((kind !== "genre" && kind !== "decade" && kind !== "bpm" && kind !== "artist_tag" && kind !== "missing_metadata") || updated === undefined) return null;
     return new Date(updated * 1000).toLocaleDateString();
   });
 
@@ -158,7 +163,7 @@
   });
 
   async function fetchSongs(k: typeof kind, g: typeof genre, at: typeof artistTag, d: typeof decade, b: typeof bpm, pid: typeof playlistId): Promise<Song[]> {
-    if ((k === "genre" || k === "decade" || k === "bpm" || k === "artist_tag") && pid !== undefined) {
+    if ((k === "genre" || k === "decade" || k === "bpm" || k === "artist_tag" || k === "missing_metadata") && pid !== undefined) {
       const items = await invoke<PlaylistItem[]>("get_playlist_tracks", { playlistId: pid });
       return items.filter((item) => !!item.song).map((item) => item.song as Song);
     }
@@ -599,6 +604,10 @@
           <div class="w-full h-full bg-brand-main bg-gradient-to-br from-slate-700/40 to-slate-900/30 flex items-center justify-center overflow-hidden border border-slate-400/20 shadow-[0_0_28px_3px_rgba(100,116,139,0.3)]">
             <Music class="w-16 h-16 text-slate-300" />
           </div>
+        {:else if kind === "missing_metadata"}
+          <div class="w-full h-full bg-brand-main bg-gradient-to-br from-amber-600/25 to-amber-400/15 flex items-center justify-center overflow-hidden border border-amber-400/30 shadow-[0_0_28px_3px_rgba(245,158,11,0.4)]">
+            <AlertTriangle class="w-16 h-16 text-amber-500" />
+          </div>
         {:else}
           <div
             class="w-full h-full bg-brand-main flex items-center justify-center overflow-hidden border"
@@ -633,6 +642,7 @@
         onAddToPlaylist={(song) => handleAddSongToPlaylist(song.id)}
         onEditTags={(song) => openTagEditor(song.id)}
         onEditAlbum={openAlbumEditor}
+        onOpenInPicard={(song) => openInPicard([song.id])}
       />
     </div>
 
@@ -690,6 +700,7 @@
     onGoToArtist={() => navigationStore.viewArtist(song.album_artist?.trim() || song.artist || "")}
     onGoToAlbum={() => navigationStore.viewAlbum(song.album || "")}
     onEditTags={() => openTagEditor(song.id)}
+    onOpenInPicard={() => openInPicard(selectedKeys.size > 1 ? Array.from(selectedKeys, Number) : [song.id])}
     onClose={() => { contextMenuState = null; }}
   />
 {/if}
@@ -724,7 +735,7 @@
       disabled={loading || songs.length === 0}
     />
 
-    {#if (kind === "genre" || kind === "decade" || kind === "bpm") && playlistId !== undefined}
+    {#if (kind === "genre" || kind === "decade" || kind === "bpm" || kind === "missing_metadata") && playlistId !== undefined}
       <ContextMenuItem
         icon={RefreshCw}
         label={i18n.t("playlists.refreshPlaylistBtn", {}, "Refresh Playlist")}

--- a/src/lib/components/AutoPlaylistRowCard.svelte
+++ b/src/lib/components/AutoPlaylistRowCard.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Heart, Clock, Hourglass, Calendar, Music, Gauge, Tag, TrendingUp } from "lucide-svelte";
+  import { Heart, Clock, Hourglass, Calendar, Music, Gauge, Tag, TrendingUp, AlertTriangle } from "lucide-svelte";
   import { i18n } from "../stores/i18n.svelte";
   import { formatRelativeDate } from "../utils/date";
   import { playlistsStore } from "../stores/playlists.svelte";
@@ -8,7 +8,7 @@
 
   interface Props {
     label: string;
-    kind: "favourites" | "recently_added" | "most_played" | "history" | "genre" | "decade" | "bpm" | "artist_tag";
+    kind: "favourites" | "recently_added" | "most_played" | "history" | "genre" | "decade" | "bpm" | "artist_tag" | "missing_metadata";
     genre?: string;
     artistTag?: string;
     decade?: string;
@@ -22,7 +22,7 @@
   let { label, kind, genre, artistTag, decade, bpm, playlistId, updated, trackCount, onClick }: Props = $props();
 
   let displayLabel = $derived.by(() => {
-    if ((kind === "genre" || kind === "decade" || kind === "bpm" || kind === "artist_tag") && playlistId !== undefined) {
+    if ((kind === "genre" || kind === "decade" || kind === "bpm" || kind === "artist_tag" || kind === "missing_metadata") && playlistId !== undefined) {
       const pl = playlistsStore.playlists.find((p) => p.id === playlistId);
       if (pl) return getPlaylistDisplayName(pl);
     }
@@ -30,6 +30,7 @@
   });
 
   let subtitleLabel = $derived.by(() => {
+    if (kind === "missing_metadata") return i18n.t("playlists.missingMetadataAutoPlaylist");
     if (kind === "decade" || decade) return i18n.t("playlists.decadeAutoPlaylist");
     if (kind === "bpm") return i18n.t("playlists.bpmAutoPlaylist");
     if (kind === "artist_tag" || artistTag) return i18n.t("playlists.artistTagAutoPlaylist");
@@ -42,7 +43,7 @@
   });
 
   let updatedLabel = $derived.by(() => {
-    if ((kind !== "genre" && kind !== "decade" && kind !== "bpm" && kind !== "artist_tag") || updated === undefined) return null;
+    if ((kind !== "genre" && kind !== "decade" && kind !== "bpm" && kind !== "artist_tag" && kind !== "missing_metadata") || updated === undefined) return null;
     return formatRelativeDate(updated);
   });
 </script>
@@ -68,7 +69,9 @@
                 ? 'bg-[#DC2626]/15 border-[#DC2626]/30'
                 : kind === 'history'
                   ? 'bg-[#8B5CF6]/15 border-[#8B5CF6]/30'
-                  : 'bg-[#FACC15]/15 border-[#FACC15]/30'}"
+                  : kind === 'missing_metadata'
+                    ? 'bg-amber-500/15 border-amber-500/30'
+                    : 'bg-[#FACC15]/15 border-[#FACC15]/30'}"
   >
     {#if kind === "favourites"}
       <Heart class="w-5 h-5 text-[#F43F5E] fill-current" />
@@ -84,6 +87,8 @@
       <Tag class="w-5 h-5 text-[#FB923C]" />
     {:else if kind === "bpm"}
       <Gauge class="w-5 h-5 text-[#E879F9]" />
+    {:else if kind === "missing_metadata"}
+      <AlertTriangle class="w-5 h-5 text-amber-500" />
     {:else}
       <Music class="w-5 h-5 text-[#34D399]" />
     {/if}

--- a/src/lib/components/CollectionView.svelte
+++ b/src/lib/components/CollectionView.svelte
@@ -30,6 +30,7 @@
   import SongTable, { type SongTableRow } from "./SongTable.svelte";
   import { SONG_TABLE_COLUMNS } from "../utils/songColumns";
   import { rememberScroll } from "../utils/scrollMemory";
+  import { openInPicard } from "../utils/picard";
 
   // activeSubTab and activeTab are managed globally via collectionStore
 
@@ -381,6 +382,7 @@
           onRate={rateSong}
           onAddToPlaylist={(song) => handleAddSongToPlaylist(song.id)}
           onEditTags={(song) => openTagEditor(song.id)}
+          onOpenInPicard={(song) => openInPicard([song.id])}
           virtualized
           scrollMemoryKey="collection:songs"
           emptyState={songsEmptyState}
@@ -602,6 +604,7 @@
     onGoToArtist={() => navigationStore.viewArtist(song.album_artist?.trim() || song.artist || "")}
     onGoToAlbum={() => navigationStore.viewAlbum(song.album || "")}
     onEditTags={() => openTagEditor(song.id)}
+    onOpenInPicard={() => openInPicard(selectedKeys.size > 1 ? Array.from(selectedKeys, Number) : [song.id])}
     onClose={() => { contextMenuState = null; }}
   />
 {/if}

--- a/src/lib/components/ContextMenuItem.svelte
+++ b/src/lib/components/ContextMenuItem.svelte
@@ -10,14 +10,16 @@
     /** Highlights the item as a destructive action (e.g. Remove/Delete). */
     destructive?: boolean;
     disabled?: boolean;
+    title?: string;
   }
 
-  let { icon: Icon, label, onclick, accent = false, destructive = false, disabled = false }: Props = $props();
+  let { icon: Icon, label, onclick, accent = false, destructive = false, disabled = false, title }: Props = $props();
 </script>
 
 <button
   onclick={disabled ? undefined : onclick}
   {disabled}
+  {title}
   class="w-full text-left px-3 py-1.5 flex items-center gap-2.5 transition-colors {disabled
     ? 'opacity-40 cursor-not-allowed text-brand-text-secondary'
     : destructive

--- a/src/lib/components/PlaylistContextMenu.svelte
+++ b/src/lib/components/PlaylistContextMenu.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { Play, Trash2, Mic2, DiscAlbum, Edit3, Disc3 } from "lucide-svelte";
   import { i18n } from "../stores/i18n.svelte";
+  import { picardStore } from "../stores/picard.svelte";
   import ContextMenu from "./ContextMenu.svelte";
   import ContextMenuItem from "./ContextMenuItem.svelte";
   import ContextMenuDivider from "./ContextMenuDivider.svelte";
@@ -77,6 +78,8 @@
       icon={Disc3}
       label={i18n.t("picard.openInPicard")}
       onclick={() => { onOpenInPicard?.(); onClose(); }}
+      disabled={!picardStore.available}
+      title={picardStore.available ? undefined : i18n.t("picard.notFoundTooltip")}
     />
   {/if}
 

--- a/src/lib/components/PlaylistContextMenu.svelte
+++ b/src/lib/components/PlaylistContextMenu.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Play, Trash2, Mic2, DiscAlbum, Edit3 } from "lucide-svelte";
+  import { Play, Trash2, Mic2, DiscAlbum, Edit3, Disc3 } from "lucide-svelte";
   import { i18n } from "../stores/i18n.svelte";
   import ContextMenu from "./ContextMenu.svelte";
   import ContextMenuItem from "./ContextMenuItem.svelte";
@@ -14,6 +14,7 @@
     onGoToArtist,
     onGoToAlbum,
     onEditTags,
+    onOpenInPicard,
     onClose,
   }: {
     x: number;
@@ -24,6 +25,7 @@
     onGoToArtist?: () => void;
     onGoToAlbum?: () => void;
     onEditTags?: () => void;
+    onOpenInPicard?: () => void;
     onClose: () => void;
   } = $props();
 </script>
@@ -67,6 +69,15 @@
         onclick={() => { onEditTags?.(); onClose(); }}
       />
     {/if}
+  {/if}
+
+  {#if onOpenInPicard}
+    <ContextMenuDivider />
+    <ContextMenuItem
+      icon={Disc3}
+      label={i18n.t("picard.openInPicard")}
+      onclick={() => { onOpenInPicard?.(); onClose(); }}
+    />
   {/if}
 
   <ContextMenuDivider />

--- a/src/lib/components/PlaylistView.svelte
+++ b/src/lib/components/PlaylistView.svelte
@@ -38,6 +38,7 @@
   import type { PlaylistItem, Song } from "../types";
   import { parseSearchRules, isSmartPlaylistSpec } from "../utils/filterParser";
   import { rememberScroll } from "../utils/scrollMemory";
+  import { openInPicard } from "../utils/picard";
   import { invoke } from "@tauri-apps/api/core";
   import { open, save } from "@tauri-apps/plugin-dialog";
   import TagEditor from "./TagEditor.svelte";
@@ -518,6 +519,18 @@
     }
   }
 
+  function openSelectedInPicard(fallbackSongId?: number) {
+    const selectedTracks = playlistsStore.activePlaylistTracks.filter(
+      (t) => selectedUuids.has(t.uuid) && t.song
+    );
+    const songIds = selectedTracks.length > 0
+      ? selectedTracks.map((t) => t.song!.id)
+      : fallbackSongId !== undefined
+        ? [fallbackSongId]
+        : [];
+    openInPicard(songIds);
+  }
+
   async function handlePlayAll() {
     if (!activePlaylist || playlistsStore.activePlaylistTracks.length === 0) return;
     const availableTracks = playlistsStore.activePlaylistTracks.filter((t) => t.song && !isItemUnavailable(t));
@@ -854,6 +867,7 @@
           onRowContextMenu={handleRowContextMenu}
           onRate={rateSong}
           onEditTags={(song) => openTagEditor(song.id)}
+          onOpenInPicard={(song) => openSelectedInPicard(song.id)}
           onRemoveFromPlaylist={(row) => handleRemoveItem(row.key)}
           onReorder={handleReorder}
           isRowPlaying={(row) => (!!playerStore.playlistItemUuid && playerStore.playlistItemUuid === row.key) || (!!playerStore.currentSong && !!row.song && playerStore.currentSong.id === row.song.id)}
@@ -913,6 +927,7 @@
     onGoToArtist={singleItem.song?.artist ? () => navigationStore.viewArtist(singleItem.song?.album_artist?.trim() || singleItem.song?.artist || "") : undefined}
     onGoToAlbum={singleItem.song?.album ? () => navigationStore.viewAlbum(singleItem.song?.album || "") : undefined}
     onEditTags={singleItem.song?.id && !isItemUnavailable(singleItem) ? () => openTagEditor(singleItem.song!.id) : undefined}
+    onOpenInPicard={singleItem.song?.id ? () => openSelectedInPicard(singleItem.song!.id) : undefined}
     onClose={() => { contextMenuState = null; }}
   />
 {/if}

--- a/src/lib/components/PlaylistsCollectionView.svelte
+++ b/src/lib/components/PlaylistsCollectionView.svelte
@@ -26,7 +26,7 @@
 
   interface AutoDef {
     id: string;
-    kind: "favourites" | "recently_added" | "most_played" | "history" | "genre" | "decade" | "bpm" | "artist_tag";
+    kind: "favourites" | "recently_added" | "most_played" | "history" | "genre" | "decade" | "bpm" | "artist_tag" | "missing_metadata";
     genre?: string;
     artistTag?: string;
     decade?: string;
@@ -92,6 +92,11 @@
       .filter((p) => p.dynamic_enabled && p.dynamic_spec?.startsWith("bpmrange:"))
       .sort((a, b) => BPM_BUCKET_ORDER.indexOf(a.name) - BPM_BUCKET_ORDER.indexOf(b.name))
   );
+  // Missing Metadata (#367) is a singleton diagnostic auto-playlist, not a
+  // per-value category like genre/decade/BPM/artist tag.
+  let missingMetadataAutoPlaylist = $derived(
+    playlistsStore.playlists.find((p) => p.dynamic_enabled && p.dynamic_spec === "missingmeta")
+  );
   let customPlaylists = $derived.by(() => {
     // Include non-dynamic playlists + user-created Smart playlists
     const list = playlistsStore.playlists.filter((p) => !p.dynamic_enabled || isSmartPlaylistSpec(p.dynamic_spec));
@@ -134,6 +139,16 @@
       label: i18n.t("playlists.autoHistory"),
       trackCount: playlistsStore.historyCount,
     });
+    if (missingMetadataAutoPlaylist && missingMetadataAutoPlaylist.track_count > 0) {
+      defs.push({
+        id: `auto:missing_metadata:${missingMetadataAutoPlaylist.id}`,
+        kind: "missing_metadata",
+        label: getPlaylistDisplayName(missingMetadataAutoPlaylist),
+        playlistId: missingMetadataAutoPlaylist.id,
+        updated: missingMetadataAutoPlaylist.updated,
+        trackCount: missingMetadataAutoPlaylist.track_count,
+      });
+    }
     for (const p of decadeAutoPlaylists) {
       if (p.track_count > 0) {
         const dec = p.dynamic_spec?.replace(/^decade:/, "") ?? p.name;
@@ -280,7 +295,9 @@
             ? { kind: "decade", decade: def.decade, playlistId: def.playlistId, updated: def.updated }
             : def.kind === "bpm"
               ? { kind: "bpm", bpm: def.bpm, playlistId: def.playlistId, updated: def.updated }
-              : { kind: def.kind }
+              : def.kind === "missing_metadata"
+                ? { kind: "missing_metadata", playlistId: def.playlistId, updated: def.updated }
+                : { kind: def.kind }
     );
   }
 

--- a/src/lib/components/SettingsTools.svelte
+++ b/src/lib/components/SettingsTools.svelte
@@ -115,19 +115,21 @@
     </button>
   </div>
 
-  <div class="flex flex-col gap-1.5 max-w-md">
+  <div class="flex flex-col gap-1.5">
     <label for="picard-custom-path-input" class="text-xs font-semibold text-brand-text-secondary uppercase tracking-wider">
       {i18n.t('picard.customPathLabel')}
     </label>
     <div class="flex items-center gap-2">
-      <Input
-        id="picard-custom-path-input"
-        type="text"
-        bind:value={picardCustomPath}
-        onchange={handlePicardCustomPathChange}
-        placeholder={i18n.t('picard.customPathPlaceholder')}
-        class="flex-1"
-      />
+      <div class="max-w-md flex-1">
+        <Input
+          id="picard-custom-path-input"
+          type="text"
+          bind:value={picardCustomPath}
+          onchange={handlePicardCustomPathChange}
+          placeholder={i18n.t('picard.customPathPlaceholder')}
+          class="w-full"
+        />
+      </div>
       <Button onclick={handleBrowsePicardPath} variant="secondary" size="sm">
         <FolderOpen class="w-4 h-4" />
         {i18n.t('picard.browseBtn')}

--- a/src/lib/components/SettingsTools.svelte
+++ b/src/lib/components/SettingsTools.svelte
@@ -138,20 +138,6 @@
   </div>
 </div>
 
-<div class="bg-brand-sidebar border border-brand-border rounded-xl p-6 space-y-5">
-  <div class="flex flex-wrap items-center gap-3">
-    <Button onclick={handlePruneMissing} disabled={collectionStore.isScanning} variant="secondary" size="sm">
-      <Eraser class="w-4 h-4" />
-      {i18n.t('settings.pruneMissingBtn')}
-    </Button>
-    <span class="text-xs text-brand-text-secondary">{i18n.t('settings.pruneMissingHint')}</span>
-
-    {#if pruneMsg}
-      <span class="text-xs text-brand-accent-text font-medium transition-all">{pruneMsg}</span>
-    {/if}
-  </div>
-</div>
-
 <div class="bg-brand-sidebar border border-brand-border rounded-xl p-6 space-y-4">
   <div class="pb-3 flex justify-between items-center">
     <div class="flex items-center gap-3">
@@ -200,5 +186,19 @@
         </button>
       </div>
     </div>
+  </div>
+</div>
+
+<div class="bg-brand-sidebar border border-brand-border rounded-xl p-6 space-y-5">
+  <div class="flex flex-wrap items-center gap-3">
+    <Button onclick={handlePruneMissing} disabled={collectionStore.isScanning} variant="secondary" size="sm">
+      <Eraser class="w-4 h-4" />
+      {i18n.t('settings.pruneMissingBtn')}
+    </Button>
+    <span class="text-xs text-brand-text-secondary">{i18n.t('settings.pruneMissingHint')}</span>
+
+    {#if pruneMsg}
+      <span class="text-xs text-brand-accent-text font-medium transition-all">{pruneMsg}</span>
+    {/if}
   </div>
 </div>

--- a/src/lib/components/SettingsTools.svelte
+++ b/src/lib/components/SettingsTools.svelte
@@ -3,13 +3,15 @@
   import { navigationStore } from "../stores/navigation.svelte";
   import { i18n } from "../stores/i18n.svelte";
   import { prefs } from "../stores/prefs.svelte";
+  import { picardStore } from "../stores/picard.svelte";
   import { onMount } from "svelte";
   import { invoke } from "@tauri-apps/api/core";
+  import { open } from "@tauri-apps/plugin-dialog";
   import { openExternalUrl } from "../utils/openExternalUrl";
   import OrganizeFiles from "./OrganizeFiles.svelte";
   import Button from "./Button.svelte";
   import Input from "./Input.svelte";
-  import { Eraser, Sparkles, Check, Eye, EyeOff } from "lucide-svelte";
+  import { Eraser, Sparkles, Check, Eye, EyeOff, Disc3, AlertTriangle, RefreshCw, FolderOpen } from "lucide-svelte";
 
   const PRUNE_MESSAGE_DURATION_MS = 8000;
 
@@ -17,6 +19,34 @@
   let organizeRefreshKey = $state(0);
   let showAcoustidKey = $state(false);
   let hasEnvKey = $state(false);
+  let picardCustomPath = $state("");
+  let isRecheckingPicard = $state(false);
+
+  async function handlePicardCustomPathChange() {
+    await invoke("set_app_setting", { key: "picard_path", value: picardCustomPath.trim() });
+    await picardStore.refresh();
+  }
+
+  async function handleBrowsePicardPath() {
+    const selected = await open({
+      multiple: false,
+      title: i18n.t("picard.browseBtn"),
+      filters: [{ name: "Picard executable", extensions: ["exe"] }],
+    });
+    if (selected && typeof selected === "string") {
+      picardCustomPath = selected;
+      await handlePicardCustomPathChange();
+    }
+  }
+
+  async function handleRecheckPicard() {
+    isRecheckingPicard = true;
+    try {
+      await picardStore.refresh();
+    } finally {
+      isRecheckingPicard = false;
+    }
+  }
 
   async function handlePruneMissing() {
     const { deletedSongs, removedFolders, mergedDuplicates } = await collectionStore.pruneMissing();
@@ -39,10 +69,72 @@
     } catch (e) {
       console.error("Failed to check AcoustID env key on mount:", e);
     }
+    try {
+      const settings = await invoke<Record<string, string>>("get_all_app_settings");
+      picardCustomPath = settings?.picard_path ?? "";
+    } catch (e) {
+      console.error("Failed to load Picard custom path on mount:", e);
+    }
   });
 </script>
 
 <OrganizeFiles embedded songIds={[]} initialScope="library" refreshKey={organizeRefreshKey} />
+
+<div class="bg-brand-sidebar border border-brand-border rounded-xl p-6 space-y-4">
+  <div class="pb-3 flex justify-between items-center">
+    <div class="flex items-center gap-3">
+      <div class="p-2 rounded-xl bg-brand-accent/15 text-brand-accent-text shrink-0">
+        <Disc3 class="w-5 h-5" />
+      </div>
+      <div class="space-y-1 min-w-0">
+        <h3 class="font-bold text-sm text-brand-text-primary">{i18n.t('picard.integrationTitle')}</h3>
+        <p class="text-xs text-brand-text-secondary leading-relaxed">
+          {i18n.t('picard.integrationDesc1')} <button onclick={() => openExternalUrl("https://picard.musicbrainz.org")} class="text-brand-accent hover:underline">MusicBrainz Picard</button> {i18n.t('picard.integrationDesc2')}
+        </p>
+      </div>
+    </div>
+  </div>
+
+  <div class="flex items-center gap-2 text-xs font-medium">
+    {#if picardStore.available}
+      <Check class="w-3.5 h-3.5 text-brand-accent-text shrink-0" />
+      <span class="text-brand-accent-text truncate" title={picardStore.path ?? undefined}>
+        {i18n.t('picard.foundAt', { path: picardStore.path ?? '' })}
+      </span>
+    {:else}
+      <AlertTriangle class="w-3.5 h-3.5 text-amber-500 shrink-0" />
+      <span class="text-brand-text-secondary">{i18n.t('picard.notFound')}</span>
+    {/if}
+    <button
+      onclick={handleRecheckPicard}
+      disabled={isRecheckingPicard}
+      class="ml-1 text-brand-text-secondary hover:text-brand-accent-text transition-colors disabled:opacity-50"
+      title={i18n.t('picard.recheckTooltip')}
+    >
+      <RefreshCw class="w-3.5 h-3.5 {isRecheckingPicard ? 'animate-spin' : ''}" />
+    </button>
+  </div>
+
+  <div class="flex flex-col gap-1.5 max-w-md">
+    <label for="picard-custom-path-input" class="text-xs font-semibold text-brand-text-secondary uppercase tracking-wider">
+      {i18n.t('picard.customPathLabel')}
+    </label>
+    <div class="flex items-center gap-2">
+      <Input
+        id="picard-custom-path-input"
+        type="text"
+        bind:value={picardCustomPath}
+        onchange={handlePicardCustomPathChange}
+        placeholder={i18n.t('picard.customPathPlaceholder')}
+        class="flex-1"
+      />
+      <Button onclick={handleBrowsePicardPath} variant="secondary" size="sm">
+        <FolderOpen class="w-4 h-4" />
+        {i18n.t('picard.browseBtn')}
+      </Button>
+    </div>
+  </div>
+</div>
 
 <div class="bg-brand-sidebar border border-brand-border rounded-xl p-6 space-y-5">
   <div class="flex flex-wrap items-center gap-3">

--- a/src/lib/components/SongContextMenu.svelte
+++ b/src/lib/components/SongContextMenu.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Play, Plus, ListPlus, Mic2, DiscAlbum, Edit3, Folder, Layers, Pin, PinOff } from "lucide-svelte";
+  import { Play, Plus, ListPlus, Mic2, DiscAlbum, Edit3, Folder, Layers, Pin, PinOff, Disc3 } from "lucide-svelte";
   import { invoke } from "@tauri-apps/api/core";
   import { i18n } from "../stores/i18n.svelte";
   import { playlistsStore } from "../stores/playlists.svelte";
@@ -22,6 +22,7 @@
     onGoToArtist,
     onGoToAlbum,
     onEditTags,
+    onOpenInPicard,
     onOrganizeFiles,
     onClose,
   }: {
@@ -36,6 +37,7 @@
     onGoToArtist?: () => void;
     onGoToAlbum?: () => void;
     onEditTags?: () => void;
+    onOpenInPicard?: () => void;
     onOrganizeFiles?: () => void;
     onClose: () => void;
   } = $props();
@@ -132,6 +134,14 @@
       icon={Edit3}
       label={i18n.t("collection.editTagsTooltip")}
       onclick={() => { onEditTags?.(); onClose(); }}
+    />
+  {/if}
+
+  {#if onOpenInPicard}
+    <ContextMenuItem
+      icon={Disc3}
+      label={i18n.t("picard.openInPicard")}
+      onclick={() => { onOpenInPicard?.(); onClose(); }}
     />
   {/if}
 </ContextMenu>

--- a/src/lib/components/SongContextMenu.svelte
+++ b/src/lib/components/SongContextMenu.svelte
@@ -2,6 +2,7 @@
   import { Play, Plus, ListPlus, Mic2, DiscAlbum, Edit3, Folder, Layers, Pin, PinOff, Disc3 } from "lucide-svelte";
   import { invoke } from "@tauri-apps/api/core";
   import { i18n } from "../stores/i18n.svelte";
+  import { picardStore } from "../stores/picard.svelte";
   import { playlistsStore } from "../stores/playlists.svelte";
   import { pinnedStore } from "../stores/pinned.svelte";
   import { toastStore } from "../stores/toast.svelte";
@@ -142,6 +143,8 @@
       icon={Disc3}
       label={i18n.t("picard.openInPicard")}
       onclick={() => { onOpenInPicard?.(); onClose(); }}
+      disabled={!picardStore.available}
+      title={picardStore.available ? undefined : i18n.t("picard.notFoundTooltip")}
     />
   {/if}
 </ContextMenu>

--- a/src/lib/components/SongTable.svelte
+++ b/src/lib/components/SongTable.svelte
@@ -21,6 +21,7 @@
   import { navigationStore } from "../stores/navigation.svelte";
   import { playerStore } from "../stores/player.svelte";
   import { i18n } from "../stores/i18n.svelte";
+  import { picardStore } from "../stores/picard.svelte";
   import { formatDate, formatFileSize, formatSampleRate, formatBitDepth, formatChannels, formatDuration } from "../utils/formatters";
   import { formatDateAdded } from "../utils/date";
   import { formatTrackNumber } from "../utils/artist";
@@ -583,8 +584,9 @@
       {#if onOpenInPicard}
         <button
           onclick={() => onOpenInPicard?.(song)}
-          class="text-brand-text-secondary hover:text-brand-accent-text transition-colors"
-          title={i18n.t("picard.openInPicard")}
+          class="text-brand-text-secondary hover:text-brand-accent-text transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+          disabled={!picardStore.available}
+          title={picardStore.available ? i18n.t("picard.openInPicard") : i18n.t("picard.notFoundTooltip")}
         >
           <Disc3 class="w-4 h-4" />
         </button>

--- a/src/lib/components/SongTable.svelte
+++ b/src/lib/components/SongTable.svelte
@@ -37,7 +37,7 @@
   import CoverArt from "./CoverArt.svelte";
   import NowPlayingBars from "./NowPlayingBars.svelte";
   import EmptyState from "./EmptyState.svelte";
-  import { Play, Plus, Edit3, Trash2, GripVertical, AlertTriangle, Music, Clock, DiscAlbum } from "lucide-svelte";
+  import { Play, Plus, Edit3, Trash2, GripVertical, AlertTriangle, Music, Clock, DiscAlbum, Disc3 } from "lucide-svelte";
   import { VirtualList } from "svelte-virtual-list-ts";
   import type { Snippet } from "svelte";
 
@@ -72,6 +72,8 @@
     onEditTags: (song: Song) => void;
     /** Adds a per-row "edit this song's album" quick action (AutoPlaylistDetailView only). */
     onEditAlbum?: (song: Song) => void;
+    /** Adds a per-row "open this song's file in MusicBrainz Picard" quick action (#367). */
+    onOpenInPicard?: (song: Song) => void;
     /** When set, position rows show a drag handle and pointer-based reorder is enabled (PlaylistView only). */
     onReorder?: (fromIndex: number, toIndex: number, selectedKeys: string[]) => void;
     /** When set in "position" mode, the leading column header becomes a sortable control for this field instead of a plain label. */
@@ -113,6 +115,7 @@
     onRemoveFromPlaylist,
     onEditTags,
     onEditAlbum,
+    onOpenInPicard,
     onReorder,
     positionSortField,
     interactiveWhenDisabled = false,
@@ -575,6 +578,15 @@
           title={i18n.t("songTags.editAlbumTooltip", {}, "Edit Album")}
         >
           <DiscAlbum class="w-4 h-4" />
+        </button>
+      {/if}
+      {#if onOpenInPicard}
+        <button
+          onclick={() => onOpenInPicard?.(song)}
+          class="text-brand-text-secondary hover:text-brand-accent-text transition-colors"
+          title={i18n.t("picard.openInPicard")}
+        >
+          <Disc3 class="w-4 h-4" />
         </button>
       {/if}
       {#if onRemoveFromPlaylist}

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -979,7 +979,9 @@ export const en = {
     close: "Close"
   },
   picard: {
-    openInPicard: "Open in Picard"
+    openInPicard: "Open in Picard",
+    openAllInPicard: "Open All in Picard",
+    openSelectedInPicard: "Open {count} in Picard"
   },
   smartPlaylistBuilder: {
     fallbackName: "Smart Playlist",

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -413,6 +413,7 @@ export const en = {
     autoRecentlyAdded: "Recently Added",
     autoMostPlayed: "Most Played",
     autoHistory: "History",
+    autoMissingMetadata: "Missing Metadata",
     updatedOn: "Updated {date}",
     saveAsCustomTooltip: "Save as Custom Playlist",
     activePlaylistTitle: "Playlists",
@@ -485,6 +486,7 @@ export const en = {
     artistTagAutoPlaylist: "Artist Tag",
     decadeAutoPlaylist: "Decade",
     bpmAutoPlaylist: "BPM",
+    missingMetadataAutoPlaylist: "Missing Metadata",
     bpmDownTempo: "Down-Tempo BPM",
     bpmMidTempo: "Mid-Tempo BPM",
     bpmUptempo: "Uptempo BPM",
@@ -975,6 +977,9 @@ export const en = {
     unknownError: "Unknown error",
     applying: "Applying...",
     close: "Close"
+  },
+  picard: {
+    openInPicard: "Open in Picard"
   },
   smartPlaylistBuilder: {
     fallbackName: "Smart Playlist",

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -981,7 +981,17 @@ export const en = {
   picard: {
     openInPicard: "Open in Picard",
     openAllInPicard: "Open All in Picard",
-    openSelectedInPicard: "Open {count} in Picard"
+    openSelectedInPicard: "Open {count} in Picard",
+    notFoundTooltip: "MusicBrainz Picard not found. Install it from picard.musicbrainz.org, or set a custom path in Settings.",
+    integrationTitle: "MusicBrainz Picard Integration",
+    integrationDesc1: "Hand off songs to",
+    integrationDesc2: "for canonical tag lookups and fixes, then rescan to pick up the changes.",
+    foundAt: "Found at {path}",
+    notFound: "Not found — install it from picard.musicbrainz.org, or set a custom path below.",
+    customPathLabel: "Custom Path (optional)",
+    customPathPlaceholder: "C:\\Program Files\\MusicBrainz Picard\\picard.exe",
+    browseBtn: "Browse...",
+    recheckTooltip: "Re-check for Picard"
   },
   smartPlaylistBuilder: {
     fallbackName: "Smart Playlist",

--- a/src/lib/stores/navigation.svelte.ts
+++ b/src/lib/stores/navigation.svelte.ts
@@ -8,9 +8,20 @@ export type ActiveSubTab = "songs" | "albums" | "artists" | "genres";
 type PlaylistsSubTab = "auto" | "custom";
 
 /** An auto-playlist reference (Favourites, Recently Added, genre, decade, BPM,
- * or the genre-less "No Genre" group), for the auto-playlist detail view. */
+ * Missing Metadata, or the genre-less "No Genre" group), for the auto-playlist
+ * detail view. */
 export interface AutoPlaylistRef {
-  kind: "favourites" | "recently_added" | "most_played" | "history" | "genre" | "decade" | "bpm" | "no_genre" | "artist_tag";
+  kind:
+    | "favourites"
+    | "recently_added"
+    | "most_played"
+    | "history"
+    | "genre"
+    | "decade"
+    | "bpm"
+    | "no_genre"
+    | "artist_tag"
+    | "missing_metadata";
   /** For kind "genre": the curated tag's plain name (#548) — a top-level
    * card name or a sub-genre chip name, resolved the same way either way
    * (see `viewGenreTag`). */

--- a/src/lib/stores/picard.svelte.ts
+++ b/src/lib/stores/picard.svelte.ts
@@ -1,0 +1,31 @@
+import { invoke } from "@tauri-apps/api/core";
+
+/** Whether/where MusicBrainz Picard was found on this machine (#367) —
+ * checked once at startup so every "Open in Picard" action can disable
+ * itself instead of always showing and failing on click, and so the
+ * Settings integration card can show the resolved path. */
+class PicardStore {
+  path = $state<string | null>(null);
+  private initialized = false;
+
+  get available(): boolean {
+    return this.path !== null;
+  }
+
+  async init() {
+    if (this.initialized) return;
+    this.initialized = true;
+    await this.refresh();
+  }
+
+  async refresh() {
+    try {
+      this.path = await invoke<string | null>("get_picard_path");
+    } catch (err) {
+      console.error("Failed to check MusicBrainz Picard availability:", err);
+      this.path = null;
+    }
+  }
+}
+
+export const picardStore = new PicardStore();

--- a/src/lib/stores/picard.test.ts
+++ b/src/lib/stores/picard.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { invoke } from "@tauri-apps/api/core";
+import { picardStore } from "./picard.svelte";
+
+describe("PicardStore", () => {
+  beforeEach(() => {
+    (picardStore as any).initialized = false;
+    picardStore.path = null;
+    vi.mocked(invoke).mockReset();
+  });
+
+  it("is unavailable before init/refresh", () => {
+    expect(picardStore.available).toBe(false);
+    expect(picardStore.path).toBeNull();
+  });
+
+  it("becomes available once the backend resolves a path", async () => {
+    vi.mocked(invoke).mockResolvedValue(String.raw`C:\Program Files\MusicBrainz Picard\picard.exe`);
+    await picardStore.init();
+    expect(invoke).toHaveBeenCalledWith("get_picard_path");
+    expect(picardStore.available).toBe(true);
+    expect(picardStore.path).toBe(String.raw`C:\Program Files\MusicBrainz Picard\picard.exe`);
+  });
+
+  it("stays unavailable when the backend finds nothing", async () => {
+    vi.mocked(invoke).mockResolvedValue(null);
+    await picardStore.init();
+    expect(picardStore.available).toBe(false);
+    expect(picardStore.path).toBeNull();
+  });
+
+  it("only calls the backend once across repeated init() calls", async () => {
+    vi.mocked(invoke).mockResolvedValue(null);
+    await picardStore.init();
+    await picardStore.init();
+    await picardStore.init();
+    expect(invoke).toHaveBeenCalledTimes(1);
+  });
+
+  it("refresh() re-checks even after init()", async () => {
+    vi.mocked(invoke).mockResolvedValueOnce(null).mockResolvedValueOnce("/usr/bin/picard");
+    await picardStore.init();
+    expect(picardStore.available).toBe(false);
+    await picardStore.refresh();
+    expect(picardStore.available).toBe(true);
+    expect(picardStore.path).toBe("/usr/bin/picard");
+  });
+
+  it("falls back to unavailable if the backend call throws", async () => {
+    vi.mocked(invoke).mockRejectedValue("boom");
+    await picardStore.init();
+    expect(picardStore.available).toBe(false);
+    expect(picardStore.path).toBeNull();
+  });
+});

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -406,7 +406,7 @@ export type PinnedItemType = "song" | "album" | "artist" | "playlist" | "auto_pl
  * Played/History have no backing playlist row, so `playlistId`/`updated` are
  * absent for those kinds. */
 export interface AutoPlaylistItem {
-  kind: "favourites" | "recently_added" | "most_played" | "history" | "genre" | "decade" | "bpm" | "artist_tag";
+  kind: "favourites" | "recently_added" | "most_played" | "history" | "genre" | "decade" | "bpm" | "artist_tag" | "missing_metadata";
   genre?: string;
   artistTag?: string;
   decade?: string;

--- a/src/lib/utils/picard.test.ts
+++ b/src/lib/utils/picard.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { invoke } from "@tauri-apps/api/core";
+import { toastStore } from "../stores/toast.svelte";
+import { openInPicard } from "./picard";
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(),
+}));
+
+vi.mock("../stores/toast.svelte", () => ({
+  toastStore: { show: vi.fn() },
+}));
+
+describe("openInPicard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("invokes open_in_picard with the given song ids", async () => {
+    (invoke as any).mockResolvedValue(undefined);
+    await openInPicard([1, 2, 3]);
+    expect(invoke).toHaveBeenCalledWith("open_in_picard", { songIds: [1, 2, 3] });
+    expect(toastStore.show).not.toHaveBeenCalled();
+  });
+
+  it("does nothing for an empty selection", async () => {
+    await openInPicard([]);
+    expect(invoke).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a launch failure (e.g. Picard not found) as an error toast", async () => {
+    (invoke as any).mockRejectedValue("MusicBrainz Picard not found.");
+    await openInPicard([1]);
+    expect(toastStore.show).toHaveBeenCalledWith("MusicBrainz Picard not found.", "error");
+  });
+});

--- a/src/lib/utils/picard.ts
+++ b/src/lib/utils/picard.ts
@@ -1,0 +1,17 @@
+import { invoke } from "@tauri-apps/api/core";
+import { toastStore } from "../stores/toast.svelte";
+
+/**
+ * Launches MusicBrainz Picard with the given songs' files (#367) — a
+ * one-way handoff; Luminous's scanner/watcher picks up any tag changes
+ * later. Surfaces the backend's "Picard not found" message (or any other
+ * launch failure) as a toast rather than throwing into the caller.
+ */
+export async function openInPicard(songIds: number[]): Promise<void> {
+  if (songIds.length === 0) return;
+  try {
+    await invoke("open_in_picard", { songIds });
+  } catch (err) {
+    toastStore.show(String(err), "error");
+  }
+}

--- a/src/lib/utils/playlist.test.ts
+++ b/src/lib/utils/playlist.test.ts
@@ -157,4 +157,19 @@ describe("playlist utils", () => {
     };
     expect(getPlaylistDisplayName(playlist)).toBe("Metal; Death Metal Favourites (Smart)");
   });
+
+  it("never appends a population-mode suffix to the Missing Metadata auto-playlist (#367)", () => {
+    const playlist: Playlist = {
+      id: 11,
+      name: "Missing Metadata",
+      dynamic_spec: "missingmeta",
+      population_mode: "favourites",
+      created: 100,
+      updated: 100,
+      track_count: 3,
+      dynamic_enabled: true,
+      is_queue: false,
+    };
+    expect(getPlaylistDisplayName(playlist)).toBe("Missing Metadata");
+  });
 });

--- a/src/lib/utils/playlist.ts
+++ b/src/lib/utils/playlist.ts
@@ -55,7 +55,15 @@ export function getPlaylistDisplayName(
   // required (a chip's own card already exists separately, so there's
   // nothing to strip a parent's name out of).
   const baseName = getBpmBucketLabel(playlist.dynamic_spec, playlist.name);
-  if (!playlist.dynamic_enabled || isSmartPlaylistSpec(playlist.dynamic_spec)) {
+  // Missing Metadata (#367) is a diagnostic singleton, not a library-data
+  // category — a population-mode suffix ("Missing Metadata (Favourites)")
+  // wouldn't mean anything useful, so it's excluded the same way Smart
+  // Playlists are.
+  if (
+    !playlist.dynamic_enabled ||
+    isSmartPlaylistSpec(playlist.dynamic_spec) ||
+    playlist.dynamic_spec === "missingmeta"
+  ) {
     return baseName;
   }
   const suffix = getPopulationModeSuffix(playlist.population_mode);

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -20,6 +20,7 @@
   import { prefs } from '../lib/stores/prefs.svelte';
   import { tagsStore } from '../lib/stores/tags.svelte';
   import { updaterStore } from '../lib/stores/updater.svelte';
+  import { picardStore } from '../lib/stores/picard.svelte';
   import { toastStore } from '../lib/stores/toast.svelte';
   import { isLinux as platformIsLinux } from '../lib/platform';
   import { onMount } from 'svelte';
@@ -54,6 +55,7 @@
     prefs.init();
     tagsStore.load().catch((err) => console.error('Failed to load tags:', err));
     updaterStore.init();
+    picardStore.init();
     void getCurrentWindow().show().catch(() => {});
 
     function handleGlobalHotkeys(e: KeyboardEvent) {


### PR DESCRIPTION
## 📋 Summary
Addresses #367 — adds a "Missing Metadata" auto-playlist and a one-way handoff bridge to MusicBrainz Picard, so users can find songs missing core tags and fix them in a dedicated tool instead of Luminous growing its own deep-tagging UI.

- **"Missing Metadata" auto-playlist**: a system-managed auto-playlist (`dynamic_spec = "missingmeta"`) surfacing songs with a blank title, artist, or album — always-complete via the existing dynamic-playlist reconciler, no library-size threshold (the point is to catch even a single bad song).
- **Picard bridge**: an "Open in Picard" action wherever "Edit Tags" already appears (song context menus, row actions, playlist context menu), plus a bulk "Open All/N in Picard" action in the Missing Metadata playlist's overflow menu. Launches the Picard executable with the selected file paths; Luminous's existing file-watcher/incremental scanner picks up any tag changes on the next pass. No MusicBrainz API calls are added to Luminous itself — canonical lookup stays Picard's job.
- **Settings integration card**: a new "MusicBrainz Picard Integration" card in Settings → Tools (above AcoustID) showing found/not-found status with the resolved path, a re-check button, and an optional custom-path override with a Browse... picker.
- Every "Open in Picard" action disables itself (rather than hiding) when Picard can't be found, backed by a `picardStore` that checks once at startup.

**Bug fix found and fixed along the way (unrelated to Picard):** in Artist detail view, songs with no album tag ("loose singles") used to vanish entirely as soon as that artist had even one song with a real album elsewhere — the fallback that surfaces them was gated on "this artist has zero albums" instead of computed per song.

## 🔍 Implementation Notes
- Backend: `src-tauri/src/collection/query.rs` (`get_songs_missing_core_tags`), `src-tauri/src/playlist/dynamic.rs` (new `missingmeta` dispatch branch), `src-tauri/src/playlist/auto_sync.rs` (`sync_missing_metadata_auto_playlist`), `src-tauri/src/picard.rs` (new — cross-platform executable discovery + launch; macOS isn't a Luminous build target, so it's not handled), `src-tauri/src/commands/picard.rs` (new — `open_in_picard`, `get_picard_path`), `src-tauri/src/pins.rs` (pinning the Missing Metadata playlist to Home).
- Frontend: `src/lib/stores/picard.svelte.ts` (new — Picard-availability store), `src/lib/utils/picard.ts` (new — shared `openInPicard` helper), plus wiring across `SongContextMenu`, `PlaylistContextMenu`, `SongTable`, `AutoPlaylistDetailView`, `PlaylistsCollectionView`, `AutoPlaylistCard`/`RowCard`, and the new Picard card in `SettingsTools.svelte`.
- Deliberately scoped narrowly (per repo product-scope philosophy): no MusicBrainz API integration in Luminous, no flatpak/Linux desktop-file discovery, no "watch Picard and auto-rescan on exit" hook. `picard.rs`/`commands/picard.rs` are scoped strictly to process discovery/launch, kept separate from any future MusicBrainz *API* enrichment feature (e.g. a Details Pane, loosely tracked under epic #677).
- Filed #736 for a pre-existing, unrelated flaky test discovered while working on this (`pins::tests::pin_unpin_round_trip_for_each_item_type`, a timer-resolution race in a test helper's temp-dir naming).

## 🧪 Test Plan
- [x] `bun run check` (svelte-check + knip) — 0 errors/warnings
- [x] `bun run test -- --run` (frontend) — 551 passed
- [x] `cargo test` (src-tauri) — 250 passed; `cargo clippy`/`cargo fmt --check` clean
- [x] Manually verified in the app by the user (`bun run tauri dev`): Missing Metadata playlist populates/clears correctly, Picard launches with the right files loaded from multiple entry points, disabled state and Settings card work as expected, and the Artist Singles fix was confirmed.

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed — no screenshot harness entries needed for this issue
