### PR TITLE
polish: Top Albums chart contrast, layout, and Recently Added count

### DIFF
--- a/src/lib/components/HomeRowList.svelte
+++ b/src/lib/components/HomeRowList.svelte
@@ -96,10 +96,14 @@
     return i18n.t("home.chartSteady");
   }
 
-  function peakWeeksLabel(chart: TopAlbumChartInfo): string {
+  function peakLabel(chart: TopAlbumChartInfo): string {
+    return i18n.t("home.chartPeak", { peak: chart.peak_rank });
+  }
+
+  function weeksOnChartLabel(chart: TopAlbumChartInfo): string {
     return chart.weeks_on_chart === 1
-      ? i18n.t("home.chartPeakWeek", { peak: chart.peak_rank })
-      : i18n.t("home.chartPeakWeeks", { peak: chart.peak_rank, weeks: chart.weeks_on_chart });
+      ? i18n.t("home.chartWeek")
+      : i18n.t("home.chartWeeksCount", { weeks: chart.weeks_on_chart });
   }
 
   // Mirrors ArtistDetailView's openPlaylist: genre/decade auto-playlists open
@@ -147,7 +151,7 @@
   }
 </script>
 
-<div class="space-y-4">
+<div class="h-full flex flex-col gap-4">
   {#if title && onHeaderClick}
     <button
       type="button"
@@ -169,7 +173,7 @@
     </h2>
   {/if}
 
-  <div class="flex flex-col gap-2">
+  <div class="flex-1 flex flex-col justify-between gap-2">
     {#each items as item, i (keyFor(item))}
       <!-- svelte-ignore a11y_click_events_have_key_events -->
       <!-- svelte-ignore a11y_no_static_element_interactions -->
@@ -182,9 +186,29 @@
         class="group flex items-center gap-3 px-3 py-2.5 rounded-lg bg-brand-sidebar border border-brand-border/60 outline-2 -outline-offset-2 outline-transparent hover:outline-brand-accent transition-[outline-color,border-color] duration-200 select-none"
       >
         {#if variant === "rank" || variant === "chart"}
-          <span class="w-5 shrink-0 text-center text-sm font-bold text-brand-text-secondary tabular-nums">
-            {String(rankFor(item, i)).padStart(2, "0")}
-          </span>
+          <div class="w-5 shrink-0 flex flex-col items-center gap-0.5">
+            <span class="text-center text-sm font-bold text-brand-text-secondary tabular-nums">
+              {String(rankFor(item, i)).padStart(2, "0")}
+            </span>
+            {#if variant === "chart" && item.type === "album" && item.chart}
+              {@const chart = item.chart}
+              <span
+                class="flex items-center justify-center text-brand-text-primary"
+                aria-label={movementLabel(chart.movement)}
+                title={movementLabel(chart.movement)}
+              >
+                {#if chart.movement === "new"}
+                  <span class="text-[8px] font-bold uppercase tracking-wide">{i18n.t('home.chartNew')}</span>
+                {:else if chart.movement === "rising"}
+                  <TrendingUp class="w-3 h-3" />
+                {:else if chart.movement === "falling"}
+                  <TrendingDown class="w-3 h-3" />
+                {:else}
+                  <Minus class="w-3 h-3" />
+                {/if}
+              </span>
+            {/if}
+          </div>
         {/if}
 
         <div class="relative shrink-0 overflow-hidden">
@@ -213,7 +237,7 @@
         </div>
 
         {#if item.type === "album" || item.type === "song"}
-          <div class="min-w-0 flex-1 flex flex-col gap-0.5">
+          <div class="min-w-0 flex-1 flex flex-col gap-0.5 {variant === 'chart' ? 'leading-tight' : ''}">
             <div class="flex items-center justify-between gap-2">
               <p class="truncate text-sm font-semibold text-brand-text-primary min-w-0">{titleFor(item)}</p>
               <span class="text-xs text-brand-text-secondary font-medium tabular-nums shrink-0">{yearFor(item)}</span>
@@ -231,24 +255,8 @@
             {#if variant === "chart" && item.type === "album" && item.chart}
               {@const chart = item.chart}
               <div class="flex items-center justify-between gap-2">
-                <span
-                  class="flex items-center gap-1 text-xs font-semibold {chart.movement === 'rising' ? 'text-green-400' : chart.movement === 'falling' ? 'text-red-400' : 'text-brand-text-secondary'}"
-                  aria-label={movementLabel(chart.movement)}
-                  title={movementLabel(chart.movement)}
-                >
-                  {#if chart.movement === "new"}
-                    <span class="uppercase tracking-wide">{i18n.t('home.chartNew')}</span>
-                  {:else if chart.movement === "rising"}
-                    <TrendingUp class="w-3.5 h-3.5" />
-                  {:else if chart.movement === "falling"}
-                    <TrendingDown class="w-3.5 h-3.5" />
-                  {:else}
-                    <Minus class="w-3.5 h-3.5" />
-                  {/if}
-                </span>
-                <span class="text-xs text-brand-text-secondary font-medium tabular-nums shrink-0">
-                  {peakWeeksLabel(chart)}
-                </span>
+                <span class="text-xs text-brand-text-secondary font-medium tabular-nums shrink-0">{peakLabel(chart)}</span>
+                <span class="text-xs text-brand-text-secondary font-medium tabular-nums shrink-0">{weeksOnChartLabel(chart)}</span>
               </div>
             {/if}
           </div>

--- a/src/lib/components/HomeView.svelte
+++ b/src/lib/components/HomeView.svelte
@@ -62,7 +62,7 @@
       const [artists, top, added, featured] = await Promise.all([
         invoke<ArtistItem[]>("get_top_artists", { limit: 15 }),
         invoke<TopAlbumItem[]>("get_top_albums", { limit: 10 }),
-        invoke<HomeItem[]>("get_recently_added", { limit: 10 }),
+        invoke<HomeItem[]>("get_recently_added", { limit: 12 }),
         invoke<HomeItem[]>("get_featured_albums", { limit: 5 }),
       ]);
       topArtists = artists;
@@ -116,15 +116,6 @@
       <h1 class="text-3xl font-heading font-bold text-brand-text-primary">
         {timeOfDayGreeting}
       </h1>
-      <p class="text-sm text-brand-text-secondary mt-1">
-        {collectionStore.stats.total_songs > 0
-          ? i18n.t('home.libraryOverview', {
-              songs: collectionStore.stats.total_songs,
-              albums: collectionStore.stats.total_albums,
-              artists: collectionStore.stats.total_artists
-            })
-          : i18n.t('home.exploreSub')}
-      </p>
     </div>
 
     <div class="px-6 pt-4 space-y-12">

--- a/src/lib/components/HomeView.test.ts
+++ b/src/lib/components/HomeView.test.ts
@@ -99,7 +99,7 @@ describe("HomeView.svelte", () => {
     await waitFor(() => {
       expect(invoke).toHaveBeenCalledWith("get_top_artists", { limit: 15 });
       expect(invoke).toHaveBeenCalledWith("get_top_albums", { limit: 10 });
-      expect(invoke).toHaveBeenCalledWith("get_recently_added", { limit: 10 });
+      expect(invoke).toHaveBeenCalledWith("get_recently_added", { limit: 12 });
       expect(invoke).toHaveBeenCalledWith("get_featured_albums", { limit: 5 });
     });
   });

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -52,7 +52,6 @@ export const en = {
     greetingAfternoon: "Good Afternoon",
     greetingEvening: "Good Evening",
     greetingNight: "Good Night",
-    exploreSub: "Explore your music collection",
     loading: "Loading your collection...",
     topArtists: "Top Artists",
     topAlbums: "Top 10 Albums",
@@ -60,12 +59,12 @@ export const en = {
     chartRising: "Rising",
     chartFalling: "Falling",
     chartSteady: "Steady",
-    chartPeakWeek: "Peak #{peak} · 1 week",
-    chartPeakWeeks: "Peak #{peak} · {weeks} weeks",
+    chartPeak: "Peak #{peak}",
+    chartWeek: "1 week",
+    chartWeeksCount: "{weeks} weeks",
     recentlyAdded: "Recently Added",
     pinned: "Pinned",
     exploreLibrary: "Explore Your Library",
-    libraryOverview: "Explore your music collection: {artists} Artists • {albums} Albums • {songs} Songs",
     emptyState: "Start adding music to see your personalized collections"
   },
   emptyLibrary: {

--- a/src/lib/locales/fr.ts
+++ b/src/lib/locales/fr.ts
@@ -52,7 +52,6 @@ export const fr = {
     greetingAfternoon: "Bon après-midi",
     greetingEvening: "Bonsoir",
     greetingNight: "Bonne nuit",
-    exploreSub: "Explorez votre collection musicale",
     loading: "Chargement de votre collection...",
     topArtists: "Artistes populaires",
     topAlbums: "Top 10 des albums",
@@ -60,12 +59,12 @@ export const fr = {
     chartRising: "En hausse",
     chartFalling: "En baisse",
     chartSteady: "Stable",
-    chartPeakWeek: "Sommet n°{peak} · 1 semaine",
-    chartPeakWeeks: "Sommet n°{peak} · {weeks} semaines",
+    chartPeak: "Sommet n°{peak}",
+    chartWeek: "1 semaine",
+    chartWeeksCount: "{weeks} semaines",
     recentlyAdded: "Ajoutés récemment",
     pinned: "Épinglé",
     exploreLibrary: "Explorez votre bibliothèque",
-    libraryOverview: "Explorez votre collection musicale : {artists} artistes • {albums} albums • {songs} titres",
     emptyState: "Commencez à ajouter de la musique pour voir vos collections personnalisées"
   },
   emptyLibrary: {


### PR DESCRIPTION
## 📋 Summary
Milestone 2.0 polish pass on the Home view's Top Albums chart and Recently Added row, following up on the weekly Top Albums chart (#662).

## 🔍 Implementation Notes
- Removed the generic "Explore your music collection" subtitle (and the now-unused `home.exploreSub`/`home.libraryOverview` locale strings) from `HomeView.svelte`.
- `HomeRowList.svelte`: the rising/falling/steady/new chart-movement indicator is now `text-brand-text-primary` instead of red/green (too low-contrast against the row background), and it moved from beside the peak stat to directly under the rank number.
- Split the combined "Peak #N · n weeks" stat into two separate spans — "Peak #N" left-aligned, "n week(s)" right-aligned — replacing the `home.chartPeakWeek(s)` locale keys with `home.chartPeak` / `home.chartWeek` / `home.chartWeeksCount`.
- Tightened line-height (`leading-tight`) on the Top Albums text stack now that it carries a third line, scoped to `variant === "chart"` only so Most Played/Recently Added are unaffected.
- Extended Recently Added from 10 to 12 items (`get_recently_added` limit).
- Top Albums (10 rows) and Recently Added (12 rows) sit side-by-side in a two-column grid; Top Albums' rows are now stretched with `flex justify-between` so their combined height lines up with Recently Added's, using the grid's own row-stretch instead of a hardcoded gap value.

## 🧪 Test Plan
- [x] `bun run check` (svelte-check)
- [x] `bun run test -- --run` (frontend, full suite — 653 passed)
- [ ] `cargo test` (no Rust changed)
- [x] Manually verified in the app by the user

## 📸 Screenshots
Before/after reviewed interactively with the user during the session; no screenshot harness update needed (no new screenshot-worthy feature, per existing Home screenshots).

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed — not applicable, no new feature surface
