### PR TITLE
feat: album cover-stack "Open Images" UI (#760)

### DIFF
--- a/src/lib/components/AlbumDetailView.svelte
+++ b/src/lib/components/AlbumDetailView.svelte
@@ -10,6 +10,7 @@
   import { pinnedStore } from "../stores/pinned.svelte";
   import { shuffleArray } from "../utils/shuffle";
   import CoverArt from "./CoverArt.svelte";
+  import CoverStack from "./CoverStack.svelte";
   import SongRating from "./SongRating.svelte";
   import FavouriteCornerFlag from "./FavouriteCornerFlag.svelte";
   import BoxSetDiscIcons from "./BoxSetDiscIcons.svelte";
@@ -100,6 +101,11 @@
   let albumItem = $derived(
     collectionStore.albums.find((a) => a.album === albumName) || null
   );
+
+  /** Any one track's id, used to look up extended local artwork (#98/#760)
+   * for this album's directory — there's no dedicated album id in the
+   * schema (see #758), so a representative song stands in for one. */
+  let representativeSongId = $derived(songs[0]?.id);
 
   let artistName = $derived.by(() => {
     if (albumItem?.artist) return albumItem.artist;
@@ -459,11 +465,13 @@
       {#if !windowLayoutStore.isDetailHeaderCollapsed}
       <div class="relative w-40 h-40 hidden sm:block shrink-0">
         <div class="absolute inset-0 overflow-hidden border border-brand-border/60 shadow-2xl">
-          <CoverArt
-            songId={undefined}
-            artEmbedded={albumItem?.art_embedded}
-            artAutomatic={albumItem?.art_automatic}
-            artManual={albumItem?.art_manual}
+          <CoverStack
+            covers={[{
+              artEmbedded: albumItem?.art_embedded,
+              artAutomatic: albumItem?.art_automatic,
+              artManual: albumItem?.art_manual,
+            }]}
+            extendedArtworkSongId={representativeSongId}
             sizeClass="w-full h-full object-cover"
           />
           {#if albumItem && albumItem.rating === 5}

--- a/src/lib/components/CoverStack.svelte
+++ b/src/lib/components/CoverStack.svelte
@@ -123,8 +123,8 @@
         />
         {#if showExtendedArtworkUi}
           {#if extraArtworkCount > 0}
-            <div class="absolute top-1 right-1 z-10 px-1.5 py-0.5 rounded-full bg-black/70 text-white text-[10px] leading-none font-semibold flex items-center gap-0.5 pointer-events-none">
-              <ImagesIcon class="w-3 h-3" weight="fill" />
+            <div class="absolute top-1 right-1 z-10 px-2 py-1 rounded-full bg-black/70 text-white text-base leading-none font-semibold flex items-center gap-1 pointer-events-none">
+              <ImagesIcon class="w-6 h-6" weight="fill" />
               {extraArtworkCount}
             </div>
           {/if}
@@ -137,8 +137,8 @@
               ? i18n.t("common.openImagesCount", { count: extraArtworkCount })
               : i18n.t("common.openImages")}
           >
-            <span class="flex items-center gap-1 px-2 py-1 rounded-md bg-black/60 text-white text-xs font-medium">
-              <ImagesIcon class="w-3.5 h-3.5" />
+            <span class="flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-black/60 text-white text-sm font-medium">
+              <ImagesIcon class="w-5 h-5" />
               {i18n.t("common.openImages")}
             </span>
           </div>

--- a/src/lib/components/CoverStack.svelte
+++ b/src/lib/components/CoverStack.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
   import CoverArt from "./CoverArt.svelte";
   import { getArtistGradient } from "../utils/artist";
+  import { collectionStore } from "../stores/collection.svelte";
+  import { extractLocalArtworkPath } from "../types";
+  import { i18n } from "../stores/i18n.svelte";
+  import { ImagesIcon } from "phosphor-svelte";
   import {
     COVER_STACK_OFFSET_X_PX,
     COVER_STACK_OFFSET_Y_PX,
@@ -23,6 +27,17 @@
     direction?: "right" | "left";
     fallbackName?: string | null;
     hoverEffect?: boolean;
+    /**
+     * When set, and exactly one cover is being shown (i.e. not the
+     * multi-song box-set collage), CoverStack checks for additional
+     * hierarchical local artwork (#98/#757) via
+     * `collectionStore.getExtendedArtworkForSong` — if more than one file
+     * was discovered it shows a count badge, and whenever at least one
+     * local file was found it reveals an "Open Images" hover control that
+     * opens it in the OS's default image viewer (#760). No in-app
+     * lightbox/gallery is built here, per owner feedback on #98.
+     */
+    extendedArtworkSongId?: number;
   }
 
   let {
@@ -32,7 +47,38 @@
     direction = "right",
     fallbackName = null,
     hoverEffect = false,
+    extendedArtworkSongId = undefined,
   }: Props = $props();
+
+  let extendedArtwork = $state<import("../types").ExtendedArtworkResponse | null>(null);
+
+  $effect(() => {
+    const songId = extendedArtworkSongId;
+    if (songId === undefined) {
+      extendedArtwork = null;
+      return;
+    }
+    let cancelled = false;
+    collectionStore.getExtendedArtworkForSong(songId).then((result) => {
+      if (!cancelled) extendedArtwork = result;
+    });
+    return () => {
+      cancelled = true;
+    };
+  });
+
+  let openImagesPath = $derived(extractLocalArtworkPath(extendedArtwork?.primary_uri));
+  let showExtendedArtworkUi = $derived(
+    extendedArtworkSongId !== undefined && covers.length <= 1 && !!openImagesPath
+  );
+  let extraArtworkCount = $derived(extendedArtwork && extendedArtwork.count > 1 ? extendedArtwork.count : 0);
+
+  async function handleOpenImages(e: MouseEvent) {
+    e.stopPropagation();
+    if (openImagesPath) {
+      await collectionStore.openArtworkPath(openImagesPath);
+    }
+  }
 
   let activeCovers = $derived.by(() => {
     if (!covers || covers.length === 0) return [];
@@ -67,7 +113,7 @@
 <div class="flex items-center {direction === 'left' ? 'justify-end' : 'justify-center'} w-full h-full my-auto select-none">
   {#if activeCovers.length > 0}
     {#if activeCovers.length === 1}
-      <div class="{sizeClass} overflow-hidden relative">
+      <div class="{sizeClass} overflow-hidden relative group/artwork">
         <CoverArt
           songId={activeCovers[0].songId}
           artEmbedded={activeCovers[0].artEmbedded}
@@ -75,6 +121,28 @@
           artManual={activeCovers[0].artManual}
           sizeClass="w-full h-full"
         />
+        {#if showExtendedArtworkUi}
+          {#if extraArtworkCount > 0}
+            <div class="absolute top-1 right-1 z-10 px-1.5 py-0.5 rounded-full bg-black/70 text-white text-[10px] leading-none font-semibold flex items-center gap-0.5 pointer-events-none">
+              <ImagesIcon class="w-3 h-3" weight="fill" />
+              {extraArtworkCount}
+            </div>
+          {/if}
+          <!-- svelte-ignore a11y_click_events_have_key_events -->
+          <!-- svelte-ignore a11y_no_static_element_interactions -->
+          <div
+            class="absolute inset-0 z-10 flex items-center justify-center bg-black/50 opacity-0 group-hover/artwork:opacity-100 transition-opacity duration-200 cursor-pointer"
+            onclick={handleOpenImages}
+            title={extraArtworkCount > 0
+              ? i18n.t("common.openImagesCount", { count: extraArtworkCount })
+              : i18n.t("common.openImages")}
+          >
+            <span class="flex items-center gap-1 px-2 py-1 rounded-md bg-black/60 text-white text-xs font-medium">
+              <ImagesIcon class="w-3.5 h-3.5" />
+              {i18n.t("common.openImages")}
+            </span>
+          </div>
+        {/if}
       </div>
     {:else}
       <div class="relative {sizeClass} flex items-center justify-center shrink-0">

--- a/src/lib/components/CoverStack.test.ts
+++ b/src/lib/components/CoverStack.test.ts
@@ -1,11 +1,22 @@
 import "@testing-library/jest-dom";
-import { describe, it, expect, vi } from "vitest";
-import { render } from "@testing-library/svelte";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, waitFor, fireEvent } from "@testing-library/svelte";
+import { invoke } from "@tauri-apps/api/core";
+import type { ExtendedArtworkResponse } from "../types";
 import CoverStack from "./CoverStack.svelte";
 
 vi.mock("@tauri-apps/api/core", () => ({
   invoke: vi.fn().mockResolvedValue(""),
 }));
+
+vi.mock("@tauri-apps/api/window", () => ({
+  getCurrentWindow: vi.fn(() => ({
+    onResized: vi.fn(() => Promise.resolve(() => {})),
+    onMoved: vi.fn(() => Promise.resolve(() => {})),
+  })),
+}));
+
+import { collectionStore } from "../stores/collection.svelte";
 
 describe("CoverStack.svelte", () => {
   const mockCovers = [
@@ -40,5 +51,111 @@ describe("CoverStack.svelte", () => {
 
     const rootDiv = container.firstElementChild as HTMLElement;
     expect(rootDiv.className).toContain("justify-end");
+  });
+
+  describe("extended artwork (#98/#760)", () => {
+    const RESPONSE_WITH_EXTRAS: ExtendedArtworkResponse = {
+      count: 3,
+      primary_uri: "luminous-art://local/C:/Music/Artist/Album/cover.jpg",
+      artist_portrait_uri: null,
+      band_logo_uri: null,
+      fanart_uri: null,
+      items: [
+        { category: "primary_cover", uri: "luminous-art://local/C:/Music/Artist/Album/cover.jpg" },
+        { category: "back_cover", uri: "luminous-art://local/C:/Music/Artist/Album/back.jpg" },
+        { category: "booklet", uri: "luminous-art://local/C:/Music/Artist/Album/booklet.jpg" },
+      ],
+    };
+
+    const RESPONSE_SINGLE: ExtendedArtworkResponse = {
+      count: 1,
+      primary_uri: "luminous-art://local/C:/Music/Artist/Album/cover.jpg",
+      artist_portrait_uri: null,
+      band_logo_uri: null,
+      fanart_uri: null,
+      items: [{ category: "primary_cover", uri: "luminous-art://local/C:/Music/Artist/Album/cover.jpg" }],
+    };
+
+    beforeEach(() => {
+      vi.clearAllMocks();
+      collectionStore.extendedArtworkBySong = {};
+    });
+
+    it("shows a count badge when more than one artwork file was discovered", async () => {
+      vi.mocked(invoke).mockImplementation(async (cmd: string) => {
+        if (cmd === "get_extended_artwork_for_song") return RESPONSE_WITH_EXTRAS;
+        return "";
+      });
+
+      const { getByText } = render(CoverStack, {
+        props: { covers: [mockCovers[0]], extendedArtworkSongId: 1 },
+      });
+
+      await waitFor(() => expect(getByText("3")).toBeInTheDocument());
+    });
+
+    it("does not show a count badge when only one artwork file was discovered", async () => {
+      vi.mocked(invoke).mockImplementation(async (cmd: string) => {
+        if (cmd === "get_extended_artwork_for_song") return RESPONSE_SINGLE;
+        return "";
+      });
+
+      const { container, getByTitle } = render(CoverStack, {
+        props: { covers: [mockCovers[0]], extendedArtworkSongId: 1 },
+      });
+
+      // The hover "Open Images" control still appears — there's a real file
+      // to open — just no count badge, since "1" would be noise.
+      await waitFor(() => expect(getByTitle("Open images")).toBeInTheDocument());
+      expect(container.textContent).not.toContain("1");
+    });
+
+    it("does not show any extended-artwork UI when no extendedArtworkSongId is given", async () => {
+      const { queryByTitle } = render(CoverStack, {
+        props: { covers: [mockCovers[0]] },
+      });
+
+      // No fetch was even attempted.
+      expect(invoke).not.toHaveBeenCalledWith("get_extended_artwork_for_song", expect.anything());
+      expect(queryByTitle("Open images")).not.toBeInTheDocument();
+    });
+
+    it("opens the primary artwork path when the Open Images control is clicked", async () => {
+      const invokeMock = vi.mocked(invoke).mockImplementation(async (cmd: string) => {
+        if (cmd === "get_extended_artwork_for_song") return RESPONSE_WITH_EXTRAS;
+        if (cmd === "open_artwork_path") return undefined;
+        return "";
+      });
+
+      const { getByTitle } = render(CoverStack, {
+        props: { covers: [mockCovers[0]], extendedArtworkSongId: 1 },
+      });
+
+      const openControl = await waitFor(() => getByTitle("Open 3 images"));
+      await fireEvent.click(openControl);
+
+      await waitFor(() =>
+        expect(invokeMock).toHaveBeenCalledWith("open_artwork_path", {
+          path: "C:/Music/Artist/Album/cover.jpg",
+        })
+      );
+    });
+
+    it("shows no extended-artwork UI when rendering a multi-song box-set collage", async () => {
+      vi.mocked(invoke).mockImplementation(async (cmd: string) => {
+        if (cmd === "get_extended_artwork_for_song") return RESPONSE_WITH_EXTRAS;
+        return "";
+      });
+
+      const { queryByTitle } = render(CoverStack, {
+        // More than one distinct-song cover — the box-set collage case,
+        // where a single song's extended artwork isn't meaningful.
+        props: { covers: mockCovers, extendedArtworkSongId: 1 },
+      });
+
+      await new Promise((r) => setTimeout(r, 0));
+      expect(queryByTitle("Open images")).not.toBeInTheDocument();
+      expect(queryByTitle("Open 3 images")).not.toBeInTheDocument();
+    });
   });
 });

--- a/src/lib/components/Miniplayer.svelte
+++ b/src/lib/components/Miniplayer.svelte
@@ -7,7 +7,6 @@
   import { i18n } from "../stores/i18n.svelte";
   import { formatDuration } from "../utils/formatters";
   import CoverArt from "./CoverArt.svelte";
-  import CoverStack from "./CoverStack.svelte";
   import WaveformSeekBar from "./WaveformSeekBar.svelte";
   import SongRating from "./SongRating.svelte";
   import { isLinux } from "../platform";
@@ -253,14 +252,11 @@
   <div class="relative z-10 w-full h-full flex flex-col items-center justify-between pointer-events-auto">
     <div class="flex-1 w-full flex items-center justify-center min-h-0 py-2">
       <div class="relative aspect-square h-full max-h-full max-w-[90%] rounded-none overflow-hidden border border-brand-border/30 bg-brand-sidebar flex items-center justify-center {isHovered ? 'scale-[0.98]' : ''} transition-transform duration-300">
-        <CoverStack
-          covers={[{
-            songId: playerStore.currentSong?.id,
-            artEmbedded: playerStore.currentSong?.art_embedded,
-            artAutomatic: playerStore.currentSong?.art_automatic,
-            artManual: playerStore.currentSong?.art_manual,
-          }]}
-          extendedArtworkSongId={playerStore.currentSong?.id}
+        <CoverArt
+          songId={playerStore.currentSong?.id}
+          artEmbedded={playerStore.currentSong?.art_embedded}
+          artAutomatic={playerStore.currentSong?.art_automatic}
+          artManual={playerStore.currentSong?.art_manual}
           sizeClass="w-full h-full object-cover"
         />
       </div>

--- a/src/lib/components/Miniplayer.svelte
+++ b/src/lib/components/Miniplayer.svelte
@@ -7,6 +7,7 @@
   import { i18n } from "../stores/i18n.svelte";
   import { formatDuration } from "../utils/formatters";
   import CoverArt from "./CoverArt.svelte";
+  import CoverStack from "./CoverStack.svelte";
   import WaveformSeekBar from "./WaveformSeekBar.svelte";
   import SongRating from "./SongRating.svelte";
   import { isLinux } from "../platform";
@@ -252,11 +253,14 @@
   <div class="relative z-10 w-full h-full flex flex-col items-center justify-between pointer-events-auto">
     <div class="flex-1 w-full flex items-center justify-center min-h-0 py-2">
       <div class="relative aspect-square h-full max-h-full max-w-[90%] rounded-none overflow-hidden border border-brand-border/30 bg-brand-sidebar flex items-center justify-center {isHovered ? 'scale-[0.98]' : ''} transition-transform duration-300">
-        <CoverArt
-          songId={playerStore.currentSong?.id}
-          artEmbedded={playerStore.currentSong?.art_embedded}
-          artAutomatic={playerStore.currentSong?.art_automatic}
-          artManual={playerStore.currentSong?.art_manual}
+        <CoverStack
+          covers={[{
+            songId: playerStore.currentSong?.id,
+            artEmbedded: playerStore.currentSong?.art_embedded,
+            artAutomatic: playerStore.currentSong?.art_automatic,
+            artManual: playerStore.currentSong?.art_manual,
+          }]}
+          extendedArtworkSongId={playerStore.currentSong?.id}
           sizeClass="w-full h-full object-cover"
         />
       </div>

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -891,6 +891,8 @@ export const en = {
     scrollLeft: "Scroll left",
     scrollRight: "Scroll right",
     albumArtAlt: "Album Art",
+    openImages: "Open images",
+    openImagesCount: "Open {count} images",
     enableLogoPulse: "Click to enable logo pulsing",
     disableLogoPulse: "Click to disable logo pulsing",
     toggleLogoPulsing: "Toggle Luminous logo pulsing",

--- a/src/lib/locales/fr.ts
+++ b/src/lib/locales/fr.ts
@@ -922,6 +922,8 @@ export const fr = {
     scrollLeft: "Défiler vers la gauche",
     scrollRight: "Défiler vers la droite",
     albumArtAlt: "Pochette d'album",
+    openImages: "Ouvrir les images",
+    openImagesCount: "Ouvrir {count} images",
     enableLogoPulse: "Cliquez pour activer la pulsation du logo",
     disableLogoPulse: "Cliquez pour désactiver la pulsation du logo",
     toggleLogoPulsing: "Basculer la pulsation du logo Luminous",

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -440,6 +440,24 @@ export function resolveArtUrl(art: string | null | undefined): string | null {
   return getCoverArtUrl(`luminous-art://local/${art}`);
 }
 
+/**
+ * Extracts the raw filesystem path from a `luminous-art://local/...` URI —
+ * the reverse of `local_artwork_uri()` in covermanager.rs. Extended artwork
+ * URIs (#98) are always in this form, since `scan_extended_artwork` only
+ * ever returns absolute filesystem paths. Returns null for any other URI
+ * shape (e.g. a cached `luminous-art://album-....jpg` single-cover URI,
+ * which has no real folder path for the OS image viewer to open).
+ */
+export function extractLocalArtworkPath(uri: string | null | undefined): string | null {
+  if (!uri) return null;
+  const prefix = "luminous-art://local/";
+  if (!uri.startsWith(prefix)) return null;
+  // Not percent-decoded: `local_artwork_uri()` in covermanager.rs writes the
+  // path unencoded (see its doc comment), so this is the exact inverse —
+  // decoding here would wrongly throw on a path containing a literal '%'.
+  return uri.slice(prefix.length);
+}
+
 export type HomeItem =
   | { type: "song"; song: Song }
   | { type: "album"; album: AlbumItem; chart?: TopAlbumChartInfo }


### PR DESCRIPTION
## 📋 Summary
Addresses #760, fourth of #98's sub-issues, stacked on #764 (#759). Extends `CoverStack.svelte` to surface #757/#758's discovered artwork with a count badge and an "Open Images" hover control, and wires it into `AlbumDetailView`'s hero cover and `Miniplayer`'s foreground artwork.

## 🔍 Implementation Notes
- New opt-in `extendedArtworkSongId` prop on `CoverStack` — only takes effect when exactly one cover is being shown (not the existing multi-song box-set collage mode), so the existing playlist/box-set rendering paths are untouched.
- On hover: reveals an "Open Images" overlay that calls the new `open_artwork_path` command with the primary artwork's real filesystem path (extracted from its `luminous-art://local/...` URI via `extractLocalArtworkPath`).
- A small count badge appears only when more than one file was discovered (`count > 1`) — showing "1" on every album would just be noise.
- Deliberately no in-app lightbox/gallery, per owner feedback already recorded on #98 — "Open Images" handing off to the OS viewer is the intended browsing entry point.
- Added `common.openImages`/`common.openImagesCount` to `en.ts` and `fr.ts` (actual French translation, not a copy).

## 🧪 Test Plan
- [x] `bun run check` (svelte-check + knip) — clean
- [x] `bun run test -- --run` (frontend) — 583 passed (5 new in `CoverStack.test.ts`)
- [ ] `cargo test` (src-tauri) — no backend changes in this PR
- [ ] Manually verified in the app — **not done by me**; this is the first sub-issue with real UI, please verify in the dev server (see below)

## 📸 Screenshots
Not captured — recommend verifying live in `bun run tauri dev` instead (see manual test notes below).

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed — no docs impact; screenshots skipped, see above
