### PR TITLE
feat: extended artwork types & store plumbing (#759)

### DIFF
--- a/src/lib/stores/collection.extendedArtwork.test.ts
+++ b/src/lib/stores/collection.extendedArtwork.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
+import type { ExtendedArtworkResponse } from "../types";
+
+vi.mock("@tauri-apps/api/window", () => ({
+  getCurrentWindow: vi.fn(() => ({
+    onResized: vi.fn(() => Promise.resolve(() => {})),
+    onMoved: vi.fn(() => Promise.resolve(() => {})),
+  })),
+}));
+
+import { collectionStore } from "./collection.svelte";
+
+const SAMPLE_RESPONSE: ExtendedArtworkResponse = {
+  count: 2,
+  primary_uri: "luminous-art://local/C:/Music/Artist/Album/cover.jpg",
+  artist_portrait_uri: null,
+  band_logo_uri: null,
+  fanart_uri: null,
+  items: [
+    { category: "primary_cover", uri: "luminous-art://local/C:/Music/Artist/Album/cover.jpg" },
+    { category: "back_cover", uri: "luminous-art://local/C:/Music/Artist/Album/back.jpg" },
+  ],
+};
+
+describe("CollectionStore - extended artwork (#98/#759)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Cached results from earlier tests must not leak between cases.
+    collectionStore.extendedArtworkBySong = {};
+    collectionStore.extendedArtworkByArtist = {};
+
+    vi.mocked(listen).mockImplementation(async () => () => {});
+  });
+
+  it("fetches extended artwork for a song and caches the result", async () => {
+    const invokeMock = vi.mocked(invoke).mockImplementation(async (cmd: string) => {
+      if (cmd === "get_extended_artwork_for_song") return SAMPLE_RESPONSE;
+      return null;
+    });
+
+    const first = await collectionStore.getExtendedArtworkForSong(42);
+    expect(invokeMock).toHaveBeenCalledWith("get_extended_artwork_for_song", { songId: 42 });
+    expect(first).toEqual(SAMPLE_RESPONSE);
+    expect(collectionStore.extendedArtworkBySong[42]).toEqual(SAMPLE_RESPONSE);
+
+    // Second call for the same song must hit the cache, not the backend again.
+    const second = await collectionStore.getExtendedArtworkForSong(42);
+    expect(second).toEqual(SAMPLE_RESPONSE);
+    expect(invokeMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("dedupes concurrent fetches for the same song into one backend call", async () => {
+    let resolveInvoke: (value: ExtendedArtworkResponse) => void;
+    const pending = new Promise<ExtendedArtworkResponse>((resolve) => {
+      resolveInvoke = resolve;
+    });
+    const invokeMock = vi.mocked(invoke).mockImplementation(async (cmd: string) => {
+      if (cmd === "get_extended_artwork_for_song") return pending;
+      return null;
+    });
+
+    const call1 = collectionStore.getExtendedArtworkForSong(7);
+    const call2 = collectionStore.getExtendedArtworkForSong(7);
+    resolveInvoke!(SAMPLE_RESPONSE);
+
+    const [result1, result2] = await Promise.all([call1, call2]);
+    expect(result1).toEqual(SAMPLE_RESPONSE);
+    expect(result2).toEqual(SAMPLE_RESPONSE);
+    expect(invokeMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("fetches extended artwork for an artist keyed case-insensitively", async () => {
+    const invokeMock = vi.mocked(invoke).mockImplementation(async (cmd: string, args?: any) => {
+      if (cmd === "get_extended_artwork_for_artist" && args?.artist === "Shania Twain") {
+        return SAMPLE_RESPONSE;
+      }
+      return null;
+    });
+
+    const result = await collectionStore.getExtendedArtworkForArtist("Shania Twain");
+    expect(result).toEqual(SAMPLE_RESPONSE);
+    expect(collectionStore.extendedArtworkByArtist["shania twain"]).toEqual(SAMPLE_RESPONSE);
+
+    // A different-cased lookup for the same artist should hit the cache.
+    const cached = await collectionStore.getExtendedArtworkForArtist("SHANIA TWAIN");
+    expect(cached).toEqual(SAMPLE_RESPONSE);
+    expect(invokeMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns an empty result without throwing when the backend call fails", async () => {
+    vi.mocked(invoke).mockImplementation(async (cmd: string) => {
+      if (cmd === "get_extended_artwork_for_song") throw new Error("scan failed");
+      return null;
+    });
+
+    const result = await collectionStore.getExtendedArtworkForSong(99);
+    expect(result).toEqual({
+      count: 0,
+      primary_uri: null,
+      artist_portrait_uri: null,
+      band_logo_uri: null,
+      fanart_uri: null,
+      items: [],
+    });
+    // A failed fetch isn't cached — a later call should retry, not stay stuck empty.
+    expect(collectionStore.extendedArtworkBySong[99]).toBeUndefined();
+  });
+
+  it("returns an empty result for a null/undefined artist name without invoking", async () => {
+    const invokeMock = vi.mocked(invoke);
+    const result = await collectionStore.getExtendedArtworkForArtist(undefined);
+    expect(result.count).toBe(0);
+    expect(invokeMock).not.toHaveBeenCalledWith("get_extended_artwork_for_artist", expect.anything());
+  });
+
+  it("opens an artwork path via the open_artwork_path command", async () => {
+    const invokeMock = vi.mocked(invoke).mockResolvedValue(undefined);
+    await collectionStore.openArtworkPath("C:/Music/Artist/Album/cover.jpg");
+    expect(invokeMock).toHaveBeenCalledWith("open_artwork_path", { path: "C:/Music/Artist/Album/cover.jpg" });
+  });
+});

--- a/src/lib/stores/collection.svelte.ts
+++ b/src/lib/stores/collection.svelte.ts
@@ -12,6 +12,7 @@ import type {
   AlbumItem,
   ArtistItem,
   ArtistProfile,
+  ExtendedArtworkResponse,
   RecentSearchItem,
   QueuePopulationMode,
 } from "../types";
@@ -66,6 +67,19 @@ type ColumnWidths = Partial<Record<keyof VisibleColumns, number>>;
 /** Song-count milestones that trigger Milestone-tier celebrations. */
 const MILESTONE_THRESHOLDS = [100, 500, 1000, 2500, 5000, 10000];
 
+/** Fallback for a failed extended-artwork fetch (#98/#759) — an empty result
+ * rather than throwing, so callers (cover-stack badge, artist visuals) can
+ * treat "scan failed" the same as "nothing found" without their own
+ * try/catch. */
+const EMPTY_EXTENDED_ARTWORK: ExtendedArtworkResponse = {
+  count: 0,
+  primary_uri: null,
+  artist_portrait_uri: null,
+  band_logo_uri: null,
+  fanart_uri: null,
+  items: [],
+};
+
 class CollectionStore {
   directories = $state<MusicDirectory[]>([]);
   stats = $state<LibraryStats>({
@@ -103,6 +117,21 @@ class CollectionStore {
   albums = $state<AlbumItem[]>([]);
   artists = $state<ArtistItem[]>([]);
   artistProfiles = $state<Record<string, ArtistProfile>>({});
+  /** On-demand extended-artwork cache (#98/#759), keyed by song id — unlike
+   * `artistProfiles`, this is never bulk-loaded: scanning every song's album
+   * folder eagerly would be far too expensive, so entries are fetched lazily
+   * by `getExtendedArtworkForSong()` and kept here so the same song showing
+   * up in multiple places (e.g. a cover-stack re-rendering) doesn't re-scan
+   * the filesystem every time. */
+  extendedArtworkBySong = $state<Record<number, ExtendedArtworkResponse>>({});
+  /** Same idea as {@link extendedArtworkBySong}, keyed by lowercased artist
+   * name (matching `artistProfiles`' key convention) via
+   * `getExtendedArtworkForArtist()`. */
+  extendedArtworkByArtist = $state<Record<string, ExtendedArtworkResponse>>({});
+  /** In-flight extended-artwork fetches, so concurrent callers for the same
+   * key (e.g. `ArtistCard` and `TopNavigation` rendering the same artist at
+   * once) share one backend call instead of each firing their own. */
+  private extendedArtworkFetches = new Map<string, Promise<ExtendedArtworkResponse>>();
   searchResults = $state<Song[]>([]);
   searchQuery = $state<string>("");
   searchLoading = $state<boolean>(false);
@@ -497,6 +526,74 @@ class CollectionStore {
       };
     }
     return saved;
+  }
+
+  /** Cached extended-artwork lookup for a song's album (#98/#760) — returns
+   * the cached result if already fetched, otherwise scans on demand via
+   * `get_extended_artwork_for_song` and caches the result. Concurrent calls
+   * for the same `songId` share one in-flight request. */
+  async getExtendedArtworkForSong(songId: number): Promise<ExtendedArtworkResponse> {
+    const cached = this.extendedArtworkBySong[songId];
+    if (cached) return cached;
+
+    const fetchKey = `song:${songId}`;
+    const inFlight = this.extendedArtworkFetches.get(fetchKey);
+    if (inFlight) return inFlight;
+
+    const promise = invoke<ExtendedArtworkResponse>("get_extended_artwork_for_song", { songId })
+      .then((result) => {
+        this.extendedArtworkBySong = { ...this.extendedArtworkBySong, [songId]: result };
+        return result;
+      })
+      .catch((err) => {
+        console.error("Failed to load extended artwork for song:", err);
+        return EMPTY_EXTENDED_ARTWORK;
+      })
+      .finally(() => {
+        this.extendedArtworkFetches.delete(fetchKey);
+      });
+
+    this.extendedArtworkFetches.set(fetchKey, promise);
+    return promise;
+  }
+
+  /** Cached extended-artwork lookup for an artist's portrait/logo/fanart
+   * (#98/#761) — same lazy-fetch-and-cache pattern as
+   * {@link getExtendedArtworkForSong}, keyed by lowercased artist name to
+   * match `artistProfiles`. */
+  async getExtendedArtworkForArtist(artistName: string | null | undefined): Promise<ExtendedArtworkResponse> {
+    if (!artistName) return EMPTY_EXTENDED_ARTWORK;
+    const key = artistName.toLowerCase();
+
+    const cached = this.extendedArtworkByArtist[key];
+    if (cached) return cached;
+
+    const fetchKey = `artist:${key}`;
+    const inFlight = this.extendedArtworkFetches.get(fetchKey);
+    if (inFlight) return inFlight;
+
+    const promise = invoke<ExtendedArtworkResponse>("get_extended_artwork_for_artist", { artist: artistName })
+      .then((result) => {
+        this.extendedArtworkByArtist = { ...this.extendedArtworkByArtist, [key]: result };
+        return result;
+      })
+      .catch((err) => {
+        console.error("Failed to load extended artwork for artist:", err);
+        return EMPTY_EXTENDED_ARTWORK;
+      })
+      .finally(() => {
+        this.extendedArtworkFetches.delete(fetchKey);
+      });
+
+    this.extendedArtworkFetches.set(fetchKey, promise);
+    return promise;
+  }
+
+  /** Opens a discovered artwork file (a raw filesystem path, not a
+   * `luminous-art://` URI) in the OS's default image viewer — the "Open
+   * Images" hover action (#760). */
+  async openArtworkPath(path: string): Promise<void> {
+    await invoke("open_artwork_path", { path });
   }
 
   async addDirectory(path: string) {

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -279,6 +279,14 @@ export interface ArtistItem {
   song_count: number;
   total_playcount?: number;
   genre?: string | null;
+  /** Locally-discovered artist visuals (#98/#761) — not returned by
+   * `get_artists()`; populated on demand via
+   * `collectionStore.getExtendedArtworkForArtist()` (see `ExtendedArtworkResponse`),
+   * since scanning every artist's folder eagerly for a list view would be
+   * far too expensive. `undefined` means "not fetched yet", not "none found". */
+  portrait_uri?: string | null;
+  band_logo_uri?: string | null;
+  fanart_uri?: string | null;
 }
 
 export interface ArtistSocialLink {
@@ -292,6 +300,51 @@ export interface ArtistProfile {
   tags: string[];
   social_links: ArtistSocialLink[];
   bio?: string | null;
+  /** Same on-demand artist visuals as {@link ArtistItem} — see there for why
+   * these aren't populated by `get_artist_profile()`/`get_all_artist_profiles()`. */
+  portrait_uri?: string | null;
+  band_logo_uri?: string | null;
+  fanart_uri?: string | null;
+}
+
+/**
+ * Category within the Standardized Artwork Hierarchy (#98) — mirrors
+ * `ArtworkCategory::as_str()` in `covermanager.rs` exactly. Don't rename a
+ * value here without updating there.
+ */
+export type ExtendedArtworkCategory =
+  | "primary_cover"
+  | "back_cover"
+  | "disc_media"
+  | "booklet"
+  | "matrix"
+  | "artist_portrait"
+  | "band_logo"
+  | "fanart_banner"
+  | "subfolder";
+
+/** One discovered artwork file, as returned by `get_extended_artwork_for_song`/
+ * `get_extended_artwork_for_artist`. `uri` is a raw `luminous-art://` URI —
+ * resolve it with {@link getCoverArtUrl} before using it in an `<img>` src,
+ * same as any other cover art URI in this codebase. */
+export interface ExtendedArtworkItem {
+  category: ExtendedArtworkCategory;
+  uri: string;
+}
+
+/** Response shape for `get_extended_artwork_for_song`/`_for_artist` (#758).
+ * `items` carries every discovered file in hierarchy order; the `*_uri`
+ * fields pull out the ones most callers actually need without having to
+ * scan `items` themselves. `primary_uri` is the album cover-stack's
+ * thumbnail and "Open Images" target (#760); the artist fields feed
+ * `ArtistDetailView`/`ArtistCard`/`TopNavigation` (#761). */
+export interface ExtendedArtworkResponse {
+  count: number;
+  primary_uri: string | null;
+  artist_portrait_uri: string | null;
+  band_logo_uri: string | null;
+  fanart_uri: string | null;
+  items: ExtendedArtworkItem[];
 }
 
 /** A Luminous-native song tag (#224), independent of the embedded `Song.genre`. */


### PR DESCRIPTION
## 📋 Summary
Addresses #759, third of #98's sub-issues, stacked on #763 (#758). Adds the frontend types matching #758's IPC response shape and a lazy-fetch-and-cache layer in `collectionStore` so #760/#761 can consume it without writing their own `invoke()` plumbing.

## 🔍 Implementation Notes
- `ExtendedArtworkCategory`/`ExtendedArtworkItem`/`ExtendedArtworkResponse` in `src/lib/types/index.ts` mirror the Rust response shape from #758 field-for-field.
- `ArtistItem`/`ArtistProfile` get optional `portrait_uri`/`band_logo_uri`/`fanart_uri` fields, but — unlike the rest of those interfaces — these are **not** populated by `get_artists()`/`get_artist_profile()`. They're populated client-side, on demand, via the new store methods below. Scanning every artist's folder eagerly for a list view would defeat the whole point of #758's on-demand design.
- `collectionStore.getExtendedArtworkForSong(songId)` / `getExtendedArtworkForArtist(artistName)`: lazy fetch, cached by song id / lowercased artist name (matching the existing `artistProfiles` key convention), with in-flight dedupe so the same key rendering in two places at once (e.g. an artist in a card and in search results) shares one backend call. A failed fetch returns an empty result rather than throwing, and is *not* cached, so a later call retries instead of getting stuck empty.
- `collectionStore.openArtworkPath(path)` wraps the new `open_artwork_path` command for #760's "Open Images" action.
- Deliberately left `theme.svelte.ts` untouched — its cover-art theming only needs the single primary cover, already served correctly by the existing `art_automatic`/`art_manual`/`get_cover_art_uri` pipeline (improved further by #757's embedded-picture fix). Extended/multi-category artwork has no bearing on it, despite #98's description calling out `theme.svelte.ts` as something to update.
- Also had to run `bun install` in this worktree — its `node_modules/.bin` was completely empty (pre-existing environment gap, unrelated to this change); `bun.lock` is unchanged.

## 🧪 Test Plan
- [x] `bun run check` (svelte-check + knip) — clean
- [x] `bun run test -- --run` (frontend) — 578 passed (6 new, in `collection.extendedArtwork.test.ts`)
- [ ] `cargo test` (src-tauri) — no backend changes in this PR
- [ ] Manually verified in the app — not applicable; no component calls these store methods yet (see #760/#761)

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed — n/a, no user-facing behavior change in this PR
