### PR TITLE
feat: add Moment Mix (time-based) auto-playlist

### DIFF
--- a/src-tauri/src/collection/query.rs
+++ b/src-tauri/src/collection/query.rs
@@ -572,6 +572,32 @@ impl CollectionScanner {
         Ok(songs)
     }
 
+    /// A random cross-section of the library — the fallback used by the
+    /// Daypart Mix auto-playlist (#223) when no single genre grouping has
+    /// enough songs on its own. Unlike every other query in this file, this
+    /// intentionally ignores population-mode bias in favor of a flat
+    /// `ORDER BY RANDOM()` (the same idiom `get_featured_albums` already
+    /// uses) — a "some songs from anywhere" fallback has nothing meaningful
+    /// to bias toward.
+    pub fn get_random_songs(&self, limit: i64) -> Result<Vec<Song>> {
+        let conn = self.db.pool.get()?;
+        let sql = format!(
+            "SELECT {} FROM songs
+             WHERE source IN (1, 2)
+               AND unavailable = 0
+               AND not_included = 0
+             ORDER BY RANDOM()
+             LIMIT ?1",
+            SONG_SELECT_COLS
+        );
+        let mut stmt = conn.prepare(&sql)?;
+        let songs = stmt
+            .query_map(params![limit], row_to_song)?
+            .filter_map(|r| r.ok())
+            .collect();
+        Ok(songs)
+    }
+
     /// Distinct artist tags across all artist profiles in the library.
     pub fn get_library_artist_tags(&self) -> Result<Vec<String>> {
         let conn = self.db.pool.get()?;

--- a/src-tauri/src/pins.rs
+++ b/src-tauri/src/pins.rs
@@ -260,6 +260,32 @@ pub fn resolve_auto_playlist(
                     track_count: p.track_count,
                 })
         }
+        "daypart" => {
+            // Singleton like "missing_metadata", but resolved by *prefix*
+            // rather than exact spec match (#223) — the row's spec changes
+            // (new bucket/date/genre) every time the daypart boundary
+            // crosses, and the pin must survive that: it's keyed on
+            // `Playlist.id`, which never changes, not on the spec's content.
+            playlists
+                .iter()
+                .find(|p| {
+                    p.dynamic_enabled
+                        && p.track_count > 0
+                        && p.dynamic_spec
+                            .as_deref()
+                            .is_some_and(|s| s.starts_with("daypart:"))
+                })
+                .map(|p| AutoPlaylistItem {
+                    kind: kind.to_string(),
+                    genre: None,
+                    artist_tag: None,
+                    decade: None,
+                    bpm: None,
+                    playlist_id: Some(p.id),
+                    updated: Some(p.updated),
+                    track_count: p.track_count,
+                })
+        }
         "genre" | "decade" | "bpm" | "artist_tag" => {
             let selector = selector.unwrap_or("").to_string();
             let prefix = match kind {

--- a/src-tauri/src/playlist/auto_sync.rs
+++ b/src-tauri/src/playlist/auto_sync.rs
@@ -7,6 +7,8 @@ use crate::collection::CollectionScanner;
 use crate::models::QueuePopulationMode;
 use crate::tags::TagManager;
 use anyhow::Result;
+use chrono::Timelike;
+use rand::seq::IndexedRandom;
 use rusqlite::params;
 use std::collections::HashSet;
 use uuid::Uuid;
@@ -38,6 +40,32 @@ fn format_bpm_range_spec(min: f64, max: Option<f64>) -> String {
     }
 }
 
+/// The four fixed Daypart Mix buckets (#223): local-hour ranges deliberately
+/// mirror `HomeView.svelte`'s `getTimeOfDayGreeting()` (05-11 / 12-16 /
+/// 17-20 / else) so the Home greeting and the Daypart Mix card always agree
+/// on "what part of the day is it" — if one changes, the other must too.
+/// Pure/hour-only so boundary edges (04:59 vs 05:00, etc.) are directly
+/// unit-testable without touching the wall clock.
+fn daypart_bucket_for_hour(hour: u32) -> (&'static str, &'static str) {
+    match hour {
+        5..=11 => ("morning", "Morning Mix"),
+        12..=16 => ("afternoon", "Afternoon Mix"),
+        17..=20 => ("evening", "Evening Mix"),
+        _ => ("latenight", "Late Night Mix"),
+    }
+}
+
+/// Bucket id, display name, and local calendar date (the `dynamic_spec`
+/// reroll cache key — see [`PlaylistManager::sync_daypart_auto_playlist`])
+/// for a given local timestamp. Takes `now` as a parameter rather than
+/// calling `Local::now()` internally so tests can inject arbitrary times.
+fn daypart_bucket_and_date(
+    now: chrono::DateTime<chrono::Local>,
+) -> (&'static str, &'static str, String) {
+    let (bucket, name) = daypart_bucket_for_hour(now.hour());
+    (bucket, name, now.date_naive().to_string())
+}
+
 impl PlaylistManager {
     /// Runs all three auto-playlist syncs (genre, decade, BPM) in one call —
     /// the frontend used to invoke these as three separate IPC round trips
@@ -48,6 +76,7 @@ impl PlaylistManager {
         self.sync_bpm_auto_playlists()?;
         self.sync_artist_tag_auto_playlists()?;
         self.sync_missing_metadata_auto_playlist()?;
+        self.sync_daypart_auto_playlist()?;
         Ok(())
     }
 
@@ -567,6 +596,188 @@ impl PlaylistManager {
                 conn.execute(
                     "INSERT INTO playlists (name, dynamic_enabled, dynamic_spec, created, updated) VALUES (?1, 1, ?2, ?3, ?3)",
                     params![NAME, SPEC, now],
+                )?;
+                conn.last_insert_rowid()
+            }
+        };
+
+        for (position, song) in songs.iter().enumerate() {
+            conn.execute(
+                "INSERT INTO playlist_items (playlist_id, song_id, position, uuid, type) VALUES (?1, ?2, ?3, ?4, 0)",
+                params![playlist_id, song.id, position as i32, Uuid::new_v4().to_string()],
+            )?;
+        }
+
+        Ok(())
+    }
+
+    /// Picks a genre grouping for the Daypart Mix (#223) by walking the
+    /// curated Genre hierarchy (`TagManager::get_tag_hierarchy`, #548): pick
+    /// a random node — a top-level group or one of its curated children —
+    /// and resolve it to a name with enough songs to be worth a mix.
+    ///
+    /// A picked child under the 25-song minimum on its own (e.g. "Soft
+    /// Rock" with 10 songs) walks up to its parent group instead (e.g.
+    /// "Rock" with 408) rather than falling straight to a library-wide
+    /// shuffle — the parent's rollup already includes every curated child,
+    /// so this still reads as a coherent, related-genre mix. Returns `None`
+    /// (the random-fill fallback marker) when there's no curated hierarchy
+    /// at all, or the resolved grouping is still under the threshold even
+    /// at the parent level (a small/sparse library).
+    fn pick_daypart_genre_grouping(&self) -> Result<Option<String>> {
+        let tag_manager = TagManager::new(self.db.clone());
+        // Self-contained and idempotent, same rationale as
+        // `sync_genre_auto_playlists` — don't rely on `sync_genre_auto_playlists`
+        // having already run earlier in the same `sync_all_auto_playlists()`
+        // call (or the async `library-changed` listener) to have populated
+        // `tag_groups`/`tag_assignments` first.
+        tag_manager.reconcile_hierarchy()?;
+        let hierarchy = tag_manager.get_tag_hierarchy()?;
+
+        enum Candidate<'a> {
+            Group {
+                name: &'a str,
+                song_count: i64,
+            },
+            Child {
+                name: &'a str,
+                song_count: i64,
+                parent_name: &'a str,
+                parent_count: i64,
+            },
+        }
+
+        let mut candidates: Vec<Candidate> = Vec::new();
+        for group in &hierarchy {
+            candidates.push(Candidate::Group {
+                name: &group.name,
+                song_count: group.song_count,
+            });
+            for child in &group.children {
+                candidates.push(Candidate::Child {
+                    name: &child.name,
+                    song_count: child.song_count,
+                    parent_name: &group.name,
+                    parent_count: group.song_count,
+                });
+            }
+        }
+
+        let Some(picked) = candidates.choose(&mut rand::rng()) else {
+            return Ok(None);
+        };
+
+        let (resolved_name, resolved_count) = match picked {
+            Candidate::Group { name, song_count } => (*name, *song_count),
+            Candidate::Child {
+                name,
+                song_count,
+                parent_name,
+                parent_count,
+            } => {
+                if *song_count >= MIN_LIBRARY_SONGS_FOR_AUTO_PLAYLIST {
+                    (*name, *song_count)
+                } else {
+                    (*parent_name, *parent_count)
+                }
+            }
+        };
+
+        if resolved_count < MIN_LIBRARY_SONGS_FOR_AUTO_PLAYLIST {
+            return Ok(None);
+        }
+        Ok(Some(resolved_name.to_string()))
+    }
+
+    /// Regenerates the single "Daypart Mix" auto-playlist (#223) — a
+    /// system-managed `playlists` row with `dynamic_enabled = 1` and
+    /// `dynamic_spec = "daypart:<bucket>:<local-date>:<resolved-name>"`.
+    /// Unlike every other auto-playlist category, there is exactly ONE row
+    /// for all four dayparts (Morning/Afternoon/Evening/Late Night) — the
+    /// same row's `name` and `dynamic_spec` are rewritten in place as the
+    /// local-time bucket changes, rather than materializing one row per
+    /// bucket. This is what lets a Home-page pin (keyed on `Playlist.id`,
+    /// not on `dynamic_spec`) survive every boundary crossing untouched.
+    ///
+    /// Reroll timing: the genre grouping is only re-picked when the row's
+    /// stored `bucket:date` prefix no longer matches today's real local
+    /// bucket/date (see [`daypart_bucket_and_date`]) — repeated calls within
+    /// the same bucket on the same calendar day are a no-op, so this is safe
+    /// to call from every `sync_all_auto_playlists()` call site (startup,
+    /// `finish_scan`, manual refresh, and the frontend's periodic
+    /// boundary-check timer) without thrashing the selection.
+    ///
+    /// Playback continuity (confirmed design decision, #223): this does a
+    /// full delete+reinsert of `playlist_items` — the same full-rewrite
+    /// shape every other `sync_*_auto_playlists` function already uses —
+    /// and deliberately does NOT touch `AppState::player`'s in-memory queue.
+    /// A currently-playing session is therefore never interrupted, skipped,
+    /// or reordered by a boundary crossing; it simply keeps playing its
+    /// already-loaded songs; the DB becomes correct immediately, and a
+    /// long-running live queue only catches up the next time the playlist
+    /// is loaded/replayed. This is deliberate, not an oversight: hot-
+    /// relabeling an in-progress queue's upcoming tracks was considered and
+    /// rejected as unnecessary complexity for a rare edge case.
+    pub fn sync_daypart_auto_playlist(&self) -> Result<()> {
+        const SPEC_PREFIX: &str = "daypart:";
+
+        let (bucket, bucket_name, today) = daypart_bucket_and_date(chrono::Local::now());
+
+        let conn = self.db.pool.get()?;
+        let now = chrono::Utc::now().timestamp();
+
+        let existing_row: Option<(i64, Option<String>, String)> = conn
+            .query_row(
+                "SELECT id, dynamic_spec, COALESCE(population_mode, 'all') FROM playlists WHERE dynamic_enabled = 1 AND dynamic_spec LIKE 'daypart:%'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .ok();
+
+        if let Some((_, Some(spec), _)) = &existing_row {
+            let mut parts = spec.strip_prefix(SPEC_PREFIX).unwrap_or("").splitn(3, ':');
+            let stored_bucket = parts.next().unwrap_or("");
+            let stored_date = parts.next().unwrap_or("");
+            if stored_bucket == bucket && stored_date == today {
+                // Already correct for today's bucket — no reroll, no rewrite.
+                return Ok(());
+            }
+        }
+
+        let mode = existing_row
+            .as_ref()
+            .map(|(_, _, m)| QueuePopulationMode::from(m.as_str()))
+            .unwrap_or_default();
+
+        let resolved_name = self.pick_daypart_genre_grouping()?.unwrap_or_default();
+        let new_spec = format!("{SPEC_PREFIX}{bucket}:{today}:{resolved_name}");
+        let songs = self.songs_for_spec(&new_spec, mode)?;
+
+        // Creation gate: only skip creating a brand-new row if this pass
+        // didn't find enough songs (mirrors genre/decade/BPM's "need an
+        // existing row OR >= threshold songs" gate). An existing row is
+        // always updated in place regardless of the new count — same
+        // tolerance genre/decade/BPM already have once created.
+        if existing_row.is_none() && songs.len() < MIN_LIBRARY_SONGS_FOR_AUTO_PLAYLIST as usize {
+            return Ok(());
+        }
+
+        let playlist_id = match &existing_row {
+            Some((id, _, _)) => {
+                conn.execute(
+                    "UPDATE playlists SET name = ?1, dynamic_spec = ?2, updated = ?3 WHERE id = ?4",
+                    params![bucket_name, new_spec, now, id],
+                )?;
+                conn.execute(
+                    "DELETE FROM playlist_items WHERE playlist_id = ?1",
+                    params![id],
+                )?;
+                *id
+            }
+            None => {
+                conn.execute(
+                    "INSERT INTO playlists (name, dynamic_enabled, dynamic_spec, created, updated) VALUES (?1, 1, ?2, ?3, ?3)",
+                    params![bucket_name, new_spec, now],
                 )?;
                 conn.last_insert_rowid()
             }
@@ -1132,6 +1343,438 @@ mod tests {
         assert_eq!(
             tracks[0].song.as_ref().unwrap().title.as_deref(),
             Some("No Album")
+        );
+
+        let _ = std::fs::remove_dir_all(temp_dir);
+    }
+
+    // -----------------------------------------------------------------------
+    // Daypart Mix auto-playlist (#223)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_daypart_bucket_for_hour_matches_home_greeting_boundaries() {
+        assert_eq!(daypart_bucket_for_hour(5).0, "morning");
+        assert_eq!(daypart_bucket_for_hour(11).0, "morning");
+        assert_eq!(daypart_bucket_for_hour(12).0, "afternoon");
+        assert_eq!(daypart_bucket_for_hour(16).0, "afternoon");
+        assert_eq!(daypart_bucket_for_hour(17).0, "evening");
+        assert_eq!(daypart_bucket_for_hour(20).0, "evening");
+        assert_eq!(daypart_bucket_for_hour(21).0, "latenight");
+        assert_eq!(daypart_bucket_for_hour(4).0, "latenight");
+        assert_eq!(daypart_bucket_for_hour(0).0, "latenight");
+    }
+
+    #[test]
+    fn test_sync_daypart_creates_singleton_row_with_bucket_name() {
+        let (db, temp_dir) = setup_test_db();
+        let db_arc = std::sync::Arc::new(db);
+
+        {
+            let conn = db_arc.pool.get().unwrap();
+            for i in 1..=30 {
+                conn.execute(
+                    &format!(
+                        "INSERT INTO songs (title, genre, source, unavailable) VALUES ('Rock Song {}', 'Rock', 1, 0)",
+                        i
+                    ),
+                    [],
+                )
+                .unwrap();
+            }
+        }
+
+        let manager = PlaylistManager::new(db_arc.clone()).unwrap();
+        manager.sync_daypart_auto_playlist().unwrap();
+
+        let playlists = manager.get_playlists().unwrap();
+        let daypart_playlists: Vec<_> = playlists
+            .iter()
+            .filter(|p| {
+                p.dynamic_enabled
+                    && p.dynamic_spec
+                        .as_deref()
+                        .unwrap_or("")
+                        .starts_with("daypart:")
+            })
+            .collect();
+
+        assert_eq!(
+            daypart_playlists.len(),
+            1,
+            "exactly one Daypart Mix row must exist, never one per bucket"
+        );
+        assert!(daypart_playlists[0].name.ends_with("Mix"));
+
+        let _ = std::fs::remove_dir_all(temp_dir);
+    }
+
+    #[test]
+    fn test_sync_daypart_does_not_reroll_within_same_bucket_and_date() {
+        let (db, temp_dir) = setup_test_db();
+        let db_arc = std::sync::Arc::new(db);
+
+        {
+            let conn = db_arc.pool.get().unwrap();
+            for i in 1..=30 {
+                conn.execute(
+                    &format!(
+                        "INSERT INTO songs (title, genre, source, unavailable) VALUES ('Rock Song {}', 'Rock', 1, 0)",
+                        i
+                    ),
+                    [],
+                )
+                .unwrap();
+            }
+        }
+
+        let manager = PlaylistManager::new(db_arc.clone()).unwrap();
+        manager.sync_daypart_auto_playlist().unwrap();
+
+        let playlists = manager.get_playlists().unwrap();
+        let first = playlists
+            .iter()
+            .find(|p| {
+                p.dynamic_spec
+                    .as_deref()
+                    .unwrap_or("")
+                    .starts_with("daypart:")
+            })
+            .unwrap()
+            .clone();
+
+        // Repeated calls within the same bucket/date must be a complete
+        // no-op (same `updated` timestamp, same spec) — this is what keeps
+        // every other `sync_all_auto_playlists()` call site (finish_scan,
+        // manual refresh, mount) from thrashing the genre selection.
+        manager.sync_daypart_auto_playlist().unwrap();
+        manager.sync_daypart_auto_playlist().unwrap();
+
+        let playlists_after = manager.get_playlists().unwrap();
+        let after = playlists_after
+            .iter()
+            .find(|p| {
+                p.dynamic_spec
+                    .as_deref()
+                    .unwrap_or("")
+                    .starts_with("daypart:")
+            })
+            .unwrap();
+
+        assert_eq!(first.id, after.id);
+        assert_eq!(first.dynamic_spec, after.dynamic_spec);
+        assert_eq!(first.updated, after.updated);
+
+        let _ = std::fs::remove_dir_all(temp_dir);
+    }
+
+    #[test]
+    fn test_sync_daypart_renames_and_repopulates_same_row_across_bucket_change() {
+        let (db, temp_dir) = setup_test_db();
+        let db_arc = std::sync::Arc::new(db);
+
+        {
+            let conn = db_arc.pool.get().unwrap();
+            for i in 1..=30 {
+                conn.execute(
+                    &format!(
+                        "INSERT INTO songs (title, genre, source, unavailable) VALUES ('Rock Song {}', 'Rock', 1, 0)",
+                        i
+                    ),
+                    [],
+                )
+                .unwrap();
+            }
+        }
+
+        let manager = PlaylistManager::new(db_arc.clone()).unwrap();
+        manager.sync_daypart_auto_playlist().unwrap();
+
+        let playlists = manager.get_playlists().unwrap();
+        let before = playlists
+            .iter()
+            .find(|p| {
+                p.dynamic_spec
+                    .as_deref()
+                    .unwrap_or("")
+                    .starts_with("daypart:")
+            })
+            .unwrap()
+            .clone();
+
+        // Simulate a boundary crossing by directly rewriting the stored spec
+        // to an earlier bucket/date than "now" would ever compute, so the
+        // next sync is forced to treat it as stale and regenerate — same
+        // effect as time actually advancing, without depending on the wall
+        // clock in the test.
+        const STALE_SPEC: &str = "daypart:latenight:2000-01-01:Rock";
+        {
+            let conn = db_arc.pool.get().unwrap();
+            conn.execute(
+                "UPDATE playlists SET dynamic_spec = ?1 WHERE id = ?2",
+                params![STALE_SPEC, before.id],
+            )
+            .unwrap();
+        }
+
+        manager.sync_daypart_auto_playlist().unwrap();
+
+        let playlists_after = manager.get_playlists().unwrap();
+        let after = playlists_after
+            .iter()
+            .find(|p| {
+                p.dynamic_spec
+                    .as_deref()
+                    .unwrap_or("")
+                    .starts_with("daypart:")
+            })
+            .unwrap();
+
+        assert_eq!(
+            before.id, after.id,
+            "boundary crossing must rewrite the SAME row, never create a second one"
+        );
+        assert_ne!(
+            after.dynamic_spec.as_deref(),
+            Some(STALE_SPEC),
+            "the stale bucket/date must trigger a regen with a fresh spec, not be left as-is"
+        );
+        assert_eq!(
+            playlists_after
+                .iter()
+                .filter(|p| p
+                    .dynamic_spec
+                    .as_deref()
+                    .unwrap_or("")
+                    .starts_with("daypart:"))
+                .count(),
+            1,
+            "still exactly one Daypart Mix row after the boundary crossing"
+        );
+
+        let _ = std::fs::remove_dir_all(temp_dir);
+    }
+
+    #[test]
+    fn test_sync_daypart_falls_back_to_parent_group_when_child_below_threshold() {
+        let (db, temp_dir) = setup_test_db();
+        let db_arc = std::sync::Arc::new(db);
+
+        {
+            let conn = db_arc.pool.get().unwrap();
+            // 10 "Soft Rock" songs (curated as a child of "Rock") — below the
+            // 25-song minimum on its own.
+            for i in 1..=10 {
+                conn.execute(
+                    &format!(
+                        "INSERT INTO songs (title, genre, source, unavailable) VALUES ('Soft Rock Song {}', 'Rock; Soft Rock', 1, 0)",
+                        i
+                    ),
+                    [],
+                )
+                .unwrap();
+            }
+            // 398 more plain "Rock" songs, so the "Rock" group rolls up to
+            // 408 total — the owner's own Soft Rock (10) / Rock (408) example.
+            for i in 1..=398 {
+                conn.execute(
+                    &format!(
+                        "INSERT INTO songs (title, genre, source, unavailable) VALUES ('Rock Song {}', 'Rock', 1, 0)",
+                        i
+                    ),
+                    [],
+                )
+                .unwrap();
+            }
+        }
+
+        let manager = PlaylistManager::new(db_arc.clone()).unwrap();
+        // Only one curated grouping exists ("Rock" / "Soft Rock"), so the
+        // random pick is deterministic regardless of which node it lands on:
+        // "Rock" resolves directly, and "Soft Rock" (10 songs) must walk up
+        // to "Rock" (408) rather than falling to a random-library-fill.
+        manager.sync_daypart_auto_playlist().unwrap();
+
+        let playlists = manager.get_playlists().unwrap();
+        let daypart_pl = playlists
+            .iter()
+            .find(|p| {
+                p.dynamic_spec
+                    .as_deref()
+                    .unwrap_or("")
+                    .starts_with("daypart:")
+            })
+            .expect("Daypart Mix should be created");
+
+        assert!(
+            daypart_pl
+                .dynamic_spec
+                .as_deref()
+                .unwrap()
+                .ends_with(":Rock"),
+            "must resolve to the parent group \"Rock\", not the undersized child \"Soft Rock\": got {:?}",
+            daypart_pl.dynamic_spec
+        );
+        assert_eq!(
+            manager.get_playlist_tracks(daypart_pl.id).unwrap().len(),
+            408
+        );
+
+        let _ = std::fs::remove_dir_all(temp_dir);
+    }
+
+    #[test]
+    fn test_sync_daypart_falls_back_to_random_fill_when_no_grouping_clears_threshold() {
+        let (db, temp_dir) = setup_test_db();
+        let db_arc = std::sync::Arc::new(db);
+
+        {
+            let conn = db_arc.pool.get().unwrap();
+            // Two curated groups, each with only 15 songs (below 25) and no
+            // children to roll up into — total library is 30, well above 25,
+            // but no single grouping clears the threshold on its own.
+            for i in 1..=15 {
+                conn.execute(
+                    &format!(
+                        "INSERT INTO songs (title, genre, source, unavailable) VALUES ('Jazz Song {}', 'Jazz', 1, 0)",
+                        i
+                    ),
+                    [],
+                )
+                .unwrap();
+            }
+            for i in 1..=15 {
+                conn.execute(
+                    &format!(
+                        "INSERT INTO songs (title, genre, source, unavailable) VALUES ('Blues Song {}', 'Blues', 1, 0)",
+                        i
+                    ),
+                    [],
+                )
+                .unwrap();
+            }
+        }
+
+        let manager = PlaylistManager::new(db_arc.clone()).unwrap();
+        manager.sync_daypart_auto_playlist().unwrap();
+
+        let playlists = manager.get_playlists().unwrap();
+        let daypart_pl = playlists
+            .iter()
+            .find(|p| {
+                p.dynamic_spec
+                    .as_deref()
+                    .unwrap_or("")
+                    .starts_with("daypart:")
+            })
+            .expect("Daypart Mix should still be created via random-fill fallback");
+
+        assert!(
+            daypart_pl.dynamic_spec.as_deref().unwrap().ends_with(':'),
+            "empty trailing name marks the random-fill fallback: got {:?}",
+            daypart_pl.dynamic_spec
+        );
+        assert_eq!(
+            manager.get_playlist_tracks(daypart_pl.id).unwrap().len(),
+            30,
+            "random-fill should include the whole (small) library"
+        );
+
+        let _ = std::fs::remove_dir_all(temp_dir);
+    }
+
+    #[test]
+    fn test_sync_daypart_skips_creation_when_library_too_small() {
+        let (db, temp_dir) = setup_test_db();
+        let db_arc = std::sync::Arc::new(db);
+
+        {
+            let conn = db_arc.pool.get().unwrap();
+            for i in 1..=10 {
+                conn.execute(
+                    &format!(
+                        "INSERT INTO songs (title, genre, source, unavailable) VALUES ('Song {}', 'Rock', 1, 0)",
+                        i
+                    ),
+                    [],
+                )
+                .unwrap();
+            }
+        }
+
+        let manager = PlaylistManager::new(db_arc.clone()).unwrap();
+        manager.sync_daypart_auto_playlist().unwrap();
+
+        let playlists = manager.get_playlists().unwrap();
+        assert!(
+            !playlists.iter().any(|p| p
+                .dynamic_spec
+                .as_deref()
+                .unwrap_or("")
+                .starts_with("daypart:")),
+            "a library with only 10 songs total must not get a Daypart Mix"
+        );
+
+        let _ = std::fs::remove_dir_all(temp_dir);
+    }
+
+    #[test]
+    fn test_sync_daypart_tolerant_once_created_below_threshold() {
+        let (db, temp_dir) = setup_test_db();
+        let db_arc = std::sync::Arc::new(db);
+
+        {
+            let conn = db_arc.pool.get().unwrap();
+            for i in 1..=30 {
+                conn.execute(
+                    &format!(
+                        "INSERT INTO songs (title, genre, source, unavailable) VALUES ('Rock Song {}', 'Rock', 1, 0)",
+                        i
+                    ),
+                    [],
+                )
+                .unwrap();
+            }
+        }
+
+        let manager = PlaylistManager::new(db_arc.clone()).unwrap();
+        manager.sync_daypart_auto_playlist().unwrap();
+        let playlists = manager.get_playlists().unwrap();
+        let daypart_pl = playlists
+            .iter()
+            .find(|p| {
+                p.dynamic_spec
+                    .as_deref()
+                    .unwrap_or("")
+                    .starts_with("daypart:")
+            })
+            .unwrap();
+        let id = daypart_pl.id;
+
+        // Force a "stale" spec (as in the boundary-change test above) but
+        // shrink the library below the threshold first — once created, a
+        // reroll landing below 25 songs must still update in place, not
+        // delete the row (same tolerance genre/decade/BPM already have).
+        {
+            let conn = db_arc.pool.get().unwrap();
+            conn.execute(
+                "UPDATE playlists SET dynamic_spec = 'daypart:latenight:2000-01-01:Rock' WHERE id = ?1",
+                params![id],
+            )
+            .unwrap();
+            conn.execute(
+                "DELETE FROM songs WHERE id NOT IN (SELECT id FROM songs LIMIT 5)",
+                [],
+            )
+            .unwrap();
+        }
+
+        manager.sync_daypart_auto_playlist().unwrap();
+
+        let playlists_after = manager.get_playlists().unwrap();
+        assert!(
+            playlists_after.iter().any(|p| p.id == id),
+            "Daypart Mix must not be deleted just because a reroll landed below 25 songs"
         );
 
         let _ = std::fs::remove_dir_all(temp_dir);

--- a/src-tauri/src/playlist/dynamic.rs
+++ b/src-tauri/src/playlist/dynamic.rs
@@ -12,6 +12,11 @@ use anyhow::Result;
 use rusqlite::{params, OptionalExtension};
 use uuid::Uuid;
 
+/// Size of the random-fill fallback for a Daypart Mix (#223) whose picked
+/// genre grouping doesn't clear the auto-playlist minimum — a bounded
+/// "shuffle across the library" sample rather than every song at once.
+const DAYPART_RANDOM_FILL_LIMIT: i64 = 200;
+
 /// What a reconcile pass changed in one dynamic playlist.
 #[derive(Debug)]
 pub struct DynamicPlaylistDelta {
@@ -79,9 +84,15 @@ impl PlaylistManager {
 
     /// Every library song matching a dynamic spec, in the order the spec's
     /// population mode dictates. The single dispatch point for all spec
-    /// kinds (decade:, bpmrange:, artisttag:, missingmeta, tag:, smart-rule
-    /// query).
-    fn songs_for_spec(&self, spec: &str, mode: QueuePopulationMode) -> Result<Vec<Song>> {
+    /// kinds (decade:, bpmrange:, artisttag:, missingmeta, tag:, daypart:,
+    /// smart-rule query). `pub(super)` so `auto_sync.rs`'s
+    /// `sync_daypart_auto_playlist` can materialize a freshly-resolved
+    /// `daypart:` spec through the same path every other category uses.
+    pub(super) fn songs_for_spec(
+        &self,
+        spec: &str,
+        mode: QueuePopulationMode,
+    ) -> Result<Vec<Song>> {
         let scanner = CollectionScanner::new(self.db.clone());
         if let Some(decade) = spec.strip_prefix("decade:") {
             scanner.get_songs_by_decade(decade, NO_SONG_LIMIT, mode)
@@ -100,6 +111,24 @@ impl PlaylistManager {
             // contains a "field:" rule).
             let tag_manager = TagManager::new(self.db.clone());
             tag_manager.get_songs_by_curated_tag(name, NO_SONG_LIMIT, mode)
+        } else if let Some(rest) = spec.strip_prefix("daypart:") {
+            // "<bucket>:<date>:<resolved-name>" — bucket/date are only the
+            // reroll cache key `sync_daypart_auto_playlist` checks; here we
+            // only care about the already-resolved trailing name (empty
+            // means the random-fill fallback was chosen). This never
+            // re-picks anything itself, so calling this via
+            // `populate_dynamic_playlist`/reconcile does not reroll the mix.
+            let name = rest.splitn(3, ':').nth(2).unwrap_or("");
+            if name.is_empty() {
+                // Unlike a genre match (naturally bounded by how many songs
+                // carry that genre), "random songs from anywhere" has no
+                // natural size — cap it to a real mix-sized sample rather
+                // than shuffling the entire library into one playlist.
+                scanner.get_random_songs(DAYPART_RANDOM_FILL_LIMIT)
+            } else {
+                let tag_manager = TagManager::new(self.db.clone());
+                tag_manager.get_songs_by_curated_tag(name, NO_SONG_LIMIT, mode)
+            }
         } else {
             let query = spec.replace(';', " ");
             scanner.search_songs_by_mode(&query, NO_SONG_LIMIT, mode)
@@ -324,6 +353,79 @@ mod tests {
         ));
         let db = Database::new(temp_dir.clone()).unwrap();
         (db, temp_dir)
+    }
+
+    #[test]
+    fn test_songs_for_spec_daypart_prefix_dispatches_to_curated_tag_lookup() {
+        let (db, temp_dir) = setup_test_db();
+        let db_arc = std::sync::Arc::new(db);
+        {
+            let conn = db_arc.pool.get().unwrap();
+            for i in 1..=3 {
+                conn.execute(
+                    "INSERT INTO songs (title, artist, genre, source, unavailable) VALUES (?1, 'A', 'Jazz', 1, 0)",
+                    params![format!("Jazz Song {i}")],
+                )
+                .unwrap();
+            }
+            conn.execute(
+                "INSERT INTO songs (title, artist, genre, source, unavailable) VALUES ('Other', 'A', 'Blues', 1, 0)",
+                [],
+            )
+            .unwrap();
+        }
+
+        let manager = PlaylistManager::new(db_arc.clone()).unwrap();
+        let daypart_songs = manager
+            .songs_for_spec("daypart:morning:2026-09-03:Jazz", QueuePopulationMode::All)
+            .unwrap();
+        let tag_songs = manager
+            .songs_for_spec("tag:Jazz", QueuePopulationMode::All)
+            .unwrap();
+
+        assert_eq!(daypart_songs.len(), 3);
+        let mut daypart_ids: Vec<_> = daypart_songs.iter().map(|s| s.id).collect();
+        let mut tag_ids: Vec<_> = tag_songs.iter().map(|s| s.id).collect();
+        daypart_ids.sort();
+        tag_ids.sort();
+        assert_eq!(
+            daypart_ids, tag_ids,
+            "a daypart: spec's trailing name must resolve to the same songs as a tag: spec (mode All orders randomly, so order isn't compared)"
+        );
+
+        let _ = std::fs::remove_dir_all(temp_dir);
+    }
+
+    #[test]
+    fn test_songs_for_spec_daypart_empty_name_uses_random_fill() {
+        let (db, temp_dir) = setup_test_db();
+        let db_arc = std::sync::Arc::new(db);
+        {
+            let conn = db_arc.pool.get().unwrap();
+            for i in 1..=5 {
+                conn.execute(
+                    "INSERT INTO songs (title, artist, genre, source, unavailable) VALUES (?1, 'A', ?2, 1, 0)",
+                    params![
+                        format!("Song {i}"),
+                        if i % 2 == 0 { "Jazz" } else { "Blues" },
+                    ],
+                )
+                .unwrap();
+            }
+        }
+
+        let manager = PlaylistManager::new(db_arc.clone()).unwrap();
+        let songs = manager
+            .songs_for_spec("daypart:morning:2026-09-03:", QueuePopulationMode::All)
+            .unwrap();
+
+        assert_eq!(
+            songs.len(),
+            5,
+            "empty trailing name marks the random-fill fallback — every available song, capped by DAYPART_RANDOM_FILL_LIMIT"
+        );
+
+        let _ = std::fs::remove_dir_all(temp_dir);
     }
 
     #[test]

--- a/src/lib/components/AutoPlaylistCard.svelte
+++ b/src/lib/components/AutoPlaylistCard.svelte
@@ -10,7 +10,8 @@
     GaugeIcon as Gauge,
     TagIcon as Tag,
     TrendUpIcon as TrendingUp,
-    WarningIcon as AlertTriangle
+    WarningIcon as AlertTriangle,
+    SunHorizonIcon as SunHorizon
   } from "phosphor-svelte";
   import CardBadge from "./CardBadge.svelte";
   import type { PlaylistItem, Song } from "../types";
@@ -24,7 +25,7 @@
 
   interface Props {
     label: string;
-    kind: "favourites" | "recently_added" | "most_played" | "history" | "genre" | "decade" | "bpm" | "artist_tag" | "missing_metadata";
+    kind: "favourites" | "recently_added" | "most_played" | "history" | "genre" | "decade" | "bpm" | "artist_tag" | "missing_metadata" | "daypart";
     genre?: string;
     artistTag?: string;
     decade?: string;
@@ -42,7 +43,10 @@
   let { label, kind, genre, artistTag, decade, bpm, playlistId, updated, trackCount, onClick, widthClass = "w-full" }: Props = $props();
 
   let displayLabel = $derived.by(() => {
-    if ((kind === "genre" || kind === "decade" || kind === "bpm" || kind === "artist_tag" || kind === "missing_metadata") && playlistId !== undefined) {
+    if (
+      (kind === "genre" || kind === "decade" || kind === "bpm" || kind === "artist_tag" || kind === "missing_metadata" || kind === "daypart") &&
+      playlistId !== undefined
+    ) {
       const pl = playlistsStore.playlists.find((p) => p.id === playlistId);
       if (pl) return getPlaylistDisplayName(pl);
     }
@@ -51,6 +55,7 @@
 
   let subtitleLabel = $derived.by(() => {
     if (kind === "missing_metadata") return i18n.t("playlists.missingMetadataAutoPlaylist");
+    if (kind === "daypart") return i18n.t("playlists.daypartAutoPlaylist");
     if (kind === "decade" || decade) return i18n.t("playlists.decadeAutoPlaylist");
     if (kind === "bpm") return i18n.t("playlists.bpmAutoPlaylist");
     if (kind === "artist_tag" || artistTag) return i18n.t("playlists.artistTagAutoPlaylist");
@@ -73,7 +78,7 @@
     const pid = playlistId;
 
     const request =
-      (k === "genre" || k === "decade" || k === "bpm" || k === "artist_tag" || k === "missing_metadata") && pid !== undefined
+      (k === "genre" || k === "decade" || k === "bpm" || k === "artist_tag" || k === "missing_metadata" || k === "daypart") && pid !== undefined
         ? invoke<PlaylistItem[]>("get_playlist_tracks", { playlistId: pid }).then((items) =>
             items.filter((item) => !!item.song).map((item) => item.song as Song)
           )
@@ -108,7 +113,9 @@
   // they're rebuilt from the whole library on every load, so a coverstack of
   // whichever songs happen to be in them right now reads as arbitrary rather
   // than representative (unlike a genre, decade, BPM, or user playlist).
-  let topCovers = $derived(kind === "genre" || kind === "decade" || kind === "bpm" || kind === "artist_tag" ? songsToCoverStack(songs) : []);
+  let topCovers = $derived(
+    kind === "genre" || kind === "decade" || kind === "bpm" || kind === "artist_tag" || kind === "daypart" ? songsToCoverStack(songs) : []
+  );
 
   let badgeColorClass = $derived.by(() => {
     switch (kind) {
@@ -121,11 +128,16 @@
       case "most_played": return "bg-[#DC2626] text-white";
       case "history": return "bg-[#8B5CF6] text-white";
       case "missing_metadata": return "bg-amber-600 text-white";
+      case "daypart": return "bg-[#0D9488] text-white";
     }
   });
 
   let updatedLabel = $derived.by(() => {
-    if ((kind !== "genre" && kind !== "decade" && kind !== "bpm" && kind !== "artist_tag" && kind !== "missing_metadata") || updated === undefined) return null;
+    if (
+      (kind !== "genre" && kind !== "decade" && kind !== "bpm" && kind !== "artist_tag" && kind !== "missing_metadata" && kind !== "daypart") ||
+      updated === undefined
+    )
+      return null;
     return formatRelativeDate(updated);
   });
 </script>
@@ -137,8 +149,8 @@
   class="{widthClass} bg-brand-sidebar border border-brand-border/60 rounded-xl p-4 flex flex-col text-left hover:border-brand-accent/40 transition-all duration-200 group"
 >
   <div class="aspect-square w-full mb-3 bg-brand-main relative flex items-center justify-center">
-    {#if (kind === "genre" || kind === "decade" || kind === "bpm" || kind === "artist_tag") && topCovers.length > 0}
-      <div class="w-full h-full bg-brand-main bg-gradient-to-br {kind === 'decade' ? 'from-[#2563EB]/25 to-[#38BDF8]/15 border-[#38BDF8]/30 shadow-[0_0_20px_2px_rgba(56,189,248,0.35)]' : kind === 'bpm' ? 'from-[#C026D3]/25 to-[#E879F9]/15 border-[#E879F9]/30 shadow-[0_0_20px_2px_rgba(232,121,249,0.35)]' : kind === 'artist_tag' ? 'from-[#EA580C]/25 to-[#FB923C]/15 border-[#FB923C]/30 shadow-[0_0_20px_2px_rgba(251,146,60,0.35)]' : 'from-[#059669]/25 to-[#34D399]/15 border-[#34D399]/30 shadow-[0_0_20px_2px_rgba(52,211,153,0.35)]'} flex items-center justify-center overflow-hidden border relative">
+    {#if (kind === "genre" || kind === "decade" || kind === "bpm" || kind === "artist_tag" || kind === "daypart") && topCovers.length > 0}
+      <div class="w-full h-full bg-brand-main bg-gradient-to-br {kind === 'decade' ? 'from-[#2563EB]/25 to-[#38BDF8]/15 border-[#38BDF8]/30 shadow-[0_0_20px_2px_rgba(56,189,248,0.35)]' : kind === 'bpm' ? 'from-[#C026D3]/25 to-[#E879F9]/15 border-[#E879F9]/30 shadow-[0_0_20px_2px_rgba(232,121,249,0.35)]' : kind === 'artist_tag' ? 'from-[#EA580C]/25 to-[#FB923C]/15 border-[#FB923C]/30 shadow-[0_0_20px_2px_rgba(251,146,60,0.35)]' : kind === 'daypart' ? 'from-[#0D9488]/25 to-[#2DD4BF]/15 border-[#2DD4BF]/30 shadow-[0_0_20px_2px_rgba(45,212,191,0.35)]' : 'from-[#059669]/25 to-[#34D399]/15 border-[#34D399]/30 shadow-[0_0_20px_2px_rgba(52,211,153,0.35)]'} flex items-center justify-center overflow-hidden border relative">
         <CoverStack covers={topCovers} hoverEffect={true} sizeClass="w-[82%] h-[82%]" />
       </div>
     {:else if kind === "favourites"}
@@ -176,6 +188,10 @@
     {:else if kind === "missing_metadata"}
       <div class="w-full h-full bg-brand-main bg-gradient-to-br from-amber-600/25 to-amber-400/15 flex items-center justify-center overflow-hidden border border-amber-400/30 shadow-[0_0_20px_2px_rgba(245,158,11,0.35)]">
         <AlertTriangle class="w-10 h-10 text-amber-500" />
+      </div>
+    {:else if kind === "daypart"}
+      <div class="w-full h-full bg-brand-main bg-gradient-to-br from-[#0D9488]/25 to-[#2DD4BF]/15 flex items-center justify-center overflow-hidden border border-[#2DD4BF]/30 shadow-[0_0_20px_2px_rgba(45,212,191,0.35)]">
+        <SunHorizon class="w-10 h-10 text-[#2DD4BF]" />
       </div>
     {:else}
       <div class="w-full h-full bg-brand-main bg-gradient-to-br from-slate-700/40 to-slate-900/30 flex items-center justify-center overflow-hidden border border-slate-400/20 shadow-[0_0_20px_2px_rgba(100,116,139,0.25)]">

--- a/src/lib/components/AutoPlaylistDetailView.svelte
+++ b/src/lib/components/AutoPlaylistDetailView.svelte
@@ -45,7 +45,8 @@
     PushPinIcon as Pin,
     PushPinSlashIcon as PinOff,
     WarningIcon as AlertTriangle,
-    ArrowSquareOutIcon as OpenInPicard
+    ArrowSquareOutIcon as OpenInPicard,
+    SunHorizonIcon as SunHorizon
   } from "phosphor-svelte";
   import { shuffleArray } from "../utils/shuffle";
   import type { PlaylistItem, QueuePopulationMode, Song } from "../types";
@@ -146,14 +147,26 @@
               const pl = playlistsStore.playlists.find((p) => p.id === playlistId);
               return pl?.name || toTitleCase(artistTag || "") || i18n.t("playlists.artistTagAutoPlaylist");
             })()
-          : kind === "no_genre"
+          : kind === "daypart"
+            ? (() => {
+                // The row's own `name` IS the current bucket's mix name
+                // (e.g. "Afternoon Mix") — updated in place by the backend
+                // every time the daypart boundary crosses (#223).
+                const pl = playlistsStore.playlists.find((p) => p.id === playlistId);
+                return pl?.name || i18n.t("playlists.daypartAutoPlaylist");
+              })()
+            : kind === "no_genre"
             ? i18n.t("songTags.noGenre", {}, "No Genre")
             : genre || i18n.t("artistDetail.unknownGenre");
     const suffix = getPopulationModeSuffix(populationMode);
     return suffix ? i18n.t("playlists.populationModeTitleFormat", { base, suffix }) : base;
   });
 
-  let topCovers = $derived((kind === "genre" || kind === "decade" || kind === "bpm" || kind === "no_genre" || kind === "artist_tag") ? songsToCoverStack(songs) : []);
+  let topCovers = $derived(
+    (kind === "genre" || kind === "decade" || kind === "bpm" || kind === "no_genre" || kind === "artist_tag" || kind === "daypart")
+      ? songsToCoverStack(songs)
+      : []
+  );
 
   /** Genre auto-playlist header color (#548): follows the curated tag's own
    * color — a chip's playlist uses its parent card's color — instead of the
@@ -173,7 +186,11 @@
   });
 
   let updatedLabel = $derived.by(() => {
-    if ((kind !== "genre" && kind !== "decade" && kind !== "bpm" && kind !== "artist_tag" && kind !== "missing_metadata") || updated === undefined) return null;
+    if (
+      (kind !== "genre" && kind !== "decade" && kind !== "bpm" && kind !== "artist_tag" && kind !== "missing_metadata" && kind !== "daypart") ||
+      updated === undefined
+    )
+      return null;
     return new Date(updated * 1000).toLocaleDateString();
   });
 
@@ -186,7 +203,7 @@
   });
 
   async function fetchSongs(k: typeof kind, g: typeof genre, at: typeof artistTag, d: typeof decade, b: typeof bpm, pid: typeof playlistId): Promise<Song[]> {
-    if ((k === "genre" || k === "decade" || k === "bpm" || k === "artist_tag" || k === "missing_metadata") && pid !== undefined) {
+    if ((k === "genre" || k === "decade" || k === "bpm" || k === "artist_tag" || k === "missing_metadata" || k === "daypart") && pid !== undefined) {
       const items = await invoke<PlaylistItem[]>("get_playlist_tracks", { playlistId: pid });
       return items.filter((item) => !!item.song).map((item) => item.song as Song);
     }
@@ -570,7 +587,7 @@
           </div>
         </div>
 
-        {#if (kind === "genre" || kind === "decade" || kind === "bpm" || kind === "artist_tag") && playlistId !== undefined}
+        {#if (kind === "genre" || kind === "decade" || kind === "bpm" || kind === "artist_tag" || kind === "daypart") && playlistId !== undefined}
           <div class="flex flex-wrap items-center gap-2.5 mt-2.5 select-none relative z-40">
             <!-- Queue population mode tabs (#120): what bias to (re)populate this auto-playlist with -->
             <PopulationModeTabs
@@ -598,6 +615,10 @@
           </div>
         {:else if (kind === "decade" || kind === "bpm") && topCovers.length > 0}
           <div class="w-full h-full bg-brand-main bg-gradient-to-br {kind === 'decade' ? 'from-[#2563EB]/25 to-[#38BDF8]/15 border-[#38BDF8]/30 shadow-[0_0_28px_3px_rgba(56,189,248,0.4)]' : 'from-[#C026D3]/25 to-[#E879F9]/15 border-[#E879F9]/30 shadow-[0_0_28px_3px_rgba(232,121,249,0.4)]'} flex items-center justify-center overflow-hidden border relative">
+            <CoverStack covers={topCovers} sizeClass="w-[82%] h-[82%]" />
+          </div>
+        {:else if kind === "daypart" && topCovers.length > 0}
+          <div class="w-full h-full bg-brand-main bg-gradient-to-br from-[#0D9488]/25 to-[#2DD4BF]/15 border-[#2DD4BF]/30 shadow-[0_0_28px_3px_rgba(45,212,191,0.4)] flex items-center justify-center overflow-hidden border relative">
             <CoverStack covers={topCovers} sizeClass="w-[82%] h-[82%]" />
           </div>
         {:else if kind === "no_genre" && topCovers.length > 0}
@@ -639,6 +660,10 @@
         {:else if kind === "missing_metadata"}
           <div class="w-full h-full bg-brand-main bg-gradient-to-br from-amber-600/25 to-amber-400/15 flex items-center justify-center overflow-hidden border border-amber-400/30 shadow-[0_0_28px_3px_rgba(245,158,11,0.4)]">
             <AlertTriangle class="w-16 h-16 text-amber-500" />
+          </div>
+        {:else if kind === "daypart"}
+          <div class="w-full h-full bg-brand-main bg-gradient-to-br from-[#0D9488]/25 to-[#2DD4BF]/15 flex items-center justify-center overflow-hidden border border-[#2DD4BF]/30 shadow-[0_0_28px_3px_rgba(45,212,191,0.4)]">
+            <SunHorizon class="w-16 h-16 text-[#2DD4BF]" />
           </div>
         {:else}
           <div
@@ -767,7 +792,7 @@
       disabled={loading || songs.length === 0}
     />
 
-    {#if (kind === "genre" || kind === "decade" || kind === "bpm" || kind === "missing_metadata") && playlistId !== undefined}
+    {#if (kind === "genre" || kind === "decade" || kind === "bpm" || kind === "missing_metadata" || kind === "daypart") && playlistId !== undefined}
       <ContextMenuItem
         icon={RefreshCw}
         label={i18n.t("playlists.refreshPlaylistBtn", {}, "Refresh Playlist")}

--- a/src/lib/components/AutoPlaylistRowCard.svelte
+++ b/src/lib/components/AutoPlaylistRowCard.svelte
@@ -8,7 +8,8 @@
     GaugeIcon as Gauge,
     TagIcon as Tag,
     TrendUpIcon as TrendingUp,
-    WarningIcon as AlertTriangle
+    WarningIcon as AlertTriangle,
+    SunHorizonIcon as SunHorizon
   } from "phosphor-svelte";
   import { i18n } from "../stores/i18n.svelte";
   import { formatRelativeDate } from "../utils/date";
@@ -18,7 +19,7 @@
 
   interface Props {
     label: string;
-    kind: "favourites" | "recently_added" | "most_played" | "history" | "genre" | "decade" | "bpm" | "artist_tag" | "missing_metadata";
+    kind: "favourites" | "recently_added" | "most_played" | "history" | "genre" | "decade" | "bpm" | "artist_tag" | "missing_metadata" | "daypart";
     genre?: string;
     artistTag?: string;
     decade?: string;
@@ -32,7 +33,10 @@
   let { label, kind, genre, artistTag, decade, bpm, playlistId, updated, trackCount, onClick }: Props = $props();
 
   let displayLabel = $derived.by(() => {
-    if ((kind === "genre" || kind === "decade" || kind === "bpm" || kind === "artist_tag" || kind === "missing_metadata") && playlistId !== undefined) {
+    if (
+      (kind === "genre" || kind === "decade" || kind === "bpm" || kind === "artist_tag" || kind === "missing_metadata" || kind === "daypart") &&
+      playlistId !== undefined
+    ) {
       const pl = playlistsStore.playlists.find((p) => p.id === playlistId);
       if (pl) return getPlaylistDisplayName(pl);
     }
@@ -41,6 +45,7 @@
 
   let subtitleLabel = $derived.by(() => {
     if (kind === "missing_metadata") return i18n.t("playlists.missingMetadataAutoPlaylist");
+    if (kind === "daypart") return i18n.t("playlists.daypartAutoPlaylist");
     if (kind === "decade" || decade) return i18n.t("playlists.decadeAutoPlaylist");
     if (kind === "bpm") return i18n.t("playlists.bpmAutoPlaylist");
     if (kind === "artist_tag" || artistTag) return i18n.t("playlists.artistTagAutoPlaylist");
@@ -53,7 +58,11 @@
   });
 
   let updatedLabel = $derived.by(() => {
-    if ((kind !== "genre" && kind !== "decade" && kind !== "bpm" && kind !== "artist_tag" && kind !== "missing_metadata") || updated === undefined) return null;
+    if (
+      (kind !== "genre" && kind !== "decade" && kind !== "bpm" && kind !== "artist_tag" && kind !== "missing_metadata" && kind !== "daypart") ||
+      updated === undefined
+    )
+      return null;
     return formatRelativeDate(updated);
   });
 </script>
@@ -81,7 +90,9 @@
                   ? 'bg-[#8B5CF6]/15 border-[#8B5CF6]/30'
                   : kind === 'missing_metadata'
                     ? 'bg-amber-500/15 border-amber-500/30'
-                    : 'bg-[#FACC15]/15 border-[#FACC15]/30'}"
+                    : kind === 'daypart'
+                      ? 'bg-[#2DD4BF]/15 border-[#2DD4BF]/30'
+                      : 'bg-[#FACC15]/15 border-[#FACC15]/30'}"
   >
     {#if kind === "favourites"}
       <Heart class="w-5 h-5 text-[#F43F5E] fill-current" />
@@ -99,6 +110,8 @@
       <Gauge class="w-5 h-5 text-[#E879F9]" />
     {:else if kind === "missing_metadata"}
       <AlertTriangle class="w-5 h-5 text-amber-500" />
+    {:else if kind === "daypart"}
+      <SunHorizon class="w-5 h-5 text-[#2DD4BF]" />
     {:else}
       <Music class="w-5 h-5 text-[#34D399]" />
     {/if}

--- a/src/lib/components/HomeView.svelte
+++ b/src/lib/components/HomeView.svelte
@@ -23,6 +23,14 @@
   let isLoading = $state(true);
   let libraryChangedDebounce: ReturnType<typeof setTimeout> | undefined;
 
+  /** Polled rather than computed once, so the greeting (and the Daypart Mix
+   * pin's implicit "current bucket") actually flips while the user sits on
+   * Home across a boundary, instead of only updating on the next unrelated
+   * re-render (#223). Matches playlists.svelte.ts's own boundary-check
+   * cadence. */
+  let daypartBucket = $state(getDaypartBucket());
+  let daypartPollTimer: ReturnType<typeof setInterval> | undefined;
+
   /** Routes "Top Artists" to Collection → Artists, pre-sorted by popularity
    * (total plays). CollectionView reads its initial sort from localStorage
    * on mount, so writing it here before navigating is enough — see #169. */
@@ -39,14 +47,14 @@
     navigationStore.activeSubTab = "artists";
   }
 
-  function getTimeOfDayGreeting(): string {
-    switch (getDaypartBucket()) {
+  const timeOfDayGreeting = $derived.by((): string => {
+    switch (daypartBucket) {
       case "morning": return i18n.t("home.greetingMorning");
       case "afternoon": return i18n.t("home.greetingAfternoon");
       case "evening": return i18n.t("home.greetingEvening");
       case "latenight": return i18n.t("home.greetingNight");
     }
-  }
+  });
 
   async function loadCuratedData() {
     isLoading = true;
@@ -89,8 +97,13 @@
       libraryChangedDebounce = setTimeout(loadCuratedData, 500);
     });
 
+    daypartPollTimer = setInterval(() => {
+      daypartBucket = getDaypartBucket();
+    }, 60_000);
+
     return () => {
       clearTimeout(libraryChangedDebounce);
+      clearInterval(daypartPollTimer);
       unlistenScan.then((fn) => fn());
       unlistenLibrary.then((fn) => fn());
     };
@@ -101,7 +114,7 @@
   <div class="flex-1 overflow-y-auto {playerStore.currentSong ? 'pb-28' : 'pb-6'}" use:rememberScroll={"home"}>
     <div class="px-6 pt-8">
       <h1 class="text-3xl font-heading font-bold text-brand-text-primary">
-        {getTimeOfDayGreeting()}
+        {timeOfDayGreeting}
       </h1>
       <p class="text-sm text-brand-text-secondary mt-1">
         {collectionStore.stats.total_songs > 0

--- a/src/lib/components/HomeView.svelte
+++ b/src/lib/components/HomeView.svelte
@@ -14,6 +14,7 @@
   import LibraryWelcome from "./LibraryWelcome.svelte";
   import { i18n } from "../stores/i18n.svelte";
   import { rememberScroll } from "../utils/scrollMemory";
+  import { getDaypartBucket } from "../utils/daypart";
 
   let topArtists = $state<ArtistItem[]>([]);
   let topAlbums = $state<HomeItem[]>([]);
@@ -39,11 +40,12 @@
   }
 
   function getTimeOfDayGreeting(): string {
-    const hour = new Date().getHours();
-    if (hour >= 5 && hour < 12) return i18n.t("home.greetingMorning");
-    if (hour >= 12 && hour < 17) return i18n.t("home.greetingAfternoon");
-    if (hour >= 17 && hour < 21) return i18n.t("home.greetingEvening");
-    return i18n.t("home.greetingNight");
+    switch (getDaypartBucket()) {
+      case "morning": return i18n.t("home.greetingMorning");
+      case "afternoon": return i18n.t("home.greetingAfternoon");
+      case "evening": return i18n.t("home.greetingEvening");
+      case "latenight": return i18n.t("home.greetingNight");
+    }
   }
 
   async function loadCuratedData() {

--- a/src/lib/components/PlaylistsCollectionView.svelte
+++ b/src/lib/components/PlaylistsCollectionView.svelte
@@ -34,7 +34,7 @@
 
   interface AutoDef {
     id: string;
-    kind: "favourites" | "recently_added" | "most_played" | "history" | "genre" | "decade" | "bpm" | "artist_tag" | "missing_metadata";
+    kind: "favourites" | "recently_added" | "most_played" | "history" | "genre" | "decade" | "bpm" | "artist_tag" | "missing_metadata" | "daypart";
     genre?: string;
     artistTag?: string;
     decade?: string;
@@ -105,6 +105,13 @@
   let missingMetadataAutoPlaylist = $derived(
     playlistsStore.playlists.find((p) => p.dynamic_enabled && p.dynamic_spec === "missingmeta")
   );
+  // Daypart Mix (#223) is also a singleton, but unlike missing-metadata its
+  // dynamic_spec changes content (bucket/date/genre) every time the daypart
+  // boundary crosses — matched by prefix, not exact spec, so the same row
+  // (and any Home pin keyed on its id) is found across every crossing.
+  let daypartMixPlaylist = $derived(
+    playlistsStore.playlists.find((p) => p.dynamic_enabled && p.dynamic_spec?.startsWith("daypart:"))
+  );
   let customPlaylists = $derived.by(() => {
     // Include non-dynamic playlists + user-created Smart playlists
     const list = playlistsStore.playlists.filter((p) => !p.dynamic_enabled || isSmartPlaylistSpec(p.dynamic_spec));
@@ -155,6 +162,16 @@
         playlistId: missingMetadataAutoPlaylist.id,
         updated: missingMetadataAutoPlaylist.updated,
         trackCount: missingMetadataAutoPlaylist.track_count,
+      });
+    }
+    if (daypartMixPlaylist && daypartMixPlaylist.track_count > 0) {
+      defs.push({
+        id: `auto:daypart:${daypartMixPlaylist.id}`,
+        kind: "daypart",
+        label: getPlaylistDisplayName(daypartMixPlaylist),
+        playlistId: daypartMixPlaylist.id,
+        updated: daypartMixPlaylist.updated,
+        trackCount: daypartMixPlaylist.track_count,
       });
     }
     for (const p of decadeAutoPlaylists) {
@@ -305,7 +322,9 @@
               ? { kind: "bpm", bpm: def.bpm, playlistId: def.playlistId, updated: def.updated }
               : def.kind === "missing_metadata"
                 ? { kind: "missing_metadata", playlistId: def.playlistId, updated: def.updated }
-                : { kind: def.kind }
+                : def.kind === "daypart"
+                  ? { kind: "daypart", playlistId: def.playlistId, updated: def.updated }
+                  : { kind: def.kind }
     );
   }
 

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -487,6 +487,7 @@ export const en = {
     decadeAutoPlaylist: "Decade",
     bpmAutoPlaylist: "BPM",
     missingMetadataAutoPlaylist: "Missing Metadata",
+    daypartAutoPlaylist: "Daypart Mix",
     bpmDownTempo: "Down-Tempo BPM",
     bpmMidTempo: "Mid-Tempo BPM",
     bpmUptempo: "Uptempo BPM",

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -487,7 +487,7 @@ export const en = {
     decadeAutoPlaylist: "Decade",
     bpmAutoPlaylist: "BPM",
     missingMetadataAutoPlaylist: "Missing Metadata",
-    daypartAutoPlaylist: "Daypart Mix",
+    daypartAutoPlaylist: "Moment Mix",
     bpmDownTempo: "Down-Tempo BPM",
     bpmMidTempo: "Mid-Tempo BPM",
     bpmUptempo: "Uptempo BPM",

--- a/src/lib/locales/fr.ts
+++ b/src/lib/locales/fr.ts
@@ -484,6 +484,8 @@ export const fr = {
     artistTagAutoPlaylist: "Tag d'artiste",
     decadeAutoPlaylist: "Décennie",
     bpmAutoPlaylist: "BPM",
+    missingMetadataAutoPlaylist: "Métadonnées manquantes",
+    daypartAutoPlaylist: "Mix du moment",
     bpmDownTempo: "Tempo lent BPM",
     bpmMidTempo: "Tempo moyen BPM",
     bpmUptempo: "Tempo enlevé BPM",

--- a/src/lib/stores/navigation.svelte.ts
+++ b/src/lib/stores/navigation.svelte.ts
@@ -21,7 +21,8 @@ export interface AutoPlaylistRef {
     | "bpm"
     | "no_genre"
     | "artist_tag"
-    | "missing_metadata";
+    | "missing_metadata"
+    | "daypart";
   /** For kind "genre": the curated tag's plain name (#548) — a top-level
    * card name or a sub-genre chip name, resolved the same way either way
    * (see `viewGenreTag`). */

--- a/src/lib/stores/playlists.svelte.ts
+++ b/src/lib/stores/playlists.svelte.ts
@@ -4,6 +4,13 @@ import type { Playlist, PlaylistItem, QueuePopulationMode, Song } from "../types
 import { applySongStats, type SongStatsPayload } from "../utils/stats";
 import { toastStore } from "./toast.svelte";
 import { i18n } from "./i18n.svelte";
+import { getDaypartBucket } from "../utils/daypart";
+
+/** How often to check whether the Daypart Mix's local-time bucket has
+ * crossed a boundary while the app stays open (#223) — cheap since the
+ * backend sync is a no-op unless the bucket actually changed, so a modest
+ * interval is fine without needing second-level precision. */
+const DAYPART_BOUNDARY_CHECK_INTERVAL_MS = 60_000;
 
 class PlaylistsStore {
   playlists = $state<Playlist[]>([]);
@@ -132,6 +139,34 @@ class PlaylistsStore {
     } catch (err) {
       console.error("Failed to initialize PlaylistsStore:", err);
     }
+    this.startDaypartBoundaryWatch();
+  }
+
+  private lastKnownDaypartBucket = getDaypartBucket();
+  private daypartBoundaryTimer: ReturnType<typeof setInterval> | null = null;
+
+  /** Genre/decade/BPM/artist-tag auto-playlists only need to resync on a
+   * scan or an explicit refresh — the Daypart Mix (#223) also needs to
+   * resync at exact clock boundaries even while the app just sits open
+   * (e.g. left on the Home page across Morning -> Afternoon), which none of
+   * those call sites cover. `sync_all_auto_playlists` is cheap to call
+   * redundantly (the daypart sync is a same-bucket no-op otherwise), so
+   * this just re-checks the current bucket periodically and resyncs only
+   * when it actually changed — mirrors `updaterStore`'s own periodic-check
+   * timer for its own unrelated concern. */
+  private startDaypartBoundaryWatch() {
+    if (this.daypartBoundaryTimer) return;
+    this.daypartBoundaryTimer = setInterval(async () => {
+      const bucket = getDaypartBucket();
+      if (bucket === this.lastKnownDaypartBucket) return;
+      this.lastKnownDaypartBucket = bucket;
+      try {
+        await invoke("sync_all_auto_playlists");
+        await this.refreshPlaylists();
+      } catch (err) {
+        console.error("Failed to resync Daypart Mix on boundary change:", err);
+      }
+    }, DAYPART_BOUNDARY_CHECK_INTERVAL_MS);
   }
 
   async refreshPlaylists() {

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -408,7 +408,7 @@ export type PinnedItemType = "song" | "album" | "artist" | "playlist" | "auto_pl
  * Played/History have no backing playlist row, so `playlistId`/`updated` are
  * absent for those kinds. */
 export interface AutoPlaylistItem {
-  kind: "favourites" | "recently_added" | "most_played" | "history" | "genre" | "decade" | "bpm" | "artist_tag" | "missing_metadata";
+  kind: "favourites" | "recently_added" | "most_played" | "history" | "genre" | "decade" | "bpm" | "artist_tag" | "missing_metadata" | "daypart";
   genre?: string;
   artistTag?: string;
   decade?: string;

--- a/src/lib/utils/daypart.test.ts
+++ b/src/lib/utils/daypart.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { getDaypartBucket } from "./daypart";
+
+describe("getDaypartBucket", () => {
+  // Boundaries must match src-tauri/src/playlist/auto_sync.rs's
+  // daypart_bucket_for_hour exactly (#223) — this is the frontend half of
+  // that shared convention.
+  it("buckets 05:00-11:59 as morning", () => {
+    expect(getDaypartBucket(new Date(2026, 0, 1, 5, 0))).toBe("morning");
+    expect(getDaypartBucket(new Date(2026, 0, 1, 11, 59))).toBe("morning");
+  });
+
+  it("buckets 12:00-16:59 as afternoon", () => {
+    expect(getDaypartBucket(new Date(2026, 0, 1, 12, 0))).toBe("afternoon");
+    expect(getDaypartBucket(new Date(2026, 0, 1, 16, 59))).toBe("afternoon");
+  });
+
+  it("buckets 17:00-20:59 as evening", () => {
+    expect(getDaypartBucket(new Date(2026, 0, 1, 17, 0))).toBe("evening");
+    expect(getDaypartBucket(new Date(2026, 0, 1, 20, 59))).toBe("evening");
+  });
+
+  it("buckets 21:00-04:59 as latenight, wrapping midnight", () => {
+    expect(getDaypartBucket(new Date(2026, 0, 1, 21, 0))).toBe("latenight");
+    expect(getDaypartBucket(new Date(2026, 0, 1, 23, 59))).toBe("latenight");
+    expect(getDaypartBucket(new Date(2026, 0, 1, 0, 0))).toBe("latenight");
+    expect(getDaypartBucket(new Date(2026, 0, 1, 4, 59))).toBe("latenight");
+  });
+});

--- a/src/lib/utils/daypart.ts
+++ b/src/lib/utils/daypart.ts
@@ -1,0 +1,14 @@
+/** The four Daypart Mix buckets (#223), shared between the Home greeting
+ * and the Daypart Mix auto-playlist so both always agree on "what part of
+ * the day is it". Hour ranges mirror `src-tauri/src/playlist/auto_sync.rs`'s
+ * `daypart_bucket_for_hour` — if one changes, the other must too. */
+export type DaypartBucket = "morning" | "afternoon" | "evening" | "latenight";
+
+/** Local-hour bucket for a given `Date` (defaults to now). */
+export function getDaypartBucket(date: Date = new Date()): DaypartBucket {
+  const hour = date.getHours();
+  if (hour >= 5 && hour < 12) return "morning";
+  if (hour >= 12 && hour < 17) return "afternoon";
+  if (hour >= 17 && hour < 21) return "evening";
+  return "latenight";
+}


### PR DESCRIPTION
## 📋 Summary
Adds a "Moment Mix" auto-playlist that changes through the day — Morning, Afternoon, Evening, and Late Night — built from the curated Genre hierarchy. Addresses #223.
Boundaries match the existing Home greeting hour buckets (05–11 Morning, 12–16 Afternoon, 17–20 Evening, else Late Night).

## 🔍 Implementation Notes
- **Single playlist row, not four.** Crossing a boundary renames and repopulates the same row in place (`dynamic_spec = "daypart:<bucket>:<date>:<name>"` acts as a cache key), so a Home pin (keyed on `playlist_id`) survives every crossing.
- **Genre selection walks the curated tag hierarchy** (`tag_groups`/`tag_assignments`, #548): picks a random top-level genre or sub-genre; if a picked sub-genre is too small on its own (e.g. "Soft Rock" with 10 songs), walks up to its parent group (e.g. "Rock" with 408) instead of giving up. Falls back to a random cross-section of the library if nothing clears 25 songs, and skips creation entirely if the library itself is under 25 songs.
- **No reroll thrashing.** The genre is cached against today's bucket+date, so repeated `sync_all_auto_playlists()` calls (scan finish, manual refresh, tab mount) within the same bucket/day don't reshuffle the mix underneath the user.
- **Playback is never interrupted by a boundary crossing.** Traced both dynamic-playlist code paths: the incremental `reconcile_dynamic_playlist` (which mirrors deltas into a live-playing queue) is only reachable from the `library-changed`/`song-stats-changed` event path — never from any `sync_*_auto_playlists` function, daypart included. A boundary regen does the same full delete+reinsert every other scheduled auto-playlist already does, which never touches the player's in-memory queue synchronously. This was an explicit design decision (DB-only truth, no live-queue hot-relabeling) confirmed during planning.
- **Resyncs while the app just sits open.** A ~60s periodic timer (mirroring `updaterStore`'s pattern) checks whether the bucket changed and resyncs if so — not just on scan/mount like the other auto-playlist categories.
- **Home greeting live-updates too.** Found during manual testing that the greeting only recomputed on unrelated re-renders, not on the clock itself — fixed with the same 60s-poll pattern so it flips live while sitting on Home across a boundary.
- Pin resolution (`pins.rs`) matches Daypart Mix by spec *prefix* rather than exact spec, same shape as the existing `missing_metadata` singleton, so a pin keeps resolving as the row's content changes underneath it.
- Incidental fix bundled in (confirmed with repo owner): `fr.ts` was missing `missingMetadataAutoPlaylist`, an existing gap unrelated to #223 found while editing the same locale block.
- English label is "Moment Mix" (French "Mix du moment").

## 🧪 Test Plan
- [x] `bun run check` (svelte-check + knip) — clean
- [x] `bun run test -- --run` (frontend) — 561 passed
- [x] `cargo test` (src-tauri) — 265 passed; `cargo fmt -- --check` and `cargo clippy --lib` clean
- [x] Manually verified in the app: pinned the mix to Home, crossed the Afternoon→Evening boundary live, confirmed the playlist detail view updates in place (same row, new name/tracklist) and the Home pin/greeting now live-update without needing to navigate away and back.

## ✅ Checklist
- [x] No unrelated changes bundled in (aside from the confirmed one-line `fr.ts` gap fix noted above)
- [x] Docs/screenshots updated if user-facing behavior changed — no screenshot harness entry needed; this is a new auto-playlist card that follows the existing genre/decade/bpm card visual pattern
