### PR TITLE
fix: restore visible box set disc icons on cover art

### DIFF
--- a/src/lib/components/BoxSetDiscIcons.svelte
+++ b/src/lib/components/BoxSetDiscIcons.svelte
@@ -35,7 +35,8 @@
   >
     {#each Array(visibleDiscs) as _, i (i)}
       <Disc
-        class="{currentSize.icon} text-white fill-black/40 drop-shadow-[0_1px_2px_rgba(0,0,0,0.8)] {i > 0 ? currentSize.overlap : ''}"
+        weight="fill"
+        class="{currentSize.icon} text-white drop-shadow-[0_1px_2px_rgba(0,0,0,0.8)] {i > 0 ? currentSize.overlap : ''}"
         style="z-index: {visibleDiscs - i}"
       />
     {/each}


### PR DESCRIPTION
## 📋 Summary
Fixes #750. Box set disc icons became nearly invisible (black on dark cover art) after the Lucide → Phosphor icon migration in 271aa49, because `fill-black/40` was carried over from the old stroke-based icon and now colors the entire solid Phosphor glyph black instead of just its interior.

## 🔍 Implementation Notes
`src/lib/components/BoxSetDiscIcons.svelte` now passes `weight="fill"` and relies on `text-white` for color, matching the convention already used by `FavouriteCornerFlag`'s `Heart` icon. No other files changed.

## 🧪 Test Plan
- [x] `bun run check` (svelte-check) — 0 errors
- [x] `bun run test -- --run` (frontend) — 528 passed
- [ ] `cargo test` (src-tauri, if Rust changed) — not applicable, no Rust changes
- [x] Manually verified in the app — confirmed the regression (black, hard to see) then confirmed the fix (white, visible) in `bun run tauri dev` against a multi-disc box set album

## 📸 Screenshots
N/A — verified live in the dev app per the test plan above; no screenshot harness for this project can render the real Tauri IPC-backed UI (see `.claude/CLAUDE.md`).

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed — N/A, no docs/screenshot assets reference this icon
