### PR TITLE
feat: prompt with 'Restart to update' toast instead of abrupt auto-update installs

### DIFF
--- a/src/lib/components/Toast.svelte
+++ b/src/lib/components/Toast.svelte
@@ -8,11 +8,13 @@
     SparkleIcon as Sparkles,
     XIcon as X,
     ClipboardIcon as Clipboard,
-    CheckIcon as Check
+    CheckIcon as Check,
+    ArrowsClockwiseIcon as RefreshCw
   } from "phosphor-svelte";
   import { toastStore } from "../stores/toast.svelte";
   import { i18n } from "../stores/i18n.svelte";
   import { portal } from "../utils/portal";
+  import Button from "./Button.svelte";
 
   const COPY_FEEDBACK_DURATION_MS = 1500;
   let copiedToastId = $state<number | null>(null);
@@ -104,6 +106,17 @@
         <span class="flex-1 text-pretty">{toast.text}</span>
       {/if}
       <div class="flex items-center gap-1 shrink-0">
+        {#if toast.action}
+          <Button
+            onclick={() => toast.action!.onClick()}
+            variant="primary"
+            size="sm"
+            class="shrink-0"
+          >
+            <RefreshCw class="w-3.5 h-3.5" />
+            {toast.action.label}
+          </Button>
+        {/if}
         {#if toast.variant === "error"}
           <button
             type="button"

--- a/src/lib/components/Toast.test.ts
+++ b/src/lib/components/Toast.test.ts
@@ -95,4 +95,22 @@ describe("Toast.svelte", () => {
 
     expect(screen.queryByLabelText("Copié dans le presse-papiers")).toBeInTheDocument();
   });
+
+  it("renders a toast action button and invokes its callback on click without dismissing the toast", async () => {
+    const onClick = vi.fn();
+    const id = toastStore.show("Update downloaded — restart to finish installing.", "success", undefined, undefined, {
+      label: "Restart to Update",
+      onClick,
+    });
+
+    render(Toast);
+
+    const actionBtn = screen.getByText("Restart to Update");
+    expect(actionBtn).toBeInTheDocument();
+
+    await fireEvent.click(actionBtn);
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+    expect(toastStore.messages.find((m) => m.id === id)).toBeDefined();
+  });
 });

--- a/src/lib/stores/toast.svelte.ts
+++ b/src/lib/stores/toast.svelte.ts
@@ -2,11 +2,17 @@ import { TOAST_DURATION_MS } from "../constants";
 
 type ToastVariant = "info" | "error" | "success" | "milestone" | "warning";
 
+interface ToastAction {
+  label: string;
+  onClick: () => void;
+}
+
 interface ToastMessage {
   id: number;
   text: string;
   variant: ToastVariant;
   url?: string;
+  action?: ToastAction;
 }
 
 class ToastStore {
@@ -14,9 +20,15 @@ class ToastStore {
   private nextId = 0;
   private timers = new Map<number, ReturnType<typeof setTimeout>>();
 
-  show(text: string, variant: ToastVariant = "info", durationMs?: number, url?: string) {
+  show(
+    text: string,
+    variant: ToastVariant = "info",
+    durationMs?: number,
+    url?: string,
+    action?: ToastAction
+  ) {
     const id = this.nextId++;
-    this.messages.push({ id, text, variant, url });
+    this.messages.push({ id, text, variant, url, action });
     this.scheduleDismiss(id, durationMs);
     return id;
   }

--- a/src/lib/stores/toast.test.ts
+++ b/src/lib/stores/toast.test.ts
@@ -59,4 +59,23 @@ describe("ToastStore", () => {
     expect(() => vi.advanceTimersByTime(500)).not.toThrow();
     expect(toastStore.messages).toHaveLength(0);
   });
+
+  it("show() stores an optional action and invoking its onClick calls the provided callback", () => {
+    const onClick = vi.fn();
+    toastStore.show("Update ready", "success", undefined, undefined, { label: "Restart", onClick });
+
+    expect(toastStore.messages).toHaveLength(1);
+    expect(toastStore.messages[0].action).toEqual({ label: "Restart", onClick });
+
+    toastStore.messages[0].action!.onClick();
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("a toast shown without durationMs persists indefinitely, action or not", () => {
+    toastStore.show("Update ready", "success", undefined, undefined, { label: "Restart", onClick: vi.fn() });
+
+    vi.advanceTimersByTime(10 * 60 * 1000);
+
+    expect(toastStore.messages).toHaveLength(1);
+  });
 });

--- a/src/lib/stores/updater.svelte.ts
+++ b/src/lib/stores/updater.svelte.ts
@@ -180,6 +180,15 @@ class UpdaterStore {
   async checkForUpdates() {
     if (this.isExternallyManaged) return;
 
+    // Never clobber an in-flight download or one already sitting ready to
+    // restart — re-checking (the periodic timer, or another manual click)
+    // would silently close and discard `pendingUpdate`, and a later restart
+    // click would then call `install()` on a fresh Update that was never
+    // actually downloaded, which the plugin rejects.
+    if (this.installStatus === "downloading" || this.installStatus === "ready-to-restart") {
+      return;
+    }
+
     this.checkStatus = "checking";
     this.errorMessage = null;
     this.installStatus = "idle";
@@ -279,6 +288,12 @@ class UpdaterStore {
       await relaunch();
     } catch (err) {
       console.error("Failed to restart for update:", err);
+      this.installStatus = "error";
+      this.errorMessage = extractErrorMessage(err, "Failed to restart for update");
+      toastStore.show(
+        i18n.t("settings.updateInstallError", {}, "Update failed."),
+        "error"
+      );
     }
   }
 }

--- a/src/lib/stores/updater.svelte.ts
+++ b/src/lib/stores/updater.svelte.ts
@@ -1,6 +1,8 @@
 import { invoke } from "@tauri-apps/api/core";
 import { check as checkForUpdate, type Update } from "@tauri-apps/plugin-updater";
 import { relaunch } from "@tauri-apps/plugin-process";
+import { toastStore } from "./toast.svelte";
+import { i18n } from "./i18n.svelte";
 
 interface InstallFormatInfo {
   format: string;
@@ -241,6 +243,16 @@ class UpdaterStore {
         }
       });
       this.installStatus = "ready-to-restart";
+      toastStore.show(
+        i18n.t("settings.updateReadyToRestart", {}, "Update downloaded — restart to finish installing."),
+        "success",
+        undefined,
+        undefined,
+        {
+          label: i18n.t("settings.updateRestartBtn", {}, "Restart to Update"),
+          onClick: () => this.restartNow(),
+        }
+      );
     } catch (err: unknown) {
       console.error("Failed to download and install update:", err);
       this.installStatus = "error";

--- a/src/lib/stores/updater.svelte.ts
+++ b/src/lib/stores/updater.svelte.ts
@@ -225,7 +225,14 @@ class UpdaterStore {
     this.errorMessage = null;
 
     try {
-      await this.pendingUpdate.downloadAndInstall((event) => {
+      // Deliberately `download()` only, not `downloadAndInstall()`: on Windows the
+      // native install step exits the process synchronously (`std::process::exit(0)`
+      // inside the plugin's Rust installer call) before this promise could ever
+      // resolve, so `installStatus` would never reach "ready-to-restart" and the
+      // user would never see a restart prompt — the update would silently install
+      // and relaunch the app out from under them. Installing is deferred to
+      // `restartNow()`, run only once the user acts on the prompt.
+      await this.pendingUpdate.download((event) => {
         switch (event.event) {
           case "Started":
             this.downloadProgress = { downloaded: 0, total: event.data.contentLength ?? null };
@@ -262,6 +269,13 @@ class UpdaterStore {
 
   async restartNow() {
     try {
+      // `install()` performs the actual file replacement. On Windows this exits the
+      // current process itself and the installer relaunches the app, so `relaunch()`
+      // below is unreachable there; on macOS/Linux `install()` just swaps files and
+      // relaunch() is what actually restarts the app.
+      if (this.pendingUpdate) {
+        await this.pendingUpdate.install();
+      }
       await relaunch();
     } catch (err) {
       console.error("Failed to restart for update:", err);

--- a/src/lib/stores/updater.test.ts
+++ b/src/lib/stores/updater.test.ts
@@ -1,7 +1,8 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { updaterStore } from "./updater.svelte";
 import { check } from "@tauri-apps/plugin-updater";
 import { relaunch } from "@tauri-apps/plugin-process";
+import { toastStore } from "./toast.svelte";
 
 function fakeUpdate(overrides: Partial<{ version: string }> = {}) {
   return {
@@ -137,6 +138,43 @@ describe("UpdaterStore", () => {
     await updaterStore.downloadAndInstall();
 
     expect(updaterStore.installStatus).toBe("ready-to-restart");
+  });
+
+  describe("downloadAndInstall toast notification", () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it("fires a persistent toast with a restart action on success", async () => {
+      const showSpy = vi.spyOn(toastStore, "show");
+      const update = fakeUpdate({ version: "2.0.0" });
+      vi.mocked(check).mockResolvedValueOnce(update);
+
+      await updaterStore.checkForUpdates();
+      await updaterStore.downloadAndInstall();
+
+      expect(showSpy).toHaveBeenCalledTimes(1);
+      const [, variant, durationMs, url, action] = showSpy.mock.calls[0];
+      expect(variant).toBe("success");
+      expect(durationMs).toBeUndefined();
+      expect(url).toBeUndefined();
+      expect(action).toEqual({ label: expect.any(String), onClick: expect.any(Function) });
+    });
+
+    it("wires the toast's restart action to restartNow()", async () => {
+      const showSpy = vi.spyOn(toastStore, "show");
+      const update = fakeUpdate({ version: "2.0.0" });
+      vi.mocked(check).mockResolvedValueOnce(update);
+
+      await updaterStore.checkForUpdates();
+      await updaterStore.downloadAndInstall();
+
+      const action = showSpy.mock.calls[0][4];
+      action!.onClick();
+      await Promise.resolve();
+
+      expect(relaunch).toHaveBeenCalled();
+    });
   });
 
   it("restartNow calls relaunch", async () => {

--- a/src/lib/stores/updater.test.ts
+++ b/src/lib/stores/updater.test.ts
@@ -8,7 +8,8 @@ function fakeUpdate(overrides: Partial<{ version: string }> = {}) {
   return {
     version: overrides.version ?? "1.2.3",
     currentVersion: "1.0.0",
-    downloadAndInstall: vi.fn().mockResolvedValue(undefined),
+    download: vi.fn().mockResolvedValue(undefined),
+    install: vi.fn().mockResolvedValue(undefined),
     close: vi.fn().mockResolvedValue(undefined),
   } as any;
 }
@@ -115,7 +116,7 @@ describe("UpdaterStore", () => {
     await Promise.resolve();
     await Promise.resolve();
 
-    expect(update.downloadAndInstall).toHaveBeenCalled();
+    expect(update.download).toHaveBeenCalled();
   });
 
   it("does not auto-install when the format does not support self-update", async () => {
@@ -127,16 +128,18 @@ describe("UpdaterStore", () => {
     await updaterStore.checkForUpdates();
     await Promise.resolve();
 
-    expect(update.downloadAndInstall).not.toHaveBeenCalled();
+    expect(update.download).not.toHaveBeenCalled();
   });
 
-  it("downloadAndInstall transitions to ready-to-restart on success", async () => {
+  it("downloadAndInstall downloads only (not install) and transitions to ready-to-restart on success", async () => {
     const update = fakeUpdate({ version: "2.0.0" });
     vi.mocked(check).mockResolvedValueOnce(update);
 
     await updaterStore.checkForUpdates();
     await updaterStore.downloadAndInstall();
 
+    expect(update.download).toHaveBeenCalled();
+    expect(update.install).not.toHaveBeenCalled();
     expect(updaterStore.installStatus).toBe("ready-to-restart");
   });
 
@@ -161,7 +164,7 @@ describe("UpdaterStore", () => {
       expect(action).toEqual({ label: expect.any(String), onClick: expect.any(Function) });
     });
 
-    it("wires the toast's restart action to restartNow()", async () => {
+    it("wires the toast's restart action to restartNow(), which installs then relaunches", async () => {
       const showSpy = vi.spyOn(toastStore, "show");
       const update = fakeUpdate({ version: "2.0.0" });
       vi.mocked(check).mockResolvedValueOnce(update);
@@ -172,13 +175,26 @@ describe("UpdaterStore", () => {
       const action = showSpy.mock.calls[0][4];
       action!.onClick();
       await Promise.resolve();
+      await Promise.resolve();
 
+      expect(update.install).toHaveBeenCalled();
       expect(relaunch).toHaveBeenCalled();
     });
   });
 
   it("restartNow calls relaunch", async () => {
     await updaterStore.restartNow();
+    expect(relaunch).toHaveBeenCalled();
+  });
+
+  it("restartNow installs the pending update before relaunching", async () => {
+    const update = fakeUpdate({ version: "2.0.0" });
+    vi.mocked(check).mockResolvedValueOnce(update);
+    await updaterStore.checkForUpdates();
+
+    await updaterStore.restartNow();
+
+    expect(update.install).toHaveBeenCalled();
     expect(relaunch).toHaveBeenCalled();
   });
 

--- a/src/lib/stores/updater.test.ts
+++ b/src/lib/stores/updater.test.ts
@@ -131,6 +131,24 @@ describe("UpdaterStore", () => {
     expect(update.download).not.toHaveBeenCalled();
   });
 
+  it("checkForUpdates is a no-op while a download is in flight or ready to restart, so it can't discard pendingUpdate out from under a later restart click", async () => {
+    const update = fakeUpdate({ version: "2.0.0" });
+    vi.mocked(check).mockResolvedValueOnce(update);
+    await updaterStore.checkForUpdates();
+    await updaterStore.downloadAndInstall();
+    expect(updaterStore.installStatus).toBe("ready-to-restart");
+
+    vi.mocked(check).mockClear();
+    await updaterStore.checkForUpdates();
+
+    expect(check).not.toHaveBeenCalled();
+    expect(update.close).not.toHaveBeenCalled();
+    expect(updaterStore.installStatus).toBe("ready-to-restart");
+
+    await updaterStore.restartNow();
+    expect(update.install).toHaveBeenCalled();
+  });
+
   it("downloadAndInstall downloads only (not install) and transitions to ready-to-restart on success", async () => {
     const update = fakeUpdate({ version: "2.0.0" });
     vi.mocked(check).mockResolvedValueOnce(update);
@@ -196,6 +214,25 @@ describe("UpdaterStore", () => {
 
     expect(update.install).toHaveBeenCalled();
     expect(relaunch).toHaveBeenCalled();
+  });
+
+  it("restartNow surfaces a visible error instead of silently failing when install() rejects", async () => {
+    // e.g. `pendingUpdate` got replaced by a fresh, not-yet-downloaded Update
+    // object — the plugin's `install()` rejects with "called before download".
+    const update = fakeUpdate({ version: "2.0.0" });
+    update.install = vi.fn().mockRejectedValue(new Error("Update.install called before Update.download"));
+    vi.mocked(check).mockResolvedValueOnce(update);
+    await updaterStore.checkForUpdates();
+    const showSpy = vi.spyOn(toastStore, "show");
+
+    await updaterStore.restartNow();
+
+    expect(relaunch).not.toHaveBeenCalled();
+    expect(updaterStore.installStatus).toBe("error");
+    expect(updaterStore.errorMessage).toBe("Update.install called before Update.download");
+    expect(showSpy).toHaveBeenCalledWith(expect.any(String), "error");
+
+    showSpy.mockRestore();
   });
 
   it("records lastCheckedAt after a successful check", async () => {


### PR DESCRIPTION
## 📋 Summary
Adds a proactive, non-intrusive "Restart to update" toast so a background auto-update no longer installs silently — the user gets a persistent notification with a Restart action once the download is ready, and can dismiss it and restart on their own schedule. Fixes #409.

## 🔍 Implementation Notes
- `src/lib/stores/toast.svelte.ts` / `src/lib/components/Toast.svelte`: `ToastMessage`/`show()` now support an optional `action: { label, onClick }`, rendered as a primary button alongside the existing dismiss/copy buttons.
- `src/lib/stores/updater.svelte.ts`: on successful download, fires a persistent toast ("Update downloaded — restart to finish installing.") with a "Restart to Update" action wired to `restartNow()`. Reuses the existing `settings.updateReadyToRestart` / `settings.updateRestartBtn` i18n keys — no new locale strings needed.
- Skipped the `TopNavigation.svelte` header button proposed in the issue's original design doc — the toast plus the existing Sidebar update badge already cover "proactive but non-intrusive" without adding a third UI surface. The issue also referenced a `FoldersView.svelte` that doesn't exist in this repo; the real restart UI lives in `SettingsGeneral.svelte`, left unchanged.
- Two real bugs surfaced only by testing against the actual Tauri updater plugin (not visible from unit tests) and were fixed as part of this change, since they blocked the feature's actual acceptance criteria:
  1. **`downloadAndInstall()` → separate `download()`/`install()`.** On Windows, the plugin's combined `downloadAndInstall()` exits the process synchronously inside its native install step, before the JS promise could ever resolve — so `installStatus` never reached `"ready-to-restart"` and the app silently installed and relaunched itself with no prompt at all. Installing is now deferred to `restartNow()`, run only when the user clicks Restart.
  2. **`checkForUpdates()` could discard an in-flight or completed download.** It unconditionally closed and replaced `pendingUpdate` on every call (including the periodic background check), so a re-check between download-finished and the user clicking Restart would silently break the pending install — `restartNow()` would then reject with `Update.install called before Update.download`, previously only logged to the console. `checkForUpdates()` now no-ops while `installStatus` is `"downloading"` or `"ready-to-restart"`, and `restartNow()` surfaces any failure via an error toast + `installStatus = "error"` (which already drives a "Retry" button in Settings).

## 🧪 Test Plan
- [x] `bun run check` (svelte-check) — 0 errors/warnings, knip clean
- [x] `bun run test -- --run` (frontend) — 572/572 passing
- [ ] `cargo test` (src-tauri, if Rust changed) — no Rust changes in this PR
- [x] Manually verified in the app — tested against a real published GitHub release (temporarily rolling the app's own version below latest, per the repo's own updater endpoint) under both update policies:
  - **Notify me**: clicked "Download Update," saw the toast with a working "Restart to Update" button, clicked it, app relaunched onto the new version correctly.
  - **Install automatically**: update downloaded in the background, toast appeared unprompted, Restart button relaunched correctly.

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed — no screenshot-harness changes needed (toast/notification, not a new screenshot-eligible view)
