### PR TITLE
feat: artist portrait, band logo & fanart hero UI (#761)

### DIFF
--- a/src/lib/components/ArtistCard.svelte
+++ b/src/lib/components/ArtistCard.svelte
@@ -59,7 +59,7 @@
 >
   <div class="aspect-square w-full mb-3 bg-brand-main relative flex items-center justify-center overflow-hidden">
     {#if artistPortraitUrl}
-      <div class="w-36 h-36 relative overflow-hidden bg-brand-sidebar border border-brand-border shrink-0">
+      <div class="w-full h-full relative overflow-hidden bg-brand-sidebar border border-brand-border shrink-0">
         <img
           src={artistPortraitUrl}
           alt={artist.name || i18n.t('collection.unknownArtist')}

--- a/src/lib/components/ArtistCard.svelte
+++ b/src/lib/components/ArtistCard.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
-  import type { ArtistItem, AlbumItem, Song } from "../types";
+  import type { ArtistItem, AlbumItem, Song, ExtendedArtworkResponse } from "../types";
+  import { getCoverArtUrl } from "../types";
   import { i18n } from "../stores/i18n.svelte";
+  import { collectionStore } from "../stores/collection.svelte";
   import CoverStack from "./CoverStack.svelte";
   import GenreChips from "./GenreChips.svelte";
   import { getArtistCoverStack } from "../utils/covers";
@@ -24,6 +26,26 @@
   let covers = $derived(getArtistCoverStack(artistAlbums, artistSongs));
 
   let hasGenre = $derived(!!artist.genre?.trim());
+
+  // Locally-discovered artist portrait (#98/#761) — replaces the album-art
+  // CoverStack composite when found, since a real photo of the artist beats
+  // a collage of their albums' covers.
+  let artistArtwork = $state<ExtendedArtworkResponse | null>(null);
+  $effect(() => {
+    const name = artist.name;
+    if (!name) {
+      artistArtwork = null;
+      return;
+    }
+    let cancelled = false;
+    collectionStore.getExtendedArtworkForArtist(name).then((result) => {
+      if (!cancelled) artistArtwork = result;
+    });
+    return () => {
+      cancelled = true;
+    };
+  });
+  let artistPortraitUrl = $derived(getCoverArtUrl(artistArtwork?.artist_portrait_uri));
 </script>
 
 <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
@@ -35,12 +57,20 @@
   onkeydown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); customClick?.(e as unknown as MouseEvent); } }}
   class="artist-card group bg-brand-sidebar border border-brand-border/60 rounded-xl p-4 flex flex-col items-start text-left outline-2 -outline-offset-2 outline-transparent hover:outline-brand-accent transition-[outline-color,border-color] duration-200 select-none"
 >
-  <div class="aspect-square w-full mb-3 bg-brand-main relative flex items-center justify-center">
-    <CoverStack
-      covers={covers}
-      fallbackName={artist.name || i18n.t('collection.unknownArtist')}
-      sizeClass="w-36 h-36"
-    />
+  <div class="aspect-square w-full mb-3 bg-brand-main relative flex items-center justify-center overflow-hidden">
+    {#if artistPortraitUrl}
+      <img
+        src={artistPortraitUrl}
+        alt={artist.name || i18n.t('collection.unknownArtist')}
+        class="w-36 h-36 rounded-full object-cover border border-brand-border/40"
+      />
+    {:else}
+      <CoverStack
+        covers={covers}
+        fallbackName={artist.name || i18n.t('collection.unknownArtist')}
+        sizeClass="w-36 h-36"
+      />
+    {/if}
   </div>
 
   <span

--- a/src/lib/components/ArtistCard.svelte
+++ b/src/lib/components/ArtistCard.svelte
@@ -62,7 +62,7 @@
       <img
         src={artistPortraitUrl}
         alt={artist.name || i18n.t('collection.unknownArtist')}
-        class="w-36 h-36 rounded-full object-cover border border-brand-border/40"
+        class="w-36 h-36 object-cover border border-brand-border"
       />
     {:else}
       <CoverStack

--- a/src/lib/components/ArtistCard.svelte
+++ b/src/lib/components/ArtistCard.svelte
@@ -59,11 +59,13 @@
 >
   <div class="aspect-square w-full mb-3 bg-brand-main relative flex items-center justify-center overflow-hidden">
     {#if artistPortraitUrl}
-      <img
-        src={artistPortraitUrl}
-        alt={artist.name || i18n.t('collection.unknownArtist')}
-        class="w-36 h-36 object-cover border border-brand-border"
-      />
+      <div class="w-36 h-36 relative overflow-hidden bg-brand-sidebar border border-brand-border shrink-0">
+        <img
+          src={artistPortraitUrl}
+          alt={artist.name || i18n.t('collection.unknownArtist')}
+          class="w-full h-full object-cover"
+        />
+      </div>
     {:else}
       <CoverStack
         covers={covers}

--- a/src/lib/components/ArtistCard.test.ts
+++ b/src/lib/components/ArtistCard.test.ts
@@ -1,12 +1,22 @@
 import "@testing-library/jest-dom";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, fireEvent } from "@testing-library/svelte";
+import { invoke } from "@tauri-apps/api/core";
 import ArtistCard from "./ArtistCard.svelte";
 import type { ArtistItem, AlbumItem, Song } from "../types";
 
 vi.mock("@tauri-apps/api/core", () => ({
   invoke: vi.fn().mockResolvedValue([]),
 }));
+
+vi.mock("@tauri-apps/api/window", () => ({
+  getCurrentWindow: vi.fn(() => ({
+    onResized: vi.fn(() => Promise.resolve(() => {})),
+    onMoved: vi.fn(() => Promise.resolve(() => {})),
+  })),
+}));
+
+import { collectionStore } from "../stores/collection.svelte";
 
 describe("ArtistCard.svelte", () => {
   const mockArtist: ArtistItem = {
@@ -50,6 +60,7 @@ describe("ArtistCard.svelte", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    collectionStore.extendedArtworkByArtist = {};
   });
 
   it("renders artist name, genre chip, and song count", () => {
@@ -111,5 +122,29 @@ describe("ArtistCard.svelte", () => {
 
     await fireEvent.click(getByText("Dave Hawkins"));
     expect(handleClick).toHaveBeenCalled();
+  });
+
+  it("renders a discovered artist portrait instead of the album-art composite (#98/#761)", async () => {
+    vi.mocked(invoke).mockImplementation(async (cmd: string) => {
+      if (cmd === "get_extended_artwork_for_artist") {
+        return {
+          count: 1,
+          primary_uri: null,
+          artist_portrait_uri: "luminous-art://local/C:/Music/Dave Hawkins/artist.jpg",
+          band_logo_uri: null,
+          fanart_uri: null,
+          items: [],
+        };
+      }
+      return [];
+    });
+
+    const { findByAltText } = render(ArtistCard, {
+      props: { artist: mockArtist, artistAlbums: [mockAlbum] },
+    });
+
+    const portrait = await findByAltText("Dave Hawkins");
+    expect(portrait.tagName).toBe("IMG");
+    expect(portrait.getAttribute("src")).toBe("luminous-art://local/C:/Music/Dave Hawkins/artist.jpg");
   });
 });

--- a/src/lib/components/ArtistDetailView.svelte
+++ b/src/lib/components/ArtistDetailView.svelte
@@ -368,7 +368,7 @@
 </script>
 
 <div class="flex-1 flex flex-col overflow-y-auto bg-brand-main text-brand-text-secondary h-full carousel-scroll" use:rememberScroll={`artist-detail:${artistName}`}>
-  <div class="relative z-30 w-full border-b border-brand-border/60 bg-brand-main/60 backdrop-blur-md px-6 {windowLayoutStore.isDetailHeaderCollapsed ? 'py-3' : 'pt-6 pb-6'} overflow-hidden">
+  <div class="relative z-30 w-full border-b border-brand-border/60 bg-brand-main/60 backdrop-blur-md px-6 {windowLayoutStore.isDetailHeaderCollapsed ? 'py-3' : 'pt-6 pb-6 min-h-48'} overflow-hidden">
     {#if fanartBannerUrl && !windowLayoutStore.isDetailHeaderCollapsed}
       <div class="absolute inset-0 z-0 pointer-events-none" aria-hidden="true">
         <img src={fanartBannerUrl} alt="" class="w-full h-full object-cover opacity-25" />
@@ -382,7 +382,7 @@
           <img
             src={bandLogoUrl}
             alt={artistName}
-            class="max-h-14 sm:max-h-20 w-auto object-contain object-left"
+            class="h-10 sm:h-12 w-auto max-w-full object-contain object-left"
           />
         {:else}
           <h1 class="text-3xl sm:text-4xl font-heading font-bold text-brand-text-primary leading-snug truncate py-0.5">{artistName}</h1>

--- a/src/lib/components/ArtistDetailView.svelte
+++ b/src/lib/components/ArtistDetailView.svelte
@@ -31,8 +31,9 @@
     PushPinIcon as Pin,
     PushPinSlashIcon as PinOff
   } from "phosphor-svelte";
-  import type { Song, Playlist, AlbumItem, PlayContext, ArtistProfile } from "../types";
-  import { resolveSocialUrl, formatDisplayLabel } from "../utils/artistSocials";
+  import type { Song, Playlist, AlbumItem, PlayContext, ArtistProfile, ExtendedArtworkResponse } from "../types";
+  import { getCoverArtUrl } from "../types";
+  import { resolveSocialUrl, formatDisplayLabel, deriveFanartTvUrl } from "../utils/artistSocials";
   import { getArtistAlbums, classifyRelease } from "../utils/artist";
   import { songsToCoverStack } from "../utils/covers";
   import { parseMultiValue, joinMultiValue } from "../utils/multiValue";
@@ -67,6 +68,29 @@
   let hasBio = $derived(!!artistProfile?.bio);
   let hasSocials = $derived((artistProfile?.social_links?.length ?? 0) > 0);
   let hasProfileContent = $derived(hasWebsite || hasTags || hasBio || hasSocials);
+
+  // Locally-discovered artist visuals (#98/#761) — portrait/logo/fanart,
+  // fetched on demand per artist since scanning every artist's folder
+  // eagerly would be far too expensive (see #758's design notes).
+  let artistArtwork = $state<ExtendedArtworkResponse | null>(null);
+  $effect(() => {
+    const name = artistName;
+    let cancelled = false;
+    collectionStore.getExtendedArtworkForArtist(name).then((result) => {
+      if (!cancelled) artistArtwork = result;
+    });
+    return () => {
+      cancelled = true;
+    };
+  });
+  let artistPortraitUrl = $derived(getCoverArtUrl(artistArtwork?.artist_portrait_uri));
+  let bandLogoUrl = $derived(getCoverArtUrl(artistArtwork?.band_logo_uri));
+  let fanartBannerUrl = $derived(getCoverArtUrl(artistArtwork?.fanart_uri));
+
+  // Derived, read-only fanart.tv link (#98/#761) from the user-entered
+  // MusicBrainz social link's MBID — not a fetch, just a computed URL, same
+  // as any other link in this section.
+  let fanartTvUrl = $derived(deriveFanartTvUrl(artistProfile?.social_links));
 
   function handleTagClick(tag: string) {
     collectionStore.searchQuery = `artist-tag:${tag}`;
@@ -344,11 +368,25 @@
 </script>
 
 <div class="flex-1 flex flex-col overflow-y-auto bg-brand-main text-brand-text-secondary h-full carousel-scroll" use:rememberScroll={`artist-detail:${artistName}`}>
-  <div class="relative z-30 w-full border-b border-brand-border/60 bg-brand-main/60 backdrop-blur-md px-6 {windowLayoutStore.isDetailHeaderCollapsed ? 'py-3' : 'pt-6 pb-6'}">
+  <div class="relative z-30 w-full border-b border-brand-border/60 bg-brand-main/60 backdrop-blur-md px-6 {windowLayoutStore.isDetailHeaderCollapsed ? 'py-3' : 'pt-6 pb-6'} overflow-hidden">
+    {#if fanartBannerUrl && !windowLayoutStore.isDetailHeaderCollapsed}
+      <div class="absolute inset-0 z-0 pointer-events-none" aria-hidden="true">
+        <img src={fanartBannerUrl} alt="" class="w-full h-full object-cover opacity-25" />
+        <div class="absolute inset-0 bg-gradient-to-t from-brand-main via-brand-main/70 to-brand-main/30"></div>
+      </div>
+    {/if}
     <div class="flex items-start justify-between gap-6 relative z-10">
       <div class="flex flex-col justify-end gap-1.5 max-w-xl">
         {#if !windowLayoutStore.isDetailHeaderCollapsed}
-        <h1 class="text-3xl sm:text-4xl font-heading font-bold text-brand-text-primary leading-snug truncate py-0.5">{artistName}</h1>
+        {#if bandLogoUrl}
+          <img
+            src={bandLogoUrl}
+            alt={artistName}
+            class="max-h-14 sm:max-h-20 w-auto object-contain object-left"
+          />
+        {:else}
+          <h1 class="text-3xl sm:text-4xl font-heading font-bold text-brand-text-primary leading-snug truncate py-0.5">{artistName}</h1>
+        {/if}
 
         <div class="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-brand-text-secondary font-medium">
           {#if rawGenre}
@@ -395,9 +433,17 @@
         </div>
       </div>
 
-      {#if !windowLayoutStore.isDetailHeaderCollapsed && headerCovers.length > 0}
+      {#if !windowLayoutStore.isDetailHeaderCollapsed && (artistPortraitUrl || headerCovers.length > 0)}
         <div class="relative w-48 h-36 hidden sm:block shrink-0 flex items-center justify-end">
-          <CoverStack covers={headerCovers} direction="left" sizeClass="w-28 h-28" />
+          {#if artistPortraitUrl}
+            <img
+              src={artistPortraitUrl}
+              alt={artistName}
+              class="w-28 h-28 rounded-full object-cover border border-brand-border/60 shadow-2xl"
+            />
+          {:else}
+            <CoverStack covers={headerCovers} direction="left" sizeClass="w-28 h-28" />
+          {/if}
         </div>
       {/if}
     </div>
@@ -498,6 +544,27 @@
                   </div>
                 </button>
               {/each}
+
+              <!-- Derived Fanart.tv link (#98/#761) — computed from the
+                   MusicBrainz link's MBID above, not a stored/user-editable
+                   social link, so it isn't part of the {#each} above. -->
+              {#if fanartTvUrl}
+                <button
+                  type="button"
+                  onclick={() => handleOpenUrl(fanartTvUrl)}
+                  class="flex items-center gap-2.5 sm:gap-3 group text-left transition-colors cursor-pointer min-w-0"
+                >
+                  <div class="w-7 h-7 sm:w-8 sm:h-8 rounded-full bg-brand-main/60 border border-brand-border flex items-center justify-center text-brand-text-secondary group-hover:text-brand-accent group-hover:border-brand-accent/40 transition-colors shrink-0 shadow-2xs">
+                    <SocialIcon platform="fanart_tv" size={14} />
+                  </div>
+                  <div class="flex items-center gap-1 min-w-0 flex-1">
+                    <span class="text-xs font-medium text-brand-text-primary group-hover:text-brand-accent truncate transition-colors">
+                      Fanart.tv
+                    </span>
+                    <ExternalLink class="w-3 h-3 text-brand-text-secondary opacity-0 group-hover:opacity-100 transition-opacity shrink-0" />
+                  </div>
+                </button>
+              {/if}
             </div>
           </div>
         {/if}

--- a/src/lib/components/ArtistDetailView.svelte
+++ b/src/lib/components/ArtistDetailView.svelte
@@ -436,11 +436,15 @@
       {#if !windowLayoutStore.isDetailHeaderCollapsed && (artistPortraitUrl || headerCovers.length > 0)}
         <div class="relative w-48 h-36 hidden sm:block shrink-0 flex items-center justify-end">
           {#if artistPortraitUrl}
-            <img
-              src={artistPortraitUrl}
-              alt={artistName}
-              class="w-28 h-28 rounded-full object-cover border border-brand-border/60 shadow-2xl"
-            />
+            <div class="flex items-center justify-end w-full h-full my-auto select-none">
+              <div class="w-28 h-28 overflow-hidden relative rounded-full">
+                <img
+                  src={artistPortraitUrl}
+                  alt={artistName}
+                  class="w-full h-full object-cover"
+                />
+              </div>
+            </div>
           {:else}
             <CoverStack covers={headerCovers} direction="left" sizeClass="w-28 h-28" />
           {/if}

--- a/src/lib/components/ArtistDetailView.svelte
+++ b/src/lib/components/ArtistDetailView.svelte
@@ -437,7 +437,7 @@
         <div class="relative w-48 h-36 hidden sm:block shrink-0 flex items-center justify-end">
           {#if artistPortraitUrl}
             <div class="flex items-center justify-end w-full h-full my-auto select-none">
-              <div class="w-28 h-28 overflow-hidden relative border border-brand-border">
+              <div class="w-28 h-28 overflow-hidden relative bg-brand-sidebar border border-brand-border">
                 <img
                   src={artistPortraitUrl}
                   alt={artistName}

--- a/src/lib/components/ArtistDetailView.svelte
+++ b/src/lib/components/ArtistDetailView.svelte
@@ -437,7 +437,7 @@
         <div class="relative w-48 h-36 hidden sm:block shrink-0 flex items-center justify-end">
           {#if artistPortraitUrl}
             <div class="flex items-center justify-end w-full h-full my-auto select-none">
-              <div class="w-28 h-28 overflow-hidden relative rounded-full">
+              <div class="w-28 h-28 overflow-hidden relative border border-brand-border">
                 <img
                   src={artistPortraitUrl}
                   alt={artistName}

--- a/src/lib/components/ArtistDetailView.test.ts
+++ b/src/lib/components/ArtistDetailView.test.ts
@@ -39,6 +39,9 @@ describe("ArtistDetailView", () => {
         bio: "Canadian music icon",
       },
     };
+    // Extended-artwork cache is on the singleton store — must not leak
+    // between tests (#98/#761).
+    collectionStore.extendedArtworkByArtist = {};
   });
 
   it("renders artist name and action buttons including Edit", async () => {
@@ -127,5 +130,82 @@ describe("ArtistDetailView", () => {
     render(ArtistDetailView, { props: { artistName: "Shania Twain" } });
 
     expect(await screen.findByText("Unknown genre")).toBeTruthy();
+  });
+
+  describe("extended artist artwork (#98/#761)", () => {
+    it("renders a discovered artist portrait and band logo instead of the album-art composite and text heading", async () => {
+      const invokeMock = vi.mocked(invoke);
+      invokeMock.mockImplementation((cmd: string, args?: any) => {
+        if (cmd === "get_songs_by_artist") return Promise.resolve([]);
+        if (cmd === "get_playlists_by_artist") return Promise.resolve([]);
+        if (cmd === "get_compilations_by_artist") return Promise.resolve([]);
+        if (cmd === "get_artist_profile") {
+          return Promise.resolve({
+            artist_key: args?.artist || "Shania Twain",
+            website: "https://www.shaniatwain.com",
+            tags: [],
+            social_links: [],
+            bio: null,
+          });
+        }
+        if (cmd === "get_extended_artwork_for_artist") {
+          return Promise.resolve({
+            count: 2,
+            primary_uri: null,
+            artist_portrait_uri: "luminous-art://local/C:/Music/Shania Twain/artist.jpg",
+            band_logo_uri: "luminous-art://local/C:/Music/Shania Twain/logo.png",
+            fanart_uri: null,
+            items: [],
+          });
+        }
+        return Promise.resolve();
+      });
+
+      render(ArtistDetailView, { props: { artistName: "Shania Twain" } });
+
+      const images = await screen.findAllByAltText("Shania Twain");
+      expect(images.length).toBe(2); // portrait + band logo
+      expect(screen.queryByRole("heading", { name: "Shania Twain" })).toBeNull();
+    });
+
+    it("falls back to the plain text heading when no band logo was discovered", async () => {
+      render(ArtistDetailView, { props: { artistName: "Shania Twain" } });
+
+      expect(await screen.findByRole("heading", { name: "Shania Twain" })).toBeTruthy();
+    });
+
+    it("shows a derived fanart.tv link when a MusicBrainz link with a recognizable MBID is present", async () => {
+      const invokeMock = vi.mocked(invoke);
+      invokeMock.mockImplementation((cmd: string, args?: any) => {
+        if (cmd === "get_songs_by_artist") return Promise.resolve([]);
+        if (cmd === "get_playlists_by_artist") return Promise.resolve([]);
+        if (cmd === "get_compilations_by_artist") return Promise.resolve([]);
+        if (cmd === "get_artist_profile") {
+          return Promise.resolve({
+            artist_key: args?.artist || "Shania Twain",
+            website: null,
+            tags: [],
+            social_links: [
+              { platform: "musicbrainz", handle_or_url: "https://musicbrainz.org/artist/7249b899-8db8-43e7-9e6e-22f1e736024e" },
+            ],
+            bio: null,
+          });
+        }
+        return Promise.resolve();
+      });
+      collectionStore.artistProfiles = {
+        "shania twain": {
+          artist_key: "Shania Twain",
+          tags: [],
+          social_links: [
+            { platform: "musicbrainz", handle_or_url: "https://musicbrainz.org/artist/7249b899-8db8-43e7-9e6e-22f1e736024e" },
+          ],
+        },
+      };
+
+      render(ArtistDetailView, { props: { artistName: "Shania Twain" } });
+
+      expect(await screen.findByText("Fanart.tv")).toBeTruthy();
+    });
   });
 });

--- a/src/lib/components/ArtistRowCard.svelte
+++ b/src/lib/components/ArtistRowCard.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
-  import type { ArtistItem, AlbumItem, Song } from "../types";
+  import type { ArtistItem, AlbumItem, Song, ExtendedArtworkResponse } from "../types";
+  import { getCoverArtUrl } from "../types";
   import { i18n } from "../stores/i18n.svelte";
+  import { collectionStore } from "../stores/collection.svelte";
   import CoverArt from "./CoverArt.svelte";
   import GenreChips from "./GenreChips.svelte";
   import { getArtistCoverStack } from "../utils/covers";
@@ -18,6 +20,25 @@
   // the front/topmost tile), so the row's single cover always matches it.
   let frontCover = $derived(getArtistCoverStack(artistAlbums, artistSongs, 1)[0]);
   let hasGenre = $derived(!!artist.genre?.trim());
+
+  // Locally-discovered artist portrait (#98/#761) — same as ArtistCard,
+  // replaces the album-art composite when found.
+  let artistArtwork = $state<ExtendedArtworkResponse | null>(null);
+  $effect(() => {
+    const name = artist.name;
+    if (!name) {
+      artistArtwork = null;
+      return;
+    }
+    let cancelled = false;
+    collectionStore.getExtendedArtworkForArtist(name).then((result) => {
+      if (!cancelled) artistArtwork = result;
+    });
+    return () => {
+      cancelled = true;
+    };
+  });
+  let artistPortraitUrl = $derived(getCoverArtUrl(artistArtwork?.artist_portrait_uri));
 </script>
 
 <!-- svelte-ignore a11y_click_events_have_key_events -->
@@ -30,13 +51,21 @@
   class="group grid grid-cols-[auto_1fr_auto] grid-rows-[auto_auto] items-center gap-x-3 gap-y-0.5 px-3 py-2.5 rounded-lg bg-brand-sidebar border border-brand-border/60 outline-2 -outline-offset-2 outline-transparent hover:outline-brand-accent transition-[outline-color,border-color] duration-200 select-none"
 >
   <div class="row-span-2 relative overflow-hidden">
-    <CoverArt
-      songId={frontCover?.songId}
-      artEmbedded={frontCover?.artEmbedded ?? false}
-      artAutomatic={frontCover?.artAutomatic ?? null}
-      artManual={frontCover?.artManual ?? null}
-      sizeClass="w-11 h-11"
-    />
+    {#if artistPortraitUrl}
+      <img
+        src={artistPortraitUrl}
+        alt={artist.name || i18n.t('collection.unknownArtist')}
+        class="w-11 h-11 rounded-full object-cover border border-brand-border/40"
+      />
+    {:else}
+      <CoverArt
+        songId={frontCover?.songId}
+        artEmbedded={frontCover?.artEmbedded ?? false}
+        artAutomatic={frontCover?.artAutomatic ?? null}
+        artManual={frontCover?.artManual ?? null}
+        sizeClass="w-11 h-11"
+      />
+    {/if}
   </div>
 
   <p class="col-span-2 min-w-0 truncate text-sm font-semibold text-brand-text-primary">{artist.name || i18n.t('collection.unknownArtist')}</p>

--- a/src/lib/components/ArtistRowCard.svelte
+++ b/src/lib/components/ArtistRowCard.svelte
@@ -55,7 +55,7 @@
       <img
         src={artistPortraitUrl}
         alt={artist.name || i18n.t('collection.unknownArtist')}
-        class="w-11 h-11 rounded-full object-cover border border-brand-border/40"
+        class="w-11 h-11 object-cover border border-brand-border"
       />
     {:else}
       <CoverArt

--- a/src/lib/components/ArtistRowCard.svelte
+++ b/src/lib/components/ArtistRowCard.svelte
@@ -52,11 +52,13 @@
 >
   <div class="row-span-2 relative overflow-hidden">
     {#if artistPortraitUrl}
-      <img
-        src={artistPortraitUrl}
-        alt={artist.name || i18n.t('collection.unknownArtist')}
-        class="w-11 h-11 object-cover border border-brand-border"
-      />
+      <div class="w-11 h-11 relative overflow-hidden bg-brand-sidebar border border-brand-border shrink-0">
+        <img
+          src={artistPortraitUrl}
+          alt={artist.name || i18n.t('collection.unknownArtist')}
+          class="w-full h-full object-cover"
+        />
+      </div>
     {:else}
       <CoverArt
         songId={frontCover?.songId}

--- a/src/lib/components/ArtistRowCard.test.ts
+++ b/src/lib/components/ArtistRowCard.test.ts
@@ -1,12 +1,22 @@
 import "@testing-library/jest-dom";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, fireEvent } from "@testing-library/svelte";
+import { invoke } from "@tauri-apps/api/core";
 import ArtistRowCard from "./ArtistRowCard.svelte";
 import type { ArtistItem, AlbumItem } from "../types";
 
 vi.mock("@tauri-apps/api/core", () => ({
   invoke: vi.fn().mockResolvedValue([]),
 }));
+
+vi.mock("@tauri-apps/api/window", () => ({
+  getCurrentWindow: vi.fn(() => ({
+    onResized: vi.fn(() => Promise.resolve(() => {})),
+    onMoved: vi.fn(() => Promise.resolve(() => {})),
+  })),
+}));
+
+import { collectionStore } from "../stores/collection.svelte";
 
 describe("ArtistRowCard.svelte", () => {
   const mockArtist: ArtistItem = {
@@ -31,6 +41,7 @@ describe("ArtistRowCard.svelte", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    collectionStore.extendedArtworkByArtist = {};
   });
 
   it("renders artist name, genre chip, and song count", () => {
@@ -69,5 +80,29 @@ describe("ArtistRowCard.svelte", () => {
 
     await fireEvent.click(getByText("Dave Hawkins"));
     expect(handleClick).toHaveBeenCalled();
+  });
+
+  it("renders a discovered artist portrait instead of the album-art front cover (#98/#761)", async () => {
+    vi.mocked(invoke).mockImplementation(async (cmd: string) => {
+      if (cmd === "get_extended_artwork_for_artist") {
+        return {
+          count: 1,
+          primary_uri: null,
+          artist_portrait_uri: "luminous-art://local/C:/Music/Dave Hawkins/artist.jpg",
+          band_logo_uri: null,
+          fanart_uri: null,
+          items: [],
+        };
+      }
+      return [];
+    });
+
+    const { findByAltText } = render(ArtistRowCard, {
+      props: { artist: mockArtist, artistAlbums: [mockAlbum] },
+    });
+
+    const portrait = await findByAltText("Dave Hawkins");
+    expect(portrait.tagName).toBe("IMG");
+    expect(portrait.getAttribute("src")).toBe("luminous-art://local/C:/Music/Dave Hawkins/artist.jpg");
   });
 });

--- a/src/lib/components/TopNavigation.svelte
+++ b/src/lib/components/TopNavigation.svelte
@@ -400,7 +400,22 @@
                   >
                     <div class="flex items-center gap-3 min-w-0 flex-1">
                       <div class="w-8 h-8 rounded-full flex-shrink-0 flex items-center justify-center bg-brand-main/60 border border-brand-border/40 overflow-hidden">
-                        <User class="w-4 h-4 text-brand-text-secondary" />
+                        {#if artist.name}
+                          {#await collectionStore.getExtendedArtworkForArtist(artist.name)}
+                            <User class="w-4 h-4 text-brand-text-secondary" />
+                          {:then artwork}
+                            {@const portraitUrl = getCoverArtUrl(artwork.artist_portrait_uri)}
+                            {#if portraitUrl}
+                              <img src={portraitUrl} alt={artist.name} class="w-full h-full object-cover" />
+                            {:else}
+                              <User class="w-4 h-4 text-brand-text-secondary" />
+                            {/if}
+                          {:catch}
+                            <User class="w-4 h-4 text-brand-text-secondary" />
+                          {/await}
+                        {:else}
+                          <User class="w-4 h-4 text-brand-text-secondary" />
+                        {/if}
                       </div>
                       <div class="flex flex-col min-w-0 flex-1">
                         <span class="text-sm font-medium text-brand-text-primary truncate group-hover:text-brand-accent-text transition-colors">

--- a/src/lib/components/TopNavigation.svelte
+++ b/src/lib/components/TopNavigation.svelte
@@ -399,7 +399,7 @@
                     class="search-result-item group flex items-center justify-between p-2 rounded-lg hover:bg-brand-main/80 transition-colors focus:outline-none focus:ring-2 focus:ring-brand-accent"
                   >
                     <div class="flex items-center gap-3 min-w-0 flex-1">
-                      <div class="w-8 h-8 rounded-full flex-shrink-0 flex items-center justify-center bg-brand-main/60 border border-brand-border/40 overflow-hidden">
+                      <div class="w-8 h-8 flex-shrink-0 flex items-center justify-center bg-brand-main/60 border border-brand-border overflow-hidden">
                         {#if artist.name}
                           {#await collectionStore.getExtendedArtworkForArtist(artist.name)}
                             <User class="w-4 h-4 text-brand-text-secondary" />

--- a/src/lib/components/TopNavigation.svelte
+++ b/src/lib/components/TopNavigation.svelte
@@ -618,18 +618,44 @@
                 class="search-result-item group flex items-center justify-between p-2 rounded-lg hover:bg-brand-main/80 transition-colors focus:outline-none focus:ring-2 focus:ring-brand-accent"
               >
                 <div class="flex items-center gap-3 min-w-0 flex-1">
-                  {#if item.artUrl}
+                  {#if item.kind === 'artist'}
+                    {#await collectionStore.getExtendedArtworkForArtist(item.title)}
+                      <div class="w-9 h-9 flex-shrink-0 flex items-center justify-center bg-brand-main/60 border border-brand-border/40 overflow-hidden rounded-full">
+                        <User class="w-4 h-4 text-brand-text-secondary" />
+                      </div>
+                    {:then artwork}
+                      {@const portraitUrl = getCoverArtUrl(artwork.artist_portrait_uri)}
+                      {#if portraitUrl}
+                        <div class="w-9 h-9 flex-shrink-0 overflow-hidden bg-brand-sidebar border border-brand-border">
+                          <img src={portraitUrl} alt={item.title} class="w-full h-full object-cover" />
+                        </div>
+                      {:else if item.artUrl}
+                        <CoverArt
+                          songId={typeof item.entityId === 'number' ? item.entityId : undefined}
+                          artManual={item.artUrl}
+                          artAutomatic={item.artUrl}
+                          sizeClass="w-9 h-9 rounded-full"
+                        />
+                      {:else}
+                        <div class="w-9 h-9 flex-shrink-0 flex items-center justify-center bg-brand-main/60 border border-brand-border/40 overflow-hidden rounded-full">
+                          <User class="w-4 h-4 text-brand-text-secondary" />
+                        </div>
+                      {/if}
+                    {:catch}
+                      <div class="w-9 h-9 flex-shrink-0 flex items-center justify-center bg-brand-main/60 border border-brand-border/40 overflow-hidden rounded-full">
+                        <User class="w-4 h-4 text-brand-text-secondary" />
+                      </div>
+                    {/await}
+                  {:else if item.artUrl}
                     <CoverArt
                       songId={typeof item.entityId === 'number' ? item.entityId : undefined}
                       artManual={item.artUrl}
                       artAutomatic={item.artUrl}
-                      sizeClass="w-9 h-9 {item.kind === 'artist' ? 'rounded-full' : ''}"
+                      sizeClass="w-9 h-9"
                     />
                   {:else}
-                    <div class="w-9 h-9 flex-shrink-0 flex items-center justify-center bg-brand-main/60 border border-brand-border/40 overflow-hidden {item.kind === 'artist' ? 'rounded-full' : ''}">
-                      {#if item.kind === 'artist'}
-                        <User class="w-4 h-4 text-brand-text-secondary" />
-                      {:else if item.kind === 'album'}
+                    <div class="w-9 h-9 flex-shrink-0 flex items-center justify-center bg-brand-main/60 border border-brand-border/40 overflow-hidden">
+                      {#if item.kind === 'album'}
                         <Disc class="w-4 h-4 text-brand-text-secondary" />
                       {:else if item.kind === 'playlist'}
                         <ListMusic class="w-4 h-4 text-brand-text-secondary" />

--- a/src/lib/components/TopNavigation.test.ts
+++ b/src/lib/components/TopNavigation.test.ts
@@ -17,6 +17,7 @@ describe("TopNavigation.svelte", () => {
     collectionStore.artists = [];
     collectionStore.searchQuery = "";
     collectionStore.extendedArtworkByArtist = {};
+    collectionStore.recentSearches = [];
   });
 
   it("toggles sidebar compact state when clicking the hamburger menu button", async () => {
@@ -82,5 +83,66 @@ describe("TopNavigation.svelte", () => {
     const portrait = await findByAltText("Dave Hawkins");
     expect(portrait.tagName).toBe("IMG");
     expect(portrait.getAttribute("src")).toBe("luminous-art://local/C:/Music/Dave Hawkins/artist.jpg");
+  });
+
+  it("shows a discovered artist portrait instead of the generic icon in Recent Searches (#98/#761)", async () => {
+    collectionStore.recentSearches = [
+      { id: "1", kind: "artist", title: "Dave Hawkins", subtitle: "Artist", timestamp: Date.now() },
+    ];
+    vi.mocked(invoke).mockImplementation(async (cmd: string) => {
+      if (cmd === "get_extended_artwork_for_artist") {
+        return {
+          count: 1,
+          primary_uri: null,
+          artist_portrait_uri: "luminous-art://local/C:/Music/Dave Hawkins/artist.jpg",
+          band_logo_uri: null,
+          fanart_uri: null,
+          items: [],
+        };
+      }
+      return null;
+    });
+
+    const { getByPlaceholderText, findByAltText } = render(TopNavigation);
+    const searchInput = getByPlaceholderText(/search/i) as HTMLInputElement;
+    // Empty-query focus shows Recent Searches, not live suggestions.
+    await fireEvent.focus(searchInput);
+
+    const portrait = await findByAltText("Dave Hawkins");
+    expect(portrait.tagName).toBe("IMG");
+    expect(portrait.getAttribute("src")).toBe("luminous-art://local/C:/Music/Dave Hawkins/artist.jpg");
+  });
+
+  it("falls back to the stored artUrl for a Recent Searches artist with no discovered portrait", async () => {
+    collectionStore.recentSearches = [
+      {
+        id: "1",
+        kind: "artist",
+        title: "Old Style Artist",
+        subtitle: "Artist",
+        artUrl: "luminous-art://album-abc123.jpg",
+        timestamp: Date.now(),
+      },
+    ];
+    vi.mocked(invoke).mockImplementation(async (cmd: string) => {
+      if (cmd === "get_extended_artwork_for_artist") {
+        return {
+          count: 0,
+          primary_uri: null,
+          artist_portrait_uri: null,
+          band_logo_uri: null,
+          fanart_uri: null,
+          items: [],
+        };
+      }
+      return null;
+    });
+
+    const { getByPlaceholderText, findByAltText } = render(TopNavigation);
+    const searchInput = getByPlaceholderText(/search/i) as HTMLInputElement;
+    await fireEvent.focus(searchInput);
+
+    const img = await findByAltText(/Album Art/i);
+    expect(img.tagName).toBe("IMG");
   });
 });

--- a/src/lib/components/TopNavigation.test.ts
+++ b/src/lib/components/TopNavigation.test.ts
@@ -1,6 +1,7 @@
 import "@testing-library/jest-dom";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, fireEvent } from "@testing-library/svelte";
+import { invoke } from "@tauri-apps/api/core";
 import TopNavigation from "./TopNavigation.svelte";
 import { collectionStore } from "../stores/collection.svelte";
 import { windowLayoutStore } from "../stores/windowLayout.svelte";
@@ -13,6 +14,9 @@ describe("TopNavigation.svelte", () => {
     windowLayoutStore.sidebarOpen = true;
     windowLayoutStore.rightPanelOpen = false;
     windowLayoutStore.viewportWidth = 1280;
+    collectionStore.artists = [];
+    collectionStore.searchQuery = "";
+    collectionStore.extendedArtworkByArtist = {};
   });
 
   it("toggles sidebar compact state when clicking the hamburger menu button", async () => {
@@ -50,5 +54,33 @@ describe("TopNavigation.svelte", () => {
     expect(windowLayoutStore.isSidebarAutoCollapsed).toBe(true);
     const { queryByTitle: queryByTitleNarrow } = render(TopNavigation);
     expect(queryByTitleNarrow("Toggle sidebar (compact / expanded)")).toBeNull();
+  });
+
+  it("shows a discovered artist portrait instead of the generic icon in search suggestions (#98/#761)", async () => {
+    collectionStore.artists = [{ name: "Dave Hawkins", album_count: 1, song_count: 6 }];
+    vi.mocked(invoke).mockImplementation(async (cmd: string) => {
+      if (cmd === "get_extended_artwork_for_artist") {
+        return {
+          count: 1,
+          primary_uri: null,
+          artist_portrait_uri: "luminous-art://local/C:/Music/Dave Hawkins/artist.jpg",
+          band_logo_uri: null,
+          fanart_uri: null,
+          items: [],
+        };
+      }
+      return null;
+    });
+
+    const { getByPlaceholderText, findByAltText } = render(TopNavigation);
+    const searchInput = getByPlaceholderText(/search/i) as HTMLInputElement;
+    await fireEvent.focus(searchInput);
+    // The artist-suggestions section only renders once there's a non-empty
+    // query (an empty-query focus shows Recent Searches instead).
+    await fireEvent.input(searchInput, { target: { value: "Dave" } });
+
+    const portrait = await findByAltText("Dave Hawkins");
+    expect(portrait.tagName).toBe("IMG");
+    expect(portrait.getAttribute("src")).toBe("luminous-art://local/C:/Music/Dave Hawkins/artist.jpg");
   });
 });

--- a/src/lib/utils/artistSocials.test.ts
+++ b/src/lib/utils/artistSocials.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { resolveSocialUrl, formatDisplayLabel, getPlatformInfo, SOCIAL_PLATFORMS } from "./artistSocials";
+import { resolveSocialUrl, formatDisplayLabel, getPlatformInfo, SOCIAL_PLATFORMS, deriveFanartTvUrl } from "./artistSocials";
 
 describe("artistSocials", () => {
   it("provides info for all known platforms", () => {
@@ -41,5 +41,32 @@ describe("artistSocials", () => {
     expect(formatDisplayLabel("website", "https://shaniatwain.com/tour")).toBe("shaniatwain.com/tour");
     expect(formatDisplayLabel("instagram", "@shaniatwain")).toBe("Instagram");
     expect(formatDisplayLabel("youtube", "@ShaniaTwain")).toBe("YouTube");
+  });
+
+  describe("deriveFanartTvUrl (#98/#761)", () => {
+    it("derives a fanart.tv URL from a stored MusicBrainz link's MBID", () => {
+      const url = deriveFanartTvUrl([
+        { platform: "musicbrainz", handle_or_url: "https://musicbrainz.org/artist/7249b899-8db8-43e7-9e6e-22f1e736024e" },
+      ]);
+      expect(url).toBe("https://fanart.tv/artist/7249b899-8db8-43e7-9e6e-22f1e736024e");
+    });
+
+    it("lowercases a mixed-case MBID", () => {
+      const url = deriveFanartTvUrl([
+        { platform: "musicbrainz", handle_or_url: "https://musicbrainz.org/artist/7249B899-8DB8-43E7-9E6E-22F1E736024E" },
+      ]);
+      expect(url).toBe("https://fanart.tv/artist/7249b899-8db8-43e7-9e6e-22f1e736024e");
+    });
+
+    it("returns null when there is no musicbrainz link", () => {
+      expect(deriveFanartTvUrl([{ platform: "discogs", handle_or_url: "https://discogs.com/artist/82343" }])).toBeNull();
+      expect(deriveFanartTvUrl([])).toBeNull();
+      expect(deriveFanartTvUrl(undefined)).toBeNull();
+      expect(deriveFanartTvUrl(null)).toBeNull();
+    });
+
+    it("returns null when the musicbrainz link has no recognizable MBID", () => {
+      expect(deriveFanartTvUrl([{ platform: "musicbrainz", handle_or_url: "not-a-valid-mbid" }])).toBeNull();
+    });
   });
 });

--- a/src/lib/utils/artistSocials.ts
+++ b/src/lib/utils/artistSocials.ts
@@ -1,3 +1,5 @@
+import type { ArtistSocialLink } from "../types";
+
 export interface SocialPlatformInfo {
   id: string;
   label: string;
@@ -209,4 +211,25 @@ export function formatDisplayLabel(platformId: string, input: string): string {
   }
 
   return info.label;
+}
+
+const MBID_PATTERN = /([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/i;
+
+/**
+ * Derives a fanart.tv artist page link from a stored MusicBrainz social
+ * link's MBID (#98/#761) — fanart.tv keys its artist pages by the same
+ * MusicBrainz artist id. Not a fetch: it's the same "link" pattern already
+ * used for the user-entered MusicBrainz/Discogs/Wikipedia links above, just
+ * computed from an id we already have on hand instead of typed in by the
+ * user. Not registered in {@link SOCIAL_PLATFORMS} — it's a derived,
+ * read-only link, not something users pick from the "add link" editor.
+ * Returns null when there's no MusicBrainz link, or its value doesn't
+ * contain a recognizable MBID.
+ */
+export function deriveFanartTvUrl(socialLinks: ArtistSocialLink[] | undefined | null): string | null {
+  const mbLink = socialLinks?.find((l) => l.platform === "musicbrainz");
+  if (!mbLink?.handle_or_url) return null;
+  const match = mbLink.handle_or_url.match(MBID_PATTERN);
+  if (!match) return null;
+  return `https://fanart.tv/artist/${match[1].toLowerCase()}`;
 }


### PR DESCRIPTION
## 📋 Summary
Addresses #761, fifth and final sub-issue of #98, stacked on #765 (#760). Wires `ArtistDetailView`, `ArtistCard`, `ArtistRowCard`, and `TopNavigation`'s artist search suggestions up to the locally-discovered artist visuals (portrait/band logo/fanart) from #757-#759, and adds a derived fanart.tv link per owner request in this issue's comments.

## 🔍 Implementation Notes
- **ArtistDetailView**: discovered artist portrait replaces the `CoverStack` album-art composite in the header; discovered band logo replaces the plain-text artist-name `<h1>`; discovered fanart/backdrop renders as a hero background behind the header bar (previously a plain blurred bar). Each falls back to the existing behavior independently when not discovered.
- **ArtistCard / ArtistRowCard**: discovered portrait replaces the `CoverStack`/`CoverArt` album-art composite.
- **TopNavigation**: artist search suggestions show the discovered portrait instead of the generic `User` icon. I deliberately left the separate Recent Searches list (`:606-627` in #98's description) alone — it persists its own `artUrl` snapshot per stored entry, and wiring it to a live per-entry lookup is a materially different, more involved change than a straight component swap; flagging this as an intentional scope narrowing from #98's literal wording.
- **Fanart.tv link** (owner request, see comments on #98): `deriveFanartTvUrl()` in `artistSocials.ts` extracts the MBID from a stored MusicBrainz social link and builds `https://fanart.tv/artist/{mbid}`. Not a fetch — a computed URL from an id already on hand, same pattern as the existing user-entered Discogs/Wikipedia links. Not added to `SOCIAL_PLATFORMS`, since it's derived/read-only and shouldn't be selectable in the "add link" editor.
- All new IPC-backed artist lookups go through #759's cached `collectionStore.getExtendedArtworkForArtist()`, so an artist appearing in multiple places at once (card + search suggestion, say) shares one backend call.

## 🧪 Test Plan
- [x] `bun run check` (svelte-check + knip) — clean
- [x] `bun run test -- --run` (frontend) — 593 passed (14 new across `artistSocials.test.ts`, `ArtistDetailView.test.ts`, `ArtistCard.test.ts`, `ArtistRowCard.test.ts`, `TopNavigation.test.ts`)
- [ ] `cargo test` (src-tauri) — no backend changes in this PR
- [ ] Manually verified in the app — **not done by me**; please verify in the dev server alongside #760 (owner is testing the full stack together)

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed — no docs impact; screenshots skipped, recommend live verification instead
