### PR TITLE
fix: correct play button icon optical centering

### DIFF
--- a/src/lib/components/Miniplayer.svelte
+++ b/src/lib/components/Miniplayer.svelte
@@ -345,7 +345,7 @@
             class="w-10 h-10 rounded-full bg-brand-accent hover:bg-brand-accent-hover text-brand-accent-contrast flex items-center justify-center transition-colors flex-shrink-0"
             title={i18n.t('playerBar.play')}
           >
-            <Play class="w-5 h-5 fill-current ml-0.5" />
+            <Play class="w-5 h-5 fill-current" />
           </button>
         {/if}
 

--- a/src/lib/components/PlayerBar.svelte
+++ b/src/lib/components/PlayerBar.svelte
@@ -324,7 +324,7 @@
           class="w-8 h-8 rounded-full bg-brand-accent hover:bg-brand-accent-hover text-brand-accent-contrast flex items-center justify-center transition-colors"
           title={i18n.t('playerBar.play')}
         >
-          <Play class="w-4 h-4 fill-current ml-0.5" />
+          <Play class="w-4 h-4 fill-current" />
         </button>
       {/if}
 


### PR DESCRIPTION
## 📋 Summary
Fixes the play/pause button's play-triangle icon sitting off-center in its circular button.

## 🔍 Implementation Notes
The `ml-0.5` nudge on the Play icon (PlayerBar.svelte, Miniplayer.svelte) was tuned for lucide-svelte's triangle glyph, whose visual centroid sits noticeably left of its bounding box. The codebase later migrated icons to phosphor-svelte, whose Play triangle is already nearly centroid-centered on its own. The leftover 2px nudge overcorrected, pushing the icon visibly right of center. Removed the nudge in both places; the Pause icon (symmetric bars) never needed one and is unchanged.

## 🧪 Test Plan
- [x] `bun run check` (svelte-check)
- [ ] `bun run test -- --run` (frontend)
- [ ] `cargo test` (src-tauri, if Rust changed) — no Rust changed
- [ ] Manually verified in the app (describe what you did)

## 📸 Screenshots
N/A — CSS-only centering tweak, not screenshot-harness tracked.

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed — no docs/screenshot-config updates needed for this micro-tweak
