### PR TITLE
fix: remove misleading release country row from Info Panel (#770)

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -11,7 +11,7 @@ Created by [Eric Soltys](https://esoltys.github.io/), a Canadian software develo
 - **Frontend Architecture**: [Svelte 5 (Runes)](https://svelte.dev/) & [TypeScript](https://www.typescriptlang.org/)
 - **Database Engine**: [SQLite](https://sqlite.org/) via `rusqlite` & `r2d2`
 - **UI Framework & Styling**: [Tailwind CSS v4](https://tailwindcss.com/)
-- **Icons**: [Phosphor Icons](https://phosphoricons.com/)
+- **Icons**: [Phosphor Icons](https://phosphoricons.com/) and [Simple Icons](https://simpleicons.org/)
 - **Typography**: [Inter](https://rsms.me/inter/) font family by Rasmus Andersson
 
 ### Audio Engine & Signal Processing

--- a/src/lib/components/RightPanel.svelte
+++ b/src/lib/components/RightPanel.svelte
@@ -77,7 +77,6 @@
           ? currentSong.musicbrainz_release_type.charAt(0).toUpperCase() + currentSong.musicbrainz_release_type.slice(1)
           : undefined,
       },
-      { label: i18n.t('playerBar.musicbrainzReleaseCountryLabel', {}, 'Country'), value: currentSong.musicbrainz_release_country },
       { label: i18n.t('playerBar.barcodeLabel', {}, 'Barcode'), value: currentSong.barcode },
       { label: i18n.t('playerBar.catalogNumberLabel', {}, 'Catalog #'), value: currentSong.catalog_number },
     ];

--- a/src/lib/components/RightPanel.test.ts
+++ b/src/lib/components/RightPanel.test.ts
@@ -157,21 +157,20 @@ describe("RightPanel.svelte", () => {
     );
   });
 
-  it("shows release type/country/barcode/catalog # as plain text, title-casing the release type", () => {
+  it("shows release type/barcode/catalog # as plain text, title-casing the release type", () => {
     playerStore.currentSong = {
       ...mockSong,
       musicbrainz_release_type: "album",
-      musicbrainz_release_country: "JP",
       barcode: "4988011329586",
       catalog_number: "PHCR-1144",
     };
-    const { getByText, getByAltText } = render(RightPanel);
+    const { getByText, getByAltText, queryByText } = render(RightPanel);
 
     expect(getByAltText("MusicBrainz")).toBeInTheDocument();
     expect(getByText("Album")).toBeInTheDocument();
-    expect(getByText("JP")).toBeInTheDocument();
     expect(getByText("4988011329586")).toBeInTheDocument();
     expect(getByText("PHCR-1144")).toBeInTheDocument();
+    expect(queryByText("Country")).not.toBeInTheDocument();
   });
 
   it("shows the MusicBrainz section for release metadata alone, with no MusicBrainz IDs at all", () => {


### PR DESCRIPTION
## 📋 Summary
Addresses #770. Removes the `Country` row from the right sidebar Info Panel's MusicBrainz section.

## 🔍 Implementation Notes
- The field surfaced from tags was `musicbrainz_release_country` (`RELEASECOUNTRY`), which indicates the album release/pressing territory. For multi-country digital releases in MusicBrainz, this field frequently defaults to the first country alphabetically (e.g. `AT` / Austria for *Roses* by the Australian band The Paper Kites).
- Because Picard does not write the artist's country of origin into file tags by default, displaying this release event territory labeled as "Country" is misleading to users expecting the band's nationality.
- In `src/lib/components/RightPanel.svelte`, `musicbrainz_release_country` is removed from `musicbrainzMetaRows`. The underlying database column and `Song` model field remain intact for library metadata completeness and Picard tag interoperability, but are no longer surfaced in the UI.
- Updated `CREDITS.md` to credit Simple Icons alongside Phosphor Icons.

## 🧪 Test Plan
- [x] `bun run check` (svelte-check) — 0 errors, 0 warnings
- [x] `bun run test -- --run` (frontend) — 14/14 tests pass in `RightPanel.test.ts`
- [x] Manually verified in the app

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs updated (CREDITS.md)
