### PR TITLE
fix: pin cargo-audit install to --locked to fix Security Audit CI (next)

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -24,6 +24,17 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
+      # rustsec/audit-check installs cargo-audit via a plain `cargo install
+      # cargo-audit` with no version pin and no --locked, so it re-resolves
+      # cargo-audit's own dependencies fresh. That currently pulls tinyvec
+      # 1.13.0, which fails to compile on the runner's Rust toolchain
+      # (upstream tinyvec/rustc edition-resolution bug). Installing here
+      # with --locked (using cargo-audit's own tested Cargo.lock, which
+      # pins an older working tinyvec) puts a working binary on PATH first,
+      # so the action's own install step just finds and reuses it.
+      - name: Install cargo-audit
+        run: cargo install cargo-audit --locked
+
       - name: Security audit Cargo.lock
         uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2.0.0
         with:


### PR DESCRIPTION
## 📋 Summary
Same fix as #741, applied to `next` since it's currently failing the same "Security Audit" CI check. `rustsec/audit-check` installs `cargo-audit` with a plain `cargo install cargo-audit` — no version pin, no `--locked` — which re-resolves cargo-audit's own dependency tree fresh on every run. That currently resolves `tinyvec v1.13.0`, which fails to compile on the GitHub Actions runner's current Rust toolchain with `error: cannot find macro 'vec' in this scope` (an upstream tinyvec/rustc edition-resolution issue), so the job errors out before it ever runs the actual audit.

## 🔍 Implementation Notes
Added a step before the `rustsec/audit-check` action that runs `cargo install cargo-audit --locked`. This uses cargo-audit's own published `Cargo.lock` (which pins `tinyvec v1.11.0`, unaffected by the issue) instead of resolving fresh. The action's own install step (`findOrInstall`) checks `which cargo-audit` first, so once it's already on `PATH` the action just reuses it and skips its own broken install.

No changes to the actual audit logic, ignore list, or advisories — this is purely a CI plumbing fix, identical to #741 which is already merged/verified against `main`.

## 🧪 Test Plan
- [ ] `bun run check` (svelte-check) — N/A, no frontend changes
- [ ] `bun run test -- --run` (frontend) — N/A, no frontend changes
- [ ] `cargo test` (src-tauri, if Rust changed) — N/A, no Rust source changes
- [x] Same fix already verified green on #741 (`main`) — all checks passed including `Cargo Security Audit`
- [ ] CI: this PR's own "Security Audit" check should go green

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed — N/A, no user-facing behavior changed
