### PR TITLE
feat: real launch-at-login support via tauri-plugin-autostart

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -299,6 +299,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "auto-launch"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f012b8cc0c850f34117ec8252a44418f2e34a2cf501de89e29b241ae5f79471"
+dependencies = [
+ "dirs 4.0.0",
+ "thiserror 1.0.69",
+ "winreg 0.10.1",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1146,11 +1157,31 @@ dependencies = [
 
 [[package]]
 name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys 0.3.7",
+]
+
+[[package]]
+name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.5.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users 0.4.6",
+ "winapi",
 ]
 
 [[package]]
@@ -1161,7 +1192,7 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.5.2",
  "windows-sys 0.61.2",
 ]
 
@@ -1294,7 +1325,7 @@ dependencies = [
  "rustc_version",
  "toml 1.1.4+spec-1.1.0",
  "vswhom",
- "winreg",
+ "winreg 0.55.0",
 ]
 
 [[package]]
@@ -2898,6 +2929,7 @@ dependencies = [
  "symphonia",
  "tauri",
  "tauri-build",
+ "tauri-plugin-autostart",
  "tauri-plugin-dialog",
  "tauri-plugin-fs",
  "tauri-plugin-global-shortcut",
@@ -4106,6 +4138,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags 2.13.1",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -5376,7 +5419,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "cookie",
- "dirs",
+ "dirs 6.0.0",
  "dunce",
  "embed_plist",
  "getrandom 0.3.4",
@@ -5427,7 +5470,7 @@ checksum = "bc9ce40b16101cb6ea63d3e221567affd1c3a9205f95d7bc574941a10636b632"
 dependencies = [
  "anyhow",
  "cargo_toml",
- "dirs",
+ "dirs 6.0.0",
  "glob",
  "heck 0.5.0",
  "json-patch",
@@ -5495,6 +5538,20 @@ dependencies = [
  "serde_json",
  "tauri-utils",
  "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-autostart"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "459383cebc193cdd03d1ba4acc40f2c408a7abce419d64bdcd2d745bc2886f70"
+dependencies = [
+ "auto-launch",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -5680,7 +5737,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "806d9dac662c2e4594ff03c647a552f2c9bd544e7d0f683ec58f872f952ce4af"
 dependencies = [
  "base64 0.22.1",
- "dirs",
+ "dirs 6.0.0",
  "flate2",
  "futures-util",
  "http",
@@ -6236,7 +6293,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "045979e3f037cd18ad1cb2a419dfda133c5c29c9f3453370079f2255d46c257e"
 dependencies = [
  "crossbeam-channel",
- "dirs",
+ "dirs 6.0.0",
  "libappindicator",
  "muda",
  "objc2",
@@ -7199,6 +7256,15 @@ dependencies = [
 
 [[package]]
 name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "winreg"
 version = "0.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
@@ -7252,7 +7318,7 @@ dependencies = [
  "block2",
  "cookie",
  "crossbeam-channel",
- "dirs",
+ "dirs 6.0.0",
  "dom_query",
  "dpi",
  "dunce",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -33,6 +33,7 @@ tauri-plugin-notification = "2"
 tauri-plugin-single-instance = "2"
 tauri-plugin-updater = "2"
 tauri-plugin-process = "2"
+tauri-plugin-autostart = "2"
 # Cross-restart window geometry persistence (Windows/macOS/X11-Linux — see
 # geometry_capture_supported() in commands/window.rs for why this can't help
 # on Wayland).

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -12,6 +12,7 @@
     "positioner:default",
     "updater:default",
     "process:allow-restart",
+    "autostart:default",
     {
       "identifier": "fs:allow-read",
       "allow": [

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -223,6 +223,31 @@ pub async fn set_minimize_to_tray_enabled(
     Ok(())
 }
 
+/// Source of truth is the OS registration itself (registry key / LaunchAgent /
+/// XDG autostart entry), read via the plugin's manager — no DB shadow copy,
+/// so this can never drift from what's actually installed on the system.
+#[tauri::command]
+pub fn get_autostart_enabled(app: tauri::AppHandle) -> Result<bool, String> {
+    use tauri_plugin_autostart::ManagerExt;
+    app.autolaunch().is_enabled().map_err(|e| e.to_string())
+}
+
+/// Unlike the fire-and-forget settings writes above, this can genuinely fail
+/// (sandboxed install, permissions, a relocated AppImage) — so it returns a
+/// real error the frontend awaits and reverts the toggle on, instead of
+/// assuming success.
+#[tauri::command]
+pub fn set_autostart_enabled(app: tauri::AppHandle, enabled: bool) -> Result<(), String> {
+    use tauri_plugin_autostart::ManagerExt;
+    let manager = app.autolaunch();
+    if enabled {
+        manager.enable()
+    } else {
+        manager.disable()
+    }
+    .map_err(|e| e.to_string())
+}
+
 #[tauri::command]
 pub fn get_commit_hash() -> String {
     option_env!("BUILD_COMMIT_HASH").unwrap_or("").to_string()

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -37,6 +37,7 @@ pub mod waveform;
 
 use std::sync::Arc;
 use tauri::{Emitter, Manager};
+use tauri_plugin_autostart::MacosLauncher;
 use tauri_plugin_global_shortcut::{Code, GlobalShortcutExt, ShortcutState};
 use tokio::sync::Mutex;
 
@@ -631,6 +632,10 @@ pub fn run() {
         .plugin(tauri_plugin_positioner::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_process::init())
+        // `MacosLauncher::LaunchAgent` is required by the plugin's cross-platform
+        // API but inert on the platforms Luminous actually ships (Windows/Linux) —
+        // it only takes effect on a macOS build, which this project doesn't target.
+        .plugin(tauri_plugin_autostart::init(MacosLauncher::LaunchAgent, None))
         .plugin(build_prevent_default_plugin())
         .plugin(tauri_plugin_single_instance::init(|app, args, _cwd| {
             tray::restore_main_window(app);
@@ -984,6 +989,8 @@ pub fn run() {
             commands::settings::set_fade_settings,
             commands::settings::get_minimize_to_tray_enabled,
             commands::settings::set_minimize_to_tray_enabled,
+            commands::settings::get_autostart_enabled,
+            commands::settings::set_autostart_enabled,
             install_format::get_install_format,
             // Stats commands
             commands::stats::set_song_rating,

--- a/src/lib/components/SettingsGeneral.svelte
+++ b/src/lib/components/SettingsGeneral.svelte
@@ -221,6 +221,18 @@
       label={i18n.t('settings.minimizeToTrayLabel')}
     />
   </div>
+
+  <div class="flex items-center justify-between gap-4 py-4">
+    <div class="flex flex-col gap-0.5 min-w-0">
+      <span class="text-sm font-medium text-brand-text-primary">{i18n.t('settings.launchAtLoginLabel')}</span>
+      <p class="text-xs text-brand-text-secondary">{i18n.t('settings.launchAtLoginHint')}</p>
+    </div>
+    <Toggle
+      checked={prefs.autostartEnabled}
+      onchange={(v) => prefs.setAutostart(v)}
+      label={i18n.t('settings.launchAtLoginLabel')}
+    />
+  </div>
 </div>
 
 {#if updaterStore.isExternallyManaged}

--- a/src/lib/components/SettingsGeneral.test.ts
+++ b/src/lib/components/SettingsGeneral.test.ts
@@ -1,12 +1,17 @@
 import "@testing-library/jest-dom";
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render } from "@testing-library/svelte";
+import { render, fireEvent } from "@testing-library/svelte";
 import SettingsGeneral from "./SettingsGeneral.svelte";
+import { invoke } from "@tauri-apps/api/core";
+import { prefs } from "../stores/prefs.svelte";
 
 vi.mock("@tauri-apps/api/core", () => ({
   invoke: vi.fn().mockImplementation((cmd: string) => {
     if (cmd === "get_commit_hash") {
       return Promise.resolve("048f421");
+    }
+    if (cmd === "get_minimize_to_tray_enabled" || cmd === "get_autostart_enabled") {
+      return Promise.resolve(false);
     }
     return Promise.resolve([]);
   }),
@@ -29,5 +34,17 @@ describe("SettingsGeneral.svelte", () => {
     const { findByText } = render(SettingsGeneral);
     expect(await findByText(/v0\.75\.0/)).toBeInTheDocument();
     expect(await findByText(/build 048f421/)).toBeInTheDocument();
+  });
+
+  it("reflects prefs.autostartEnabled and calls set_autostart_enabled on toggle", async () => {
+    prefs.autostartEnabled = false;
+    const { findByRole } = render(SettingsGeneral);
+    const toggle = await findByRole("switch", { name: "Launch at login" });
+    expect(toggle).toHaveAttribute("aria-checked", "false");
+
+    await fireEvent.click(toggle);
+
+    expect(prefs.autostartEnabled).toBe(true);
+    expect(invoke).toHaveBeenCalledWith("set_autostart_enabled", { enabled: true });
   });
 });

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -236,6 +236,8 @@ export const en = {
     ratingStyleHint: "Choose Heart to mark songs as favourites, or 5-star for half-step ratings — both save to the same rating.",
     minimizeToTrayLabel: "Minimize to tray",
     minimizeToTrayHint: "Closing the window hides Luminous to the system tray instead of quitting.",
+    launchAtLoginLabel: "Launch at login",
+    launchAtLoginHint: "Starts Luminous automatically when you sign in.",
     appAndUpdatesTitle: "Application & Updates",
     updateCheckNowBtn: "Check for Updates",
     updateChecking: "Checking...",

--- a/src/lib/locales/fr.ts
+++ b/src/lib/locales/fr.ts
@@ -236,6 +236,8 @@ export const fr = {
     ratingStyleHint: "Choisissez Cœur pour marquer les chansons comme favorites, ou 5 étoiles pour des notes par demi-étoile — les deux utilisent la même note.",
     minimizeToTrayLabel: "Réduire dans la barre système",
     minimizeToTrayHint: "Fermer la fenêtre masque Luminous dans la barre système au lieu de quitter l'application.",
+    launchAtLoginLabel: "Lancer au démarrage",
+    launchAtLoginHint: "Démarre Luminous automatiquement à l'ouverture de session.",
     appAndUpdatesTitle: "Application & Mises à jour",
     updateCheckNowBtn: "Rechercher des mises à jour",
     updateChecking: "Vérification...",

--- a/src/lib/stores/prefs.svelte.test.ts
+++ b/src/lib/stores/prefs.svelte.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { invoke } from "@tauri-apps/api/core";
+import { prefs } from "./prefs.svelte";
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(),
+}));
+
+describe("prefs.setAutostart", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prefs.autostartEnabled = false;
+  });
+
+  it("optimistically sets the new value and persists it via invoke", async () => {
+    vi.mocked(invoke).mockResolvedValueOnce(undefined);
+
+    await prefs.setAutostart(true);
+
+    expect(prefs.autostartEnabled).toBe(true);
+    expect(invoke).toHaveBeenCalledWith("set_autostart_enabled", { enabled: true });
+  });
+
+  it("reverts to the previous value when the backend call fails", async () => {
+    vi.mocked(invoke).mockRejectedValueOnce(new Error("permission denied"));
+
+    await prefs.setAutostart(true);
+
+    expect(prefs.autostartEnabled).toBe(false);
+  });
+});

--- a/src/lib/stores/prefs.svelte.ts
+++ b/src/lib/stores/prefs.svelte.ts
@@ -40,6 +40,8 @@ class PrefsStore {
   genreSortAsc = $state<boolean>(true);
   /** Off by default — closing the window quits unless explicitly opted in. */
   minimizeToTray = $state<boolean>(false);
+  /** Off by default; mirrors the OS's actual registration, queried fresh on init. */
+  autostartEnabled = $state<boolean>(false);
 
   async init() {
     const prefs = await invoke<UiPreferences>("get_ui_preferences");
@@ -55,6 +57,11 @@ class PrefsStore {
     this.genreSortField = prefs.genre_sort_field;
     this.genreSortAsc = prefs.genre_sort_asc;
     this.minimizeToTray = await invoke<boolean>("get_minimize_to_tray_enabled");
+    try {
+      this.autostartEnabled = await invoke<boolean>("get_autostart_enabled");
+    } catch (e) {
+      console.error("Failed to read autostart state:", e);
+    }
   }
 
   /** Persist the whole current state — fire-and-forget on the backend. */
@@ -135,6 +142,20 @@ class PrefsStore {
   setMinimizeToTray(enabled: boolean) {
     this.minimizeToTray = enabled;
     invoke("set_minimize_to_tray_enabled", { enabled });
+  }
+
+  /** Proxies straight to the OS via the plugin, which can fail (permissions,
+   * sandboxed install) — awaits the result and reverts the toggle rather than
+   * assuming success. */
+  async setAutostart(enabled: boolean) {
+    const previous = this.autostartEnabled;
+    this.autostartEnabled = enabled;
+    try {
+      await invoke("set_autostart_enabled", { enabled });
+    } catch (e) {
+      console.error("Failed to set autostart:", e);
+      this.autostartEnabled = previous;
+    }
   }
 }
 


### PR DESCRIPTION
## 📋 Summary
Adds real OS-level "Launch at login" support via `tauri-plugin-autostart`, exposed as a toggle in Settings. Fixes #435.

## 🔍 Implementation Notes
- Registered `tauri_plugin_autostart::init(MacosLauncher::LaunchAgent, None)` in the plugin chain (`src-tauri/src/lib.rs`). The `MacosLauncher` argument is required by the plugin's cross-platform API but inert since Luminous doesn't currently target macOS.
- New commands `get_autostart_enabled` / `set_autostart_enabled` (`src-tauri/src/commands/settings.rs`) proxy directly to the plugin's `AutoLaunchManager` rather than shadow-persisting a flag in the `app_state` DB table. The OS-level registration (Windows registry `Run` key / Linux XDG autostart entry) is already durable and is the actual source of truth, so storing a second copy would risk it drifting from reality — exactly the kind of "fake toggle" this issue exists to fix.
- `set_autostart_enabled` can genuinely fail (permissions, sandboxed install, a relocated AppImage), so unlike most prefs writes in this codebase it isn't fire-and-forget — the frontend (`prefs.svelte.ts`'s `setAutostart`) awaits it and reverts the toggle on failure.
- Added `"autostart:default"` to `src-tauri/capabilities/default.json`.
- Added the Settings toggle (English + French locale strings) directly below the existing "Minimize to tray" toggle in `SettingsGeneral.svelte`, following its exact pattern.

## 🧪 Test Plan
- [x] `bun run check` (svelte-check + knip) — 0 errors/warnings
- [x] `bun run test -- --run` (frontend) — new/updated tests in `SettingsGeneral.test.ts` and `prefs.svelte.test.ts` pass
- [x] `cargo test` (src-tauri) — all 265 existing tests pass, `cargo check` clean
- [x] Manually verified in the running app: toggled "Launch at login" on, confirmed a `Luminous Music Player` entry appeared in `HKCU\Software\Microsoft\Windows\CurrentVersion\Run`; toggled it off, confirmed the entry was removed.

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed — n/a (a Settings toggle, no dedicated screenshot needed for this scope)
