### PR TITLE
fix: restore vertical scrollbars on song-table views

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -88,13 +88,18 @@
   }
 
   /* Custom scrollbar styling */
+  * {
+    scrollbar-width: thin;
+    scrollbar-color: var(--color-border) transparent;
+  }
+
   ::-webkit-scrollbar {
     width: 8px;
     height: 8px;
   }
 
   ::-webkit-scrollbar-track {
-    background: var(--bg-main);
+    background: transparent;
   }
 
   ::-webkit-scrollbar-thumb {

--- a/src/lib/components/AlbumDetailView.svelte
+++ b/src/lib/components/AlbumDetailView.svelte
@@ -364,7 +364,7 @@
 </script>
 
 <div
-  class="relative flex-1 flex flex-col overflow-y-auto text-brand-text-secondary h-full carousel-scroll {backdropUrl ? '' : 'bg-brand-main'}"
+  class="relative flex-1 flex flex-col overflow-y-auto text-brand-text-secondary h-full {backdropUrl ? '' : 'bg-brand-main'}"
   use:rememberScroll={`album-detail:${albumName}`}
 >
   {#if backdropUrl}
@@ -566,12 +566,3 @@
   />
 {/if}
 
-<style>
-  :global(.carousel-scroll) {
-    scrollbar-width: none;
-    -ms-overflow-style: none;
-  }
-  :global(.carousel-scroll::-webkit-scrollbar) {
-    display: none;
-  }
-</style>

--- a/src/lib/components/ArtistDetailView.svelte
+++ b/src/lib/components/ArtistDetailView.svelte
@@ -349,7 +349,7 @@
   }
 </script>
 
-<div class="flex-1 flex flex-col overflow-y-auto bg-brand-main text-brand-text-secondary h-full carousel-scroll" use:rememberScroll={`artist-detail:${artistName}`}>
+<div class="flex-1 flex flex-col overflow-y-auto bg-brand-main text-brand-text-secondary h-full" use:rememberScroll={`artist-detail:${artistName}`}>
   <div class="relative z-30 w-full border-b border-brand-border/60 bg-brand-main/60 backdrop-blur-md px-6 {windowLayoutStore.isDetailHeaderCollapsed ? 'py-3' : 'pt-6 pb-6'}">
     <div class="flex items-start justify-between gap-6 relative z-10">
       <div class="flex flex-col justify-end gap-1.5 max-w-xl">
@@ -672,12 +672,3 @@
   />
 {/if}
 
-<style>
-  :global(.carousel-scroll) {
-    scrollbar-width: none;
-    -ms-overflow-style: none;
-  }
-  :global(.carousel-scroll::-webkit-scrollbar) {
-    display: none;
-  }
-</style>

--- a/src/lib/components/AutoPlaylistDetailView.svelte
+++ b/src/lib/components/AutoPlaylistDetailView.svelte
@@ -460,7 +460,7 @@
 {/snippet}
 
 <div
-  class="flex-1 flex flex-col overflow-y-auto carousel-scroll bg-brand-main text-brand-text-secondary h-full"
+  class="flex-1 flex flex-col overflow-y-auto bg-brand-main text-brand-text-secondary h-full"
   use:rememberScroll={`autoplaylist:${view.kind}:${view.genre ?? view.decade ?? view.bpm ?? ""}`}
 >
   <div class="relative z-30 w-full border-b border-brand-border/60 bg-brand-main/60 backdrop-blur-md px-6 pt-6 pb-6 shrink-0">
@@ -779,13 +779,4 @@
   </Modal>
 {/if}
 
-<style>
-  :global(.carousel-scroll) {
-    scrollbar-width: none;
-    -ms-overflow-style: none;
-  }
-  :global(.carousel-scroll::-webkit-scrollbar) {
-    display: none;
-  }
-</style>
 

--- a/src/lib/components/HorizontalScrollRow.svelte
+++ b/src/lib/components/HorizontalScrollRow.svelte
@@ -92,11 +92,11 @@
 </div>
 
 <style>
-  :global(.carousel-scroll) {
+  .carousel-scroll {
     scrollbar-width: none;
     -ms-overflow-style: none;
   }
-  :global(.carousel-scroll::-webkit-scrollbar) {
+  .carousel-scroll::-webkit-scrollbar {
     display: none;
   }
 </style>

--- a/src/lib/components/PlaylistView.svelte
+++ b/src/lib/components/PlaylistView.svelte
@@ -614,7 +614,7 @@
 
   {#if activePlaylist}
     <div
-      class="flex-1 flex flex-col min-h-0 relative z-10 overflow-y-auto carousel-scroll"
+      class="flex-1 flex flex-col min-h-0 relative z-10 overflow-y-auto"
       use:rememberScroll={`playlist:${playlistsStore.activePlaylistId}`}
     >
     <div class="relative z-30 w-full overflow-hidden border-b border-brand-border/60 bg-brand-main/60 backdrop-blur-md px-6 {windowLayoutStore.isDetailHeaderCollapsed ? 'py-3' : 'pt-6 pb-6'} shrink-0">
@@ -1044,13 +1044,4 @@
   </Modal>
 {/if}
 
-<style>
-  :global(.carousel-scroll) {
-    scrollbar-width: none;
-    -ms-overflow-style: none;
-  }
-  :global(.carousel-scroll::-webkit-scrollbar) {
-    display: none;
-  }
-</style>
 


### PR DESCRIPTION
## 📋 Summary
Fixes #792. Views containing a song table (`AlbumDetailView`, `ArtistDetailView`, `AutoPlaylistDetailView`, and `PlaylistView`) were hiding their vertical scrollbar entirely, leaving users who cannot use a mouse wheel or trackpad gesture with no way to scroll through their tracks.

## 🔍 Implementation Notes
The root scroll containers in all four views carried the class `carousel-scroll`, and each component included a `<style>` block declaring `:global(.carousel-scroll) { scrollbar-width: none; … }`. That class was designed for `HorizontalScrollRow`'s scrollbar-free, arrow-button carousel, but was inadvertently copy-pasted onto page-level vertical scroll containers.

Changes:
- Removed `carousel-scroll` from the root container `div` in `AlbumDetailView`, `ArtistDetailView`, `AutoPlaylistDetailView`, and `PlaylistView`.
- Removed the now-redundant `:global(.carousel-scroll)` `<style>` blocks from those four components.
- Scoped `.carousel-scroll` locally (dropped `:global`) in `HorizontalScrollRow` so horizontal carousels still hide their scrollbar but the style no longer leaks globally.
- Updated `app.css`: changed `::-webkit-scrollbar-track` from `var(--bg-main)` to `transparent` (so scrollbars overlay blurred cover art cleanly) and added `scrollbar-width: thin; scrollbar-color: var(--color-border) transparent;` for consistent Firefox/standards styling.

## 🧪 Test Plan
- [x] `bun run check` — 0 errors, 0 warnings
- [x] `bun run test:run` — 62 test files, 536 tests, all passed
- [ ] `cargo test` — no Rust changes
- [x] Manually verified in the app (see walkthrough)

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed
