### PR TITLE
feat: support local .lrc sidecar files for lyrics lookup (#155)

### DIFF
--- a/features/lyrics.feature
+++ b/features/lyrics.feature
@@ -8,3 +8,17 @@ Feature: Lyrics View
     And the database already has cached lyrics for this song
     When I open the lyrics panel
     Then the system should display the cached lyrics immediately without making a network request
+
+  Scenario: Loading sidecar .lrc lyrics from disk
+    Given a song is playing with a local audio file
+    And a sidecar .lrc file exists next to the audio file
+    When I open the lyrics panel
+    Then the system should display the sidecar lyrics immediately without making a network request
+
+  Scenario: Sidecar .lrc takes priority over embedded lyrics and online fetch
+    Given a song is playing with a local audio file
+    And the database already has cached lyrics for this song
+    And a sidecar .lrc file exists next to the audio file
+    When I open the lyrics panel
+    Then the system should display the sidecar lyrics immediately without making a network request
+

--- a/src-tauri/src/collection.rs
+++ b/src-tauri/src/collection.rs
@@ -1061,6 +1061,14 @@ pub(crate) fn read_tags(path: &Path) -> Result<Song> {
 
     song.art_embedded = candidate_tags.iter().any(|t| !t.pictures().is_empty());
 
+    // Check for sidecar .lrc lyrics next to the audio file (#155).
+    // Sidecar .lrc files take precedence over embedded tags because they are
+    // typically high-confidence synced lyrics intentionally placed by the user.
+    if let Some(sidecar) = crate::lyrics::read_sidecar_lrc(path, song.title.as_deref(), song.track)
+    {
+        song.lyrics = Some(sidecar);
+    }
+
     Ok(song)
 }
 
@@ -2484,6 +2492,33 @@ mod tests {
         assert_eq!(
             song.art_automatic.unwrap(),
             folder_art_path.to_string_lossy().to_string()
+        );
+
+        let _ = std::fs::remove_dir_all(&temp_dir);
+    }
+
+    #[test]
+    fn test_read_tags_loads_sidecar_lrc() {
+        let temp_dir = std::env::temp_dir().join(format!(
+            "luminous_sidecar_lrc_test_{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let _ = std::fs::create_dir_all(&temp_dir);
+
+        let audio_path = temp_dir.join("track.wav");
+        let lrc_path = temp_dir.join("track.lrc");
+
+        write_test_wav(&audio_path);
+        std::fs::write(&lrc_path, b"[00:05.00] Sidecar lyric line").unwrap();
+
+        let song = read_tags(&audio_path).unwrap();
+
+        assert_eq!(
+            song.lyrics,
+            Some("[00:05.00] Sidecar lyric line".to_string())
         );
 
         let _ = std::fs::remove_dir_all(&temp_dir);

--- a/src-tauri/src/commands/lyrics.rs
+++ b/src-tauri/src/commands/lyrics.rs
@@ -31,6 +31,30 @@ pub async fn save_lyrics(
     lyrics: String,
 ) -> Result<(), String> {
     let conn = state.db.pool.get().map_err(|e| e.to_string())?;
+
+    let (path_str, title, track): (Option<String>, Option<String>, Option<i32>) = conn
+        .query_row(
+            "SELECT path, title, track FROM songs WHERE id = ?1",
+            rusqlite::params![song_id],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .unwrap_or((None, None, None));
+
+    if let Some(ref path_str) = path_str {
+        let audio_path = std::path::Path::new(path_str);
+        if let Some(lrc_path) = crate::lyrics::find_sidecar_lrc(audio_path, title.as_deref(), track)
+        {
+            let clean_lyrics = if lyrics.starts_with("[synced:false]\n") {
+                &lyrics["[synced:false]\n".len()..]
+            } else if lyrics.starts_with("[synced:false]") {
+                &lyrics["[synced:false]".len()..]
+            } else {
+                &lyrics
+            };
+            let _ = std::fs::write(&lrc_path, clean_lyrics);
+        }
+    }
+
     conn.execute(
         "UPDATE songs SET lyrics = ?1 WHERE id = ?2",
         rusqlite::params![lyrics, song_id],

--- a/src-tauri/src/lyrics.rs
+++ b/src-tauri/src/lyrics.rs
@@ -5,6 +5,7 @@
 use anyhow::{anyhow, Result};
 use reqwest::Client;
 use serde::Deserialize;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 /// Deserialized LRCLIB `/api/get` response. `_id` is unused but kept so
@@ -187,6 +188,238 @@ impl LyricsManager {
     }
 }
 
+/// Normalize a filename stem or title string for robust matching:
+/// lowercases and replaces punctuation/separators with whitespace.
+fn normalize_stem(s: &str) -> String {
+    s.chars()
+        .map(|c| {
+            if c.is_alphanumeric() {
+                c.to_ascii_lowercase()
+            } else {
+                ' '
+            }
+        })
+        .collect::<String>()
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn strip_disc_prefix(stem: &str) -> Option<&str> {
+    let bytes = stem.as_bytes();
+    // Check "D-TT " or "D-TT-" or "D.TT " e.g. "1-02 " (len >= 5)
+    if bytes.len() >= 5
+        && bytes[0].is_ascii_digit()
+        && (bytes[1] == b'-' || bytes[1] == b'.')
+        && bytes[2].is_ascii_digit()
+        && bytes[3].is_ascii_digit()
+    {
+        return Some(&stem[2..]);
+    }
+    // Check "DD-TT " e.g. "01-02 " (len >= 6)
+    if bytes.len() >= 6
+        && bytes[0].is_ascii_digit()
+        && bytes[1].is_ascii_digit()
+        && (bytes[2] == b'-' || bytes[2] == b'.')
+        && bytes[3].is_ascii_digit()
+        && bytes[4].is_ascii_digit()
+    {
+        return Some(&stem[3..]);
+    }
+    None
+}
+
+fn extract_track_and_title_from_stem(stem: &str) -> (Option<i32>, Option<String>) {
+    let effective_stem = strip_disc_prefix(stem).unwrap_or(stem);
+    let mut parts = effective_stem.splitn(2, |c: char| c == '-' || c == '_' || c == ' ');
+    if let Some(first) = parts.next() {
+        if let Ok(num) = first.trim().parse::<i32>() {
+            let title = parts.next().map(|t| {
+                t.trim_start_matches(|c: char| c == '-' || c == '_' || c == ' ')
+                    .trim()
+                    .to_string()
+            });
+            return (Some(num), title);
+        }
+    }
+    (None, None)
+}
+
+/// Look for a sidecar `.lrc` file in the same directory as `audio_path`.
+///
+/// Precedence:
+/// 1. Direct match: `<audio_stem>.lrc` and `<audio_stem>.LRC`.
+/// 2. Disc prefix strip: e.g. `1-01 Track.flac` -> `01 - Track.lrc`, `01 Track.lrc`.
+/// 3. Sibling directory scan: matches files in the parent folder ending with `.lrc`/`.LRC`
+///    against track number and/or title (e.g. `Artist - Album - 02 Track.lrc`, `Artist_Album_01_Track.lrc`).
+pub fn find_sidecar_lrc(
+    audio_path: &Path,
+    title: Option<&str>,
+    track: Option<i32>,
+) -> Option<PathBuf> {
+    // 1. Direct match with .lrc or .LRC
+    let direct_lrc = audio_path.with_extension("lrc");
+    if direct_lrc.is_file() {
+        return Some(direct_lrc);
+    }
+    let direct_upper = audio_path.with_extension("LRC");
+    if direct_upper.is_file() {
+        return Some(direct_upper);
+    }
+
+    let parent = audio_path.parent()?;
+    let stem = audio_path.file_stem()?.to_str()?;
+
+    // 2. Try disc-prefix stripped candidates directly if filename starts with disc number
+    // e.g. "1-02 Big Guns" or "1.02 Big Guns" -> track "02", title "Big Guns"
+    let mut candidate_stems: Vec<String> = Vec::new();
+
+    if let Some(stripped) = strip_disc_prefix(stem) {
+        candidate_stems.push(stripped.to_string());
+        let trimmed_leading = stripped
+            .trim_start_matches(|c: char| c == '-' || c == '_' || c == ' ')
+            .trim();
+        if !trimmed_leading.is_empty() {
+            candidate_stems.push(trimmed_leading.to_string());
+        }
+    }
+
+    if let Some(t) = title.filter(|t| !t.trim().is_empty()) {
+        let clean_t = t.trim();
+        candidate_stems.push(clean_t.to_string());
+        if let Some(trk) = track.filter(|&t| t > 0) {
+            candidate_stems.push(format!("{:02} - {}", trk, clean_t));
+            candidate_stems.push(format!("{:02} {}", trk, clean_t));
+            candidate_stems.push(format!("{} - {}", trk, clean_t));
+            candidate_stems.push(format!("{} {}", trk, clean_t));
+        }
+    }
+
+    for cand_stem in &candidate_stems {
+        let p_lrc = parent.join(format!("{cand_stem}.lrc"));
+        if p_lrc.is_file() {
+            return Some(p_lrc);
+        }
+        let p_upper = parent.join(format!("{cand_stem}.LRC"));
+        if p_upper.is_file() {
+            return Some(p_upper);
+        }
+    }
+
+    // 3. Scan sibling files in parent directory for tag-prefixed conventions
+    // (e.g. "Dorothy - Gifts From the Holy Ghost - 02 Big Guns.lrc")
+    let entries = std::fs::read_dir(parent).ok()?;
+    let mut lrc_files: Vec<PathBuf> = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_file() {
+            if let Some(ext) = path.extension().and_then(|e| e.to_str()) {
+                if ext.eq_ignore_ascii_case("lrc") {
+                    lrc_files.push(path);
+                }
+            }
+        }
+    }
+
+    if lrc_files.is_empty() {
+        return None;
+    }
+
+    // Determine target track number and normalized title
+    let (target_track_num, target_title_norm) = match (track, title) {
+        (Some(trk), Some(tit)) if trk > 0 && !tit.trim().is_empty() => {
+            (Some(trk), Some(normalize_stem(tit)))
+        }
+        (Some(trk), _) if trk > 0 => (Some(trk), None),
+        (_, Some(tit)) if !tit.trim().is_empty() => (None, Some(normalize_stem(tit))),
+        _ => {
+            let (extracted_trk, extracted_tit) = extract_track_and_title_from_stem(stem);
+            (extracted_trk, extracted_tit.map(|t| normalize_stem(&t)))
+        }
+    };
+
+    let mut best_match: Option<(u8, PathBuf)> = None;
+
+    for lrc_path in lrc_files {
+        let Some(lrc_stem) = lrc_path.file_stem().and_then(|s| s.to_str()) else {
+            continue;
+        };
+        let lrc_norm = normalize_stem(lrc_stem);
+        let lrc_tokens: Vec<&str> = lrc_norm.split_whitespace().collect();
+
+        let track_matches = target_track_num.map_or(false, |trk| {
+            let trk_2 = format!("{:02}", trk);
+            let trk_1 = format!("{}", trk);
+            lrc_tokens.iter().any(|&tok| tok == trk_2 || tok == trk_1)
+        });
+
+        let title_matches = target_title_norm.as_ref().map_or(false, |norm_title| {
+            if norm_title.is_empty() {
+                return false;
+            }
+            if lrc_norm.contains(norm_title) {
+                return true;
+            }
+            let title_tokens: Vec<&str> = norm_title.split_whitespace().collect();
+            if !title_tokens.is_empty() && title_tokens.iter().all(|&tt| lrc_tokens.contains(&tt)) {
+                return true;
+            }
+            false
+        });
+
+        let is_valid = match (target_track_num.is_some(), target_title_norm.is_some()) {
+            (true, true) => title_matches, // When title is known, title must match; score 3 prefers track match too
+            (false, true) => title_matches,
+            (true, false) => track_matches,
+            (false, false) => false,
+        };
+
+        if !is_valid {
+            continue;
+        }
+
+        let score = match (track_matches, title_matches) {
+            (true, true) => 3,
+            (false, true) => 2,
+            (true, false) => 1,
+            (false, false) => 0,
+        };
+
+        if score > 0 {
+            if let Some((best_score, _)) = best_match {
+                if score > best_score {
+                    best_match = Some((score, lrc_path));
+                }
+            } else {
+                best_match = Some((score, lrc_path));
+            }
+        }
+    }
+
+    best_match.map(|(_, path)| path)
+}
+
+/// Read and return the contents of a sidecar `.lrc` file if one exists next to `audio_path`.
+/// Handles UTF-8 BOM if present, strips trailing/leading whitespace, and ignores empty files.
+/// Synced LRC content is returned as-is; plain text is marked with `[synced:false]\n`.
+pub fn read_sidecar_lrc(
+    audio_path: &Path,
+    title: Option<&str>,
+    track: Option<i32>,
+) -> Option<String> {
+    let lrc_path = find_sidecar_lrc(audio_path, title, track)?;
+    let content = std::fs::read_to_string(&lrc_path).ok()?;
+    let trimmed = content.strip_prefix('\u{feff}').unwrap_or(&content).trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    if is_synced_lrc(trimmed) || trimmed.starts_with("[synced:false]") {
+        Some(trimmed.to_string())
+    } else {
+        Some(format!("[synced:false]\n{trimmed}"))
+    }
+}
+
 /// Resolve lyrics for `song_id`: return cached lyrics immediately when the
 /// cache holds synced (or already-checked-unsynced) text, otherwise query
 /// online providers via `lyrics_manager` and cache the result. Extracted
@@ -202,16 +435,37 @@ pub async fn get_lyrics_for_song(
 ) -> Result<String, String> {
     // 1. Check database cache and instrumental flag
     let conn = db.pool.get().map_err(|e| e.to_string())?;
-    let (cached_lyrics, is_instrumental): (Option<String>, bool) = conn
+    let (path_str, cached_lyrics, is_instrumental, title, track): (
+        Option<String>,
+        Option<String>,
+        bool,
+        Option<String>,
+        Option<i32>,
+    ) = conn
         .query_row(
-            "SELECT lyrics, COALESCE(is_instrumental, 0) FROM songs WHERE id = ?1",
+            "SELECT path, lyrics, COALESCE(is_instrumental, 0), title, track FROM songs WHERE id = ?1",
             rusqlite::params![song_id],
-            |row| Ok((row.get(0)?, row.get(1)?)),
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?, row.get(4)?)),
         )
-        .unwrap_or((None, false));
+        .unwrap_or((None, None, false, None, None));
 
     if is_instrumental {
         return Err("Song is marked as instrumental".to_string());
+    }
+
+    // 2. Check for local sidecar .lrc file next to the audio file (#155)
+    if let Some(ref path_str) = path_str {
+        let audio_path = Path::new(path_str);
+        if let Some(sidecar_lyrics) = read_sidecar_lrc(audio_path, title.as_deref(), track) {
+            // If cached lyrics differ from the sidecar file (or on force refresh), update the database
+            if cached_lyrics.as_deref() != Some(&sidecar_lyrics) {
+                let _ = conn.execute(
+                    "UPDATE songs SET lyrics = ?1 WHERE id = ?2",
+                    rusqlite::params![sidecar_lyrics, song_id],
+                );
+            }
+            return Ok(sidecar_lyrics);
+        }
     }
 
     if let Some(ref lyrics) = cached_lyrics {
@@ -227,7 +481,7 @@ pub async fn get_lyrics_for_song(
         }
     }
 
-    // 2. Fetch metadata from DB to search online
+    // 3. Fetch metadata from DB to search online
     let (artist, title, album, len_ns) = conn
         .query_row(
             "SELECT artist, title, album, length_nanosec FROM songs WHERE id = ?1",
@@ -355,5 +609,131 @@ mod tests {
     fn test_is_synced_lrc() {
         assert!(is_synced_lrc("[00:12.00] Line of lyrics"));
         assert!(!is_synced_lrc("Plain lyrics line without LRC timestamp"));
+    }
+
+    #[test]
+    fn test_normalize_stem() {
+        assert_eq!(
+            normalize_stem("Dorothy - Gifts From the Holy Ghost - 02 Big Guns"),
+            "dorothy gifts from the holy ghost 02 big guns"
+        );
+        assert_eq!(normalize_stem("Inhale_Exhale Air"), "inhale exhale air");
+        assert_eq!(normalize_stem("Inhale+Exhale Air"), "inhale exhale air");
+        assert_eq!(normalize_stem("BEAT UP CHANEL$"), "beat up chanel");
+    }
+
+    #[test]
+    fn test_strip_disc_prefix() {
+        assert_eq!(strip_disc_prefix("1-02 Big Guns"), Some("02 Big Guns"));
+        assert_eq!(strip_disc_prefix("01-05 Loving You"), Some("05 Loving You"));
+        assert_eq!(strip_disc_prefix("1.02 Big Guns"), Some("02 Big Guns"));
+        assert_eq!(strip_disc_prefix("02 Big Guns"), None);
+    }
+
+    #[test]
+    fn test_find_sidecar_lrc_direct_and_uppercase() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let audio_path = temp_dir.path().join("song.flac");
+        let lrc_path = temp_dir.path().join("song.lrc");
+        std::fs::write(&audio_path, b"dummy audio").unwrap();
+        std::fs::write(&lrc_path, b"[00:01.00] test").unwrap();
+
+        assert_eq!(
+            find_sidecar_lrc(&audio_path, None, None),
+            Some(lrc_path.clone())
+        );
+
+        // Case-insensitive / uppercase .LRC
+        std::fs::remove_file(&lrc_path).unwrap();
+        let lrc_upper = temp_dir.path().join("song.LRC");
+        std::fs::write(&lrc_upper, b"[00:01.00] test upper").unwrap();
+        let found = find_sidecar_lrc(&audio_path, None, None);
+        assert!(found.is_some());
+        assert_eq!(
+            found.unwrap().to_string_lossy().to_lowercase(),
+            lrc_upper.to_string_lossy().to_lowercase()
+        );
+    }
+
+    #[test]
+    fn test_find_sidecar_lrc_disc_prefix_and_siblings() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let audio_path = temp_dir.path().join("1-02 Big Guns.flac");
+        let lrc_path = temp_dir
+            .path()
+            .join("Dorothy - Gifts From the Holy Ghost - 02 Big Guns.lrc");
+        std::fs::write(&audio_path, b"dummy audio").unwrap();
+        std::fs::write(&lrc_path, b"[00:07.61] Not gonna play the fool").unwrap();
+
+        // Should find via sibling matching on track (2) and title ("Big Guns")
+        let found = find_sidecar_lrc(&audio_path, Some("Big Guns"), Some(2));
+        assert_eq!(found, Some(lrc_path.clone()));
+
+        // Should also find via extracted stem info when metadata is not provided
+        let found_from_stem = find_sidecar_lrc(&audio_path, None, None);
+        assert_eq!(found_from_stem, Some(lrc_path));
+
+        // Different track should NOT match
+        let other_audio = temp_dir.path().join("1-01 A Beautiful Life.flac");
+        std::fs::write(&other_audio, b"dummy audio").unwrap();
+        let not_found = find_sidecar_lrc(&other_audio, Some("A Beautiful Life"), Some(1));
+        assert_eq!(not_found, None);
+    }
+
+    #[test]
+    fn test_read_sidecar_lrc_content() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let audio_path = temp_dir.path().join("track.mp3");
+        let lrc_path = temp_dir.path().join("track.lrc");
+        std::fs::write(&audio_path, b"dummy").unwrap();
+
+        // Synced LRC with UTF-8 BOM
+        let bom_lrc = format!("\u{feff}[00:15.00] Synced line\n[00:20.00] Next line");
+        std::fs::write(&lrc_path, bom_lrc.as_bytes()).unwrap();
+        let read = read_sidecar_lrc(&audio_path, None, None);
+        assert_eq!(
+            read,
+            Some("[00:15.00] Synced line\n[00:20.00] Next line".to_string())
+        );
+
+        // Plain text LRC (no timestamps) should get [synced:false] prefix
+        std::fs::write(&lrc_path, b"Just plain text lyrics").unwrap();
+        let read_plain = read_sidecar_lrc(&audio_path, None, None);
+        assert_eq!(
+            read_plain,
+            Some("[synced:false]\nJust plain text lyrics".to_string())
+        );
+
+        // Empty file should return None
+        std::fs::write(&lrc_path, b"   \n\t  ").unwrap();
+        assert_eq!(read_sidecar_lrc(&audio_path, None, None), None);
+    }
+
+    #[tokio::test]
+    async fn test_get_lyrics_for_song_sidecar() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db = crate::db::Database::new(temp_dir.path().to_path_buf()).unwrap();
+        let audio_path = temp_dir.path().join("track.flac");
+        let lrc_path = temp_dir.path().join("track.lrc");
+        std::fs::write(&audio_path, b"dummy audio").unwrap();
+        std::fs::write(&lrc_path, b"[00:10.00] Sidecar lyrics line").unwrap();
+
+        let conn = db.pool.get().unwrap();
+        conn.execute(
+            "INSERT INTO songs (id, title, artist, path, source, filetype, unavailable)
+             VALUES (1, 'Track', 'Artist', ?1, 1, 1, 0)",
+            rusqlite::params![audio_path.to_str().unwrap()],
+        )
+        .unwrap();
+
+        let lyrics_manager = LyricsManager::new();
+        let result = get_lyrics_for_song(&db, &lyrics_manager, 1, false).await;
+        assert_eq!(result, Ok("[00:10.00] Sidecar lyrics line".to_string()));
+
+        // Check DB was updated with sidecar lyrics
+        let cached: Option<String> = conn
+            .query_row("SELECT lyrics FROM songs WHERE id = 1", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(cached, Some("[00:10.00] Sidecar lyrics line".to_string()));
     }
 }

--- a/src-tauri/tests/lyrics_bdd.rs
+++ b/src-tauri/tests/lyrics_bdd.rs
@@ -13,6 +13,8 @@ pub struct LyricsWorld {
     title: String,
     cached_lyrics: Option<String>,
     displayed_lyrics: Option<String>,
+    audio_path: Option<std::path::PathBuf>,
+    expected_sidecar_lyrics: Option<String>,
     /// Derived from how long the real `get_lyrics_for_song` call took — see
     /// `open_lyrics_panel` for why elapsed time is a reliable proxy for
     /// "did this reach the network".
@@ -31,6 +33,8 @@ impl Default for LyricsWorld {
             title: String::new(),
             cached_lyrics: None,
             displayed_lyrics: None,
+            audio_path: None,
+            expected_sidecar_lyrics: None,
             network_call_made: false,
         }
     }
@@ -43,16 +47,54 @@ fn song_is_playing(w: &mut LyricsWorld) {
     w.artist = "Coldplay".to_string();
 }
 
+#[given("a song is playing with a local audio file")]
+fn song_playing_local_audio(w: &mut LyricsWorld) {
+    w.song_id = 2;
+    w.title = "Big Guns".to_string();
+    w.artist = "Dorothy".to_string();
+
+    let audio_file = w._temp_dir.path().join("1-02 Big Guns.flac");
+    std::fs::write(&audio_file, b"dummy flac content").expect("failed to write audio file");
+    w.audio_path = Some(audio_file.clone());
+
+    let conn = w.db.pool.get().expect("db conn failed");
+    conn.execute(
+        "INSERT OR REPLACE INTO songs (id, title, artist, path, source, filetype, unavailable, track)
+         VALUES (?1, ?2, ?3, ?4, 1, 1, 0, 2)",
+        rusqlite::params![w.song_id, w.title, w.artist, audio_file.to_str().unwrap()],
+    )
+    .unwrap();
+}
+
+#[given("a sidecar .lrc file exists next to the audio file")]
+fn sidecar_lrc_exists(w: &mut LyricsWorld) {
+    let sidecar_file = w
+        ._temp_dir
+        .path()
+        .join("Dorothy - Gifts From the Holy Ghost - 02 Big Guns.lrc");
+    let lyrics = "[00:07.61] Not gonna play the fool, big boss (when you kiss me)\n[00:11.40] Not gonna be the sad wife, babe (like the '50s)";
+    std::fs::write(&sidecar_file, lyrics.as_bytes()).expect("failed to write sidecar lrc");
+    w.expected_sidecar_lyrics = Some(lyrics.to_string());
+}
+
 #[given("the database already has cached lyrics for this song")]
 fn db_has_cached_lyrics(w: &mut LyricsWorld) {
     let lyrics = "[00:12.00] Look at the stars\n[00:18.00] Look how they shine for you";
     let conn = w.db.pool.get().expect("db conn failed");
-    conn.execute(
-        "INSERT OR REPLACE INTO songs (id, title, artist, lyrics, source, filetype, unavailable)
-         VALUES (?1, ?2, ?3, ?4, 1, 1, 0)",
-        rusqlite::params![w.song_id, w.title, w.artist, lyrics],
-    )
-    .unwrap();
+    if let Some(ref _audio_path) = w.audio_path {
+        conn.execute(
+            "UPDATE songs SET lyrics = ?1 WHERE id = ?2",
+            rusqlite::params![lyrics, w.song_id],
+        )
+        .unwrap();
+    } else {
+        conn.execute(
+            "INSERT OR REPLACE INTO songs (id, title, artist, lyrics, source, filetype, unavailable)
+             VALUES (?1, ?2, ?3, ?4, 1, 1, 0)",
+            rusqlite::params![w.song_id, w.title, w.artist, lyrics],
+        )
+        .unwrap();
+    }
     w.cached_lyrics = Some(lyrics.to_string());
 }
 
@@ -82,6 +124,12 @@ async fn open_lyrics_panel(w: &mut LyricsWorld) {
 #[then("the system should display the cached lyrics immediately without making a network request")]
 fn check_cached_displayed(w: &mut LyricsWorld) {
     assert!(w.displayed_lyrics.is_some());
+    assert!(!w.network_call_made, "Network call was made unexpectedly");
+}
+
+#[then("the system should display the sidecar lyrics immediately without making a network request")]
+fn check_sidecar_displayed(w: &mut LyricsWorld) {
+    assert_eq!(w.displayed_lyrics, w.expected_sidecar_lyrics);
     assert!(!w.network_call_made, "Network call was made unexpectedly");
 }
 


### PR DESCRIPTION
## 📋 Summary
Closes #155. Adds support for discovering, loading, and prioritizing local `.lrc` sidecar files located next to audio files in the music library, preventing redundant online API requests while preserving existing embedded-tag and online fallbacks.

## 🔍 Implementation Notes
- **Multi-tier discovery cascade (`src-tauri/src/lyrics.rs`)**: Implemented `find_sidecar_lrc` which resolves: (1) direct matches (`<stem>.lrc` and `<stem>.LRC`), (2) disc-prefix stripped matches (e.g. `1-01 Track.flac` matching `01 - Track.lrc` or `Track.lrc`), and (3) directory sibling scans matching on track number and title tokens. This reliably detects common real-world tagger patterns (such as `Dorothy - Gifts From the Holy Ghost - 02 Big Guns.lrc` for `1-02 Big Guns.flac`, `Shania Twain - Queen of Me - 06 - Inhale+Exhale Air.lrc` for `1-06 Inhale_Exhale Air.flac`, or `Wilson Phillips_Wilson Phillips_01_Hold On.lrc` for `1-01 Hold On.flac`).
- **Reading & formatting (`src-tauri/src/lyrics.rs`)**: Implemented `read_sidecar_lrc` to strip UTF-8 BOM (`\u{feff}`), trim whitespace, and preserve timestamped lyrics while prefixing non-synced plain text with `[synced:false]\n` to prevent false timestamp parsing.
- **Immediate resolution & cache bypass (`src-tauri/src/lyrics.rs`)**: Updated `get_lyrics_for_song` to check for local sidecars before querying online providers. When present, updates `songs.lyrics` in SQLite if different and returns immediately, short-circuiting network lookups.
- **Library scanner integration (`src-tauri/src/collection.rs`)**: Updated `read_tags` to populate `song.lyrics` with sidecar lyrics upon file ingestion, prioritizing them over embedded tags (`ItemKey::Lyrics`).
- **Save synchronization (`src-tauri/src/commands/lyrics.rs`)**: In `save_lyrics`, if a sidecar `.lrc` file exists on disk, user edits saved from the Lyrics view are written back to the `.lrc` file as well as SQLite.

## 🧪 Test Plan
- [x] `bun run check` (svelte-check + knip clean)
- [x] `bun run test -- --run` (71 test files, 613 tests passed)
- [x] `cargo test` (all unit and BDD suites passed)
- [x] `cargo test --test lyrics_bdd` (3 scenarios passed covering cached, sidecar, and priority logic)
- [x] `cargo test --lib lyrics` (8 unit tests covering matching, BOM stripping, formatting, and DB updating)
- [x] Manually verified in the app: loaded sidecar lyrics from `Dorothy - Gifts From the Holy Ghost - 02 Big Guns.lrc`, edited lyrics in Luminous, and verified the changes saved to disk.

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed
