### PR TITLE
fix: enable context menu and unpin on Pinned row cards (#784)

### DIFF
--- a/src/lib/components/ArtistCard.svelte
+++ b/src/lib/components/ArtistCard.svelte
@@ -13,6 +13,7 @@
     artistSongs?: Song[];
     fullAlbumCount?: number;
     onclick?: (e: MouseEvent) => void;
+    oncontextmenu?: (e: MouseEvent) => void;
   }
 
   let {
@@ -21,6 +22,7 @@
     artistSongs = [],
     fullAlbumCount: _fullAlbumCount,
     onclick: customClick,
+    oncontextmenu: customContextMenu,
   }: Props = $props();
 
   let covers = $derived(getArtistCoverStack(artistAlbums, artistSongs));
@@ -54,6 +56,7 @@
   role="button"
   tabindex="0"
   onclick={(e) => customClick?.(e)}
+  oncontextmenu={(e) => customContextMenu?.(e)}
   onkeydown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); customClick?.(e as unknown as MouseEvent); } }}
   class="artist-card group bg-brand-sidebar border border-brand-border/60 rounded-xl p-4 flex flex-col items-start text-left outline-2 -outline-offset-2 outline-transparent hover:outline-brand-accent transition-[outline-color,border-color] duration-200 select-none"
 >

--- a/src/lib/components/ArtistContextMenu.svelte
+++ b/src/lib/components/ArtistContextMenu.svelte
@@ -1,0 +1,79 @@
+<script lang="ts">
+  import {
+    PlayIcon as Play,
+    StackIcon as Layers,
+    PushPinIcon as Pin,
+    PushPinSlashIcon as PinOff
+  } from "phosphor-svelte";
+  import { i18n } from "../stores/i18n.svelte";
+  import { pinnedStore } from "../stores/pinned.svelte";
+  import { queueArtistAsPlaylist, addArtistToQueue } from "../utils/playlist";
+  import ContextMenu from "./ContextMenu.svelte";
+  import ContextMenuItem from "./ContextMenuItem.svelte";
+  import ContextMenuDivider from "./ContextMenuDivider.svelte";
+
+  interface Props {
+    x: number;
+    y: number;
+    artistName: string;
+    onPlay?: () => void;
+    onAddToQueue?: () => void;
+    onClose: () => void;
+  }
+
+  let {
+    x,
+    y,
+    artistName,
+    onPlay,
+    onAddToQueue,
+    onClose,
+  }: Props = $props();
+</script>
+
+<ContextMenu {x} {y} {onClose} estimatedHeight={180}>
+  <div class="px-3 py-1 text-[11px] font-bold text-brand-text-primary border-b border-brand-border/40 mb-1 truncate">
+    {artistName || i18n.t("collection.unknownArtist")}
+  </div>
+
+  <ContextMenuItem
+    icon={Play}
+    accent
+    label={i18n.t("playlists.contextMenuPlayArtist", {}, "Play Artist")}
+    onclick={async () => {
+      if (onPlay) {
+        onPlay();
+      } else {
+        await queueArtistAsPlaylist(artistName);
+      }
+      onClose();
+    }}
+  />
+
+  <ContextMenuItem
+    icon={Layers}
+    label={i18n.t("playlists.contextMenuAddQueue", {}, "Add to Queue")}
+    onclick={async () => {
+      if (onAddToQueue) {
+        onAddToQueue();
+      } else {
+        await addArtistToQueue(artistName);
+      }
+      onClose();
+    }}
+  />
+
+  {#if artistName}
+    <ContextMenuDivider />
+    <ContextMenuItem
+      icon={pinnedStore.isPinned("artist", artistName) ? PinOff : Pin}
+      label={pinnedStore.isPinned("artist", artistName)
+        ? i18n.t("playlists.contextMenuUnpinHome")
+        : i18n.t("playlists.contextMenuPinHome")}
+      onclick={() => {
+        pinnedStore.toggle("artist", artistName);
+        onClose();
+      }}
+    />
+  {/if}
+</ContextMenu>

--- a/src/lib/components/ArtistContextMenu.test.ts
+++ b/src/lib/components/ArtistContextMenu.test.ts
@@ -1,0 +1,85 @@
+import "@testing-library/jest-dom";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, fireEvent } from "@testing-library/svelte";
+import ArtistContextMenu from "./ArtistContextMenu.svelte";
+import { pinnedStore } from "../stores/pinned.svelte";
+
+describe("ArtistContextMenu.svelte", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders artist name header and actions", () => {
+    const { getByText } = render(ArtistContextMenu, {
+      props: {
+        x: 100,
+        y: 100,
+        artistName: "Radiohead",
+        onClose: vi.fn(),
+      },
+    });
+
+    expect(getByText("Radiohead")).toBeInTheDocument();
+    expect(getByText("Play Artist")).toBeInTheDocument();
+    expect(getByText("Add to Queue")).toBeInTheDocument();
+    expect(getByText("Pin to Home")).toBeInTheDocument();
+  });
+
+  it("calls onPlay and onClose when Play Artist is clicked", async () => {
+    const onPlay = vi.fn();
+    const onClose = vi.fn();
+    const { getByText } = render(ArtistContextMenu, {
+      props: {
+        x: 100,
+        y: 100,
+        artistName: "Radiohead",
+        onPlay,
+        onClose,
+      },
+    });
+
+    await fireEvent.click(getByText("Play Artist"));
+    expect(onPlay).toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("calls onAddToQueue and onClose when Add to Queue is clicked", async () => {
+    const onAddToQueue = vi.fn();
+    const onClose = vi.fn();
+    const { getByText } = render(ArtistContextMenu, {
+      props: {
+        x: 100,
+        y: 100,
+        artistName: "Radiohead",
+        onAddToQueue,
+        onClose,
+      },
+    });
+
+    await fireEvent.click(getByText("Add to Queue"));
+    expect(onAddToQueue).toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("shows Unpin from Home when already pinned and calls pinnedStore.toggle", async () => {
+    vi.spyOn(pinnedStore, "isPinned").mockReturnValue(true);
+    const toggleSpy = vi.spyOn(pinnedStore, "toggle").mockResolvedValue();
+    const onClose = vi.fn();
+
+    const { getByText } = render(ArtistContextMenu, {
+      props: {
+        x: 100,
+        y: 100,
+        artistName: "Radiohead",
+        onClose,
+      },
+    });
+
+    const unpinBtn = getByText("Unpin from Home");
+    expect(unpinBtn).toBeInTheDocument();
+
+    await fireEvent.click(unpinBtn);
+    expect(toggleSpy).toHaveBeenCalledWith("artist", "Radiohead");
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/src/lib/components/AutoPlaylistCard.svelte
+++ b/src/lib/components/AutoPlaylistCard.svelte
@@ -37,10 +37,26 @@
     updated?: number;
     trackCount: number;
     onClick: () => void;
+    oncontextmenu?: (e: MouseEvent) => void;
+    onContextMenu?: (e: MouseEvent) => void;
     widthClass?: string;
   }
 
-  let { label, kind, genre, artistTag, decade, bpm, playlistId, updated, trackCount, onClick, widthClass = "w-full" }: Props = $props();
+  let {
+    label,
+    kind,
+    genre,
+    artistTag,
+    decade,
+    bpm,
+    playlistId,
+    updated,
+    trackCount,
+    onClick,
+    oncontextmenu,
+    onContextMenu,
+    widthClass = "w-full",
+  }: Props = $props();
 
   let displayLabel = $derived.by(() => {
     if (
@@ -146,6 +162,7 @@
 <!-- svelte-ignore a11y_click_events_have_key_events -->
 <div
   onclick={onClick}
+  oncontextmenu={(e) => { (oncontextmenu || onContextMenu)?.(e); }}
   class="{widthClass} bg-brand-sidebar border border-brand-border/60 rounded-xl p-4 flex flex-col text-left hover:border-brand-accent/40 transition-all duration-200 group"
 >
   <div class="aspect-square w-full mb-3 bg-brand-main relative flex items-center justify-center">

--- a/src/lib/components/AutoPlaylistContextMenu.svelte
+++ b/src/lib/components/AutoPlaylistContextMenu.svelte
@@ -1,0 +1,84 @@
+<script lang="ts">
+  import {
+    PlayIcon as Play,
+    StackIcon as Layers,
+    PushPinIcon as Pin,
+    PushPinSlashIcon as PinOff
+  } from "phosphor-svelte";
+  import { i18n } from "../stores/i18n.svelte";
+  import { pinnedStore } from "../stores/pinned.svelte";
+  import type { AutoPlaylistItem } from "../types";
+  import { autoPlaylistRefKeyFor } from "../types";
+  import { queueAutoPlaylistAsPlaylist, addAutoPlaylistToQueue } from "../utils/playlist";
+  import ContextMenu from "./ContextMenu.svelte";
+  import ContextMenuItem from "./ContextMenuItem.svelte";
+  import ContextMenuDivider from "./ContextMenuDivider.svelte";
+
+  interface Props {
+    x: number;
+    y: number;
+    autoPlaylist: AutoPlaylistItem;
+    label: string;
+    onPlay?: () => void;
+    onAddToQueue?: () => void;
+    onClose: () => void;
+  }
+
+  let {
+    x,
+    y,
+    autoPlaylist,
+    label,
+    onPlay,
+    onAddToQueue,
+    onClose,
+  }: Props = $props();
+
+  let refKey = $derived(autoPlaylistRefKeyFor(autoPlaylist));
+</script>
+
+<ContextMenu {x} {y} {onClose} estimatedHeight={180}>
+  <div class="px-3 py-1 text-[11px] font-bold text-brand-text-primary border-b border-brand-border/40 mb-1 truncate">
+    {label}
+  </div>
+
+  <ContextMenuItem
+    icon={Play}
+    accent
+    label={i18n.t("playlists.contextMenuPlayPlaylist", {}, "Play Playlist")}
+    onclick={async () => {
+      if (onPlay) {
+        onPlay();
+      } else {
+        await queueAutoPlaylistAsPlaylist(autoPlaylist, label);
+      }
+      onClose();
+    }}
+  />
+
+  <ContextMenuItem
+    icon={Layers}
+    label={i18n.t("playlists.contextMenuAddQueue", {}, "Add to Queue")}
+    onclick={async () => {
+      if (onAddToQueue) {
+        onAddToQueue();
+      } else {
+        await addAutoPlaylistToQueue(autoPlaylist, label);
+      }
+      onClose();
+    }}
+  />
+
+  <ContextMenuDivider />
+
+  <ContextMenuItem
+    icon={pinnedStore.isPinned("auto_playlist", refKey) ? PinOff : Pin}
+    label={pinnedStore.isPinned("auto_playlist", refKey)
+      ? i18n.t("playlists.contextMenuUnpinHome")
+      : i18n.t("playlists.contextMenuPinHome")}
+    onclick={() => {
+      pinnedStore.toggle("auto_playlist", refKey);
+      onClose();
+    }}
+  />
+</ContextMenu>

--- a/src/lib/components/AutoPlaylistContextMenu.test.ts
+++ b/src/lib/components/AutoPlaylistContextMenu.test.ts
@@ -1,0 +1,95 @@
+import "@testing-library/jest-dom";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, fireEvent } from "@testing-library/svelte";
+import AutoPlaylistContextMenu from "./AutoPlaylistContextMenu.svelte";
+import { pinnedStore } from "../stores/pinned.svelte";
+import type { AutoPlaylistItem } from "../types";
+
+describe("AutoPlaylistContextMenu.svelte", () => {
+  const mockAutoPlaylist: AutoPlaylistItem = {
+    kind: "favourites",
+    trackCount: 25,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders auto-playlist label and actions", () => {
+    const { getByText } = render(AutoPlaylistContextMenu, {
+      props: {
+        x: 100,
+        y: 100,
+        autoPlaylist: mockAutoPlaylist,
+        label: "Favourites",
+        onClose: vi.fn(),
+      },
+    });
+
+    expect(getByText("Favourites")).toBeInTheDocument();
+    expect(getByText("Play Playlist")).toBeInTheDocument();
+    expect(getByText("Add to Queue")).toBeInTheDocument();
+    expect(getByText("Pin to Home")).toBeInTheDocument();
+  });
+
+  it("calls onPlay and onClose when Play Playlist is clicked", async () => {
+    const onPlay = vi.fn();
+    const onClose = vi.fn();
+    const { getByText } = render(AutoPlaylistContextMenu, {
+      props: {
+        x: 100,
+        y: 100,
+        autoPlaylist: mockAutoPlaylist,
+        label: "Favourites",
+        onPlay,
+        onClose,
+      },
+    });
+
+    await fireEvent.click(getByText("Play Playlist"));
+    expect(onPlay).toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("calls onAddToQueue and onClose when Add to Queue is clicked", async () => {
+    const onAddToQueue = vi.fn();
+    const onClose = vi.fn();
+    const { getByText } = render(AutoPlaylistContextMenu, {
+      props: {
+        x: 100,
+        y: 100,
+        autoPlaylist: mockAutoPlaylist,
+        label: "Favourites",
+        onAddToQueue,
+        onClose,
+      },
+    });
+
+    await fireEvent.click(getByText("Add to Queue"));
+    expect(onAddToQueue).toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("shows Unpin from Home when already pinned and calls pinnedStore.toggle", async () => {
+    vi.spyOn(pinnedStore, "isPinned").mockReturnValue(true);
+    const toggleSpy = vi.spyOn(pinnedStore, "toggle").mockResolvedValue();
+    const onClose = vi.fn();
+
+    const { getByText } = render(AutoPlaylistContextMenu, {
+      props: {
+        x: 100,
+        y: 100,
+        autoPlaylist: mockAutoPlaylist,
+        label: "Favourites",
+        onClose,
+      },
+    });
+
+    const unpinBtn = getByText("Unpin from Home");
+    expect(unpinBtn).toBeInTheDocument();
+
+    await fireEvent.click(unpinBtn);
+    expect(toggleSpy).toHaveBeenCalledWith("auto_playlist", "favourites");
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/src/lib/components/PinnedRow.svelte
+++ b/src/lib/components/PinnedRow.svelte
@@ -7,7 +7,13 @@
   import { navigationStore } from "../stores/navigation.svelte";
   import { i18n } from "../stores/i18n.svelte";
   import { getArtistAlbums, getArtistSongs } from "../utils/artist";
-  import { getPlaylistDisplayName } from "../utils/playlist";
+  import {
+    getPlaylistDisplayName,
+    queueAlbumAsPlaylist,
+    queueArtistAsPlaylist,
+    queuePlaylistAsPlaylist,
+    queueAutoPlaylistAsPlaylist
+  } from "../utils/playlist";
   import { collectionStore } from "../stores/collection.svelte";
   import HorizontalScrollRow from "./HorizontalScrollRow.svelte";
   import AlbumCard from "./AlbumCard.svelte";
@@ -15,6 +21,11 @@
   import PlaylistCard from "./PlaylistCard.svelte";
   import AutoPlaylistCard from "./AutoPlaylistCard.svelte";
   import PinnedSongCard from "./PinnedSongCard.svelte";
+  import AlbumContextMenu from "./AlbumContextMenu.svelte";
+  import SongContextMenu from "./SongContextMenu.svelte";
+  import ArtistContextMenu from "./ArtistContextMenu.svelte";
+  import PlaylistCardContextMenu from "./PlaylistCardContextMenu.svelte";
+  import AutoPlaylistContextMenu from "./AutoPlaylistContextMenu.svelte";
 
   function keyFor(item: PinnedItem): string {
     return `${item.type}:${pinnedRefKeyFor(item)}`;
@@ -152,6 +163,14 @@
     pointerDragPointerId = null;
     pointerDragEl = null;
   }
+
+  let contextMenuState = $state<{ x: number; y: number; item: PinnedItem } | null>(null);
+
+  function handleContextMenu(e: MouseEvent, item: PinnedItem) {
+    e.preventDefault();
+    e.stopPropagation();
+    contextMenuState = { x: e.clientX, y: e.clientY, item };
+  }
 </script>
 
 {#if pinnedStore.items.length > 0}
@@ -161,20 +180,30 @@
       <div
         data-pinned-index={index}
         onpointerdown={(e) => handleCardPointerDown(e, index)}
+        oncontextmenu={(e) => handleContextMenu(e, item)}
         ondragstart={(e) => e.preventDefault()}
         class="relative w-44 shrink-0 snap-start transition-opacity rounded-xl cursor-grab active:cursor-grabbing {draggedIndex === index ? 'opacity-40' : ''}"
       >
         {#if item.type === "album"}
-          <AlbumCard album={item.album} onclick={() => openItem(item)} />
+          <AlbumCard
+            album={item.album}
+            onclick={() => openItem(item)}
+            oncontextmenu={(e) => handleContextMenu(e, item)}
+          />
         {:else if item.type === "artist"}
           <ArtistCard
             artist={item.artist}
             artistAlbums={getArtistAlbums(collectionStore.albums, item.artist.name)}
             artistSongs={getArtistSongs(collectionStore.songs, item.artist.name)}
             onclick={() => openItem(item)}
+            oncontextmenu={(e) => handleContextMenu(e, item)}
           />
         {:else if item.type === "playlist"}
-          <PlaylistCard playlist={item.playlist} onClick={() => openItem(item)} />
+          <PlaylistCard
+            playlist={item.playlist}
+            onClick={() => openItem(item)}
+            oncontextmenu={(e) => handleContextMenu(e, item)}
+          />
         {:else if item.type === "auto_playlist"}
           <AutoPlaylistCard
             label={autoPlaylistLabel(item.autoPlaylist)}
@@ -187,9 +216,14 @@
             updated={item.autoPlaylist.updated}
             trackCount={item.autoPlaylist.trackCount}
             onClick={() => openItem(item)}
+            oncontextmenu={(e) => handleContextMenu(e, item)}
           />
         {:else}
-          <PinnedSongCard song={item.song} onclick={() => openItem(item)} />
+          <PinnedSongCard
+            song={item.song}
+            onclick={() => openItem(item)}
+            oncontextmenu={(e) => handleContextMenu(e, item)}
+          />
         {/if}
         {#if dragOverIndex === index && draggedIndex !== null && draggedIndex !== index}
           <div class="absolute inset-0 bg-brand-accent/30 rounded-xl pointer-events-none"></div>
@@ -197,4 +231,54 @@
       </div>
     {/each}
   </HorizontalScrollRow>
+{/if}
+
+{#if contextMenuState}
+  {@const item = contextMenuState.item}
+  {#if item.type === "album"}
+    <AlbumContextMenu
+      x={contextMenuState.x}
+      y={contextMenuState.y}
+      albumName={item.album.album || ""}
+      artistName={item.album.artist || undefined}
+      onPlay={() => queueAlbumAsPlaylist(item.album)}
+      onGoToArtist={item.album.artist ? () => navigationStore.viewArtist(item.album.artist!) : undefined}
+      onClose={() => { contextMenuState = null; }}
+    />
+  {:else if item.type === "song"}
+    <SongContextMenu
+      x={contextMenuState.x}
+      y={contextMenuState.y}
+      song={item.song}
+      onPlay={() => playerStore.playSong(item.song.id)}
+      onGoToArtist={item.song.artist ? () => navigationStore.viewArtist(item.song.album_artist?.trim() || item.song.artist || "") : undefined}
+      onGoToAlbum={item.song.album ? () => navigationStore.viewAlbum(item.song.album || "") : undefined}
+      onClose={() => { contextMenuState = null; }}
+    />
+  {:else if item.type === "artist"}
+    <ArtistContextMenu
+      x={contextMenuState.x}
+      y={contextMenuState.y}
+      artistName={item.artist.name || ""}
+      onPlay={() => queueArtistAsPlaylist(item.artist.name || "")}
+      onClose={() => { contextMenuState = null; }}
+    />
+  {:else if item.type === "playlist"}
+    <PlaylistCardContextMenu
+      x={contextMenuState.x}
+      y={contextMenuState.y}
+      playlist={item.playlist}
+      onPlay={() => queuePlaylistAsPlaylist(item.playlist)}
+      onClose={() => { contextMenuState = null; }}
+    />
+  {:else if item.type === "auto_playlist"}
+    <AutoPlaylistContextMenu
+      x={contextMenuState.x}
+      y={contextMenuState.y}
+      autoPlaylist={item.autoPlaylist}
+      label={autoPlaylistLabel(item.autoPlaylist)}
+      onPlay={() => queueAutoPlaylistAsPlaylist(item.autoPlaylist, autoPlaylistLabel(item.autoPlaylist))}
+      onClose={() => { contextMenuState = null; }}
+    />
+  {/if}
 {/if}

--- a/src/lib/components/PinnedRow.test.ts
+++ b/src/lib/components/PinnedRow.test.ts
@@ -1,0 +1,157 @@
+import "@testing-library/jest-dom";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, fireEvent, screen } from "@testing-library/svelte";
+import PinnedRow from "./PinnedRow.svelte";
+import { pinnedStore } from "../stores/pinned.svelte";
+import type { PinnedItem, Song, AlbumItem, ArtistItem, Playlist, AutoPlaylistItem } from "../types";
+
+describe("PinnedRow.svelte", () => {
+  const mockSong: Song = {
+    id: 101,
+    source: "local_file",
+    filetype: "FLAC",
+    title: "Paranoid Android",
+    artist: "Radiohead",
+    album: "OK Computer",
+    art_embedded: false,
+    art_unset: false,
+    compilation: false,
+    beginning_nanosec: 0,
+    end_nanosec: 0,
+    rating: 5,
+    playcount: 42,
+    skipcount: 1,
+    length_nanosec: 387_000_000_000,
+    added: 1_700_000_000,
+    year: 1997,
+    unavailable: false,
+  };
+
+  const mockAlbum: AlbumItem = {
+    album: "OK Computer",
+    artist: "Radiohead",
+    year: 1997,
+    track_count: 12,
+    disc_count: 1,
+    art_embedded: false,
+    art_automatic: null,
+    art_manual: null,
+    genre: "Alternative",
+    rating: 5,
+    total_duration_nanosec: 0,
+  };
+
+  const mockArtist: ArtistItem = {
+    name: "Portishead",
+    album_count: 3,
+    song_count: 30,
+    genre: "Trip Hop",
+  };
+
+  const mockPlaylist: Playlist = {
+    id: 42,
+    name: "My Best Songs",
+    dynamic_enabled: false,
+    is_queue: false,
+    created: 0,
+    updated: 0,
+    track_count: 15,
+  };
+
+  const mockAutoPlaylist: AutoPlaylistItem = {
+    kind: "favourites",
+    trackCount: 20,
+  };
+
+  const allItems: PinnedItem[] = [
+    { type: "album", album: mockAlbum },
+    { type: "song", song: mockSong },
+    { type: "artist", artist: mockArtist },
+    { type: "playlist", playlist: mockPlaylist },
+    { type: "auto_playlist", autoPlaylist: mockAutoPlaylist },
+  ];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    pinnedStore.items = [...allItems];
+  });
+
+  it("renders pinned cards when items exist", () => {
+    const { getByText } = render(PinnedRow);
+
+    expect(getByText("OK Computer")).toBeInTheDocument();
+    expect(getByText("Paranoid Android")).toBeInTheDocument();
+    expect(getByText("Portishead")).toBeInTheDocument();
+    expect(getByText("My Best Songs")).toBeInTheDocument();
+    expect(getByText("Favourite Songs")).toBeInTheDocument();
+  });
+
+  it("opens AlbumContextMenu on right-click on album card", async () => {
+    vi.spyOn(pinnedStore, "isPinned").mockReturnValue(true);
+    const { getByText } = render(PinnedRow);
+
+    const albumEl = getByText("OK Computer");
+    await fireEvent.contextMenu(albumEl);
+
+    expect(await screen.findByText("Play Album")).toBeInTheDocument();
+    expect(await screen.findByText("Unpin from Home")).toBeInTheDocument();
+  });
+
+  it("opens SongContextMenu on right-click on song card", async () => {
+    vi.spyOn(pinnedStore, "isPinned").mockReturnValue(true);
+    const { getByText } = render(PinnedRow);
+
+    const songEl = getByText("Paranoid Android");
+    await fireEvent.contextMenu(songEl);
+
+    expect(await screen.findByText("Play Song")).toBeInTheDocument();
+    expect(await screen.findByText("Unpin from Home")).toBeInTheDocument();
+  });
+
+  it("opens ArtistContextMenu on right-click on artist card", async () => {
+    vi.spyOn(pinnedStore, "isPinned").mockReturnValue(true);
+    const { getByText } = render(PinnedRow);
+
+    const artistEl = getByText("Portishead");
+    await fireEvent.contextMenu(artistEl);
+
+    expect(await screen.findByText("Play Artist")).toBeInTheDocument();
+    expect(await screen.findByText("Unpin from Home")).toBeInTheDocument();
+  });
+
+  it("opens PlaylistCardContextMenu on right-click on playlist card", async () => {
+    vi.spyOn(pinnedStore, "isPinned").mockReturnValue(true);
+    const { getByText } = render(PinnedRow);
+
+    const playlistEl = getByText("My Best Songs");
+    await fireEvent.contextMenu(playlistEl);
+
+    expect(await screen.findByText("Play Playlist")).toBeInTheDocument();
+    expect(await screen.findByText("Unpin from Home")).toBeInTheDocument();
+  });
+
+  it("opens AutoPlaylistContextMenu on right-click on auto-playlist card", async () => {
+    vi.spyOn(pinnedStore, "isPinned").mockReturnValue(true);
+    const { getByText } = render(PinnedRow);
+
+    const autoPlEl = getByText("Favourite Songs");
+    await fireEvent.contextMenu(autoPlEl);
+
+    expect(await screen.findByText("Play Playlist")).toBeInTheDocument();
+    expect(await screen.findByText("Unpin from Home")).toBeInTheDocument();
+  });
+
+  it("unpins item from Home when clicking Unpin from Home in context menu", async () => {
+    vi.spyOn(pinnedStore, "isPinned").mockReturnValue(true);
+    const toggleSpy = vi.spyOn(pinnedStore, "toggle").mockResolvedValue();
+    const { getByText } = render(PinnedRow);
+
+    const albumEl = getByText("OK Computer");
+    await fireEvent.contextMenu(albumEl);
+
+    const unpinBtn = await screen.findByText("Unpin from Home");
+    await fireEvent.click(unpinBtn);
+
+    expect(toggleSpy).toHaveBeenCalledWith("album", "OK Computer");
+  });
+});

--- a/src/lib/components/PinnedSongCard.svelte
+++ b/src/lib/components/PinnedSongCard.svelte
@@ -7,15 +7,17 @@
     song: Song;
     widthClass?: string;
     onclick?: (e: MouseEvent) => void;
+    oncontextmenu?: (e: MouseEvent) => void;
   }
 
-  let { song, widthClass = "w-full", onclick }: Props = $props();
+  let { song, widthClass = "w-full", onclick, oncontextmenu }: Props = $props();
 </script>
 
 <!-- svelte-ignore a11y_no_static_element_interactions -->
 <!-- svelte-ignore a11y_click_events_have_key_events -->
 <div
   {onclick}
+  oncontextmenu={(e) => oncontextmenu?.(e)}
   class="{widthClass} bg-brand-sidebar border border-brand-border/60 rounded-b-xl overflow-hidden flex flex-col group hover:border-brand-accent/40 transition-all duration-200 select-none cursor-pointer"
 >
   <div class="aspect-square bg-brand-main flex items-center justify-center text-brand-accent-text relative overflow-hidden w-full">

--- a/src/lib/components/PlaylistCard.svelte
+++ b/src/lib/components/PlaylistCard.svelte
@@ -19,7 +19,19 @@
 
   import { getPlaylistDisplayName } from "../utils/playlist";
 
-  let { playlist, onClick, widthClass = "w-full" }: { playlist: Playlist; onClick: () => void; widthClass?: string } = $props();
+  let {
+    playlist,
+    onClick,
+    widthClass = "w-full",
+    oncontextmenu,
+    onContextMenu,
+  }: {
+    playlist: Playlist;
+    onClick: () => void;
+    widthClass?: string;
+    oncontextmenu?: (e: MouseEvent) => void;
+    onContextMenu?: (e: MouseEvent) => void;
+  } = $props();
 
   let cardTitle = $derived(getPlaylistDisplayName(playlist));
 
@@ -78,6 +90,7 @@
 <!-- svelte-ignore a11y_click_events_have_key_events -->
 <div
   onclick={onClick}
+  oncontextmenu={(e) => { (oncontextmenu || onContextMenu)?.(e); }}
   class="{widthClass} bg-brand-sidebar border border-brand-border/60 rounded-xl p-4 flex flex-col text-left hover:border-brand-accent/40 transition-all duration-200 group relative"
 >
   <div class="aspect-square w-full mb-3 bg-brand-main relative flex items-center justify-center overflow-hidden">

--- a/src/lib/components/PlaylistCardContextMenu.svelte
+++ b/src/lib/components/PlaylistCardContextMenu.svelte
@@ -1,0 +1,82 @@
+<script lang="ts">
+  import {
+    PlayIcon as Play,
+    StackIcon as Layers,
+    PushPinIcon as Pin,
+    PushPinSlashIcon as PinOff
+  } from "phosphor-svelte";
+  import { i18n } from "../stores/i18n.svelte";
+  import { pinnedStore } from "../stores/pinned.svelte";
+  import type { Playlist } from "../types";
+  import { getPlaylistDisplayName, queuePlaylistAsPlaylist, addPlaylistToQueue } from "../utils/playlist";
+  import ContextMenu from "./ContextMenu.svelte";
+  import ContextMenuItem from "./ContextMenuItem.svelte";
+  import ContextMenuDivider from "./ContextMenuDivider.svelte";
+
+  interface Props {
+    x: number;
+    y: number;
+    playlist: Playlist;
+    onPlay?: () => void;
+    onAddToQueue?: () => void;
+    onClose: () => void;
+  }
+
+  let {
+    x,
+    y,
+    playlist,
+    onPlay,
+    onAddToQueue,
+    onClose,
+  }: Props = $props();
+
+  let title = $derived(getPlaylistDisplayName(playlist) || i18n.t("playlists.untitledPlaylistName"));
+</script>
+
+<ContextMenu {x} {y} {onClose} estimatedHeight={180}>
+  <div class="px-3 py-1 text-[11px] font-bold text-brand-text-primary border-b border-brand-border/40 mb-1 truncate">
+    {title}
+  </div>
+
+  <ContextMenuItem
+    icon={Play}
+    accent
+    label={i18n.t("playlists.contextMenuPlayPlaylist", {}, "Play Playlist")}
+    onclick={async () => {
+      if (onPlay) {
+        onPlay();
+      } else {
+        await queuePlaylistAsPlaylist(playlist);
+      }
+      onClose();
+    }}
+  />
+
+  <ContextMenuItem
+    icon={Layers}
+    label={i18n.t("playlists.contextMenuAddQueue", {}, "Add to Queue")}
+    onclick={async () => {
+      if (onAddToQueue) {
+        onAddToQueue();
+      } else {
+        await addPlaylistToQueue(playlist);
+      }
+      onClose();
+    }}
+  />
+
+  {#if !playlist.is_queue}
+    <ContextMenuDivider />
+    <ContextMenuItem
+      icon={pinnedStore.isPinned("playlist", String(playlist.id)) ? PinOff : Pin}
+      label={pinnedStore.isPinned("playlist", String(playlist.id))
+        ? i18n.t("playlists.contextMenuUnpinHome")
+        : i18n.t("playlists.contextMenuPinHome")}
+      onclick={() => {
+        pinnedStore.toggle("playlist", String(playlist.id));
+        onClose();
+      }}
+    />
+  {/if}
+</ContextMenu>

--- a/src/lib/components/PlaylistCardContextMenu.test.ts
+++ b/src/lib/components/PlaylistCardContextMenu.test.ts
@@ -1,0 +1,111 @@
+import "@testing-library/jest-dom";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, fireEvent } from "@testing-library/svelte";
+import PlaylistCardContextMenu from "./PlaylistCardContextMenu.svelte";
+import { pinnedStore } from "../stores/pinned.svelte";
+import type { Playlist } from "../types";
+
+describe("PlaylistCardContextMenu.svelte", () => {
+  const mockPlaylist: Playlist = {
+    id: 12,
+    name: "Summer Vibes",
+    dynamic_enabled: false,
+    is_queue: false,
+    created: 0,
+    updated: 0,
+    track_count: 8,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders playlist title and actions", () => {
+    const { getByText } = render(PlaylistCardContextMenu, {
+      props: {
+        x: 100,
+        y: 100,
+        playlist: mockPlaylist,
+        onClose: vi.fn(),
+      },
+    });
+
+    expect(getByText("Summer Vibes")).toBeInTheDocument();
+    expect(getByText("Play Playlist")).toBeInTheDocument();
+    expect(getByText("Add to Queue")).toBeInTheDocument();
+    expect(getByText("Pin to Home")).toBeInTheDocument();
+  });
+
+  it("calls onPlay and onClose when Play Playlist is clicked", async () => {
+    const onPlay = vi.fn();
+    const onClose = vi.fn();
+    const { getByText } = render(PlaylistCardContextMenu, {
+      props: {
+        x: 100,
+        y: 100,
+        playlist: mockPlaylist,
+        onPlay,
+        onClose,
+      },
+    });
+
+    await fireEvent.click(getByText("Play Playlist"));
+    expect(onPlay).toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("calls onAddToQueue and onClose when Add to Queue is clicked", async () => {
+    const onAddToQueue = vi.fn();
+    const onClose = vi.fn();
+    const { getByText } = render(PlaylistCardContextMenu, {
+      props: {
+        x: 100,
+        y: 100,
+        playlist: mockPlaylist,
+        onAddToQueue,
+        onClose,
+      },
+    });
+
+    await fireEvent.click(getByText("Add to Queue"));
+    expect(onAddToQueue).toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("shows Unpin from Home when already pinned and calls pinnedStore.toggle", async () => {
+    vi.spyOn(pinnedStore, "isPinned").mockReturnValue(true);
+    const toggleSpy = vi.spyOn(pinnedStore, "toggle").mockResolvedValue();
+    const onClose = vi.fn();
+
+    const { getByText } = render(PlaylistCardContextMenu, {
+      props: {
+        x: 100,
+        y: 100,
+        playlist: mockPlaylist,
+        onClose,
+      },
+    });
+
+    const unpinBtn = getByText("Unpin from Home");
+    expect(unpinBtn).toBeInTheDocument();
+
+    await fireEvent.click(unpinBtn);
+    expect(toggleSpy).toHaveBeenCalledWith("playlist", "12");
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("does not render pin button when playlist is the queue", () => {
+    const queuePlaylist: Playlist = { ...mockPlaylist, is_queue: true };
+    const { queryByText } = render(PlaylistCardContextMenu, {
+      props: {
+        x: 100,
+        y: 100,
+        playlist: queuePlaylist,
+        onClose: vi.fn(),
+      },
+    });
+
+    expect(queryByText("Pin to Home")).toBeNull();
+    expect(queryByText("Unpin from Home")).toBeNull();
+  });
+});

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -542,6 +542,8 @@ export const en = {
     contextMenuPlay: "Play Selected",
     contextMenuPlaySong: "Play Song",
     contextMenuPlayAlbum: "Play Album",
+    contextMenuPlayArtist: "Play Artist",
+    contextMenuPlayPlaylist: "Play Playlist",
     contextMenuAddQueue: "Add to Queue",
     addedToQueueSuccess: "Added {name} to Queue",
     addedToPlaylistSuccess: "Added to {name}",

--- a/src/lib/locales/fr.ts
+++ b/src/lib/locales/fr.ts
@@ -540,6 +540,8 @@ export const fr = {
     contextMenuPlay: "Lire la sélection",
     contextMenuPlaySong: "Lire la chanson",
     contextMenuPlayAlbum: "Lire l'album",
+    contextMenuPlayArtist: "Lire l'artiste",
+    contextMenuPlayPlaylist: "Lire la liste de lecture",
     contextMenuAddQueue: "Ajouter à la file",
     addedToQueueSuccess: "Ajouté {name} à la file d'attente",
     addedToPlaylistSuccess: "Ajouté à {name}",

--- a/src/lib/utils/playlist.ts
+++ b/src/lib/utils/playlist.ts
@@ -1,10 +1,11 @@
 import { invoke } from "@tauri-apps/api/core";
-import type { AlbumItem, Playlist, QueuePopulationMode, Song } from "../types";
+import type { AlbumItem, AutoPlaylistItem, Playlist, PlaylistItem, QueuePopulationMode, Song } from "../types";
 import { i18n } from "../stores/i18n.svelte";
 import { isSmartPlaylistSpec } from "./filterParser";
 import { collectionStore } from "../stores/collection.svelte";
 import { playerStore } from "../stores/player.svelte";
 import { playlistsStore } from "../stores/playlists.svelte";
+import { toastStore } from "../stores/toast.svelte";
 
 export function getPopulationModeSuffix(mode: QueuePopulationMode | string | undefined | null): string {
   switch (mode) {
@@ -87,3 +88,108 @@ export async function queueAlbumAsPlaylist(album: AlbumItem): Promise<void> {
     console.error("Failed to add album to Queue:", err);
   }
 }
+
+export async function queueArtistAsPlaylist(artistName: string): Promise<void> {
+  const name = artistName || i18n.t("collection.unknownArtist");
+  try {
+    const songs = await invoke<Song[]>("get_songs_by_artist", { artist: artistName || "" });
+    const playable = songs.filter((s) => !s.not_included && !s.unavailable);
+    if (playable.length > 0) {
+      const queuePl = await playlistsStore.requireQueue();
+      await playerStore.setShuffleMode("off");
+      await playerStore.playSongs(playable.map((s) => s.id), 0, queuePl?.id, undefined, name);
+    }
+  } catch (err) {
+    console.error("Failed to play artist:", err);
+  }
+}
+
+export async function addArtistToQueue(artistName: string): Promise<void> {
+  try {
+    const songs = await invoke<Song[]>("get_songs_by_artist", { artist: artistName || "" });
+    const playable = songs.filter((s) => !s.not_included && !s.unavailable);
+    if (playable.length > 0) {
+      await playlistsStore.addSongsToQueue(playable.map((s) => s.id));
+      const name = artistName || i18n.t("collection.unknownArtist");
+      toastStore.show(i18n.t("playlists.addedToQueueSuccess", { name }, `Added ${name} to Queue`));
+    }
+  } catch (err) {
+    console.error("Failed to add artist to Queue:", err);
+  }
+}
+
+export async function queuePlaylistAsPlaylist(playlist: Playlist): Promise<void> {
+  const name = getPlaylistDisplayName(playlist);
+  try {
+    const items = await invoke<PlaylistItem[]>("get_playlist_tracks", { playlistId: playlist.id });
+    const playable = items.filter((t) => t.song && !t.song.not_included && !t.song.unavailable).map((t) => t.song as Song);
+    if (playable.length > 0) {
+      const queuePl = await playlistsStore.requireQueue();
+      await playerStore.setShuffleMode("off");
+      await playerStore.playSongs(playable.map((s) => s.id), 0, queuePl?.id, undefined, name);
+    }
+  } catch (err) {
+    console.error("Failed to play playlist:", err);
+  }
+}
+
+export async function addPlaylistToQueue(playlist: Playlist): Promise<void> {
+  try {
+    const items = await invoke<PlaylistItem[]>("get_playlist_tracks", { playlistId: playlist.id });
+    const playable = items.filter((t) => t.song && !t.song.not_included && !t.song.unavailable).map((t) => t.song as Song);
+    if (playable.length > 0) {
+      await playlistsStore.addSongsToQueue(playable.map((s) => s.id));
+      const name = getPlaylistDisplayName(playlist);
+      toastStore.show(i18n.t("playlists.addedToQueueSuccess", { name }, `Added ${name} to Queue`));
+    }
+  } catch (err) {
+    console.error("Failed to add playlist to Queue:", err);
+  }
+}
+
+async function fetchAutoPlaylistSongs(ap: AutoPlaylistItem): Promise<Song[]> {
+  const { kind, genre, decade, bpm, artistTag, playlistId } = ap;
+  if (
+    (kind === "genre" || kind === "decade" || kind === "bpm" || kind === "artist_tag" || kind === "missing_metadata" || kind === "daypart") &&
+    playlistId !== undefined
+  ) {
+    const items = await invoke<PlaylistItem[]>("get_playlist_tracks", { playlistId });
+    return items.filter((item) => !!item.song && !item.song.not_included && !item.song.unavailable).map((item) => item.song as Song);
+  }
+  let songs: Song[] = [];
+  if (kind === "favourites") songs = await invoke<Song[]>("get_favourite_songs");
+  else if (kind === "recently_added") songs = await invoke<Song[]>("get_recently_added_songs", { limit: 50 });
+  else if (kind === "most_played") songs = await invoke<Song[]>("get_most_played_songs", { limit: 50 });
+  else if (kind === "history") songs = await invoke<Song[]>("get_recently_played_songs", { limit: 100 });
+  else if (kind === "decade") songs = await invoke<Song[]>("get_songs_by_decade", { decade: decade ?? "", limit: 50 });
+  else if (kind === "bpm") songs = await invoke<Song[]>("get_songs_by_bpm", { spec: bpm ?? "", limit: 50 });
+  else if (kind === "artist_tag") songs = await invoke<Song[]>("get_songs_by_artist_tag", { tag: artistTag ?? "", limit: 500 });
+  else songs = await invoke<Song[]>("get_songs_by_curated_tag", { tagName: genre ?? "", limit: 500 });
+  return songs.filter((s) => !s.not_included && !s.unavailable);
+}
+
+export async function queueAutoPlaylistAsPlaylist(ap: AutoPlaylistItem, label: string): Promise<void> {
+  try {
+    const playable = await fetchAutoPlaylistSongs(ap);
+    if (playable.length > 0) {
+      const queuePl = await playlistsStore.requireQueue();
+      await playerStore.setShuffleMode("off");
+      await playerStore.playSongs(playable.map((s) => s.id), 0, queuePl?.id, undefined, label);
+    }
+  } catch (err) {
+    console.error("Failed to play auto-playlist:", err);
+  }
+}
+
+export async function addAutoPlaylistToQueue(ap: AutoPlaylistItem, label: string): Promise<void> {
+  try {
+    const playable = await fetchAutoPlaylistSongs(ap);
+    if (playable.length > 0) {
+      await playlistsStore.addSongsToQueue(playable.map((s) => s.id));
+      toastStore.show(i18n.t("playlists.addedToQueueSuccess", { name: label }, `Added ${label} to Queue`));
+    }
+  } catch (err) {
+    console.error("Failed to add auto-playlist to Queue:", err);
+  }
+}
+


### PR DESCRIPTION
## 📋 Summary
Fixes #784.

Enables right-click context menu support on all card types in Home's **Pinned** row (`PinnedRow.svelte`), allowing users to "Unpin from Home" directly from the pinned card, along with relevant playback and queue options matching each item type.

## 🔍 Implementation Notes
- **Context Menus**:
  - `ArtistContextMenu.svelte`: Added context menu for artists with "Play Artist", "Add to Queue", and "Pin to Home" / "Unpin from Home".
  - `PlaylistCardContextMenu.svelte`: Added context menu for playlists with "Play Playlist", "Add to Queue", and "Pin to Home" / "Unpin from Home" (hidden if queue).
  - `AutoPlaylistContextMenu.svelte`: Added context menu for auto/smart-playlists with "Play Playlist", "Add to Queue", and "Pin to Home" / "Unpin from Home".
  - `AlbumContextMenu` and `SongContextMenu`: Reused existing context menus for album and song cards.
- **Card Components**: Added optional `oncontextmenu` / `onContextMenu` callbacks to `PinnedSongCard.svelte`, `ArtistCard.svelte`, `PlaylistCard.svelte`, and `AutoPlaylistCard.svelte`.
- **Helpers**: Added artist, playlist, and auto-playlist playback/queue helper functions in `src/lib/utils/playlist.ts`.
- **i18n**: Added `playlists.contextMenuPlayArtist` and `playlists.contextMenuPlayPlaylist` to both `en.ts` and `fr.ts`.

## 🧪 Test Plan
- [x] `bun run check` (svelte-check + knip clean)
- [x] `bun run test:run` (all 75 test files and 635 tests pass, including new suites for `PinnedRow`, `ArtistContextMenu`, `PlaylistCardContextMenu`, and `AutoPlaylistContextMenu`)
- [ ] Manually verified in the app

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed
