### PR TITLE
fix: album/artist detail views collapse to Unknown after tag rename

### DIFF
--- a/src/lib/components/AlbumDetailView.svelte
+++ b/src/lib/components/AlbumDetailView.svelte
@@ -277,23 +277,45 @@
     showAlbumTagEditor = true;
   }
 
-  function handleTagEditorSaved() {
+  async function handleTagEditorSaved() {
     collectionStore.refreshLibrary();
     tagsStore.load();
     loading = true;
-    invoke<Song[]>("get_songs_by_album", { album: albumName })
-      .then((fetchedSongs) => {
-        let filtered = [...fetchedSongs];
-        filtered.sort((a, b) => {
-          if (a.disc !== b.disc) {
-            return (a.disc ?? 1) - (b.disc ?? 1);
-          }
-          return (a.track ?? 0) - (b.track ?? 0);
-        });
-        songs = filtered;
-      })
-      .catch((err) => console.error(err))
-      .finally(() => loading = false);
+
+    // The album-level editor renames every song currently loaded here at once,
+    // so if it changed the album name, this view's `albumName` prop is now
+    // stale and re-querying by it would come up empty. Resolve the current
+    // name from one of the album's own songs and hand off to navigationStore
+    // so the album-name effect refetches under the new name. A single-song
+    // edit only ever touches one track, so it's left to the normal refetch
+    // below, which naturally drops that song if it moved to a different album.
+    if (showAlbumTagEditor && songs[0]?.id !== undefined) {
+      try {
+        const details = await invoke<{ album: string }>("get_song_details", { songId: songs[0].id });
+        if (details.album && details.album !== albumName) {
+          navigationStore.selectedAlbumName = details.album;
+          return;
+        }
+      } catch (err) {
+        console.error("Failed to resolve current album name after tag edit:", err);
+      }
+    }
+
+    try {
+      const fetchedSongs = await invoke<Song[]>("get_songs_by_album", { album: albumName });
+      let filtered = [...fetchedSongs];
+      filtered.sort((a, b) => {
+        if (a.disc !== b.disc) {
+          return (a.disc ?? 1) - (b.disc ?? 1);
+        }
+        return (a.track ?? 0) - (b.track ?? 0);
+      });
+      songs = filtered;
+    } catch (err) {
+      console.error(err);
+    } finally {
+      loading = false;
+    }
   }
 
   async function rateSong(song: Song, rating: number) {

--- a/src/lib/components/ArtistDetailView.svelte
+++ b/src/lib/components/ArtistDetailView.svelte
@@ -101,16 +101,34 @@
     editingSongId = songId;
   }
 
-  function refetchSongs() {
-    invoke<Song[]>("get_songs_by_artist", { artist: artistName }).then((fetchedSongs) => {
-      songs = Array.isArray(fetchedSongs) ? fetchedSongs : [];
-    });
+  async function refetchSongs() {
+    const fetchedSongs = await invoke<Song[]>("get_songs_by_artist", { artist: artistName });
+    songs = Array.isArray(fetchedSongs) ? fetchedSongs : [];
   }
 
-  function handleTagEditorSaved() {
+  async function handleTagEditorSaved() {
     collectionStore.refreshLibrary();
     tagsStore.load();
-    refetchSongs();
+
+    const editedSongId = editingSongId;
+    await refetchSongs();
+
+    // Renaming the just-edited track's (album) artist can leave this artist
+    // with none of its previously-loaded songs still matching `artistName` —
+    // get_songs_by_artist then comes back empty even though the artist still
+    // exists, just under a new name. Follow it instead of showing a stale,
+    // empty page.
+    if (songs.length === 0 && editedSongId !== null) {
+      try {
+        const details = await invoke<{ artist: string; album_artist: string }>("get_song_details", { songId: editedSongId });
+        const newArtist = details.album_artist || details.artist;
+        if (newArtist && newArtist !== artistName) {
+          navigationStore.selectedArtistName = newArtist;
+        }
+      } catch (err) {
+        console.error("Failed to resolve current artist name after tag edit:", err);
+      }
+    }
   }
 
   async function rateSingle(song: Song, rating: number) {


### PR DESCRIPTION
## 📋 Summary
Fixes a milestone-1.8 regression: after editing an album's metatags (or a track's artist tag), the Album Detail / Artist Detail view collapsed to "Unknown Artist"/"Unknown Album" and only recovered after navigating away and back.

## 🔍 Implementation Notes
Root cause: `AlbumDetailView.svelte`'s `handleTagEditorSaved` and `ArtistDetailView.svelte`'s `refetchSongs` re-fetched songs using the album/artist name they were opened with (a component prop). If the tag editor renamed that album or the edited track's artist, no songs matched the old name anymore, so the refetch came back empty and every derived field fell back to "Unknown".

Fix: after a tag-editor save, resolve the current name from one of the view's own songs (via `get_song_details`) and, if it changed, hand the new name to `navigationStore` so the view follows the rename — `AlbumDetailView` does this whenever the album-level editor changed the album name (it renames every loaded song at once), `ArtistDetailView` does it only when the refetch comes back empty after a single-track edit (so a track just leaving the artist doesn't wrongly redirect the page).

Files touched:
- `src/lib/components/AlbumDetailView.svelte`
- `src/lib/components/ArtistDetailView.svelte`

## 🧪 Test Plan
- [x] `bun run check` (svelte-check) — 0 errors
- [x] `bun run test -- --run AlbumDetailView ArtistDetailView` — 9 passed
- [ ] `cargo test` (no Rust changed)
- [ ] Manually verified in the app — pending user verification via `bun run tauri dev`

## 📸 Screenshots
N/A — no visual change, only data-freshness behavior.

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed — N/A, bug fix only
