### PR TITLE
feat: add watched folder indicators and metadata customization (#124)

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -11,7 +11,7 @@ Created by [Eric Soltys](https://esoltys.github.io/), a Canadian software develo
 - **Frontend Architecture**: [Svelte 5 (Runes)](https://svelte.dev/) & [TypeScript](https://www.typescriptlang.org/)
 - **Database Engine**: [SQLite](https://sqlite.org/) via `rusqlite` & `r2d2`
 - **UI Framework & Styling**: [Tailwind CSS v4](https://tailwindcss.com/)
-- **Icons**: [Phosphor Icons](https://phosphoricons.com/)
+- **Icons**: [Phosphor Icons](https://phosphoricons.com/) and [Simple Icons](https://simpleicons.org/)
 - **Typography**: [Inter](https://rsms.me/inter/) font family by Rasmus Andersson
 
 ### Audio Engine & Signal Processing

--- a/src-tauri/src/collection.rs
+++ b/src-tauri/src/collection.rs
@@ -76,6 +76,9 @@ impl CollectionScanner {
             path: path.to_string(),
             subdirs: true,
             is_available: std::path::Path::new(path).exists(),
+            nickname: None,
+            icon: None,
+            color: None,
         })
     }
 
@@ -118,7 +121,7 @@ impl CollectionScanner {
     /// List all watched directories.
     pub fn get_directories(&self) -> Result<Vec<MusicDirectory>> {
         let conn = self.db.pool.get()?;
-        let mut stmt = conn.prepare("SELECT id, path, subdirs FROM directories ORDER BY path")?;
+        let mut stmt = conn.prepare("SELECT id, path, subdirs, nickname, icon, color FROM directories ORDER BY path")?;
         let dirs = stmt
             .query_map([], |row| {
                 let path: String = row.get(1)?;
@@ -128,11 +131,30 @@ impl CollectionScanner {
                     path,
                     subdirs: row.get(2)?,
                     is_available,
+                    nickname: row.get(3)?,
+                    icon: row.get(4)?,
+                    color: row.get(5)?,
                 })
             })?
             .filter_map(|r| r.ok())
             .collect();
         Ok(dirs)
+    }
+
+    /// Update metadata (nickname, icon, color) for a watched directory.
+    pub fn update_directory_metadata(
+        &self,
+        id: i64,
+        nickname: Option<String>,
+        icon: Option<String>,
+        color: Option<String>,
+    ) -> Result<()> {
+        let conn = self.db.pool.get()?;
+        conn.execute(
+            "UPDATE directories SET nickname = ?1, icon = ?2, color = ?3 WHERE id = ?4",
+            params![nickname, icon, color, id],
+        )?;
+        Ok(())
     }
     /// Returns ids of songs (from `path`) whose file no longer exists on disk, excluding
     /// any song that lives under a watched directory root which is currently unreachable.

--- a/src-tauri/src/commands/collection.rs
+++ b/src-tauri/src/commands/collection.rs
@@ -38,6 +38,20 @@ pub async fn get_directories(state: State<'_, AppState>) -> Result<Vec<MusicDire
 }
 
 #[tauri::command]
+pub async fn update_directory_metadata(
+    id: i64,
+    nickname: Option<String>,
+    icon: Option<String>,
+    color: Option<String>,
+    state: State<'_, AppState>,
+) -> Result<(), String> {
+    let scanner = CollectionScanner::new(state.db.clone());
+    scanner
+        .update_directory_metadata(id, nickname, icon, color)
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
 pub async fn scan_directories(
     app: AppHandle,
     force: Option<bool>,

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 pub type DbPool = Pool<SqliteConnectionManager>;
 
 /// Current schema version. Increment when adding migrations.
-pub const CURRENT_SCHEMA_VERSION: i32 = 24;
+pub const CURRENT_SCHEMA_VERSION: i32 = 25;
 
 struct Migration {
     version: i32,
@@ -166,6 +166,19 @@ const MIGRATIONS: &[Migration] = &[
                 .exists([])?;
             if !has_release_type {
                 conn.execute_batch(MIGRATION_24)?;
+            }
+            Ok(())
+        },
+    },
+    Migration {
+        version: 25,
+        description: "nickname, icon, and color metadata columns on directories table (#124)",
+        apply: |conn| {
+            let has_nickname: bool = conn
+                .prepare("SELECT 1 FROM pragma_table_info('directories') WHERE name = 'nickname'")?
+                .exists([])?;
+            if !has_nickname {
+                conn.execute_batch(MIGRATION_25)?;
             }
             Ok(())
         },
@@ -711,6 +724,15 @@ ALTER TABLE songs ADD COLUMN catalog_number TEXT;
 ";
 
 // ---------------------------------------------------------------------------
+// Migration 25: nickname, icon, and color columns on directories table (#124).
+// ---------------------------------------------------------------------------
+const MIGRATION_25: &str = "
+ALTER TABLE directories ADD COLUMN nickname TEXT;
+ALTER TABLE directories ADD COLUMN icon TEXT;
+ALTER TABLE directories ADD COLUMN color TEXT;
+";
+
+// ---------------------------------------------------------------------------
 // Migration 18: tag_groups/tag_assignments — a persisted, curatable Genres
 // hierarchy (#545) layered on top of the existing `songs.genre` string
 // column. `songs.genre` remains the source of truth for which songs carry
@@ -986,6 +1008,40 @@ mod tests {
             orphaned_items, 0,
             "the discarded playlist's items must go with it"
         );
+
+        let _ = std::fs::remove_dir_all(temp_dir);
+    }
+
+    #[test]
+    fn test_migration_25_adds_directory_metadata_columns() {
+        let temp_dir = std::env::temp_dir().join(format!(
+            "luminous_migration25_test_{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let db = Database::new(temp_dir.clone()).unwrap();
+        assert_eq!(db.schema_version, CURRENT_SCHEMA_VERSION);
+
+        let conn = db.pool.get().unwrap();
+        conn.execute(
+            "INSERT INTO directories (path, subdirs, nickname, icon, color) VALUES (?1, 1, ?2, ?3, ?4)",
+            params!["/test/music", "My Library", "hard-drive", "#3b82f6"],
+        )
+        .unwrap();
+
+        let (nickname, icon, color): (Option<String>, Option<String>, Option<String>) = conn
+            .query_row(
+                "SELECT nickname, icon, color FROM directories WHERE path = '/test/music'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+            )
+            .unwrap();
+
+        assert_eq!(nickname.as_deref(), Some("My Library"));
+        assert_eq!(icon.as_deref(), Some("hard-drive"));
+        assert_eq!(color.as_deref(), Some("#3b82f6"));
 
         let _ = std::fs::remove_dir_all(temp_dir);
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -888,6 +888,7 @@ pub fn run() {
             commands::collection::add_directory,
             commands::collection::remove_directory,
             commands::collection::get_directories,
+            commands::collection::update_directory_metadata,
             commands::collection::get_library_stats,
             commands::collection::search_songs,
             commands::collection::get_library_snapshot,

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -681,6 +681,9 @@ pub struct MusicDirectory {
     pub subdirs: bool,
     #[serde(default)]
     pub is_available: bool,
+    pub nickname: Option<String>,
+    pub icon: Option<String>,
+    pub color: Option<String>,
 }
 
 /// Result of pruning missing/unavailable songs from the library.

--- a/src/lib/components/AlbumCard.svelte
+++ b/src/lib/components/AlbumCard.svelte
@@ -11,6 +11,7 @@
   import FavouriteCornerFlag from "./FavouriteCornerFlag.svelte";
   import BoxSetDiscIcons from "./BoxSetDiscIcons.svelte";
   import GenreChips from "./GenreChips.svelte";
+  import LibraryBadge from "./LibraryBadge.svelte";
  
   interface Props {
     album: AlbumItem;
@@ -53,6 +54,7 @@
     album.rating = await invoke<number>("set_album_rating", { album: album.album, rating });
   }
 
+  let albumDirectory = $derived(collectionStore.getDirectoryForAlbum(album));
 </script>
 
 <!-- svelte-ignore a11y_no_static_element_interactions -->
@@ -75,6 +77,11 @@
     {/if}
     {#if album.disc_count > 1}
       <BoxSetDiscIcons discCount={album.disc_count} size="md" />
+    {/if}
+    {#if albumDirectory}
+      <div class="absolute top-2 left-2 z-10 opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none max-w-[calc(100%-1rem)]">
+        <LibraryBadge directory={albumDirectory} size="xs" />
+      </div>
     {/if}
   </div>
   <div class="p-3.5 flex flex-col flex-1">

--- a/src/lib/components/AlbumDetailView.svelte
+++ b/src/lib/components/AlbumDetailView.svelte
@@ -25,14 +25,16 @@
   import LinkButton from "./LinkButton.svelte";
   import ColumnSelector from "./ColumnSelector.svelte";
   import SongTable, { type SongTableRow } from "./SongTable.svelte";
+  import LibraryBadge from "./LibraryBadge.svelte";
   import {
     PlusIcon as Plus,
     PencilSimpleIcon as Edit3,
     ArrowsClockwiseIcon as RefreshCw,
     PushPinIcon as Pin,
-    PushPinSlashIcon as PinOff
+    PushPinSlashIcon as PinOff,
+    FoldersIcon as Folders
   } from "phosphor-svelte";
-  import type { Song, AlbumItem, PlayContext } from "../types";
+  import type { Song, AlbumItem, PlayContext, MusicDirectory } from "../types";
   import { getCoverArtUrl, resolveArtUrl } from "../types";
   import { i18n } from "../stores/i18n.svelte";
   import { toastStore } from "../stores/toast.svelte";
@@ -106,6 +108,17 @@
    * for this album's directory — there's no dedicated album id in the
    * schema (see #758), so a representative song stands in for one. */
   let representativeSongId = $derived(songs[0]?.id);
+
+  let albumDirectories = $derived.by(() => {
+    const map = new Map<number, MusicDirectory>();
+    for (const song of songs) {
+      if (song.path) {
+        const dir = collectionStore.getDirectoryForPath(song.path);
+        if (dir) map.set(dir.id, dir);
+      }
+    }
+    return Array.from(map.values());
+  });
 
   let artistName = $derived.by(() => {
     if (albumItem?.artist) return albumItem.artist;
@@ -228,7 +241,7 @@
     genre: "1.2fr", grouping: "1.2fr", bpm: "60px", initial_key: "60px",
     bitrate: "70px", samplerate: "75px", bitdepth: "65px", channels: "70px",
     filesize: "75px", rating: "96px", playcount: "70px", skipcount: "70px",
-    lastplayed: "90px", added: "90px", duration: "80px", path: "2fr", actions: "80px",
+    lastplayed: "90px", added: "90px", duration: "80px", path: "2fr", library: "130px", actions: "80px",
   };
 
   function songToRow(song: Song): SongTableRow {
@@ -433,6 +446,19 @@
           {#if albumItem}
             <span>•</span>
             <SongRating rating={albumItem.rating} onRate={rateAlbum} size="sm" />
+          {/if}
+          {#if albumDirectories.length === 1}
+            <span>•</span>
+            <LibraryBadge directory={albumDirectories[0]} size="sm" />
+          {:else if albumDirectories.length > 1}
+            <span>•</span>
+            <span
+              class="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-lg text-xs font-medium bg-brand-sidebar/80 border border-brand-border/70 text-brand-text-secondary select-none"
+              title={albumDirectories.map((d) => d.nickname || d.path).join(", ")}
+            >
+              <Folders class="w-3.5 h-3.5 text-brand-accent-text" />
+              <span>{i18n.t('albumDetail.multiLibraries', { count: albumDirectories.length }, `${albumDirectories.length} Libraries`)}</span>
+            </span>
           {/if}
         </div>
         {/if}

--- a/src/lib/components/ArtistDetailView.svelte
+++ b/src/lib/components/ArtistDetailView.svelte
@@ -321,7 +321,7 @@
     genre: "1.2fr", grouping: "1.2fr", bpm: "60px", initial_key: "60px",
     bitrate: "70px", samplerate: "75px", bitdepth: "65px", channels: "70px",
     filesize: "75px", rating: "96px", playcount: "70px", skipcount: "70px",
-    lastplayed: "90px", added: "90px", duration: "80px", path: "2fr", actions: "80px",
+    lastplayed: "90px", added: "90px", duration: "80px", path: "2fr", library: "130px", actions: "80px",
   };
 
   let singleDiscCount = $derived(singleSongs.reduce((max, s) => Math.max(max, s.disc ?? 1), 1));

--- a/src/lib/components/AutoPlaylistDetailView.svelte
+++ b/src/lib/components/AutoPlaylistDetailView.svelte
@@ -74,7 +74,7 @@
     genre: "1.2fr", grouping: "1.2fr", bpm: "60px", initial_key: "60px",
     bitrate: "70px", samplerate: "75px", bitdepth: "65px", channels: "70px",
     filesize: "75px", rating: "96px", playcount: "70px", skipcount: "70px",
-    lastplayed: "90px", added: "90px", duration: "80px", path: "2fr", actions: "80px",
+    lastplayed: "90px", added: "90px", duration: "80px", path: "2fr", library: "130px", actions: "80px",
   };
 
   let genre = $derived(view.genre);

--- a/src/lib/components/CollectionView.svelte
+++ b/src/lib/components/CollectionView.svelte
@@ -270,7 +270,7 @@
     genre: "1.2fr", grouping: "1.2fr", bpm: "60px", initial_key: "60px",
     bitrate: "70px", samplerate: "75px", bitdepth: "65px", channels: "70px",
     filesize: "75px", rating: "96px", playcount: "70px", skipcount: "70px",
-    lastplayed: "90px", added: "90px", duration: "80px", path: "2fr", actions: "80px",
+    lastplayed: "90px", added: "90px", duration: "80px", path: "2fr", library: "130px", actions: "80px",
   };
 
   function toggleSort(field: keyof Song) {

--- a/src/lib/components/ColumnSelector.svelte
+++ b/src/lib/components/ColumnSelector.svelte
@@ -94,6 +94,7 @@
     { key: "added",     label: "collection.columnAdded" },
     { key: "duration",  label: "collection.columnDuration" },
     { key: "lastplayed",label: "collection.columnLastPlayed" },
+    { key: "library",   label: "collection.columnLibrary" },
     { key: "playcount", label: "collection.columnPlayCount" },
     { key: "rating",    label: "collection.columnRating" },
     { key: "skipcount", label: "collection.columnSkipCount" },

--- a/src/lib/components/FolderEditModal.svelte
+++ b/src/lib/components/FolderEditModal.svelte
@@ -1,0 +1,217 @@
+<script lang="ts">
+  import { untrack } from "svelte";
+  import type { MusicDirectory } from "../types";
+  import { collectionStore } from "../stores/collection.svelte";
+  import { playerStore } from "../stores/player.svelte";
+  import { i18n } from "../stores/i18n.svelte";
+  import { PLAYER_DOCK_CLEARANCE_PX } from "../constants";
+  import Button from "./Button.svelte";
+  import Input from "./Input.svelte";
+  import LibraryBadge from "./LibraryBadge.svelte";
+  import {
+    FolderIcon,
+    HardDriveIcon,
+    CloudIcon,
+    DesktopIcon,
+    UsbIcon,
+    HouseIcon,
+    DiscIcon,
+    MusicNotesIcon,
+    ArchiveIcon,
+    BroadcastIcon,
+    XIcon as X,
+    FolderSimpleIcon as FolderSimple,
+    CheckIcon as Check,
+  } from "phosphor-svelte";
+
+  interface Props {
+    directory: MusicDirectory;
+    onClose: () => void;
+  }
+
+  let { directory, onClose }: Props = $props();
+
+  let nickname = $state(untrack(() => directory.nickname ?? ""));
+  let selectedIcon = $state(untrack(() => directory.icon ?? "folder"));
+  let selectedColor = $state<string | null>(untrack(() => directory.color ?? null));
+  let saving = $state(false);
+
+  const ICON_CHOICES = [
+    { id: "folder", label: "Folder", icon: FolderIcon },
+    { id: "hard-drive", label: "Drive", icon: HardDriveIcon },
+    { id: "cloud", label: "Cloud / NAS", icon: CloudIcon },
+    { id: "desktop", label: "Computer", icon: DesktopIcon },
+    { id: "usb", label: "USB", icon: UsbIcon },
+    { id: "house", label: "Home", icon: HouseIcon },
+    { id: "disc", label: "Disc", icon: DiscIcon },
+    { id: "music", label: "Music", icon: MusicNotesIcon },
+    { id: "archive", label: "Archive", icon: ArchiveIcon },
+    { id: "broadcast", label: "Shared", icon: BroadcastIcon },
+  ];
+
+  const COLOR_CHOICES: { value: string | null; label: string }[] = [
+    { value: null, label: "Default" },
+    { value: "#3b82f6", label: "Blue" },
+    { value: "#8b5cf6", label: "Purple" },
+    { value: "#ec4899", label: "Pink" },
+    { value: "#ef4444", label: "Red" },
+    { value: "#f97316", label: "Orange" },
+    { value: "#eab308", label: "Yellow" },
+    { value: "#10b981", label: "Emerald" },
+    { value: "#06b6d4", label: "Cyan" },
+    { value: "#6366f1", label: "Indigo" },
+  ];
+
+  let previewDirectory = $derived<MusicDirectory>({
+    ...directory,
+    nickname: nickname.trim() || null,
+    icon: selectedIcon,
+    color: selectedColor,
+  });
+
+  let dockClearance = $derived(playerStore.currentSong ? PLAYER_DOCK_CLEARANCE_PX : 0);
+
+  function handleKeydown(e: KeyboardEvent) {
+    if (e.key === "Escape") {
+      onClose();
+    }
+  }
+
+  async function handleSubmit(e: SubmitEvent) {
+    e.preventDefault();
+    if (saving) return;
+    saving = true;
+    try {
+      await collectionStore.updateDirectoryMetadata(directory.id, {
+        nickname: nickname.trim() || null,
+        icon: selectedIcon,
+        color: selectedColor,
+      });
+      onClose();
+    } catch (err) {
+      console.error("Failed to update directory metadata:", err);
+    } finally {
+      saving = false;
+    }
+  }
+</script>
+
+<svelte:window onkeydown={handleKeydown} />
+
+<!-- svelte-ignore a11y_click_events_have_key_events -->
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div
+  class="fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-sm p-4"
+  style="padding-bottom: {dockClearance + 16}px"
+  onclick={(e) => { if (e.target === e.currentTarget) onClose(); }}
+>
+  <div
+    class="bg-brand-sidebar border border-brand-border rounded-2xl w-full max-w-lg shadow-2xl overflow-hidden flex flex-col animate-in fade-in zoom-in-95 duration-150"
+    style="max-height: min(90vh, calc(100vh - {dockClearance + 32}px))"
+  >
+    <div class="flex items-center justify-between px-6 py-4 border-b border-brand-border/60 bg-brand-main/50">
+      <div class="flex items-center gap-2.5 min-w-0">
+        <div class="p-2 rounded-xl bg-brand-accent/20 text-brand-accent-text shrink-0">
+          <FolderSimple class="w-5 h-5" />
+        </div>
+        <div class="min-w-0">
+          <h2 class="text-base font-bold text-brand-text-primary truncate">{i18n.t("settings.editFolderTitle")}</h2>
+          <p class="text-xs text-brand-text-secondary/70 truncate font-mono" title={directory.path}>{directory.path}</p>
+        </div>
+      </div>
+      <button
+        type="button"
+        onclick={onClose}
+        class="text-brand-text-secondary hover:text-brand-text-primary p-1.5 rounded-lg hover:bg-brand-main/80 transition-colors"
+      >
+        <X class="w-4 h-4" />
+      </button>
+    </div>
+
+    <form onsubmit={handleSubmit} class="p-6 flex-1 overflow-y-auto flex flex-col gap-5">
+      <!-- Live Preview -->
+      <div class="bg-brand-main/40 border border-brand-border/50 rounded-xl p-4 flex items-center justify-between gap-4">
+        <span class="text-xs font-semibold text-brand-text-secondary uppercase tracking-wider">
+          {i18n.t("settings.folderPreview")}
+        </span>
+        <div>
+          <LibraryBadge directory={previewDirectory} size="md" />
+        </div>
+      </div>
+
+      <!-- Nickname -->
+      <div>
+        <label for="folder-nickname-input" class="block text-xs font-semibold text-brand-text-secondary uppercase tracking-wider mb-1.5">
+          {i18n.t("settings.folderNickname")}
+        </label>
+        <Input
+          id="folder-nickname-input"
+          type="text"
+          bind:value={nickname}
+          placeholder={i18n.t("settings.folderNicknamePlaceholder")}
+          class="w-full"
+        />
+      </div>
+
+      <!-- Icon Selection -->
+      <div>
+        <span class="block text-xs font-semibold text-brand-text-secondary uppercase tracking-wider mb-2">
+          {i18n.t("settings.folderIcon")}
+        </span>
+        <div class="grid grid-cols-5 gap-2">
+          {#each ICON_CHOICES as choice}
+            {@const Icon = choice.icon}
+            {@const isSelected = selectedIcon === choice.id}
+            <button
+              type="button"
+              onclick={() => { selectedIcon = choice.id; }}
+              class="flex flex-col items-center justify-center p-2.5 rounded-xl border transition-all duration-150 gap-1
+                {isSelected
+                  ? 'bg-brand-accent/20 border-brand-accent text-brand-accent-text ring-1 ring-brand-accent'
+                  : 'bg-brand-main/40 border-brand-border/60 text-brand-text-secondary hover:text-brand-text-primary hover:border-brand-border'}"
+              title={choice.label}
+            >
+              <Icon class="w-5 h-5" />
+              <span class="text-[10px] font-medium truncate max-w-full">{choice.label}</span>
+            </button>
+          {/each}
+        </div>
+      </div>
+
+      <!-- Color Selection -->
+      <div>
+        <span class="block text-xs font-semibold text-brand-text-secondary uppercase tracking-wider mb-2">
+          {i18n.t("settings.folderColor")}
+        </span>
+        <div class="flex flex-wrap items-center gap-2.5">
+          {#each COLOR_CHOICES as choice}
+            {@const isSelected = selectedColor === choice.value}
+            <button
+              type="button"
+              onclick={() => { selectedColor = choice.value; }}
+              class="relative w-7 h-7 rounded-full border-2 transition-transform duration-150 flex items-center justify-center
+                {isSelected ? 'scale-110 ring-2 ring-brand-accent' : 'hover:scale-105'}
+                {choice.value === null ? 'bg-brand-sidebar border-brand-border' : 'border-white/20'}"
+              style={choice.value ? `background-color: ${choice.value}` : ''}
+              title={choice.label}
+            >
+              {#if isSelected}
+                <Check class="w-3.5 h-3.5 {choice.value === null ? 'text-brand-accent-text' : 'text-white'} drop-shadow-sm" />
+              {/if}
+            </button>
+          {/each}
+        </div>
+      </div>
+
+      <!-- Footer Buttons -->
+      <div class="flex items-center justify-end gap-3 pt-4 border-t border-brand-border/60 mt-2">
+        <Button type="button" variant="secondary" onclick={onClose} disabled={saving}>
+          {i18n.t("settings.cancel")}
+        </Button>
+        <Button type="submit" variant="primary" disabled={saving}>
+          {saving ? i18n.t("settings.saving", {}, "Saving...") : i18n.t("settings.saveChanges")}
+        </Button>
+      </div>
+    </form>
+  </div>
+</div>

--- a/src/lib/components/LibraryBadge.svelte
+++ b/src/lib/components/LibraryBadge.svelte
@@ -1,0 +1,87 @@
+<script lang="ts">
+  import type { Component } from "svelte";
+  import type { MusicDirectory } from "../types";
+  import {
+    FolderIcon,
+    HardDriveIcon,
+    CloudIcon,
+    DesktopIcon,
+    UsbIcon,
+    HouseIcon,
+    DiscIcon,
+    MusicNotesIcon,
+    ArchiveIcon,
+    BroadcastIcon,
+    WarningIcon,
+  } from "phosphor-svelte";
+
+  interface Props {
+    directory: MusicDirectory;
+    size?: "xs" | "sm" | "md";
+    showName?: boolean;
+    class?: string;
+  }
+
+  let {
+    directory,
+    size = "sm",
+    showName = true,
+    class: className = "",
+  }: Props = $props();
+
+  const ICONS: Record<string, Component<any>> = {
+    folder: FolderIcon,
+    "hard-drive": HardDriveIcon,
+    cloud: CloudIcon,
+    desktop: DesktopIcon,
+    usb: UsbIcon,
+    house: HouseIcon,
+    disc: DiscIcon,
+    music: MusicNotesIcon,
+    archive: ArchiveIcon,
+    broadcast: BroadcastIcon,
+  };
+
+  let IconComponent = $derived(
+    directory.icon && ICONS[directory.icon] ? ICONS[directory.icon] : FolderIcon
+  );
+
+  let displayName = $derived.by(() => {
+    if (directory.nickname && directory.nickname.trim() !== "") {
+      return directory.nickname.trim();
+    }
+    const p = directory.path.replace(/\\/g, "/").replace(/\/+$/, "");
+    const parts = p.split("/");
+    return parts[parts.length - 1] || directory.path;
+  });
+
+  let isUnavailable = $derived(directory.is_available === false);
+  let customColor = $derived(directory.color?.trim() || null);
+
+  let badgeStyle = $derived(
+    customColor
+      ? `background-color: color-mix(in srgb, ${customColor} 18%, transparent); border-color: color-mix(in srgb, ${customColor} 45%, transparent); color: ${customColor};`
+      : undefined
+  );
+</script>
+
+<span
+  class="inline-flex items-center font-medium border backdrop-blur-md transition-colors select-none max-w-full truncate
+    {size === 'xs' ? 'text-[10px] px-1.5 py-0.5 gap-1 rounded-md' : ''}
+    {size === 'sm' ? 'text-xs px-2 py-0.5 gap-1.5 rounded-lg' : ''}
+    {size === 'md' ? 'text-xs px-2.5 py-1 gap-2 rounded-xl' : ''}
+    {!customColor ? 'bg-brand-sidebar/80 border-brand-border/70 text-brand-text-secondary' : ''}
+    {isUnavailable ? 'opacity-70 border-dashed border-red-400/60' : ''}
+    {className}"
+  style={badgeStyle}
+  title={isUnavailable ? `${displayName} (Disconnected) — ${directory.path}` : `${displayName} — ${directory.path}`}
+>
+  {#if isUnavailable}
+    <WarningIcon class="{size === 'xs' ? 'w-2.5 h-2.5' : 'w-3.5 h-3.5'} text-red-400 shrink-0" />
+  {:else}
+    <IconComponent class="{size === 'xs' ? 'w-2.5 h-2.5' : size === 'sm' ? 'w-3 h-3' : 'w-3.5 h-3.5'} shrink-0" />
+  {/if}
+  {#if showName}
+    <span class="truncate">{displayName}</span>
+  {/if}
+</span>

--- a/src/lib/components/LibraryBadge.test.ts
+++ b/src/lib/components/LibraryBadge.test.ts
@@ -8,6 +8,7 @@ describe("LibraryBadge.svelte", () => {
   const baseDirectory: MusicDirectory = {
     id: 1,
     path: "C:\\Music\\HighRes",
+    subdirs: true,
     is_available: true,
     nickname: null,
     icon: null,

--- a/src/lib/components/LibraryBadge.test.ts
+++ b/src/lib/components/LibraryBadge.test.ts
@@ -1,0 +1,68 @@
+import "@testing-library/jest-dom";
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/svelte";
+import LibraryBadge from "./LibraryBadge.svelte";
+import type { MusicDirectory } from "../types";
+
+describe("LibraryBadge.svelte", () => {
+  const baseDirectory: MusicDirectory = {
+    id: 1,
+    path: "C:\\Music\\HighRes",
+    is_available: true,
+    nickname: null,
+    icon: null,
+    color: null,
+  };
+
+  it("renders folder name extracted from path by default", () => {
+    const { getByText } = render(LibraryBadge, {
+      props: { directory: baseDirectory },
+    });
+    expect(getByText("HighRes")).toBeInTheDocument();
+  });
+
+  it("renders custom nickname when specified", () => {
+    const customDir: MusicDirectory = {
+      ...baseDirectory,
+      nickname: "Studio FLACs",
+    };
+    const { getByText } = render(LibraryBadge, {
+      props: { directory: customDir },
+    });
+    expect(getByText("Studio FLACs")).toBeInTheDocument();
+  });
+
+  it("applies custom color style when specified", () => {
+    const coloredDir: MusicDirectory = {
+      ...baseDirectory,
+      color: "#8b5cf6",
+    };
+    const { container } = render(LibraryBadge, {
+      props: { directory: coloredDir },
+    });
+    const badge = container.querySelector("span");
+    expect(badge).toBeInTheDocument();
+    expect(badge?.getAttribute("style")).toMatch(/139,\s*92,\s*246/);
+  });
+
+  it("shows disconnected state and tooltip when is_available is false", () => {
+    const disconnectedDir: MusicDirectory = {
+      ...baseDirectory,
+      nickname: "External USB",
+      is_available: false,
+    };
+    const { container, getByText } = render(LibraryBadge, {
+      props: { directory: disconnectedDir },
+    });
+    expect(getByText("External USB")).toBeInTheDocument();
+    const badge = container.querySelector("span");
+    expect(badge?.getAttribute("title")).toContain("(Disconnected)");
+  });
+
+  it("supports hiding the text when showName is false", () => {
+    const { queryByText } = render(LibraryBadge, {
+      props: { directory: baseDirectory, showName: false },
+    });
+    expect(queryByText("HighRes")).toBeNull();
+  });
+});

--- a/src/lib/components/PlaylistView.svelte
+++ b/src/lib/components/PlaylistView.svelte
@@ -69,7 +69,7 @@
     genre: "1.2fr", grouping: "1.2fr", bpm: "60px", initial_key: "60px",
     bitrate: "70px", samplerate: "75px", bitdepth: "65px", channels: "70px",
     filesize: "75px", rating: "96px", playcount: "70px", skipcount: "70px",
-    lastplayed: "90px", added: "90px", duration: "80px", path: "2fr", actions: "80px",
+    lastplayed: "90px", added: "90px", duration: "80px", path: "2fr", library: "130px", actions: "80px",
   };
   import {
     COVER_STACK_OFFSET_X_PX,

--- a/src/lib/components/RightPanel.svelte
+++ b/src/lib/components/RightPanel.svelte
@@ -77,7 +77,6 @@
           ? currentSong.musicbrainz_release_type.charAt(0).toUpperCase() + currentSong.musicbrainz_release_type.slice(1)
           : undefined,
       },
-      { label: i18n.t('playerBar.musicbrainzReleaseCountryLabel', {}, 'Country'), value: currentSong.musicbrainz_release_country },
       { label: i18n.t('playerBar.barcodeLabel', {}, 'Barcode'), value: currentSong.barcode },
       { label: i18n.t('playerBar.catalogNumberLabel', {}, 'Catalog #'), value: currentSong.catalog_number },
     ];

--- a/src/lib/components/RightPanel.test.ts
+++ b/src/lib/components/RightPanel.test.ts
@@ -157,21 +157,20 @@ describe("RightPanel.svelte", () => {
     );
   });
 
-  it("shows release type/country/barcode/catalog # as plain text, title-casing the release type", () => {
+  it("shows release type/barcode/catalog # as plain text, title-casing the release type", () => {
     playerStore.currentSong = {
       ...mockSong,
       musicbrainz_release_type: "album",
-      musicbrainz_release_country: "JP",
       barcode: "4988011329586",
       catalog_number: "PHCR-1144",
     };
-    const { getByText, getByAltText } = render(RightPanel);
+    const { getByText, getByAltText, queryByText } = render(RightPanel);
 
     expect(getByAltText("MusicBrainz")).toBeInTheDocument();
     expect(getByText("Album")).toBeInTheDocument();
-    expect(getByText("JP")).toBeInTheDocument();
     expect(getByText("4988011329586")).toBeInTheDocument();
     expect(getByText("PHCR-1144")).toBeInTheDocument();
+    expect(queryByText("Country")).not.toBeInTheDocument();
   });
 
   it("shows the MusicBrainz section for release metadata alone, with no MusicBrainz IDs at all", () => {

--- a/src/lib/components/SettingsFolders.svelte
+++ b/src/lib/components/SettingsFolders.svelte
@@ -5,16 +5,22 @@
   import { onMount } from "svelte";
   import Toggle from "./Toggle.svelte";
   import Button from "./Button.svelte";
+  import LibraryBadge from "./LibraryBadge.svelte";
+  import FolderEditModal from "./FolderEditModal.svelte";
+  import type { MusicDirectory } from "../types";
   import {
     FolderIcon as Folder,
     PlusIcon as Plus,
     TrashIcon as Trash2,
+    PencilSimpleIcon as Edit3,
     ArrowsClockwiseIcon as RefreshCw,
     ArrowCounterClockwiseIcon as RotateCcw,
     ClockIcon as Clock,
     PulseIcon as Activity,
     WarningIcon as AlertTriangle
   } from "phosphor-svelte";
+
+  let editingDirectory = $state<MusicDirectory | null>(null);
 
   onMount(() => {
     loudnessStore.init();
@@ -69,10 +75,13 @@
   <div class="space-y-2">
     {#each collectionStore.directories as dir}
       <div class="flex items-center justify-between bg-brand-main/50 border border-brand-border/60 rounded-xl p-4 hover:border-brand-border transition-colors">
-        <div class="flex items-center gap-3.5 min-w-0">
-          <div class="min-w-0">
-            <p class="text-sm font-medium text-brand-text-primary truncate" title={dir.path}>{dir.path}</p>
-            <p class="text-xs mt-0.5" class:text-brand-text-secondary={dir.is_available !== false} class:text-red-400={dir.is_available === false}>
+        <div class="flex items-center gap-3.5 min-w-0 flex-1">
+          <div class="min-w-0 space-y-1">
+            <div class="flex items-center gap-2.5 min-w-0">
+              <LibraryBadge directory={dir} size="sm" />
+              <p class="text-xs text-brand-text-secondary truncate font-mono" title={dir.path}>{dir.path}</p>
+            </div>
+            <p class="text-xs" class:text-brand-text-secondary={dir.is_available !== false} class:text-red-400={dir.is_available === false}>
               {#if dir.is_available === false}
                 <span class="flex items-center gap-1">
                   <AlertTriangle class="w-3 h-3" />
@@ -86,15 +95,31 @@
             </p>
           </div>
         </div>
-        <button
-          onclick={() => handleRemoveDirectory(dir.path)}
-          class="p-2 rounded-lg bg-brand-main hover:bg-red-950/20 text-brand-text-secondary hover:text-red-400 border border-brand-border hover:border-red-900/30 transition-colors"
-          title={i18n.t('settings.folderItemStopWatch')}
-        >
-          <Trash2 class="w-4 h-4 text-brand-accent-text" />
-        </button>
+        <div class="flex items-center gap-1.5 shrink-0 ml-3">
+          <button
+            onclick={() => { editingDirectory = dir; }}
+            class="p-2 rounded-lg bg-brand-main hover:bg-brand-sidebar text-brand-text-secondary hover:text-brand-text-primary border border-brand-border hover:border-brand-accent/40 transition-colors"
+            title={i18n.t('settings.folderItemEdit', {}, 'Edit folder details')}
+          >
+            <Edit3 class="w-4 h-4" />
+          </button>
+          <button
+            onclick={() => handleRemoveDirectory(dir.path)}
+            class="p-2 rounded-lg bg-brand-main hover:bg-red-950/20 text-brand-text-secondary hover:text-red-400 border border-brand-border hover:border-red-900/30 transition-colors"
+            title={i18n.t('settings.folderItemStopWatch')}
+          >
+            <Trash2 class="w-4 h-4 text-brand-accent-text" />
+          </button>
+        </div>
       </div>
     {/each}
+
+    {#if editingDirectory}
+      <FolderEditModal
+        directory={editingDirectory}
+        onClose={() => { editingDirectory = null; }}
+      />
+    {/if}
 
     {#if collectionStore.directories.length === 0}
       <div class="border border-dashed border-brand-border rounded-xl py-12 text-center text-brand-text-secondary">

--- a/src/lib/components/SongTable.svelte
+++ b/src/lib/components/SongTable.svelte
@@ -38,6 +38,7 @@
   import CoverArt from "./CoverArt.svelte";
   import NowPlayingBars from "./NowPlayingBars.svelte";
   import EmptyState from "./EmptyState.svelte";
+  import LibraryBadge from "./LibraryBadge.svelte";
   import {
     PlayIcon as Play,
     PlusIcon as Plus,
@@ -352,6 +353,7 @@
     added: { i18nKey: "collection.tableHeaderAdded", className: "text-center hover:text-brand-text-primary transition-colors flex items-center justify-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full" },
     duration: { i18nKey: "", className: "flex items-center justify-center hover:text-brand-text-primary transition-colors font-semibold uppercase tracking-wider min-w-0 w-full" },
     path: { i18nKey: "collection.tableHeaderPath", className: "text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full", truncateClass: "max-w-[calc(100%-0.5rem)]" },
+    library: { i18nKey: "collection.tableHeaderLibrary", className: "text-left hover:text-brand-text-primary transition-colors flex items-center gap-1 font-semibold uppercase tracking-wider min-w-0 w-full", truncateClass: "max-w-[calc(100%-0.5rem)]" },
   };
 
   function headerActiveField(col: (typeof SONG_TABLE_COLUMNS)[number]): string {
@@ -564,6 +566,15 @@
   {:else if col.key === "path"}
     <div class="{secondaryColor(song)} truncate pr-4 min-w-0 text-xs font-medium" title={song.path}>
       {song.path || "—"}
+    </div>
+  {:else if col.key === "library"}
+    {@const dir = collectionStore.getDirectoryForPath(song.path)}
+    <div class="truncate pr-2 min-w-0 flex items-center">
+      {#if dir}
+        <LibraryBadge directory={dir} size="xs" />
+      {:else}
+        <span class="{secondaryColor(song)} text-xs font-medium">—</span>
+      {/if}
     </div>
   {:else if col.key === "actions"}
     <div class="flex items-center justify-center gap-2.5">

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -161,6 +161,7 @@ export const en = {
     columnFileSize: "File Size",
     columnAdded: "Date Added",
     columnPath: "File Path",
+    columnLibrary: "Library",
     columnLastPlayed: "Last Played",
     columnActions: "Actions",
     columnTrack: "Track #",
@@ -186,6 +187,7 @@ export const en = {
     tableHeaderFileSize: "Size",
     tableHeaderAdded: "Added",
     tableHeaderPath: "Path",
+    tableHeaderLibrary: "Library",
     tableHeaderLastPlayed: "Last Played",
     noTracksMatchQuery: "No songs match your query:",
     resetSearchFilters: "Reset Search & Filters"
@@ -287,6 +289,15 @@ export const en = {
     folderItemRecursive: "Recursive scanning active",
     folderItemRecursiveWatchOff: "Recursive scanning (real-time watching off)",
     folderItemStopWatch: "Stop watching this folder",
+    folderItemEdit: "Edit folder details",
+    folderItemUnavailable: "Unavailable (Drive disconnected?)",
+    editFolderTitle: "Edit Folder Details",
+    folderNickname: "Nickname",
+    folderNicknamePlaceholder: "e.g. Fast SSD, NAS, Vinyl Rips",
+    folderIcon: "Icon",
+    folderColor: "Badge Colour",
+    folderColorDefault: "Default",
+    folderPreview: "Preview",
     loudnessAnalysisActive: "Loudness Normalization is analyzing {remaining} song(s) in the background — this can look like scanning even when folder watching is off. Disable it in the Equalizer tab to stop.",
     noFoldersTitle: "No Watched Folders",
     noFoldersText: "Click \"Add Folder\" above to add your music directory.",
@@ -887,7 +898,8 @@ export const en = {
     editInfoTooltip: "Edit album info",
     refreshTooltip: "Rescan metadata and artwork for this album",
     refreshSuccess: "Album metadata and artwork refreshed",
-    refreshError: "Failed to refresh album metadata"
+    refreshError: "Failed to refresh album metadata",
+    multiLibraries: "{count} Libraries",
   },
   immersive: {
     emptyStateText: "Select a song from your collection to start playing."

--- a/src/lib/locales/fr.ts
+++ b/src/lib/locales/fr.ts
@@ -161,6 +161,7 @@ export const fr = {
     columnFileSize: "Taille du fichier",
     columnAdded: "Date d'ajout",
     columnPath: "Chemin du fichier",
+    columnLibrary: "Bibliothèque",
     columnLastPlayed: "Dernière lecture",
     columnActions: "Actions",
     columnTrack: "N° piste",
@@ -186,6 +187,7 @@ export const fr = {
     tableHeaderFileSize: "Taille",
     tableHeaderAdded: "Ajouté",
     tableHeaderPath: "Chemin",
+    tableHeaderLibrary: "Bibliothèque",
     tableHeaderLastPlayed: "Dernière lecture",
     noTracksMatchQuery: "Aucune chanson ne correspond à votre recherche :",
     resetSearchFilters: "Réinitialiser la recherche et les filtres"
@@ -287,6 +289,15 @@ export const fr = {
     folderItemRecursive: "Analyse récursive active",
     folderItemRecursiveWatchOff: "Analyse récursive (surveillance en temps réel désactivée)",
     folderItemStopWatch: "Ne plus surveiller ce dossier",
+    folderItemEdit: "Modifier les détails du dossier",
+    folderItemUnavailable: "Indisponible (Disque déconnecté ?)",
+    editFolderTitle: "Modifier les détails du dossier",
+    folderNickname: "Surnom",
+    folderNicknamePlaceholder: "ex. SSD rapide, NAS, Vinyles",
+    folderIcon: "Icône",
+    folderColor: "Couleur du badge",
+    folderColorDefault: "Par défaut",
+    folderPreview: "Aperçu",
     loudnessAnalysisActive: "La normalisation du volume analyse {remaining} chanson(s) en arrière-plan — cela peut ressembler à une analyse même lorsque la surveillance des dossiers est désactivée. Désactivez-la dans l'onglet Égaliseur pour l'arrêter.",
     noFoldersTitle: "Aucun dossier surveillé",
     noFoldersText: "Cliquez sur « Ajouter un dossier » ci-dessus pour ajouter votre répertoire musical.",
@@ -918,7 +929,8 @@ export const fr = {
     editInfoTooltip: "Modifier les infos de l'album",
     refreshTooltip: "Actualiser les métadonnées et la pochette de cet album",
     refreshSuccess: "Métadonnées et pochette de l'album actualisées",
-    refreshError: "Échec de l'actualisation de l'album"
+    refreshError: "Échec de l'actualisation de l'album",
+    multiLibraries: "{count} bibliothèques"
   },
   immersive: {
     emptyStateText: "Sélectionnez une chanson de votre collection pour commencer la lecture."

--- a/src/lib/stores/collection.svelte.ts
+++ b/src/lib/stores/collection.svelte.ts
@@ -51,6 +51,7 @@ export interface VisibleColumns {
   added: boolean;
   duration: boolean;
   lastplayed: boolean;
+  library: boolean;
   playcount: boolean;
   rating: boolean;
   skipcount: boolean;
@@ -167,6 +168,7 @@ class CollectionStore {
         added: false,
         duration: true,
         lastplayed: false,
+        library: false,
         playcount: false,
         rating: true,
         skipcount: false,
@@ -457,6 +459,71 @@ class CollectionStore {
 
   async refreshDirectories() {
     this.directories = await invoke("get_directories");
+  }
+
+  async updateDirectoryMetadata(
+    id: number,
+    metadata: { nickname?: string | null; icon?: string | null; color?: string | null }
+  ) {
+    await invoke("update_directory_metadata", {
+      id,
+      nickname: metadata.nickname ?? null,
+      icon: metadata.icon ?? null,
+      color: metadata.color ?? null,
+    });
+    await this.refreshDirectories();
+  }
+
+  /**
+   * Resolves the watched directory for a given song file path by finding the
+   * longest matching directory root. Normalizes path separators and casing.
+   */
+  getDirectoryForPath(path: string | null | undefined): MusicDirectory | undefined {
+    if (!path) return undefined;
+    const normalized = path.replace(/\\/g, "/").toLowerCase();
+    let bestMatch: MusicDirectory | undefined = undefined;
+    let longestPrefix = 0;
+    for (const dir of this.directories) {
+      const dirNorm = dir.path.replace(/\\/g, "/").toLowerCase();
+      const prefix = dirNorm.endsWith("/") ? dirNorm : dirNorm + "/";
+      if (normalized.startsWith(prefix) || normalized === dirNorm) {
+        if (dir.path.length > longestPrefix) {
+          longestPrefix = dir.path.length;
+          bestMatch = dir;
+        }
+      }
+    }
+    return bestMatch;
+  }
+
+  /**
+   * Resolves all distinct watched directories that contain songs for the specified album name.
+   */
+  getDirectoriesForAlbum(albumName: string | null | undefined): MusicDirectory[] {
+    if (!albumName) return [];
+    const matched = new Map<number, MusicDirectory>();
+    for (const song of this.songs) {
+      if (song.album === albumName && song.path) {
+        const dir = this.getDirectoryForPath(song.path);
+        if (dir) matched.set(dir.id, dir);
+      }
+    }
+    return Array.from(matched.values());
+  }
+
+  /**
+   * Resolves a representative watched directory for an album item, checking
+   * its sample song first, then falling back to an album-name lookup.
+   */
+  getDirectoryForAlbum(album: AlbumItem): MusicDirectory | undefined {
+    if (album.sample_song_id) {
+      const song = this.songs.find((s) => s.id === album.sample_song_id);
+      if (song?.path) {
+        return this.getDirectoryForPath(song.path);
+      }
+    }
+    const dirs = this.getDirectoriesForAlbum(album.album);
+    return dirs[0];
   }
 
   /**

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -206,6 +206,9 @@ export interface MusicDirectory {
   path: string;
   subdirs: boolean;
   is_available?: boolean;
+  nickname?: string | null;
+  icon?: string | null;
+  color?: string | null;
 }
 
 export type ScanPhase = "discovering" | "reading_tags" | "updating" | "done";

--- a/src/lib/utils/songColumns.ts
+++ b/src/lib/utils/songColumns.ts
@@ -37,5 +37,6 @@ export const SONG_TABLE_COLUMNS: { key: keyof VisibleColumns; field?: keyof Song
   { key: "added",        field: "added",          label: "collection.columnAdded" },
   { key: "duration",     field: "length_nanosec", label: "collection.columnDuration" },
   { key: "path",         field: "path",           label: "collection.columnPath" },
-  { key: "actions",      label: "collection.columnActions" },
+  { key: "library",                               label: "collection.columnLibrary" },
+  { key: "actions",                               label: "collection.columnActions" },
 ];


### PR DESCRIPTION
## 📋 Summary
Closes #124

Adds support for customizing watched music folders with user-defined nicknames, curated Phosphor icons, and accent color badges, along with subtle visual library indicators throughout Luminous.

## 🔍 Implementation Notes
- **Database & Schema**: Incremented `CURRENT_SCHEMA_VERSION` to 25. Added `MIGRATION_25` adding `nickname` (TEXT), `icon` (TEXT), and `color` (TEXT) columns to the `directories` table.
- **Backend**: Updated `MusicDirectory` models, directory insertion/listing queries, and added `update_directory_metadata` Tauri command.
- **Components**:
  - `LibraryBadge.svelte`: Reusable glassmorphic pill badge with Phosphor icon mapping, custom tinting via `color-mix`, and disconnected drive warning state.
  - `FolderEditModal.svelte`: Modal providing nickname input, curated Phosphor icon selection (10 icons), preset accent color palette, live badge preview, and save/cancel actions.
- **Library Integration**:
  - **Settings -> Folders**: Added edit button next to watched folders and integrated `FolderEditModal`.
  - **Album Detail Header**: Glassmorphic pill badge in the header metadata row, supporting multi-library albums.
  - **Song Table**: Optional "Library" column toggleable via `ColumnSelector.svelte` (hidden by default).
  - **Album Cards**: Subtle hover-reveal badge on cover art.
  - Player Bar explicitly excluded per design scope to avoid dock clutter.
- **i18n**: Fully translated in English (`en.ts`) and French (`fr.ts`).

## 🧪 Test Plan
- [x] `bun run check` (0 errors, 0 warnings)
- [x] `bun run test:run` (70 test files passed, 608 tests passed, including `LibraryBadge.test.ts`)
- [x] `cargo test --lib` (283 passed, including migration 25 unit tests)
- [x] Manually verified in app: folder customization modal, badge preview, persistence, Settings view, Album cards, and album detail view.

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Base branch is `next` (Milestone 2.0)
