### PR TITLE
fix: Open in Picard failures on large/already-running selections

### DIFF
--- a/src-tauri/src/commands/picard.rs
+++ b/src-tauri/src/commands/picard.rs
@@ -14,27 +14,47 @@ fn read_custom_picard_path(state: &State<'_, AppState>) -> Result<Option<String>
         .filter(|s: &String| !s.trim().is_empty()))
 }
 
-/// Launches MusicBrainz Picard with the given songs' file paths (#367) — a
-/// one-way handoff, see `crate::picard` for details. Takes song IDs rather
-/// than raw paths so only real library songs can be handed to an external
-/// process, and paths are resolved server-side.
+/// Launches MusicBrainz Picard with the given songs' *containing folders*
+/// (#367, #804) — a one-way handoff, see `crate::picard` for details. Takes
+/// song IDs rather than raw paths so only real library songs can be handed
+/// to an external process, and paths are resolved server-side.
+///
+/// Resolves to each song's parent directory rather than its own file path,
+/// deduplicated, so a same-album selection (the common case) collapses to
+/// a single argument. This is deliberately coarser than the exact
+/// selection — a folder pulls in every track Picard finds there, not just
+/// the selected ones — but it's what keeps a large cross-album selection
+/// (e.g. the whole Missing Metadata playlist) down to one argument per
+/// album instead of one per song, which both avoids the OS command-line
+/// length limit and, more importantly, avoids handing Picard's own
+/// single-instance IPC more than a couple of paths to forward at once: on
+/// Windows that IPC recreates its pipe after every message, so a burst of
+/// them can silently drop everything after the first (or, if fired at
+/// Picard in a tight loop across many chunks, destabilize it entirely).
 #[tauri::command]
 pub async fn open_in_picard(state: State<'_, AppState>, song_ids: Vec<i64>) -> Result<(), String> {
     let conn = state.db.pool.get().map_err(|e| e.to_string())?;
-    let mut paths = Vec::new();
+    let mut dirs = Vec::new();
+    let mut seen = std::collections::HashSet::new();
     for id in song_ids {
         let path: Option<String> = conn
             .query_row("SELECT path FROM songs WHERE id = ?1", [id], |row| {
                 row.get(0)
             })
             .ok();
-        if let Some(path) = path {
-            paths.push(std::path::PathBuf::from(path));
+        if let Some(dir) = path
+            .as_deref()
+            .map(std::path::Path::new)
+            .and_then(|p| p.parent())
+        {
+            if seen.insert(dir.to_path_buf()) {
+                dirs.push(dir.to_path_buf());
+            }
         }
     }
     drop(conn);
 
-    if paths.is_empty() {
+    if dirs.is_empty() {
         return Err("No local files found for the selected songs".to_string());
     }
 
@@ -43,7 +63,7 @@ pub async fn open_in_picard(state: State<'_, AppState>, song_ids: Vec<i64>) -> R
         "MusicBrainz Picard not found. Install it from picard.musicbrainz.org, or set a custom path in Settings.".to_string()
     })?;
 
-    picard::launch_picard(&exe, &paths).map_err(|e| e.to_string())
+    picard::launch_picard(&exe, &dirs).map_err(|e| e.to_string())
 }
 
 /// Resolves the Picard executable's current path, if found — `None` means

--- a/src-tauri/src/picard.rs
+++ b/src-tauri/src/picard.rs
@@ -80,18 +80,54 @@ fn which_on_path(name: &str) -> Option<PathBuf> {
         .find(|full| full.is_file())
 }
 
+/// Windows caps a process's command line at 32767 UTF-16 characters
+/// (`CreateProcessW`); a large "Open All in Picard" selection (e.g. the
+/// Missing Metadata auto-playlist with 1000+ songs) can blow past that as a
+/// single argument list, making `spawn()` fail outright. Kept well under
+/// the real ceiling so per-argument quoting overhead can't tip it over, and
+/// low enough to double as a sane ARG_MAX margin on Linux too.
+const MAX_COMMAND_LINE_CHARS: usize = 8000;
+
 /// Launches Picard with the given file/folder paths (Picard's CLI accepts
 /// one or more absolute paths as trailing arguments). Fire-and-forget —
 /// Picard is a long-lived GUI app; Luminous doesn't wait on it or read its
-/// output.
+/// output. Paths are split across multiple launches if needed to stay
+/// under the OS command-line length limit; Picard runs as a single
+/// instance, so a launch while it's already open hands its files to that
+/// running instance rather than opening a second window.
 pub fn launch_picard(exe: &Path, paths: &[PathBuf]) -> Result<()> {
     if paths.is_empty() {
         return Err(anyhow!("No files to open in Picard"));
     }
-    let mut cmd = Command::new(exe);
-    cmd.args(paths);
-    cmd.spawn().context("failed to launch MusicBrainz Picard")?;
+    for chunk in chunk_paths_by_length(paths, MAX_COMMAND_LINE_CHARS) {
+        let mut cmd = Command::new(exe);
+        cmd.args(chunk);
+        cmd.spawn().context("failed to launch MusicBrainz Picard")?;
+    }
     Ok(())
+}
+
+/// Groups paths into runs whose combined character count (plus one
+/// separator per path) stays within `max_chars`, without ever splitting a
+/// single path across chunks.
+fn chunk_paths_by_length(paths: &[PathBuf], max_chars: usize) -> Vec<Vec<&PathBuf>> {
+    let mut chunks: Vec<Vec<&PathBuf>> = Vec::new();
+    let mut current: Vec<&PathBuf> = Vec::new();
+    let mut current_len = 0;
+
+    for path in paths {
+        let len = path.as_os_str().len() + 1;
+        if !current.is_empty() && current_len + len > max_chars {
+            chunks.push(std::mem::take(&mut current));
+            current_len = 0;
+        }
+        current_len += len;
+        current.push(path);
+    }
+    if !current.is_empty() {
+        chunks.push(current);
+    }
+    chunks
 }
 
 #[cfg(test)]
@@ -121,5 +157,55 @@ mod tests {
         let exe = std::env::current_exe().unwrap();
         let result = launch_picard(&exe, &[]);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn chunk_paths_by_length_keeps_short_lists_in_one_chunk() {
+        let paths: Vec<PathBuf> = (0..5)
+            .map(|i| PathBuf::from(format!("song{i}.mp3")))
+            .collect();
+        let chunks = chunk_paths_by_length(&paths, 1000);
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].len(), 5);
+    }
+
+    #[test]
+    fn chunk_paths_by_length_splits_when_over_the_limit() {
+        // 1500 paths of ~40 chars each (~60,000 chars total) would blow past
+        // Windows' ~32K command-line limit as a single argument list (#804).
+        let paths: Vec<PathBuf> = (0..1500)
+            .map(|i| PathBuf::from(format!(r"C:\Music\Artist\Album\track_{i:04}.flac")))
+            .collect();
+        let chunks = chunk_paths_by_length(&paths, 8000);
+
+        assert!(chunks.len() > 1);
+        // No path is dropped or duplicated across chunks.
+        let total: usize = chunks.iter().map(|c| c.len()).sum();
+        assert_eq!(total, paths.len());
+        for chunk in &chunks {
+            let len: usize = chunk.iter().map(|p| p.as_os_str().len() + 1).sum();
+            assert!(len <= 8000);
+        }
+    }
+
+    #[test]
+    fn chunk_paths_by_length_never_splits_a_single_oversized_path() {
+        let huge_path = PathBuf::from("a".repeat(20_000));
+        let chunks = chunk_paths_by_length(std::slice::from_ref(&huge_path), 8000);
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].len(), 1);
+    }
+
+    #[test]
+    fn launch_picard_spawns_once_per_chunk_for_a_large_selection() {
+        let exe = std::env::current_exe().unwrap();
+        let paths: Vec<PathBuf> = (0..1500)
+            .map(|i| PathBuf::from(format!(r"C:\Music\Artist\Album\track_{i:04}.flac")))
+            .collect();
+        // `current_exe()` isn't Picard, but this only checks that spawning
+        // in chunks succeeds without hitting a command-line length error —
+        // it would previously fail as one oversized argument list (#804).
+        let result = launch_picard(&exe, &paths);
+        assert!(result.is_ok());
     }
 }

--- a/src-tauri/src/picard.rs
+++ b/src-tauri/src/picard.rs
@@ -81,29 +81,70 @@ fn which_on_path(name: &str) -> Option<PathBuf> {
 }
 
 /// Windows caps a process's command line at 32767 UTF-16 characters
-/// (`CreateProcessW`); a large "Open All in Picard" selection (e.g. the
-/// Missing Metadata auto-playlist with 1000+ songs) can blow past that as a
-/// single argument list, making `spawn()` fail outright. Kept well under
-/// the real ceiling so per-argument quoting overhead can't tip it over, and
-/// low enough to double as a sane ARG_MAX margin on Linux too.
+/// (`CreateProcessW`); a large "Open All in Picard" selection could still
+/// blow past that as a single argument list even after the caller has
+/// deduplicated songs down to their containing folders (e.g. a library
+/// where the Missing Metadata playlist spans hundreds of distinct album
+/// folders). Kept well under the real ceiling so per-argument quoting
+/// overhead can't tip it over, and low enough to double as a sane ARG_MAX
+/// margin on Linux too.
 const MAX_COMMAND_LINE_CHARS: usize = 8000;
 
+/// Gap between launches when more than one is needed (#804 follow-up).
+/// Picard's Windows single-instance IPC forwards each launch's paths to the
+/// already-running instance over a named pipe that gets closed and
+/// recreated after every message; firing launches at it back-to-back can
+/// race that recreation (dropping paths) or destabilize Picard outright —
+/// observed as Picard becoming unresponsive after a burst of launches.
+/// Comfortably longer than that pipe's recreation should ever take.
+const LAUNCH_STAGGER: std::time::Duration = std::time::Duration::from_secs(2);
+
 /// Launches Picard with the given file/folder paths (Picard's CLI accepts
-/// one or more absolute paths as trailing arguments). Fire-and-forget —
-/// Picard is a long-lived GUI app; Luminous doesn't wait on it or read its
-/// output. Paths are split across multiple launches if needed to stay
-/// under the OS command-line length limit; Picard runs as a single
-/// instance, so a launch while it's already open hands its files to that
-/// running instance rather than opening a second window.
+/// one or more absolute paths as trailing arguments, and recursively scans
+/// folders). Fire-and-forget — Picard is a long-lived GUI app; Luminous
+/// doesn't wait on it or read its output. Picard runs as a single instance,
+/// so a launch while it's already open hands its paths to that running
+/// instance rather than opening a second window.
+///
+/// Callers should already have deduplicated to as few paths as reasonably
+/// possible (e.g. per-album folders rather than per-song files, see
+/// `commands::picard::open_in_picard`) — this only splits across multiple
+/// launches as a last resort, when the combined argument list would
+/// otherwise exceed the OS command-line length limit. The first launch
+/// happens synchronously so a real failure (bad exe, permissions) surfaces
+/// to the caller immediately; any further launches happen from a
+/// background thread, spaced apart, and log rather than propagate errors.
 pub fn launch_picard(exe: &Path, paths: &[PathBuf]) -> Result<()> {
     if paths.is_empty() {
         return Err(anyhow!("No files to open in Picard"));
     }
-    for chunk in chunk_paths_by_length(paths, MAX_COMMAND_LINE_CHARS) {
-        let mut cmd = Command::new(exe);
-        cmd.args(chunk);
-        cmd.spawn().context("failed to launch MusicBrainz Picard")?;
+
+    let mut chunks = chunk_paths_by_length(paths, MAX_COMMAND_LINE_CHARS).into_iter();
+    let first = chunks
+        .next()
+        .expect("paths is non-empty, so at least one chunk exists");
+    spawn_chunk(exe, &first).context("failed to launch MusicBrainz Picard")?;
+
+    let remaining: Vec<Vec<PathBuf>> = chunks
+        .map(|chunk| chunk.into_iter().cloned().collect())
+        .collect();
+    if !remaining.is_empty() {
+        let exe = exe.to_path_buf();
+        std::thread::spawn(move || {
+            for chunk in remaining {
+                std::thread::sleep(LAUNCH_STAGGER);
+                if let Err(e) = spawn_chunk(&exe, &chunk) {
+                    log::warn!("Failed to hand additional paths to Picard: {e}");
+                }
+            }
+        });
     }
+
+    Ok(())
+}
+
+fn spawn_chunk<P: AsRef<std::ffi::OsStr>>(exe: &Path, chunk: &[P]) -> Result<()> {
+    Command::new(exe).args(chunk).spawn()?;
     Ok(())
 }
 
@@ -197,15 +238,20 @@ mod tests {
     }
 
     #[test]
-    fn launch_picard_spawns_once_per_chunk_for_a_large_selection() {
+    fn launch_picard_returns_promptly_for_a_large_selection() {
         let exe = std::env::current_exe().unwrap();
         let paths: Vec<PathBuf> = (0..1500)
-            .map(|i| PathBuf::from(format!(r"C:\Music\Artist\Album\track_{i:04}.flac")))
+            .map(|i| PathBuf::from(format!(r"C:\Music\Artist\Album{i:04}")))
             .collect();
-        // `current_exe()` isn't Picard, but this only checks that spawning
-        // in chunks succeeds without hitting a command-line length error —
-        // it would previously fail as one oversized argument list (#804).
+        // `current_exe()` isn't Picard, but this checks that (a) the first
+        // chunk's spawn succeeds without hitting a command-line length
+        // error — it would previously fail as one oversized argument list
+        // (#804) — and (b) any remaining chunks are handed off to a
+        // background thread rather than staggered inline, so this returns
+        // immediately rather than blocking for `LAUNCH_STAGGER` per chunk.
+        let start = std::time::Instant::now();
         let result = launch_picard(&exe, &paths);
         assert!(result.is_ok());
+        assert!(start.elapsed() < LAUNCH_STAGGER);
     }
 }

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -21,6 +21,7 @@
   import { tagsStore } from '../lib/stores/tags.svelte';
   import { updaterStore } from '../lib/stores/updater.svelte';
   import { picardStore } from '../lib/stores/picard.svelte';
+  import { scrobblerStore } from '../lib/stores/scrobbler.svelte';
   import { toastStore } from '../lib/stores/toast.svelte';
   import { isLinux as platformIsLinux } from '../lib/platform';
   import { themeStore } from '../lib/stores/theme.svelte';
@@ -72,6 +73,7 @@
     tagsStore.load().catch((err) => console.error('Failed to load tags:', err));
     updaterStore.init();
     picardStore.init();
+    scrobblerStore.init();
     void getCurrentWindow().show().catch(() => {});
 
     function handleGlobalHotkeys(e: KeyboardEvent) {


### PR DESCRIPTION
## 📋 Summary
Fixes #804 — "Open [All] in Picard" failing/misbehaving, found in three stages while chasing the original report:
1. With a very large selection (e.g. 1500+ songs in the Missing Metadata auto-playlist), launching Picard failed outright with "failed to launch MusicBrainz Picard".
2. After an initial fix for (1), Album Detail's "Open in Picard" only opened the *first* song of the album when Picard was already running, and hammering Picard with many launches for a large selection made it become unresponsive.
3. The "Missing MusicBrainz" auto-playlist card didn't appear in the Playlists view on a fresh launch until Settings → Integrations had been visited at least once.

## 🔍 Implementation Notes
- **(1)** `launch_picard()` passed every selected song's file path as one argument list to `Command::spawn()`. Windows caps a process's command line at ~32,767 characters (`CreateProcessW`); 1500+ absolute paths blew past that.
- **(2)** Picard's own Windows single-instance IPC (`picard/util/pipe.py`'s `WinPipe`) forwards a launch's file paths to an already-running instance as separate `LOAD` messages over a named pipe that's closed and recreated after *every single message* — and its sender loop abandons the rest of the list the moment one send races that recreation. Passing several files in one launch (or firing many launches back-to-back, my first attempt at fixing (1)) hit this repeatedly and either dropped files or destabilized Picard.
  - Fix: `open_in_picard` now resolves each selected song to its deduplicated **containing folder** (Picard scans folders recursively) instead of individual files — a same-album selection collapses to one folder argument, so there's no forwarding race left to hit. `launch_picard()` still chunks by command-line length as a last-resort safety net for a pathologically large cross-album selection, but any launches beyond the first are now spaced 2 seconds apart from a background thread instead of fired in a burst.
  - **Trade-off**: opening a folder loads every track Picard finds there, not just the selected song(s). Deliberate — keeps the common case reliable and simple rather than chasing per-file IPC delivery. Confirmed in manual testing: a 1456-song selection loaded ~1269 files into Picard within moments and did not crash Picard; the gap is expected to be Picard's own async folder scan (some paths are OneDrive-backed and may need on-demand hydration) plus our own staggered background launches still catching up, not a data-loss bug.
- **(3)** Unrelated to Picard itself: `scrobblerStore.enabled` (which gates the "Missing MusicBrainz" card's visibility) was only ever loaded by `SettingsIntegrations.svelte`'s `onMount`. `+layout.svelte` now calls `scrobblerStore.init()` at startup, same as it already does for `picardStore`. `init()` is idempotent, so `SettingsIntegrations.svelte` calling it again is a no-op.

Follow-ups, if the remaining count gap turns out to need more work once verified against a stable baseline, will be filed as a separate issue rather than block this PR.

## 🧪 Test Plan
- [x] `bun run check` (svelte-check) — 0 errors
- [x] `bun run test -- --run` (frontend) — `SettingsIntegrations` + `PlaylistsCollectionView` suites pass (4/4); full `picard.test.ts` suite unaffected (asserts invoke call shape only)
- [x] `cargo test` (src-tauri) — 302 passed, 1 ignored, 0 failed
- [x] Manually verified in the app: Album Detail "Open in Picard" with Picard both closed and already running; "Open All in Picard" on a 1456-song Missing MusicBrainz selection (no crash, loaded without the previous error); confirmed the Missing MusicBrainz card appears in Playlists without visiting Settings first

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed — n/a, no UI surface changed beyond existing card behavior working correctly
