### PR TITLE
fix: let equalizer band grids grow to fit wrapped rows on narrow widths

### DIFF
--- a/src/lib/components/Equalizer.svelte
+++ b/src/lib/components/Equalizer.svelte
@@ -481,7 +481,7 @@
     {/if}
 
     {#if mode === "graphic10"}
-      <div class="grid grid-cols-5 md:grid-cols-10 gap-3 md:gap-5 h-64 md:h-72 items-center bg-brand-main/50 border border-brand-border/50 rounded-xl p-4 md:p-6">
+      <div class="grid grid-cols-5 md:grid-cols-10 gap-3 md:gap-5 min-h-64 h-auto md:h-72 items-center bg-brand-main/50 border border-brand-border/50 rounded-xl p-4 md:p-6">
         {#each gains as gain, idx}
           <div class="flex flex-col items-center justify-between h-full group">
             <span class="text-[10px] font-bold w-full text-center transition-colors {gain > 0 ? 'text-green-400/80' : gain < 0 ? 'text-red-400/80' : 'text-brand-text-secondary/70'}">
@@ -509,7 +509,7 @@
         {/each}
       </div>
     {:else}
-      <div class="grid grid-cols-10 md:grid-cols-[repeat(20,minmax(0,1fr))] gap-1 md:gap-1.5 h-64 md:h-72 items-center bg-brand-main/50 border border-brand-border/50 rounded-xl p-3 md:p-4">
+      <div class="grid grid-cols-10 md:grid-cols-[repeat(20,minmax(0,1fr))] gap-1 md:gap-1.5 min-h-64 h-auto md:h-72 items-center bg-brand-main/50 border border-brand-border/50 rounded-xl p-3 md:p-4">
         {#each parametric as band, idx}
           <div
             class="flex flex-col items-center justify-between h-full group rounded-md transition-colors {selectedBand === idx ? 'bg-brand-accent/10 ring-1 ring-brand-accent/50' : 'hover:bg-brand-sidebar/30'}"


### PR DESCRIPTION
## 📋 Summary
Fixes #720. Below the Tailwind `md` breakpoint (<768px), the Settings → Equalizer tab's 10-band and 20-band grids wrapped into two rows but kept a fixed `h-64 md:h-72` height, so the second row overflowed the card and overlapped the "Loudness Normalization" card below it.

## 🔍 Implementation Notes
Both grid containers in `src/lib/components/Equalizer.svelte` (10-band graphic at line 484, 20-band parametric at line 512) now use `min-h-64 h-auto md:h-72` instead of `h-64 md:h-72`. Below `md` the container grows to fit however many rows the bands wrap into (floored at the original `min-h-64` height so a single row never looks cramped); at `md` and up it keeps the fixed `h-72` since it's always a single row there.

Out of scope: the issue also flagged the Settings tab pill bar (`SettingsView.svelte`) overflowing horizontally off-screen below ~768px with no scroll affordance — confirmed this still happens, but it's a separate fix left for a follow-up.

## 🧪 Test Plan
- [x] `bun run check` (svelte-check)
- [ ] `bun run test -- --run` (frontend) — no tests affected by a Tailwind class change
- [ ] `cargo test` (src-tauri, if Rust changed) — no Rust changed
- [x] Manually verified in the app (user ran `bun run tauri dev`, resized Settings → Equalizer below 768px, confirmed both grids now expand cleanly without overlapping Loudness Normalization)

## 📸 Screenshots
N/A

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed — CSS-only fix, no docs affected
