### PR TITLE
feat: layered-ellipse gradient ambient background for Immersive view

### DIFF
--- a/src/lib/utils/ellipseGradient.test.ts
+++ b/src/lib/utils/ellipseGradient.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import { generateEllipseGradientSvg, ellipseGradientDataUri } from "./ellipseGradient";
+
+describe("generateEllipseGradientSvg", () => {
+  it("produces a well-formed SVG with a background rect and one gradient+rect per layer", () => {
+    const svg = generateEllipseGradientSvg({ seed: 1, colors: ["#111111", "#222222"], layersPerColor: 2 });
+
+    expect(svg.startsWith("<svg")).toBe(true);
+    expect(svg.endsWith("</svg>")).toBe(true);
+    expect((svg.match(/<radialGradient/g) ?? []).length).toBe(4); // 2 colors * 2 layers
+    // +1 for the solid background rect
+    expect((svg.match(/<rect/g) ?? []).length).toBe(5);
+  });
+
+  it("is deterministic for a given seed", () => {
+    const a = generateEllipseGradientSvg({ seed: "album-42" });
+    const b = generateEllipseGradientSvg({ seed: "album-42" });
+    expect(a).toBe(b);
+  });
+
+  it("produces different output for different seeds", () => {
+    const a = generateEllipseGradientSvg({ seed: "album-42" });
+    const b = generateEllipseGradientSvg({ seed: "album-43" });
+    expect(a).not.toBe(b);
+  });
+
+  it("gives every gradient a unique id, even across repeated calls with the same seed and no explicit run id", () => {
+    const first = generateEllipseGradientSvg({ seed: 7 });
+    const second = generateEllipseGradientSvg({ seed: 7 });
+    // Same seed -> identical output (and therefore identical ids) is expected...
+    expect(first).toBe(second);
+
+    // ...but an unseeded call must not collide with a seeded one.
+    const unseeded = generateEllipseGradientSvg();
+    const idsIn = (svg: string) => Array.from(svg.matchAll(/id="([^"]+)"/g)).map((m) => m[1]);
+    const seededIds = new Set(idsIn(first));
+    const unseededIds = idsIn(unseeded);
+    expect(unseededIds.some((id) => seededIds.has(id))).toBe(false);
+  });
+
+  it("respects a custom size for width/height/viewBox", () => {
+    const svg = generateEllipseGradientSvg({ size: 300, seed: 1 });
+    expect(svg).toContain('width="300"');
+    expect(svg).toContain('height="300"');
+    expect(svg).toContain('viewBox="0 0 300 300"');
+  });
+
+  it("falls back to the default palette when no colors are given", () => {
+    const svg = generateEllipseGradientSvg({ seed: 1 });
+    expect(svg).toMatch(/#5135FF|#FF5828|#F69CFF|#FFA50F/);
+  });
+});
+
+describe("ellipseGradientDataUri", () => {
+  it("returns a data URI wrapping the generated SVG", () => {
+    const uri = ellipseGradientDataUri({ seed: 1 });
+    expect(uri.startsWith("data:image/svg+xml,")).toBe(true);
+    expect(decodeURIComponent(uri.replace("data:image/svg+xml,", ""))).toContain("<svg");
+  });
+});

--- a/src/lib/utils/ellipseGradient.ts
+++ b/src/lib/utils/ellipseGradient.ts
@@ -1,0 +1,137 @@
+// Layered-ellipse radial gradient generator.
+//
+// Reverse-engineered from the SVG output of Justin Jay Wang's "Layered radial"
+// method (used on openai.com 2020-2022): https://justinjay.wang/methods-for-random-gradients/
+// Each palette color gets its own radial gradient (solid color fading to
+// transparent). A full-canvas rect filled with that gradient is then warped
+// with an SVG transform (scale -> skew -> rotate -> translate) so the
+// gradient's circular falloff renders as a positioned, rotated ellipse.
+// Stacking several of these per color, then several colors, composites into
+// an organic blob gradient — fully vector, and cheap to serve.
+
+export interface EllipseGradientOptions {
+  /** Rendered <svg> width attribute. Defaults to `size`. */
+  width?: number;
+  /** Rendered <svg> height attribute. Defaults to `size`. */
+  height?: number;
+  /** Square coordinate space the ellipses are laid out and transformed in. */
+  size?: number;
+  /** Palette to draw ellipses from. Defaults to a 4-color built-in set. */
+  colors?: string[];
+  /** How many ellipse layers to stack per color. */
+  layersPerColor?: number;
+  /** Deterministic seed — same seed + options always produce the same SVG. */
+  seed?: number | string;
+  /** CSS `saturate()` filter percentage applied to the whole gradient. */
+  saturation?: number;
+}
+
+const DEFAULT_COLORS = ["#5135FF", "#FF5828", "#F69CFF", "#FFA50F"];
+const DEFAULT_SIZE = 600;
+const DEFAULT_LAYERS_PER_COLOR = 3;
+const DEFAULT_SATURATION = 125;
+
+/** Deterministic PRNG (mulberry32) so a given seed always reproduces the same gradient. */
+function createRng(seed?: number | string): () => number {
+  if (seed === undefined) return Math.random;
+
+  let state = typeof seed === "number" ? seed >>> 0 : hashString(seed);
+  return () => {
+    state |= 0;
+    state = (state + 0x6d2b79f5) | 0;
+    let t = Math.imul(state ^ (state >>> 15), 1 | state);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/** FNV-1a string hash, used to seed the PRNG from a string (e.g. a song/playlist id). */
+function hashString(value: string): number {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < value.length; i++) {
+    hash ^= value.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return hash >>> 0;
+}
+
+function randRange(rng: () => number, min: number, max: number): number {
+  return min + rng() * (max - min);
+}
+
+/** Generates a self-contained, unique-per-call layered-ellipse gradient SVG string. */
+export function generateEllipseGradientSvg(options: EllipseGradientOptions = {}): string {
+  const size = options.size ?? DEFAULT_SIZE;
+  const width = options.width ?? size;
+  const height = options.height ?? size;
+  const colors = options.colors && options.colors.length > 0 ? options.colors : DEFAULT_COLORS;
+  const layersPerColor = options.layersPerColor ?? DEFAULT_LAYERS_PER_COLOR;
+  const saturation = options.saturation ?? DEFAULT_SATURATION;
+  const rng = createRng(options.seed);
+
+  // Random per-call/per-seed prefix so multiple gradients inlined on the same
+  // page never collide on gradient element ids.
+  const runId = Math.floor(randRange(rng, 0, 1e9)).toString(36);
+  const center = size / 2;
+  const backgroundColor = colors[Math.floor(randRange(rng, 0, colors.length))];
+
+  const gradientDefs: string[] = [];
+  const layerRects: string[] = [];
+  const layerOrder: { color: string; gradientId: string }[] = [];
+
+  colors.forEach((color, colorIndex) => {
+    for (let layer = 0; layer < layersPerColor; layer++) {
+      const gradientId = `eg-${runId}-${colorIndex}-${layer}`;
+      const fx = randRange(rng, 0.15, 0.85);
+      const fy = randRange(rng, 0.3, 0.7);
+
+      gradientDefs.push(
+        `<radialGradient id="${gradientId}" fx="${fx.toFixed(4)}" fy="${fy.toFixed(4)}">` +
+          `<stop offset="0%" stop-color="${color}"/>` +
+          `<stop offset="100%" stop-color="${color}" stop-opacity="0"/>` +
+        `</radialGradient>`
+      );
+      layerOrder.push({ color, gradientId });
+    }
+  });
+
+  // Shuffle layer order (Fisher-Yates) so colors interleave instead of
+  // stacking in solid color-by-color bands.
+  for (let i = layerOrder.length - 1; i > 0; i--) {
+    const j = Math.floor(rng() * (i + 1));
+    [layerOrder[i], layerOrder[j]] = [layerOrder[j], layerOrder[i]];
+  }
+
+  for (const { gradientId } of layerOrder) {
+    const scaleX = randRange(rng, 0.8, 1.5);
+    const scaleY = randRange(rng, 0.8, 1.5);
+    const skew = randRange(rng, -10, 10);
+    const rotate = randRange(rng, 0, 360);
+    const offsetRange = size * 0.38;
+    const dx = randRange(rng, -offsetRange, offsetRange);
+    const dy = randRange(rng, -offsetRange, offsetRange);
+
+    layerRects.push(
+      `<rect x="0" y="0" width="100%" height="100%" fill="url(#${gradientId})" ` +
+        `transform="translate(${center} ${center}) scale(${scaleX.toFixed(4)} ${scaleY.toFixed(4)}) ` +
+        `skewX(${skew.toFixed(4)}) rotate(${rotate.toFixed(4)}) translate(${dx.toFixed(4)} ${dy.toFixed(4)}) ` +
+        `translate(${-center} ${-center})"/>`
+    );
+  }
+
+  return (
+    `<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" ` +
+    `width="${width}" height="${height}" viewBox="0 0 ${size} ${size}" ` +
+    `style="filter:saturate(${saturation}%)" preserveAspectRatio="xMidYMid slice">` +
+      `<defs>${gradientDefs.join("")}</defs>` +
+      `<rect x="0" y="0" width="100%" height="100%" fill="${backgroundColor}"/>` +
+      layerRects.join("") +
+    `</svg>`
+  );
+}
+
+/** Convenience wrapper for use as a CSS `background-image` value. */
+export function ellipseGradientDataUri(options?: EllipseGradientOptions): string {
+  const svg = generateEllipseGradientSvg(options);
+  return `data:image/svg+xml,${encodeURIComponent(svg)}`;
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -4,7 +4,7 @@
   import Sidebar from '../lib/components/Sidebar.svelte';
   import RightPanel from '../lib/components/RightPanel.svelte';
   import PlayerBar from '../lib/components/PlayerBar.svelte';
-  import { slide, fly } from 'svelte/transition';
+  import { slide, fly, fade } from 'svelte/transition';
   import { cubicOut } from 'svelte/easing';
   import { collectionStore } from '../lib/stores/collection.svelte';
   import { navigationStore } from '../lib/stores/navigation.svelte';
@@ -420,11 +420,16 @@
           <!-- Immersive Ambient Background: a soft layered-ellipse SVG gradient
                tinted from the current song's artwork colors (see
                immersiveAmbientSvg above). Renders the same, cheaply, on every
-               platform — no CSS blur()/backdrop-filter involved. -->
+               platform — no CSS blur()/backdrop-filter involved. Keyed on
+               song id so a track change destroys the old layer and mounts a
+               new one; Svelte plays both transitions concurrently, giving a
+               genuine cross-dissolve rather than a hard cut. -->
           {#if playerStore.currentSong}
-            <div class="absolute inset-0 z-0 opacity-30 pointer-events-none immersive-ambient">
-              {@html immersiveAmbientSvg}
-            </div>
+            {#key playerStore.currentSong.id}
+              <div class="absolute inset-0 z-0 opacity-30 pointer-events-none immersive-ambient" transition:fade={{ duration: 900 }}>
+                {@html immersiveAmbientSvg}
+              </div>
+            {/key}
           {/if}
 
           <!-- Center Container: Card and Details. Below md, the layout would

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -23,6 +23,8 @@
   import { picardStore } from '../lib/stores/picard.svelte';
   import { toastStore } from '../lib/stores/toast.svelte';
   import { isLinux as platformIsLinux } from '../lib/platform';
+  import { themeStore } from '../lib/stores/theme.svelte';
+  import { generateEllipseGradientSvg } from '../lib/utils/ellipseGradient';
   import { onMount } from 'svelte';
   import { getCurrentWebview } from '@tauri-apps/api/webview';
   import { getCurrentWindow } from '@tauri-apps/api/window';
@@ -48,6 +50,20 @@
   let effectiveSidebarWidth = $derived(
     windowLayoutStore.isSidebarAutoCollapsed ? SIDEBAR_COLLAPSED_WIDTH_PX : windowLayoutStore.sidebarWidth
   );
+
+  // Immersive ambient background: a layered-ellipse SVG gradient tinted from
+  // the current song's extracted artwork colors, seeded by song id so it's
+  // stable while a track plays and only regenerates on track change. This
+  // replaced a `blur-3xl` full-window CoverArt layer that was skipped on
+  // Linux entirely (see #452) — WebKitGTK's compositor choked on a
+  // continuous CSS blur() over a scaled image. Pure SVG with no blur/
+  // backdrop-filter renders identically (and cheaply) on every platform, so
+  // the immersive view no longer needs a Linux-specific fallback here.
+  let immersiveAmbientSvg = $derived.by(() => {
+    const art = themeStore.artworkColors;
+    const colors = art ? [art.vibrant, art.darkVibrant, art.lightVibrant, art.muted].filter((c): c is string => !!c) : undefined;
+    return generateEllipseGradientSvg({ colors, seed: playerStore.currentSong?.id ?? 'immersive-empty' });
+  });
 
   onMount(() => {
     isLinux = platformIsLinux;
@@ -401,20 +417,13 @@
              ≈ 96px) that overlays the bottom of this face, so the content centers within the
              visible area above the dock rather than the full face height. -->
         <div class="flip-face flip-back overflow-hidden bg-brand-main flex flex-col items-center justify-center pt-8 px-4 min-[420px]:px-8 pb-32 select-none {!windowLayoutStore.effectiveImmersiveMode ? 'pointer-events-none' : 'pointer-events-auto'}">
-          <!-- Immersive Ambient Blurred Background: skipped on Linux, where the
-               `blur-3xl` filter over a full-window layer is expensive on
-               WebKitGTK's compositor and can let the translucent layer sample
-               the main UI underneath instead of the intended solid backdrop
-               (see #452) — the face's own `bg-brand-main` is fallback enough. -->
-          {#if playerStore.currentSong && !isLinux}
-            <div class="absolute inset-0 z-0 opacity-20 blur-3xl pointer-events-none scale-110">
-              <CoverArt
-                songId={playerStore.currentSong?.id}
-                artEmbedded={playerStore.currentSong?.art_embedded}
-                artAutomatic={playerStore.currentSong?.art_automatic}
-                artManual={playerStore.currentSong?.art_manual}
-                sizeClass="w-full h-full object-cover"
-              />
+          <!-- Immersive Ambient Background: a soft layered-ellipse SVG gradient
+               tinted from the current song's artwork colors (see
+               immersiveAmbientSvg above). Renders the same, cheaply, on every
+               platform — no CSS blur()/backdrop-filter involved. -->
+          {#if playerStore.currentSong}
+            <div class="absolute inset-0 z-0 opacity-30 pointer-events-none immersive-ambient">
+              {@html immersiveAmbientSvg}
             </div>
           {/if}
 
@@ -513,6 +522,12 @@
 </IconContext>
 
 <style>
+  .immersive-ambient :global(svg) {
+    width: 100%;
+    height: 100%;
+    display: block;
+  }
+
   .flip-perspective {
     perspective: none;
   }


### PR DESCRIPTION
## 📋 Summary
Addresses #800. Replaces the Immersive Now Playing view's ambient background — a `blur-3xl` full-window `CoverArt` layer that was skipped entirely on Linux (#452) because WebKitGTK's compositor chokes on a continuous CSS `blur()` filter — with a generated, layered-ellipse SVG gradient tinted from the current song's extracted artwork colors. No `blur()`/`backdrop-filter` involved, so it renders identically and cheaply on every platform with no Linux-specific fallback needed. The gradient changes per song (not just per album) and cross-dissolves on track change instead of cutting instantly.

## 🔍 Implementation Notes
- `src/lib/utils/ellipseGradient.ts` (new): `generateEllipseGradientSvg()` / `ellipseGradientDataUri()`, reverse-engineered from Justin Jay Wang's "Layered radial" method (https://justinjay.wang/methods-for-random-gradients/). Each palette color gets a two-stop radial gradient (solid → transparent, off-center focal point); a full-canvas rect filled with it is warped via `scale`/`skewX`/`rotate`/`translate` to render as a positioned ellipse. Several ellipses per color are layered and shuffled into a composite blob gradient. Deterministic via an optional seed (mulberry32 PRNG) so the same seed always reproduces the same SVG.
- `src/routes/+layout.svelte`: the immersive "back face" now derives its palette from `themeStore.artworkColors` and seeds the generator with the current song id (`immersiveAmbientSvg`), so the gradient is stable while a track plays and only regenerates on track change. The layer is keyed on song id inside a `{#key}` block with a Svelte `fade` transition (900ms) so outgoing/incoming layers cross-dissolve. The `isLinux` gate on this specific layer is removed — it's no longer needed.

## 🧪 Test Plan
- [x] `bun run check` (svelte-check + knip) — 0 errors/warnings
- [x] `bun run test -- --run` (frontend) — 78 files / 653 tests passed
- [ ] `cargo test` (src-tauri) — no Rust changed
- [x] Manually verified in the app: played a song, toggled Immersive Mode, confirmed the gradient reflects the song's artwork colors, changes per song (not static across an album), and cross-dissolves between tracks

## 📸 Screenshots
Not captured for this PR — the effect is animated/color-derived per song, so a static screenshot doesn't convey it well. Verified live in `bun run tauri dev`.

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed — n/a (internal visual polish, not a new user-facing setting/flow)
