### PR TITLE
fix: keep miniplayer toggle visible at every playerbar breakpoint

### DIFF
--- a/src/lib/components/PlayerBar.svelte
+++ b/src/lib/components/PlayerBar.svelte
@@ -355,6 +355,14 @@
         {/if}
       </div>
 
+      <button
+        onclick={() => windowLayoutStore.toggleMiniplayerMode()}
+        class="min-[700px]:hidden text-brand-text-secondary hover:text-brand-accent-text transition-colors flex-shrink-0"
+        title={i18n.t('miniplayer.toggleTooltip', {}, 'Picture-in-Picture Mode (Ctrl+M)')}
+      >
+        <PictureInPicture class="w-4 h-4" />
+      </button>
+
     </div>
 
     <div class="hidden min-[700px]:flex items-center gap-2.5 w-full text-[10px] text-brand-text-secondary/60">
@@ -413,7 +421,6 @@
       class="hidden min-[700px]:block text-brand-text-secondary hover:text-brand-accent-text transition-colors p-1.5 rounded hover:bg-brand-main/60 flex-shrink-0"
       title={i18n.t('miniplayer.toggleTooltip', {}, 'Picture-in-Picture Mode (Ctrl+M)')}
     >
-
       <PictureInPicture class="w-4.5 h-4.5" />
     </button>
   </div>

--- a/src/lib/components/PlayerBar.test.ts
+++ b/src/lib/components/PlayerBar.test.ts
@@ -282,15 +282,22 @@ describe("PlayerBar.svelte", () => {
     const { getAllByTitle, getByTitle, container } = render(PlayerBar);
 
     // Gone by Compact (Full-only): shuffle, repeat, the seek row, and the
-    // whole right column (volume/mute + expand) — the transport block takes
-    // the freed space instead, sticking to the right edge via ml-auto.
+    // volume/mute controls in the right column — the transport block takes
+    // the freed space instead, sticking to the right edge via ml-auto. The
+    // miniplayer toggle itself must stay visible at every tier (issue: it
+    // should never disappear), so it has two instances that swap places at
+    // the 700px boundary: one alongside volume/mute (Full only) and one in
+    // the transport row (Compact/Minimal only, hidden again once the
+    // right-column instance takes over).
     const shuffleBtn = getAllByTitle(/shuffle/i).find(el => el.querySelector("svg"))!;
     const repeatBtn = getAllByTitle(/repeat/i).find(el => el.querySelector("svg"))!;
     expect(shuffleBtn.closest(".hidden")).toHaveClass("min-[700px]:block");
     expect(repeatBtn.closest(".hidden")).toHaveClass("min-[700px]:block");
     const volumeSlider = container.querySelector('input[type="range"]');
     expect(volumeSlider).toHaveClass("hidden", "min-[700px]:block");
-    expect(getByTitle(/picture-in-picture/i)).toHaveClass("hidden", "min-[700px]:block");
+    const [transportToggle, rightColumnToggle] = getAllByTitle(/picture-in-picture/i);
+    expect(transportToggle).toHaveClass("min-[700px]:hidden");
+    expect(rightColumnToggle).toHaveClass("hidden", "min-[700px]:block");
     const rightColumn = Array.from(container.querySelectorAll("div")).find(d => d.className.includes("justify-end"))!;
     expect(rightColumn).toHaveClass("hidden", "min-[700px]:flex");
     const seekRow = Array.from(container.querySelectorAll("div")).find(d => d.className.includes("gap-2.5"))!;


### PR DESCRIPTION
## 📋 Summary
Milestone 1.8 tweak: the miniplayer (Picture-in-Picture) toggle in the playerbar was only rendered inside the volume/mute cluster, which is hidden below the 700px "Full" breakpoint — so on narrower windows the toggle disappeared entirely. This adds a second instance in the transport row that shows only below 700px, swapping with the right-column instance at the boundary, so the toggle is reachable at every breakpoint.

## 🔍 Implementation Notes
Two `<button>` instances now exist in `PlayerBar.svelte`: the original one alongside volume/mute (`hidden min-[700px]:block`, Full tier only) and a new one in the transport row next to shuffle/repeat (`min-[700px]:hidden`, Compact/Minimal tiers only). Only one is ever visible at a given width, avoiding duplicate controls. Went through a couple of iterations before landing here — an earlier attempt tried to keep a single always-visible instance in the volume cluster, but the surrounding containers' hard `min-width`s left no room for it below 700px and it overflowed outside the pill's rounded bounds; another attempt folded it permanently into the transport row, which looked out of place at full width. The two-instance swap keeps each tier's layout intentional.

## 🧪 Test Plan
- [x] `bun run check` (svelte-check) — 0 errors
- [x] `bun run test -- --run PlayerBar` (frontend) — 16/16 passed, updated the responsive-tier test to assert both toggle instances and their breakpoint classes
- [ ] `cargo test` (src-tauri, if Rust changed) — not applicable, no Rust changes
- [x] Manually verified in the app — confirmed with the user across Full/Compact/Minimal widths

## 📸 Screenshots
N/A — icon-only change verified via manual width testing.

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed — no screenshot harness update needed, this is a small control-visibility fix, not a new screenshot-worthy feature
