### PR TITLE
fix: make migration runner resilient to schema_version gaps

### DIFF
--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -266,8 +266,19 @@ impl Database {
 
         log::info!("Database schema version: {version} (current: {CURRENT_SCHEMA_VERSION})");
 
+        // Check each migration's own recorded row rather than relying on MAX(version)
+        // being contiguous — an interrupted run in the past can leave a gap (e.g. a
+        // later migration's row present but an earlier one's missing), and MAX alone
+        // would then skip that earlier migration forever since it never re-evaluates
+        // versions below the max.
+        let mut applied_versions: std::collections::HashSet<i32> = {
+            let mut stmt = conn.prepare("SELECT version FROM schema_version")?;
+            let rows = stmt.query_map([], |row| row.get(0))?;
+            rows.collect::<rusqlite::Result<_>>()?
+        };
+
         for migration in MIGRATIONS {
-            if version < migration.version {
+            if !applied_versions.contains(&migration.version) {
                 log::info!(
                     "Running migration {}: {}",
                     migration.version,
@@ -278,6 +289,7 @@ impl Database {
                     "INSERT OR REPLACE INTO schema_version (version) VALUES (?1)",
                     params![migration.version],
                 )?;
+                applied_versions.insert(migration.version);
             }
         }
 
@@ -946,6 +958,49 @@ mod tests {
         let db = Database::new(temp_dir.clone()).unwrap();
         assert_eq!(db.schema_version, CURRENT_SCHEMA_VERSION + 1);
         assert!(db.is_newer_than_app());
+
+        let _ = std::fs::remove_dir_all(temp_dir);
+    }
+
+    #[test]
+    fn test_reopen_heals_a_gap_left_by_an_interrupted_migration() {
+        let temp_dir = std::env::temp_dir().join(format!(
+            "luminous_migration_gap_test_{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let db = Database::new(temp_dir.clone()).unwrap();
+        assert_eq!(db.schema_version, CURRENT_SCHEMA_VERSION);
+
+        // Simulate an interrupted migration 23: its schema_version row never
+        // got written even though every migration around it did, and its
+        // column was never added — as would happen if the app crashed
+        // between `apply()` completing for a later migration and 23's own
+        // `INSERT INTO schema_version`. A MAX(version)-based runner would
+        // see 26 as the max and conclude 23 (< 26) already ran.
+        {
+            let conn = db.pool.get().unwrap();
+            conn.execute("DELETE FROM schema_version WHERE version = 23", [])
+                .unwrap();
+            conn.execute("ALTER TABLE songs DROP COLUMN not_included", [])
+                .unwrap();
+        }
+        drop(db);
+
+        let reopened = Database::new(temp_dir.clone()).unwrap();
+        assert_eq!(reopened.schema_version, CURRENT_SCHEMA_VERSION);
+        let conn = reopened.pool.get().unwrap();
+        let has_not_included: bool = conn
+            .prepare("SELECT 1 FROM pragma_table_info('songs') WHERE name = 'not_included'")
+            .unwrap()
+            .exists([])
+            .unwrap();
+        assert!(
+            has_not_included,
+            "reopening should have re-run migration 23 and healed the gap"
+        );
 
         let _ = std::fs::remove_dir_all(temp_dir);
     }


### PR DESCRIPTION
## 📋 Summary
Fixes #808. The migration runner in `run_migrations` gated each migration on `MAX(version) < migration.version`, which assumes `schema_version` rows are contiguous. If a single migration's row never got written (e.g. an interrupted app run) while later migrations' rows did, `MAX(version)` climbs past the skipped one and its `version < migration.version` check becomes permanently false — that migration silently never runs again, even though its schema change was never applied. This was hit in practice: a local dev DB had rows 1-22, 24, 25, 26 in `schema_version` but not 23, and `songs` was genuinely missing the `not_included` column migration 23 adds, causing `no such column: not_included` errors at startup.

## 🔍 Implementation Notes
Changed the gate to track the full set of applied version numbers (loaded once via `SELECT version FROM schema_version`) instead of a single `MAX(version)` scalar, so any migration whose version isn't in that set still runs — regardless of what the max recorded version is. This makes the runner self-healing: a gap left by a prior interrupted run gets picked up and re-applied on the next launch. No schema/migration content changed, only the gating logic in `Database::run_migrations` (`src-tauri/src/db.rs`).

## 🧪 Test Plan
- [x] `cargo test --lib db::tests` (src-tauri) — 5/5 pass, including a new regression test `test_reopen_heals_a_gap_left_by_an_interrupted_migration` that simulates the exact scenario (deletes migration 23's `schema_version` row and drops its column while later rows/columns stay in place) and asserts a reopen heals it.
- [x] `cargo check` — clean.
- [x] Manually verified in the app: found this bug live in my own local dev DB (`no such column: not_included` at startup), patched that DB directly to unblock, and confirmed the underlying gap/root cause matches what this fix addresses.

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed — n/a, no user-facing behavior change (bugfix in internal migration bookkeeping only)
