### PR TITLE
feat: add Personal Stats view (#130)

### DIFF
--- a/src-tauri/src/commands/stats.rs
+++ b/src-tauri/src/commands/stats.rs
@@ -1,5 +1,40 @@
+use crate::models::StatsSummary;
+use crate::stats_summary::StatsRange;
 use crate::AppState;
 use tauri::{AppHandle, Emitter, State};
+
+#[tauri::command]
+pub async fn get_stats_summary(
+    range: String,
+    state: State<'_, AppState>,
+) -> Result<StatsSummary, String> {
+    let conn = state.db.pool.get().map_err(|e| e.to_string())?;
+    let range = StatsRange::parse(&range).ok_or_else(|| format!("invalid range: {range}"))?;
+    crate::stats_summary::get_summary(&conn, range).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub async fn get_stats_exclusions(
+    state: State<'_, AppState>,
+) -> Result<Vec<(String, String)>, String> {
+    let conn = state.db.pool.get().map_err(|e| e.to_string())?;
+    crate::stats::get_stats_exclusions(&conn).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub async fn set_stats_excluded(
+    entity_type: String,
+    entity_key: String,
+    excluded: bool,
+    app: AppHandle,
+    state: State<'_, AppState>,
+) -> Result<(), String> {
+    let conn = state.db.pool.get().map_err(|e| e.to_string())?;
+    crate::stats::set_stats_excluded(&conn, &entity_type, &entity_key, excluded)
+        .map_err(|e| e.to_string())?;
+    let _ = app.emit("stats-exclusions-changed", ());
+    Ok(())
+}
 
 #[tauri::command]
 pub async fn set_song_rating(

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 pub type DbPool = Pool<SqliteConnectionManager>;
 
 /// Current schema version. Increment when adding migrations.
-pub const CURRENT_SCHEMA_VERSION: i32 = 26;
+pub const CURRENT_SCHEMA_VERSION: i32 = 27;
 
 struct Migration {
     version: i32,
@@ -187,6 +187,11 @@ const MIGRATIONS: &[Migration] = &[
         version: 26,
         description: "scrobble_cache table for offline scrobbles (#83)",
         apply: |conn| Ok(conn.execute_batch(MIGRATION_26)?),
+    },
+    Migration {
+        version: 27,
+        description: "play_history song_id index and stats_exclusions table for Personal Stats (#130)",
+        apply: |conn| Ok(conn.execute_batch(MIGRATION_27)?),
     },
 ];
 
@@ -773,6 +778,24 @@ CREATE TABLE IF NOT EXISTS scrobble_cache (
     created_at         INTEGER NOT NULL DEFAULT (strftime('%s', 'now'))
 );
 CREATE INDEX IF NOT EXISTS idx_scrobble_cache_created ON scrobble_cache(created_at);
+";
+
+// ---------------------------------------------------------------------------
+// Migration 27: play_history.song_id index (aggregation joins for Personal
+// Stats previously had no index to use) and stats_exclusions — a generic
+// per-entity-kind exclusion table for the "Don't include in stats" flag
+// (#130). One table instead of per-entity boolean columns because most of
+// these entities (album/artist/genre) are denormalized text on `songs`, not
+// rows with their own primary key — `entity_key` follows the same raw-string
+// keying convention as `album_ratings.album_key`/`artist_profiles.artist_key`.
+// ---------------------------------------------------------------------------
+const MIGRATION_27: &str = "
+CREATE INDEX IF NOT EXISTS idx_play_history_song_id ON play_history(song_id);
+CREATE TABLE IF NOT EXISTS stats_exclusions (
+    entity_type TEXT NOT NULL,
+    entity_key TEXT NOT NULL,
+    PRIMARY KEY (entity_type, entity_key)
+);
 ";
 
 // ---------------------------------------------------------------------------

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -33,6 +33,7 @@ pub mod playlist_parsers;
 pub mod restart_manager;
 pub mod scrobbler;
 pub mod stats;
+pub mod stats_summary;
 pub mod tageditor;
 pub mod tags;
 pub mod tray;
@@ -1081,6 +1082,9 @@ pub fn run() {
             // Stats commands
             commands::stats::set_song_rating,
             commands::stats::set_album_rating,
+            commands::stats::get_stats_summary,
+            commands::stats::get_stats_exclusions,
+            commands::stats::set_stats_excluded,
             // Organizer commands
             commands::organizer::preview_organize,
             commands::organizer::apply_organize,

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -794,6 +794,45 @@ pub struct TopAlbumItem {
     pub movement: String,
 }
 
+/// One ranked entry in a Personal Stats Top 10 list (#130) — a song, album,
+/// artist, or genre and its play count within the selected range.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StatsTopItem {
+    /// Identity used for exclusion lookups/toggles: song id as a string,
+    /// or the raw album/artist/genre text, matching `stats_exclusions.entity_key`.
+    pub key: String,
+    pub label: String,
+    /// Secondary line, e.g. the artist for a song or album row. `None` for
+    /// artist/genre rows, which have no secondary line of their own.
+    pub secondary: Option<String>,
+    pub play_count: i64,
+    pub excluded: bool,
+    /// The song's album title, set only on `top_songs` rows — songs have no
+    /// detail page of their own, so clicking one navigates to this album
+    /// instead. `None` for every other row kind.
+    pub album: Option<String>,
+}
+
+/// Personal Stats summary for one range (#130) — top 10 songs/albums/artists/
+/// genres by play count, plus every play's raw timestamp in range so the
+/// frontend can bucket the "listening clock" histogram in local time.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StatsSummary {
+    /// "7d" | "28d" | "1y", echoing the requested range back to the caller.
+    pub range: String,
+    pub top_songs: Vec<StatsTopItem>,
+    /// Album play count is `MIN` of plays across an album's tracks (a
+    /// completionist metric — full listens front-to-back), not `SUM` like the
+    /// Home "Top Albums" chart's engagement metric — the two numbers are
+    /// deliberately different and will disagree for the same album/range.
+    pub top_albums: Vec<StatsTopItem>,
+    pub top_artists: Vec<StatsTopItem>,
+    pub top_genres: Vec<StatsTopItem>,
+    /// Unix-second timestamps of every in-range, non-excluded play, for
+    /// client-side local-time listening-clock bucketing.
+    pub play_timestamps: Vec<i64>,
+}
+
 /// Represents a dynamic item in the Home curation carousels (a Song, an Album, or a Playlist).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "camelCase")]

--- a/src-tauri/src/stats.rs
+++ b/src-tauri/src/stats.rs
@@ -118,6 +118,43 @@ pub fn get_album_rating(conn: &Connection, album: &str) -> Result<f32> {
     Ok(rating)
 }
 
+/// Every current Personal Stats exclusion (#130), as `(entity_type,
+/// entity_key)` pairs — loaded once by the frontend's exclusion store,
+/// mirroring how `PinnedStore` preloads `get_pinned_items` rather than
+/// checking pin state one item at a time.
+pub fn get_stats_exclusions(conn: &Connection) -> Result<Vec<(String, String)>> {
+    let mut stmt = conn.prepare("SELECT entity_type, entity_key FROM stats_exclusions")?;
+    let rows = stmt
+        .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))?
+        .filter_map(|r| r.ok())
+        .collect();
+    Ok(rows)
+}
+
+/// Set or clear a Personal Stats exclusion (#130) for a song/album/artist/
+/// genre, keyed the same way `stats_exclusions.entity_key` is queried in
+/// `crate::stats_summary` (song id as text, or the raw album/artist/genre
+/// string).
+pub fn set_stats_excluded(
+    conn: &Connection,
+    entity_type: &str,
+    entity_key: &str,
+    excluded: bool,
+) -> Result<()> {
+    if excluded {
+        conn.execute(
+            "INSERT OR IGNORE INTO stats_exclusions (entity_type, entity_key) VALUES (?1, ?2)",
+            params![entity_type, entity_key],
+        )?;
+    } else {
+        conn.execute(
+            "DELETE FROM stats_exclusions WHERE entity_type = ?1 AND entity_key = ?2",
+            params![entity_type, entity_key],
+        )?;
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src-tauri/src/stats_summary.rs
+++ b/src-tauri/src/stats_summary.rs
@@ -1,0 +1,434 @@
+//! Personal Stats aggregation (#130) — range-filtered Top 10 artists/albums/
+//! songs/genres and listening-clock timestamps, computed live from
+//! `play_history` + `songs`. Deliberately does **not** touch
+//! `album_chart_history` (the Home "Top Albums" weekly chart's snapshot
+//! table, #662) — that table only tracks the top 10 albums per week, so
+//! summing across weeks would silently undercount anything that never
+//! cracked a weekly top 10. See issue #130's comment thread.
+
+use crate::models::{parse_multi_value, StatsSummary, StatsTopItem};
+use anyhow::Result;
+use rusqlite::{params, Connection};
+
+/// A Personal Stats time window.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StatsRange {
+    SevenDays,
+    TwentyEightDays,
+    OneYear,
+}
+
+impl StatsRange {
+    pub fn parse(raw: &str) -> Option<Self> {
+        match raw {
+            "7d" => Some(Self::SevenDays),
+            "28d" => Some(Self::TwentyEightDays),
+            "1y" => Some(Self::OneYear),
+            _ => None,
+        }
+    }
+
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::SevenDays => "7d",
+            Self::TwentyEightDays => "28d",
+            Self::OneYear => "1y",
+        }
+    }
+
+    fn days(&self) -> i64 {
+        match self {
+            Self::SevenDays => 7,
+            Self::TwentyEightDays => 28,
+            Self::OneYear => 365,
+        }
+    }
+}
+
+const SECONDS_PER_DAY: i64 = 86_400;
+
+/// Start of a rolling range ending `now` — plain `now - N*86400` arithmetic,
+/// no calendar alignment needed (unlike the Monday-aligned weekly chart in
+/// `collection::query::week_start_utc`). Split out with an explicit `now`
+/// so tests can drive it deterministically.
+pub fn range_start_unix(range: StatsRange, now: i64) -> i64 {
+    now - range.days() * SECONDS_PER_DAY
+}
+
+const TOP_N: i64 = 10;
+
+/// Build a full Personal Stats summary for `range`, excluding any song,
+/// album, artist, or genre flagged in `stats_exclusions`.
+pub fn get_summary(conn: &Connection, range: StatsRange) -> Result<StatsSummary> {
+    get_summary_at(conn, range, chrono::Utc::now().timestamp())
+}
+
+fn get_summary_at(conn: &Connection, range: StatsRange, now: i64) -> Result<StatsSummary> {
+    let range_start = range_start_unix(range, now);
+    Ok(StatsSummary {
+        range: range.as_str().to_string(),
+        top_songs: top_songs(conn, range_start)?,
+        top_albums: top_albums(conn, range_start)?,
+        top_artists: top_artists(conn, range_start)?,
+        top_genres: top_genres(conn, range_start)?,
+        play_timestamps: play_timestamps(conn, range_start)?,
+    })
+}
+
+fn top_songs(conn: &Connection, range_start: i64) -> Result<Vec<StatsTopItem>> {
+    let mut stmt = conn.prepare(
+        "SELECT CAST(s.id AS TEXT), s.title, s.artist, COUNT(*) AS play_count, s.album
+         FROM play_history ph
+         JOIN songs s ON s.id = ph.song_id
+         WHERE ph.played_at >= ?1
+           AND s.source IN (1, 2) AND s.unavailable = 0
+           AND NOT EXISTS (
+               SELECT 1 FROM stats_exclusions se
+               WHERE se.entity_type = 'song' AND se.entity_key = CAST(s.id AS TEXT)
+           )
+         GROUP BY s.id
+         ORDER BY play_count DESC, s.title COLLATE NOCASE ASC
+         LIMIT ?2",
+    )?;
+    let rows = stmt
+        .query_map(params![range_start, TOP_N], |row| {
+            Ok(StatsTopItem {
+                key: row.get(0)?,
+                label: row.get::<_, Option<String>>(1)?.unwrap_or_default(),
+                secondary: row.get(2)?,
+                play_count: row.get(3)?,
+                excluded: false,
+                album: row.get(4)?,
+            })
+        })?
+        .filter_map(|r| r.ok())
+        .collect();
+    Ok(rows)
+}
+
+/// Album play count is `MIN` of per-track play counts within range (a
+/// completionist metric — full front-to-back listens), deliberately
+/// different from the Home "Top Albums" chart's `SUM`-based engagement
+/// metric (`CollectionScanner::get_top_albums`). The two numbers will
+/// legitimately disagree for the same album/range — see #130's discussion.
+fn top_albums(conn: &Connection, range_start: i64) -> Result<Vec<StatsTopItem>> {
+    let mut stmt = conn.prepare(
+        "SELECT s.album, MIN(COALESCE(s.album_artist, s.artist)), MIN(track_plays.plays) AS min_plays
+         FROM songs s
+         JOIN (
+             SELECT s2.id AS song_id, COUNT(*) AS plays
+             FROM play_history ph
+             JOIN songs s2 ON s2.id = ph.song_id
+             WHERE ph.played_at >= ?1
+             GROUP BY s2.id
+         ) track_plays ON track_plays.song_id = s.id
+         WHERE s.source IN (1, 2) AND s.unavailable = 0
+           AND s.album IS NOT NULL AND s.album != ''
+           AND NOT EXISTS (
+               SELECT 1 FROM stats_exclusions se
+               WHERE se.entity_type = 'album' AND se.entity_key = s.album COLLATE NOCASE
+           )
+         GROUP BY s.album
+         ORDER BY min_plays DESC, s.album COLLATE NOCASE ASC
+         LIMIT ?2",
+    )?;
+    let rows = stmt
+        .query_map(params![range_start, TOP_N], |row| {
+            Ok(StatsTopItem {
+                key: row.get(0)?,
+                label: row.get(0)?,
+                secondary: row.get(1)?,
+                play_count: row.get(2)?,
+                excluded: false,
+                album: None,
+            })
+        })?
+        .filter_map(|r| r.ok())
+        .collect();
+    Ok(rows)
+}
+
+fn top_artists(conn: &Connection, range_start: i64) -> Result<Vec<StatsTopItem>> {
+    let mut stmt = conn.prepare(
+        "SELECT COALESCE(NULLIF(s.album_artist, ''), s.artist, '') AS effective_artist,
+                COUNT(*) AS play_count
+         FROM play_history ph
+         JOIN songs s ON s.id = ph.song_id
+         WHERE ph.played_at >= ?1
+           AND s.source IN (1, 2) AND s.unavailable = 0
+           AND COALESCE(NULLIF(s.album_artist, ''), s.artist, '') != ''
+           AND NOT EXISTS (
+               SELECT 1 FROM stats_exclusions se
+               WHERE se.entity_type = 'artist'
+                 AND se.entity_key = COALESCE(NULLIF(s.album_artist, ''), s.artist, '') COLLATE NOCASE
+           )
+         GROUP BY effective_artist COLLATE NOCASE
+         ORDER BY play_count DESC, effective_artist COLLATE NOCASE ASC
+         LIMIT ?2",
+    )?;
+    let rows = stmt
+        .query_map(params![range_start, TOP_N], |row| {
+            Ok(StatsTopItem {
+                key: row.get(0)?,
+                label: row.get(0)?,
+                secondary: None,
+                play_count: row.get(1)?,
+                excluded: false,
+                album: None,
+            })
+        })?
+        .filter_map(|r| r.ok())
+        .collect();
+    Ok(rows)
+}
+
+/// `songs.genre` is a `; `-delimited multi-value string (see
+/// `crate::models::parse_multi_value`/`crate::tags::TagManager`), so genre
+/// counting can't be a plain SQL `GROUP BY` — each play is attributed to
+/// every genre tag on its song, then tallied and ranked in Rust.
+fn top_genres(conn: &Connection, range_start: i64) -> Result<Vec<StatsTopItem>> {
+    let mut stmt = conn.prepare(
+        "SELECT s.genre
+         FROM play_history ph
+         JOIN songs s ON s.id = ph.song_id
+         WHERE ph.played_at >= ?1
+           AND s.source IN (1, 2) AND s.unavailable = 0
+           AND s.genre IS NOT NULL AND s.genre != ''",
+    )?;
+    let genre_lists: Vec<String> = stmt
+        .query_map(params![range_start], |row| row.get(0))?
+        .filter_map(|r| r.ok())
+        .collect();
+
+    let excluded_genres = excluded_keys(conn, "genre")?;
+    let mut counts: std::collections::HashMap<String, i64> = std::collections::HashMap::new();
+    for raw in genre_lists {
+        for genre in parse_multi_value(&raw) {
+            if excluded_genres.contains(&genre.to_lowercase()) {
+                continue;
+            }
+            *counts.entry(genre).or_insert(0) += 1;
+        }
+    }
+
+    let mut ranked: Vec<(String, i64)> = counts.into_iter().collect();
+    ranked.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+    ranked.truncate(TOP_N as usize);
+
+    Ok(ranked
+        .into_iter()
+        .map(|(genre, play_count)| StatsTopItem {
+            key: genre.clone(),
+            label: genre,
+            secondary: None,
+            play_count,
+            excluded: false,
+            album: None,
+        })
+        .collect())
+}
+
+fn excluded_keys(
+    conn: &Connection,
+    entity_type: &str,
+) -> Result<std::collections::HashSet<String>> {
+    let mut stmt =
+        conn.prepare("SELECT entity_key FROM stats_exclusions WHERE entity_type = ?1")?;
+    let keys = stmt
+        .query_map(params![entity_type], |row| row.get::<_, String>(0))?
+        .filter_map(|r| r.ok())
+        .map(|k| k.to_lowercase())
+        .collect();
+    Ok(keys)
+}
+
+/// Raw `played_at` timestamps for every non-excluded, in-range play, for the
+/// frontend to bucket into a local-time listening clock. Bucketing happens
+/// client-side (`new Date(ts * 1000).getHours()`) rather than via a
+/// server-side UTC-offset param — simpler, no DST logic, and immune to
+/// stale-offset bugs if the user's timezone changes between listen-time and
+/// view-time.
+fn play_timestamps(conn: &Connection, range_start: i64) -> Result<Vec<i64>> {
+    let mut stmt = conn.prepare(
+        "SELECT ph.played_at
+         FROM play_history ph
+         JOIN songs s ON s.id = ph.song_id
+         WHERE ph.played_at >= ?1
+           AND s.source IN (1, 2) AND s.unavailable = 0
+           AND NOT EXISTS (
+               SELECT 1 FROM stats_exclusions se
+               WHERE se.entity_type = 'song' AND se.entity_key = CAST(s.id AS TEXT)
+           )",
+    )?;
+    let rows = stmt
+        .query_map(params![range_start], |row| row.get(0))?
+        .filter_map(|r| r.ok())
+        .collect();
+    Ok(rows)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::Database;
+
+    fn test_db() -> (Database, std::path::PathBuf) {
+        let temp_dir = std::env::temp_dir().join(format!(
+            "luminous_stats_summary_test_{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        (Database::new(temp_dir.clone()).unwrap(), temp_dir)
+    }
+
+    fn insert_song(
+        conn: &Connection,
+        path: &str,
+        title: &str,
+        artist: &str,
+        album: &str,
+        genre: &str,
+    ) -> i64 {
+        conn.execute(
+            "INSERT INTO songs (path, title, artist, album, genre, source, unavailable)
+             VALUES (?1, ?2, ?3, ?4, ?5, 1, 0)",
+            params![path, title, artist, album, genre],
+        )
+        .unwrap();
+        conn.last_insert_rowid()
+    }
+
+    fn insert_play(conn: &Connection, song_id: i64, played_at: i64) {
+        conn.execute(
+            "INSERT INTO play_history (context_type, song_id, played_at) VALUES ('song', ?1, ?2)",
+            params![song_id, played_at],
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn test_range_start_unix() {
+        let now = 1_700_000_000;
+        assert_eq!(
+            range_start_unix(StatsRange::SevenDays, now),
+            now - 7 * SECONDS_PER_DAY
+        );
+        assert_eq!(
+            range_start_unix(StatsRange::TwentyEightDays, now),
+            now - 28 * SECONDS_PER_DAY
+        );
+        assert_eq!(
+            range_start_unix(StatsRange::OneYear, now),
+            now - 365 * SECONDS_PER_DAY
+        );
+    }
+
+    #[test]
+    fn test_stats_range_parse() {
+        assert_eq!(StatsRange::parse("7d"), Some(StatsRange::SevenDays));
+        assert_eq!(StatsRange::parse("28d"), Some(StatsRange::TwentyEightDays));
+        assert_eq!(StatsRange::parse("1y"), Some(StatsRange::OneYear));
+        assert_eq!(StatsRange::parse("bogus"), None);
+    }
+
+    #[test]
+    fn test_top_songs_excludes_out_of_range_and_flagged_songs() {
+        let (db, dir) = test_db();
+        let conn = db.pool.get().unwrap();
+        let now = 1_700_000_000;
+        let range_start = range_start_unix(StatsRange::SevenDays, now);
+
+        let in_range = insert_song(&conn, "/a.flac", "In Range", "Artist A", "Album A", "Rock");
+        let out_of_range = insert_song(&conn, "/b.flac", "Out", "Artist B", "Album B", "Pop");
+        let excluded = insert_song(&conn, "/c.flac", "Excluded", "Artist C", "Album C", "Jazz");
+
+        insert_play(&conn, in_range, range_start + 10);
+        insert_play(&conn, out_of_range, range_start - 10);
+        insert_play(&conn, excluded, range_start + 10);
+        conn.execute(
+            "INSERT INTO stats_exclusions (entity_type, entity_key) VALUES ('song', ?1)",
+            params![excluded.to_string()],
+        )
+        .unwrap();
+
+        let songs = top_songs(&conn, range_start).unwrap();
+        let labels: Vec<&str> = songs.iter().map(|s| s.label.as_str()).collect();
+        assert_eq!(labels, vec!["In Range"]);
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn test_top_albums_uses_min_not_sum() {
+        let (db, dir) = test_db();
+        let conn = db.pool.get().unwrap();
+        let now = 1_700_000_000;
+        let range_start = range_start_unix(StatsRange::SevenDays, now);
+
+        // Track 1 played 5x, track 2 played 1x — MIN should be 1, not SUM (6).
+        let t1 = insert_song(&conn, "/t1.flac", "T1", "Artist", "Album", "Rock");
+        let t2 = insert_song(&conn, "/t2.flac", "T2", "Artist", "Album", "Rock");
+        for _ in 0..5 {
+            insert_play(&conn, t1, range_start + 10);
+        }
+        insert_play(&conn, t2, range_start + 10);
+
+        let albums = top_albums(&conn, range_start).unwrap();
+        assert_eq!(albums.len(), 1);
+        assert_eq!(albums[0].play_count, 1);
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn test_top_genres_splits_multi_value_and_respects_exclusions() {
+        let (db, dir) = test_db();
+        let conn = db.pool.get().unwrap();
+        let now = 1_700_000_000;
+        let range_start = range_start_unix(StatsRange::SevenDays, now);
+
+        let song = insert_song(
+            &conn,
+            "/multi.flac",
+            "Multi",
+            "Artist",
+            "Album",
+            "Metal; Symphonic Metal",
+        );
+        insert_play(&conn, song, range_start + 10);
+        conn.execute(
+            "INSERT INTO stats_exclusions (entity_type, entity_key) VALUES ('genre', 'symphonic metal')",
+            params![],
+        )
+        .unwrap();
+
+        let genres = top_genres(&conn, range_start).unwrap();
+        let labels: Vec<&str> = genres.iter().map(|g| g.label.as_str()).collect();
+        assert_eq!(labels, vec!["Metal"]);
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn test_get_summary_at_returns_all_sections() {
+        let (db, dir) = test_db();
+        let conn = db.pool.get().unwrap();
+        let now = 1_700_000_000;
+        let range_start = range_start_unix(StatsRange::SevenDays, now);
+
+        let song = insert_song(&conn, "/s.flac", "Song", "Artist", "Album", "Rock");
+        insert_play(&conn, song, range_start + 10);
+
+        let summary = get_summary_at(&conn, StatsRange::SevenDays, now).unwrap();
+        assert_eq!(summary.range, "7d");
+        assert_eq!(summary.top_songs.len(), 1);
+        assert_eq!(summary.top_albums.len(), 1);
+        assert_eq!(summary.top_artists.len(), 1);
+        assert_eq!(summary.top_genres.len(), 1);
+        assert_eq!(summary.play_timestamps, vec![range_start + 10]);
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+}

--- a/src/lib/components/AlbumContextMenu.svelte
+++ b/src/lib/components/AlbumContextMenu.svelte
@@ -8,11 +8,13 @@
     PushPinIcon as Pin,
     PushPinSlashIcon as PinOff,
     PencilSimpleIcon as Edit3,
-    ArrowSquareOutIcon as OpenInPicard
+    ArrowSquareOutIcon as OpenInPicard,
+    ChartBarIcon as BarChart2
   } from "phosphor-svelte";
   import { i18n } from "../stores/i18n.svelte";
   import { playlistsStore } from "../stores/playlists.svelte";
   import { pinnedStore } from "../stores/pinned.svelte";
+  import { statsExclusionsStore } from "../stores/statsExclusions.svelte";
   import { picardStore } from "../stores/picard.svelte";
   import { toastStore } from "../stores/toast.svelte";
   import { navigationStore } from "../stores/navigation.svelte";
@@ -73,6 +75,16 @@
     } catch (err) {
       console.error("Failed to open album in Picard:", err);
     }
+  }
+
+  async function handleToggleStatsExcluded() {
+    const excluded = !statsExclusionsStore.isExcluded("album", albumName);
+    await statsExclusionsStore.setExcluded("album", albumName, excluded);
+    const name = albumName || i18n.t("collection.unknownAlbum");
+    const message = excluded
+      ? i18n.t("stats.excludedToast", { name })
+      : i18n.t("stats.includedToast", { name });
+    toastStore.show(message);
   }
 </script>
 
@@ -153,6 +165,13 @@
         ? i18n.t("playlists.contextMenuUnpinHome")
         : i18n.t("playlists.contextMenuPinHome")}
       onclick={() => { pinnedStore.toggle("album", albumName); onClose(); }}
+    />
+    <ContextMenuItem
+      icon={BarChart2}
+      label={statsExclusionsStore.isExcluded("album", albumName)
+        ? i18n.t("stats.includeInStats")
+        : i18n.t("stats.excludeFromStats")}
+      onclick={() => { handleToggleStatsExcluded(); onClose(); }}
     />
   {/if}
 </ContextMenu>

--- a/src/lib/components/ArtistDetailView.svelte
+++ b/src/lib/components/ArtistDetailView.svelte
@@ -6,6 +6,7 @@
   import { playerStore } from "../stores/player.svelte";
   import { playlistsStore } from "../stores/playlists.svelte";
   import { pinnedStore } from "../stores/pinned.svelte";
+  import { statsExclusionsStore } from "../stores/statsExclusions.svelte";
   import { shuffleArray } from "../utils/shuffle";
   import { formatDuration } from "../utils/formatters";
   import CoverArt from "./CoverArt.svelte";
@@ -32,7 +33,8 @@
     ArrowSquareOutIcon as OpenInPicard,
     PushPinIcon as Pin,
     PushPinSlashIcon as PinOff,
-    DotsThreeIcon as MoreHorizontal
+    DotsThreeIcon as MoreHorizontal,
+    ChartBarIcon as BarChart2
   } from "phosphor-svelte";
   const ExternalLink = OpenInPicard;
   import type { Song, Playlist, AlbumItem, PlayContext, ArtistProfile, ExtendedArtworkResponse } from "../types";
@@ -382,6 +384,15 @@
     navigationStore.viewPlaylist(playlist.id);
   }
 
+  async function handleToggleStatsExcluded() {
+    const excluded = !statsExclusionsStore.isExcluded("artist", artistName);
+    await statsExclusionsStore.setExcluded("artist", artistName, excluded);
+    const message = excluded
+      ? i18n.t("stats.excludedToast", { name: artistName })
+      : i18n.t("stats.includedToast", { name: artistName });
+    toastStore.show(message);
+  }
+
   async function handlePlayAll() {
     if (playableSongs.length === 0) return;
     const queuePl = await playlistsStore.requireQueue();
@@ -460,6 +471,16 @@
               {:else}
                 <Pin class="w-4 h-4" />
               {/if}
+            {/snippet}
+          </IconActionButton>
+          <IconActionButton
+            onclick={handleToggleStatsExcluded}
+            title={statsExclusionsStore.isExcluded("artist", artistName)
+              ? i18n.t("stats.includeInStats")
+              : i18n.t("stats.excludeFromStats")}
+          >
+            {#snippet icon()}
+              <BarChart2 class="w-4 h-4" />
             {/snippet}
           </IconActionButton>
           {#if singleSongs.length > 0}

--- a/src/lib/components/GenreContextMenu.svelte
+++ b/src/lib/components/GenreContextMenu.svelte
@@ -2,9 +2,12 @@
   import {
     PencilSimpleIcon as Pencil,
     ArrowLineUpIcon as ArrowUpToLine,
-    TrashIcon as Trash2
+    TrashIcon as Trash2,
+    ChartBarIcon as BarChart2
   } from "phosphor-svelte";
   import { i18n } from "../stores/i18n.svelte";
+  import { statsExclusionsStore } from "../stores/statsExclusions.svelte";
+  import { toastStore } from "../stores/toast.svelte";
   import ContextMenu from "./ContextMenu.svelte";
   import ContextMenuItem from "./ContextMenuItem.svelte";
   import ContextMenuDivider from "./ContextMenuDivider.svelte";
@@ -23,6 +26,15 @@
   }
 
   let { x, y, name, isRoot, onRename, onPromote, onDelete, onClose }: Props = $props();
+
+  async function handleToggleStatsExcluded() {
+    const excluded = !statsExclusionsStore.isExcluded("genre", name);
+    await statsExclusionsStore.setExcluded("genre", name, excluded);
+    const message = excluded
+      ? i18n.t("stats.excludedToast", { name })
+      : i18n.t("stats.includedToast", { name });
+    toastStore.show(message);
+  }
 </script>
 
 <ContextMenu {x} {y} {onClose} estimatedHeight={isRoot ? 140 : 180}>
@@ -43,6 +55,14 @@
       onclick={() => { onPromote?.(); onClose(); }}
     />
   {/if}
+
+  <ContextMenuItem
+    icon={BarChart2}
+    label={statsExclusionsStore.isExcluded("genre", name)
+      ? i18n.t("stats.includeInStats")
+      : i18n.t("stats.excludeFromStats")}
+    onclick={() => { handleToggleStatsExcluded(); onClose(); }}
+  />
 
   <ContextMenuDivider />
 

--- a/src/lib/components/HomeRowList.svelte
+++ b/src/lib/components/HomeRowList.svelte
@@ -173,7 +173,7 @@
     </h2>
   {/if}
 
-  <div class="flex-1 flex flex-col justify-between gap-2">
+  <div class="flex-1 flex flex-col gap-2">
     {#each items as item, i (keyFor(item))}
       <!-- svelte-ignore a11y_click_events_have_key_events -->
       <!-- svelte-ignore a11y_no_static_element_interactions -->
@@ -186,7 +186,7 @@
         class="group flex items-center gap-3 px-3 py-2.5 rounded-lg bg-brand-sidebar border border-brand-border/60 outline-2 -outline-offset-2 outline-transparent hover:outline-brand-accent transition-[outline-color,border-color] duration-200 select-none"
       >
         {#if variant === "rank" || variant === "chart"}
-          <div class="w-5 shrink-0 flex flex-col items-center gap-0.5">
+          <div class="w-14 shrink-0 flex flex-col items-center gap-0.5">
             <span class="text-center text-sm font-bold text-brand-text-secondary tabular-nums">
               {String(rankFor(item, i)).padStart(2, "0")}
             </span>
@@ -198,7 +198,7 @@
                 title={movementLabel(chart.movement)}
               >
                 {#if chart.movement === "new"}
-                  <span class="text-[8px] font-bold uppercase tracking-wide">{i18n.t('home.chartNew')}</span>
+                  <span class="text-[8px] font-bold uppercase tracking-wide whitespace-nowrap">{i18n.t('home.chartNew')}</span>
                 {:else if chart.movement === "rising"}
                   <TrendingUp class="w-3 h-3" />
                 {:else if chart.movement === "falling"}

--- a/src/lib/components/HomeView.svelte
+++ b/src/lib/components/HomeView.svelte
@@ -3,12 +3,8 @@
   import { invoke } from "@tauri-apps/api/core";
   import { listen } from "@tauri-apps/api/event";
   import { playerStore } from "../stores/player.svelte";
-  import { collectionStore } from "../stores/collection.svelte";
   import { navigationStore } from "../stores/navigation.svelte";
-  import type { HomeItem, ArtistItem, TopAlbumItem, ScanProgress } from "../types";
-  import { getArtistAlbums, getArtistSongs } from "../utils/artist";
-  import HorizontalScrollRow from "./HorizontalScrollRow.svelte";
-  import ArtistCard from "./ArtistCard.svelte";
+  import type { HomeItem, TopAlbumItem, ScanProgress } from "../types";
   import HomeRowList from "./HomeRowList.svelte";
   import PinnedRow from "./PinnedRow.svelte";
   import LibraryWelcome from "./LibraryWelcome.svelte";
@@ -16,7 +12,6 @@
   import { rememberScroll } from "../utils/scrollMemory";
   import { getDaypartBucket } from "../utils/daypart";
 
-  let topArtists = $state<ArtistItem[]>([]);
   let topAlbums = $state<HomeItem[]>([]);
   let recentlyAdded = $state<HomeItem[]>([]);
   let featuredAlbums = $state<HomeItem[]>([]);
@@ -31,22 +26,6 @@
   let daypartBucket = $state(getDaypartBucket());
   let daypartPollTimer: ReturnType<typeof setInterval> | undefined;
 
-  /** Routes "Top Artists" to Collection → Artists, pre-sorted by popularity
-   * (total plays). CollectionView reads its initial sort from localStorage
-   * on mount, so writing it here before navigating is enough — see #169. */
-  function viewTopArtists() {
-    if (typeof window !== "undefined") {
-      localStorage.setItem("sort_artist_field", "total_playcount");
-      localStorage.setItem("sort_artist_asc", "false");
-    }
-    collectionStore.searchQuery = "";
-    collectionStore.searchResults = [];
-    navigationStore.selectedArtistName = null;
-    navigationStore.selectedAlbumName = null;
-    navigationStore.activeTab = "collection";
-    navigationStore.activeSubTab = "artists";
-  }
-
   const timeOfDayGreeting = $derived.by((): string => {
     switch (daypartBucket) {
       case "morning": return i18n.t("home.greetingMorning");
@@ -59,13 +38,11 @@
   async function loadCuratedData() {
     isLoading = true;
     try {
-      const [artists, top, added, featured] = await Promise.all([
-        invoke<ArtistItem[]>("get_top_artists", { limit: 15 }),
+      const [top, added, featured] = await Promise.all([
         invoke<TopAlbumItem[]>("get_top_albums", { limit: 10 }),
         invoke<HomeItem[]>("get_recently_added", { limit: 12 }),
         invoke<HomeItem[]>("get_featured_albums", { limit: 5 }),
       ]);
-      topArtists = artists;
       // Album-scoped, trend-aware ranking (#662) — replaces the old flat
       // all-time play-count mix of Album/Song/Playlist cards.
       topAlbums = top.map(
@@ -126,21 +103,6 @@
     {:else}
       <PinnedRow />
 
-      {#if topArtists.length > 0}
-        <HorizontalScrollRow title={i18n.t('home.topArtists')} onHeaderClick={viewTopArtists}>
-          {#each topArtists as artist (artist.name)}
-            <div class="w-44 shrink-0 snap-start">
-              <ArtistCard
-                {artist}
-                artistAlbums={getArtistAlbums(collectionStore.albums, artist.name)}
-                artistSongs={getArtistSongs(collectionStore.songs, artist.name)}
-                onclick={() => navigationStore.viewArtist(artist.name || "")}
-              />
-            </div>
-          {/each}
-        </HorizontalScrollRow>
-      {/if}
-
       {#if topAlbums.length > 0 || featuredAlbums.length > 0 || recentlyAdded.length > 0}
         <div class="grid grid-cols-1 lg:grid-cols-2 gap-8">
           {#if topAlbums.length > 0}
@@ -159,7 +121,7 @@
         </div>
       {/if}
 
-      {#if topArtists.length === 0 && topAlbums.length === 0 && recentlyAdded.length === 0}
+      {#if topAlbums.length === 0 && recentlyAdded.length === 0}
         <div class="flex items-center justify-center py-16">
           <LibraryWelcome />
         </div>

--- a/src/lib/components/HomeView.test.ts
+++ b/src/lib/components/HomeView.test.ts
@@ -5,17 +5,7 @@ import HomeView from "./HomeView.svelte";
 import { collectionStore } from "../stores/collection.svelte";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
-import type { HomeItem, ArtistItem, AlbumItem, TopAlbumItem, ScanProgress } from "../types";
-
-function makeArtist(overrides: Partial<ArtistItem> = {}): ArtistItem {
-  return {
-    name: "Tom Petty",
-    album_count: 2,
-    song_count: 12,
-    genre: "Rock",
-    ...overrides,
-  };
-}
+import type { HomeItem, AlbumItem, TopAlbumItem, ScanProgress } from "../types";
 
 function makeAlbum(overrides: Partial<AlbumItem> = {}): AlbumItem {
   return {
@@ -57,14 +47,12 @@ vi.mock("@tauri-apps/api/event", () => ({
   }),
 }));
 
-let mockTopArtists: ArtistItem[] = [];
 let mockTopAlbums: TopAlbumItem[] = [];
 let mockRecentlyAdded: HomeItem[] = [];
 let mockFeaturedAlbums: HomeItem[] = [];
 
 vi.mock("@tauri-apps/api/core", () => ({
   invoke: vi.fn((cmd: string) => {
-    if (cmd === "get_top_artists") return Promise.resolve(mockTopArtists);
     if (cmd === "get_top_albums") return Promise.resolve(mockTopAlbums);
     if (cmd === "get_recently_added") return Promise.resolve(mockRecentlyAdded);
     if (cmd === "get_featured_albums") return Promise.resolve(mockFeaturedAlbums);
@@ -78,7 +66,6 @@ describe("HomeView.svelte", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     for (const key of Object.keys(listenCallbacks)) delete listenCallbacks[key];
-    mockTopArtists = [];
     mockTopAlbums = [];
     mockRecentlyAdded = [];
     mockFeaturedAlbums = [];
@@ -93,11 +80,10 @@ describe("HomeView.svelte", () => {
     collectionStore.albums = [];
   });
 
-  it("fetches all four curated home queries on mount", async () => {
+  it("fetches all three curated home queries on mount", async () => {
     render(HomeView);
 
     await waitFor(() => {
-      expect(invoke).toHaveBeenCalledWith("get_top_artists", { limit: 15 });
       expect(invoke).toHaveBeenCalledWith("get_top_albums", { limit: 10 });
       expect(invoke).toHaveBeenCalledWith("get_recently_added", { limit: 12 });
       expect(invoke).toHaveBeenCalledWith("get_featured_albums", { limit: 5 });
@@ -112,14 +98,13 @@ describe("HomeView.svelte", () => {
     });
   });
 
-  it("does not show LibraryWelcome once recentlyAdded/topArtists have content, even with zero plays", async () => {
-    mockTopArtists = [makeArtist()];
+  it("does not show LibraryWelcome once recentlyAdded has content, even with zero plays", async () => {
     mockRecentlyAdded = [{ type: "album", album: makeAlbum() }];
 
     render(HomeView);
 
     await waitFor(() => {
-      expect(screen.getAllByText("Tom Petty").length).toBeGreaterThan(0);
+      expect(screen.getAllByText("Full Moon Fever").length).toBeGreaterThan(0);
     });
     expect(screen.queryByText("Welcome to Luminous")).not.toBeInTheDocument();
   });
@@ -158,7 +143,7 @@ describe("HomeView.svelte", () => {
     listenCallbacks["scan-progress"]({ payload: doneEvent });
 
     await waitFor(() => {
-      expect(invoke).toHaveBeenCalledWith("get_top_artists", { limit: 15 });
+      expect(invoke).toHaveBeenCalledWith("get_top_albums", { limit: 10 });
     });
   });
 
@@ -180,10 +165,10 @@ describe("HomeView.svelte", () => {
 
       await vi.advanceTimersByTimeAsync(500);
 
-      const topArtistsCalls = vi
+      const topAlbumsCalls = vi
         .mocked(invoke)
-        .mock.calls.filter(([cmd]) => cmd === "get_top_artists");
-      expect(topArtistsCalls).toHaveLength(1);
+        .mock.calls.filter(([cmd]) => cmd === "get_top_albums");
+      expect(topAlbumsCalls).toHaveLength(1);
     } finally {
       vi.useRealTimers();
     }

--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -13,6 +13,7 @@
     SparkleIcon as Sparkles,
     GearIcon as Settings,
     FileTextIcon as FileText,
+    ChartBarIcon as BarChart2,
     HouseIcon as Home,
     MicrophoneStageIcon as Mic2,
     DiscIcon as DiscAlbum,
@@ -241,6 +242,17 @@
       <FileText class={isCollapsed ? "w-5 h-5" : "w-4 h-4"} />
       {#if !isCollapsed}
         <span class="truncate whitespace-nowrap">{i18n.t('sidebar.lyrics')}</span>
+      {/if}
+    </button>
+
+    <button
+      onclick={() => { navigationStore.activeTab = "stats"; }}
+      class="flex items-center gap-3 transition-all duration-150 {navigationStore.activeTab === 'stats' ? 'bg-brand-accent text-brand-accent-contrast shadow-lg shadow-brand-accent/20' : 'text-brand-text-secondary hover:bg-brand-accent/10 hover:text-brand-accent-text-hover'} {isCollapsed ? 'justify-center w-10 h-10 rounded-xl p-0' : 'w-full px-3 py-1.5 rounded-lg text-sm font-medium'}"
+      title={i18n.t('sidebar.stats')}
+    >
+      <BarChart2 class={isCollapsed ? "w-5 h-5" : "w-4 h-4"} />
+      {#if !isCollapsed}
+        <span class="truncate whitespace-nowrap">{i18n.t('sidebar.stats')}</span>
       {/if}
     </button>
     {/if}

--- a/src/lib/components/SongContextMenu.svelte
+++ b/src/lib/components/SongContextMenu.svelte
@@ -12,13 +12,15 @@
     PushPinSlashIcon as PinOff,
     ArrowSquareOutIcon as OpenInPicard,
     EyeSlashIcon as EyeSlash,
-    EyeIcon as Eye
+    EyeIcon as Eye,
+    ChartBarIcon as BarChart2
   } from "phosphor-svelte";
   import { invoke } from "@tauri-apps/api/core";
   import { i18n } from "../stores/i18n.svelte";
   import { picardStore } from "../stores/picard.svelte";
   import { playlistsStore } from "../stores/playlists.svelte";
   import { pinnedStore } from "../stores/pinned.svelte";
+  import { statsExclusionsStore } from "../stores/statsExclusions.svelte";
   import { toastStore } from "../stores/toast.svelte";
   import type { Song } from "../types";
   import ContextMenu from "./ContextMenu.svelte";
@@ -74,6 +76,16 @@
       : i18n.t("playlists.unmarkedNotIncluded", { name });
     toastStore.show(message);
   }
+
+  async function handleToggleStatsExcluded() {
+    const excluded = !statsExclusionsStore.isExcluded("song", String(song.id));
+    await statsExclusionsStore.setExcluded("song", String(song.id), excluded);
+    const name = song.title || i18n.t("collection.unknownSong");
+    const message = excluded
+      ? i18n.t("stats.excludedToast", { name })
+      : i18n.t("stats.includedToast", { name });
+    toastStore.show(message);
+  }
 </script>
 
 <ContextMenu {x} {y} {onClose} estimatedHeight={280}>
@@ -126,6 +138,14 @@
   />
 
   {#if selectedCount === 1}
+    <ContextMenuItem
+      icon={BarChart2}
+      label={statsExclusionsStore.isExcluded("song", String(song.id))
+        ? i18n.t("stats.includeInStats")
+        : i18n.t("stats.excludeFromStats")}
+      onclick={() => { handleToggleStatsExcluded(); onClose(); }}
+    />
+
     <ContextMenuDivider />
 
     {#if onGoToArtist && song.artist}

--- a/src/lib/components/StatsView.svelte
+++ b/src/lib/components/StatsView.svelte
@@ -1,0 +1,190 @@
+<script lang="ts">
+  import { invoke } from "@tauri-apps/api/core";
+  import LoadingSpinner from "./LoadingSpinner.svelte";
+  import { i18n } from "../stores/i18n.svelte";
+  import { rememberScroll } from "../utils/scrollMemory";
+  import { playerStore } from "../stores/player.svelte";
+  import { ChartBarIcon as BarChart2 } from "phosphor-svelte";
+  import type { StatsRange, StatsSummary, StatsTopItem } from "../types";
+  import { bucketListeningClock } from "../utils/listeningClock";
+  import type { DaypartBucket } from "../utils/daypart";
+  import { navigationStore } from "../stores/navigation.svelte";
+
+  const VALID_RANGES: StatsRange[] = ["7d", "28d", "1y"];
+  function loadSavedRange(): StatsRange {
+    if (typeof window === "undefined") return "7d";
+    const saved = localStorage.getItem("stats_range");
+    return VALID_RANGES.includes(saved as StatsRange) ? (saved as StatsRange) : "7d";
+  }
+
+  let range = $state<StatsRange>(loadSavedRange());
+  let summary = $state<StatsSummary | null>(null);
+  let loading = $state(true);
+
+  const RANGES: { value: StatsRange; label: () => string }[] = [
+    { value: "7d", label: () => i18n.t("stats.range7d", {}, "Past 7 Days") },
+    { value: "28d", label: () => i18n.t("stats.range28d", {}, "Past 28 Days") },
+    { value: "1y", label: () => i18n.t("stats.range1y", {}, "Past Year") }
+  ];
+
+  const CLOCK_BUCKETS: { key: DaypartBucket; label: () => string }[] = [
+    { key: "morning", label: () => i18n.t("stats.clockMorning", {}, "Morning") },
+    { key: "afternoon", label: () => i18n.t("stats.clockAfternoon", {}, "Afternoon") },
+    { key: "evening", label: () => i18n.t("stats.clockEvening", {}, "Evening") },
+    { key: "latenight", label: () => i18n.t("stats.clockLateNight", {}, "Late Night") }
+  ];
+
+  let clockCounts = $derived(
+    summary
+      ? bucketListeningClock(summary.play_timestamps)
+      : { morning: 0, afternoon: 0, evening: 0, latenight: 0 }
+  );
+  let maxClockCount = $derived(Math.max(1, ...Object.values(clockCounts)));
+
+  async function loadSummary(requestedRange: StatsRange) {
+    loading = true;
+    try {
+      const result = await invoke<StatsSummary>("get_stats_summary", { range: requestedRange });
+      if (requestedRange !== range) return;
+      summary = result;
+    } catch (err) {
+      console.error("Failed to load stats summary:", err);
+      if (requestedRange === range) summary = null;
+    } finally {
+      if (requestedRange === range) loading = false;
+    }
+  }
+
+  $effect(() => {
+    loadSummary(range);
+  });
+
+  // Same order as the sidebar's Collection sub-tabs (Artists, Albums, Songs, Genres).
+  const SECTIONS: { key: keyof StatsSummary; title: () => string }[] = [
+    { key: "top_artists", title: () => i18n.t("stats.topArtists", {}, "Top Artists") },
+    { key: "top_albums", title: () => i18n.t("stats.topAlbums", {}, "Top Albums") },
+    { key: "top_songs", title: () => i18n.t("stats.topSongs", {}, "Top Songs") },
+    { key: "top_genres", title: () => i18n.t("stats.topGenres", {}, "Top Genres") }
+  ];
+
+  function itemsFor(key: keyof StatsSummary): StatsTopItem[] {
+    if (!summary) return [];
+    const value = summary[key];
+    return Array.isArray(value) ? (value as StatsTopItem[]) : [];
+  }
+
+  /** Navigates to an item's detail page. Songs have no detail page of their
+   * own, so a song row jumps to its album instead (`item.album`). */
+  function openItem(sectionKey: keyof StatsSummary, item: StatsTopItem) {
+    switch (sectionKey) {
+      case "top_artists":
+        navigationStore.viewArtist(item.key);
+        break;
+      case "top_albums":
+        navigationStore.viewAlbum(item.key);
+        break;
+      case "top_songs":
+        if (item.album) navigationStore.viewAlbum(item.album);
+        break;
+      case "top_genres":
+        navigationStore.viewGenreTag(item.key);
+        break;
+    }
+  }
+</script>
+
+<div class="flex-1 flex flex-col h-full bg-brand-main text-brand-text-primary select-none overflow-hidden relative">
+  <div class="px-6 pt-8 pb-4 shrink-0">
+    <h1 class="text-3xl font-heading font-bold text-brand-text-primary flex items-center gap-3">
+      <BarChart2 class="w-7 h-7 text-brand-accent" />
+      {i18n.t("stats.title", {}, "Stats")}
+    </h1>
+    <p class="text-sm text-brand-text-secondary mt-1">
+      {i18n.t("stats.subtitle", {}, "Your private listening insights — computed on-device, never shared.")}
+    </p>
+
+    <div class="flex items-center gap-2 mt-4">
+      {#each RANGES as r (r.value)}
+        <button
+          onclick={() => {
+            range = r.value;
+            if (typeof window !== "undefined") localStorage.setItem("stats_range", r.value);
+          }}
+          class="px-3 py-1.5 rounded-lg text-sm font-medium transition-colors {range === r.value ? 'bg-brand-accent text-brand-accent-contrast shadow-lg shadow-brand-accent/20' : 'text-brand-text-secondary hover:bg-brand-accent/10 hover:text-brand-accent-text-hover'}"
+        >
+          {r.label()}
+        </button>
+      {/each}
+    </div>
+  </div>
+
+  <div class="flex-1 overflow-y-auto px-6 pb-12" class:pb-28={!!playerStore.currentSong} use:rememberScroll={"stats"}>
+    {#if loading}
+      <div class="flex items-center justify-center h-64">
+        <LoadingSpinner label={i18n.t("stats.loading", {}, "Loading stats...")} />
+      </div>
+    {:else if !summary || summary.play_timestamps.length === 0}
+      <div class="flex items-center justify-center h-64 text-brand-text-secondary text-sm">
+        {i18n.t("stats.empty", {}, "No listening history for this range yet.")}
+      </div>
+    {:else}
+      <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-6">
+        {#each SECTIONS as section (section.key)}
+          <div class="bg-brand-sidebar border border-brand-border/60 rounded-xl p-4">
+            <h2 class="text-sm font-semibold text-brand-text-primary mb-3">{section.title()}</h2>
+            {#if itemsFor(section.key).length === 0}
+              <p class="text-xs text-brand-text-secondary">{i18n.t("stats.noData", {}, "No data for this range.")}</p>
+            {:else}
+              <ol class="space-y-2">
+                {#each itemsFor(section.key) as item, i (item.key)}
+                  {@const clickable = section.key !== "top_songs" || !!item.album}
+                  <!-- svelte-ignore a11y_click_events_have_key_events -->
+                  <!-- svelte-ignore a11y_no_static_element_interactions -->
+                  <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
+                  <li
+                    role={clickable ? "button" : undefined}
+                    tabindex={clickable ? 0 : undefined}
+                    onclick={clickable ? () => openItem(section.key, item) : undefined}
+                    onkeydown={clickable
+                      ? (e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); openItem(section.key, item); } }
+                      : undefined}
+                    class="flex items-center gap-2 text-sm rounded-md -mx-1 px-1 py-0.5 transition-colors {clickable ? 'cursor-pointer hover:bg-brand-accent/10' : ''}"
+                  >
+                    <span class="text-xs text-brand-text-secondary w-4 shrink-0">{i + 1}</span>
+                    <div class="min-w-0 flex-1">
+                      <div class="truncate text-brand-text-primary">{item.label}</div>
+                      {#if item.secondary}
+                        <div class="truncate text-xs text-brand-text-secondary">{item.secondary}</div>
+                      {/if}
+                    </div>
+                    <span class="text-xs text-brand-text-secondary shrink-0">{item.play_count}</span>
+                  </li>
+                {/each}
+              </ol>
+            {/if}
+          </div>
+        {/each}
+      </div>
+
+      <div class="bg-brand-sidebar border border-brand-border/60 rounded-xl p-4 mt-6">
+        <h2 class="text-sm font-semibold text-brand-text-primary mb-3">
+          {i18n.t("stats.listeningClock", {}, "Time of Day")}
+        </h2>
+        <div class="grid grid-cols-4 gap-4">
+          {#each CLOCK_BUCKETS as bucket (bucket.key)}
+            <div class="flex flex-col items-center gap-2">
+              <div class="w-full h-24 flex items-end bg-brand-main rounded-md overflow-hidden">
+                <div
+                  class="w-full bg-brand-accent transition-all"
+                  style="height: {((clockCounts[bucket.key] ?? 0) / maxClockCount) * 100}%"
+                ></div>
+              </div>
+              <span class="text-xs text-brand-text-secondary text-center">{bucket.label()}</span>
+              <span class="text-xs text-brand-text-primary font-medium">{clockCounts[bucket.key] ?? 0}</span>
+            </div>
+          {/each}
+        </div>
+      </div>
+    {/if}
+  </div>
+</div>

--- a/src/lib/components/StatsView.test.ts
+++ b/src/lib/components/StatsView.test.ts
@@ -1,0 +1,145 @@
+import "@testing-library/jest-dom";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, waitFor, fireEvent } from "@testing-library/svelte";
+import { invoke } from "@tauri-apps/api/core";
+import StatsView from "./StatsView.svelte";
+import { bucketListeningClock } from "../utils/listeningClock";
+import { navigationStore } from "../stores/navigation.svelte";
+import type { StatsSummary } from "../types";
+
+function makeSummary(range: StatsSummary["range"]): StatsSummary {
+  return {
+    range,
+    top_songs: [{ key: "1", label: "Song A", secondary: "Artist A", play_count: 5, excluded: false, album: "Album A" }],
+    top_albums: [{ key: "Album A", label: "Album A", secondary: "Artist A", play_count: 3, excluded: false, album: null }],
+    top_artists: [{ key: "Artist A", label: "Artist A", secondary: null, play_count: 5, excluded: false, album: null }],
+    top_genres: [{ key: "Rock", label: "Rock", secondary: null, play_count: 5, excluded: false, album: null }],
+    play_timestamps: [1_700_000_000, 1_700_003_600],
+  };
+}
+
+const invokeMock = vi.fn();
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (...args: unknown[]) => invokeMock(...args),
+}));
+
+describe("StatsView.svelte", () => {
+  beforeEach(() => {
+    invokeMock.mockReset();
+    localStorage.clear();
+    invokeMock.mockImplementation((cmd: string, args: { range?: string }) => {
+      if (cmd === "get_stats_summary") {
+        return Promise.resolve(makeSummary((args?.range as StatsSummary["range"]) ?? "7d"));
+      }
+      return Promise.resolve(null);
+    });
+  });
+
+  it("fetches the 7-day range on mount and renders Top 10 sections", async () => {
+    const { getByText, getAllByText } = render(StatsView);
+    await waitFor(() => expect(invokeMock).toHaveBeenCalledWith("get_stats_summary", { range: "7d" }));
+    await waitFor(() => expect(getByText("Song A")).toBeInTheDocument());
+    expect(getByText("Album A")).toBeInTheDocument();
+    // "Artist A" appears twice: as the song row's secondary line and as the Top Artists entry.
+    expect(getAllByText("Artist A").length).toBeGreaterThanOrEqual(2);
+    expect(getByText("Rock")).toBeInTheDocument();
+  });
+
+  it("refetches when the range switcher changes", async () => {
+    const { getByText } = render(StatsView);
+    await waitFor(() => expect(invokeMock).toHaveBeenCalledWith("get_stats_summary", { range: "7d" }));
+
+    await fireEvent.click(getByText("Past 28 Days"));
+
+    await waitFor(() => expect(invokeMock).toHaveBeenCalledWith("get_stats_summary", { range: "28d" }));
+    expect(localStorage.getItem("stats_range")).toBe("28d");
+  });
+
+  it("restores the previously selected range from localStorage on mount", async () => {
+    localStorage.setItem("stats_range", "1y");
+    render(StatsView);
+    await waitFor(() => expect(invokeMock).toHaveBeenCalledWith("get_stats_summary", { range: "1y" }));
+  });
+
+  it("navigates to the artist detail page when a Top Artists row is clicked", async () => {
+    navigationStore.selectedArtistName = null;
+    const { getAllByText } = render(StatsView);
+    await waitFor(() => expect(getAllByText("Artist A").length).toBeGreaterThan(0));
+
+    await fireEvent.click(getAllByText("Artist A")[0].closest('[role="button"]')!);
+
+    expect(navigationStore.selectedArtistName).toBe("Artist A");
+  });
+
+  it("navigates to the album detail page when a Top Albums row is clicked", async () => {
+    navigationStore.selectedAlbumName = null;
+    const { getByText } = render(StatsView);
+    await waitFor(() => expect(getByText("Album A")).toBeInTheDocument());
+
+    await fireEvent.click(getByText("Album A").closest('[role="button"]')!);
+
+    expect(navigationStore.selectedAlbumName).toBe("Album A");
+  });
+
+  it("navigates to the song's album when a Top Songs row is clicked", async () => {
+    navigationStore.selectedAlbumName = null;
+    const { getByText } = render(StatsView);
+    await waitFor(() => expect(getByText("Song A")).toBeInTheDocument());
+
+    await fireEvent.click(getByText("Song A").closest('[role="button"]')!);
+
+    expect(navigationStore.selectedAlbumName).toBe("Album A");
+  });
+
+  it("shows the empty state when there's no listening history in range", async () => {
+    invokeMock.mockImplementation((cmd: string) => {
+      if (cmd === "get_stats_summary") {
+        return Promise.resolve({
+          range: "7d",
+          top_songs: [],
+          top_albums: [],
+          top_artists: [],
+          top_genres: [],
+          play_timestamps: [],
+        } satisfies StatsSummary);
+      }
+      return Promise.resolve(null);
+    });
+
+    const { getByText } = render(StatsView);
+    await waitFor(() => expect(getByText("No listening history for this range yet.")).toBeInTheDocument());
+  });
+});
+
+describe("bucketListeningClock", () => {
+  it("buckets local hours into morning/afternoon/evening/late-night", () => {
+    const morning = new Date();
+    morning.setHours(9, 0, 0, 0);
+    const afternoon = new Date();
+    afternoon.setHours(14, 0, 0, 0);
+    const evening = new Date();
+    evening.setHours(19, 0, 0, 0);
+    const lateNight = new Date();
+    lateNight.setHours(2, 0, 0, 0);
+
+    const timestamps = [morning, afternoon, evening, lateNight].map((d) => Math.floor(d.getTime() / 1000));
+    const counts = bucketListeningClock(timestamps);
+
+    expect(counts.morning).toBe(1);
+    expect(counts.afternoon).toBe(1);
+    expect(counts.evening).toBe(1);
+    expect(counts.latenight).toBe(1);
+  });
+
+  it("returns zero counts for an empty timestamp list", () => {
+    expect(bucketListeningClock([])).toEqual({ morning: 0, afternoon: 0, evening: 0, latenight: 0 });
+  });
+
+  it("agrees with getDaypartBucket at the evening/late-night boundary (21:00)", () => {
+    const boundary = new Date();
+    boundary.setHours(21, 0, 0, 0);
+    const counts = bucketListeningClock([Math.floor(boundary.getTime() / 1000)]);
+    expect(counts.latenight).toBe(1);
+    expect(counts.evening).toBe(0);
+  });
+});

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -4,6 +4,7 @@ export const en = {
     collection: "Collection",
     playlists: "Playlists",
     lyrics: "Lyrics",
+    stats: "Stats",
     settings: "Settings",
     help: "Help",
     artists: "Artists",
@@ -603,6 +604,29 @@ export const en = {
     saveFailedPrefix: "Failed to save lyrics: ",
     noOnlineResults: "No lyrics found from any online provider.",
     insufficientMetadata: "Not enough song info (artist/title) to search for lyrics online."
+  },
+  stats: {
+    title: "Stats",
+    subtitle: "Your private listening insights — computed on-device, never shared.",
+    range7d: "Past 7 Days",
+    range28d: "Past 28 Days",
+    range1y: "Past Year",
+    topSongs: "Top Songs",
+    topAlbums: "Top Albums",
+    topArtists: "Top Artists",
+    topGenres: "Top Genres",
+    listeningClock: "Time of Day",
+    clockMorning: "Morning",
+    clockAfternoon: "Afternoon",
+    clockEvening: "Evening",
+    clockLateNight: "Late Night",
+    loading: "Loading stats...",
+    empty: "No listening history for this range yet.",
+    noData: "No data for this range.",
+    excludeFromStats: "Don't Include in Stats",
+    includeInStats: "Include in Stats",
+    excludedToast: "Excluded {name} from Stats",
+    includedToast: "Included {name} in Stats again"
   },
   help: {
     loading: "Loading user guide..."

--- a/src/lib/locales/fr.ts
+++ b/src/lib/locales/fr.ts
@@ -4,6 +4,7 @@ export const fr = {
     collection: "Collection",
     playlists: "Listes de lecture",
     lyrics: "Paroles",
+    stats: "Statistiques",
     settings: "Paramètres",
     help: "Aide",
     artists: "Artistes",
@@ -602,6 +603,29 @@ export const fr = {
     saveFailedPrefix: "Échec de l'enregistrement des paroles : ",
     noOnlineResults: "Aucune parole trouvée auprès des fournisseurs en ligne.",
     insufficientMetadata: "Informations insuffisantes (artiste/titre) pour rechercher des paroles en ligne."
+  },
+  stats: {
+    title: "Statistiques",
+    subtitle: "Vos statistiques d'écoute privées — calculées sur l'appareil, jamais partagées.",
+    range7d: "7 derniers jours",
+    range28d: "28 derniers jours",
+    range1y: "Dernière année",
+    topSongs: "Meilleurs titres",
+    topAlbums: "Meilleurs albums",
+    topArtists: "Meilleurs artistes",
+    topGenres: "Meilleurs genres",
+    listeningClock: "Moment de la journée",
+    clockMorning: "Matin",
+    clockAfternoon: "Après-midi",
+    clockEvening: "Soirée",
+    clockLateNight: "Fin de nuit",
+    loading: "Chargement des statistiques...",
+    empty: "Aucun historique d'écoute pour cette période pour le moment.",
+    noData: "Aucune donnée pour cette période.",
+    excludeFromStats: "Ne pas inclure dans les statistiques",
+    includeInStats: "Inclure dans les statistiques",
+    excludedToast: "{name} exclu des statistiques",
+    includedToast: "{name} de nouveau inclus dans les statistiques"
   },
   help: {
     loading: "Chargement du guide d'utilisation..."

--- a/src/lib/stores/navigation.svelte.ts
+++ b/src/lib/stores/navigation.svelte.ts
@@ -1,7 +1,7 @@
 import { collectionStore } from "./collection.svelte";
 import { playlistsStore } from "./playlists.svelte";
 
-export type ActiveTab = "home" | "collection" | "playlists" | "settings" | "lyrics" | "help";
+export type ActiveTab = "home" | "collection" | "playlists" | "settings" | "lyrics" | "stats" | "help";
 export type ActiveSubTab = "songs" | "albums" | "artists" | "genres";
 
 /** Which grid is shown under the Playlists tab (mirrors `ActiveSubTab` for Collection). */

--- a/src/lib/stores/statsExclusions.svelte.ts
+++ b/src/lib/stores/statsExclusions.svelte.ts
@@ -1,0 +1,48 @@
+import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
+
+type StatsEntityType = "song" | "album" | "artist" | "genre";
+
+/** Personal Stats exclusion set (#130) — preloaded once and kept in sync via
+ * `stats-exclusions-changed`, mirroring how `PinnedStore` preloads
+ * `get_pinned_items` rather than checking each item's state individually. */
+class StatsExclusionsStore {
+  private keys = $state<Set<string>>(new Set());
+
+  constructor() {
+    this.init();
+  }
+
+  private async init() {
+    try {
+      await listen("stats-exclusions-changed", () => this.refresh());
+      await this.refresh();
+    } catch (err) {
+      console.error("Failed to initialize StatsExclusionsStore:", err);
+    }
+  }
+
+  async refresh() {
+    try {
+      const pairs = await invoke<[string, string][]>("get_stats_exclusions");
+      this.keys = new Set((pairs ?? []).map(([type, key]) => `${type}:${key}`));
+    } catch (err) {
+      console.error("Failed to load stats exclusions:", err);
+    }
+  }
+
+  isExcluded(entityType: StatsEntityType, entityKey: string): boolean {
+    return this.keys.has(`${entityType}:${entityKey}`);
+  }
+
+  async setExcluded(entityType: StatsEntityType, entityKey: string, excluded: boolean) {
+    await invoke("set_stats_excluded", { entityType, entityKey, excluded });
+    await this.refresh();
+  }
+
+  async toggle(entityType: StatsEntityType, entityKey: string) {
+    await this.setExcluded(entityType, entityKey, !this.isExcluded(entityType, entityKey));
+  }
+}
+
+export const statsExclusionsStore = new StatsExclusionsStore();

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -281,6 +281,37 @@ export interface TopAlbumItem {
   movement: "new" | "rising" | "falling" | "steady";
 }
 
+/** Personal Stats time window (#130). */
+export type StatsRange = "7d" | "28d" | "1y";
+
+/** One ranked entry in a Personal Stats Top 10 list. */
+export interface StatsTopItem {
+  /** Exclusion-lookup identity: song id as a string, or the raw album/artist/genre text. */
+  key: string;
+  label: string;
+  /** Secondary line (e.g. artist for a song/album row); null for artist/genre rows. */
+  secondary: string | null;
+  play_count: number;
+  excluded: boolean;
+  /** The song's album title, set only on top_songs rows — songs have no detail
+   * page of their own, so clicking one navigates to this album instead. */
+  album: string | null;
+}
+
+/** Personal Stats summary for one range (#130). */
+export interface StatsSummary {
+  range: StatsRange;
+  top_songs: StatsTopItem[];
+  /** MIN of plays across an album's tracks (completionist metric) — deliberately
+   * different from the Home "Top Albums" chart's SUM-based engagement metric. */
+  top_albums: StatsTopItem[];
+  top_artists: StatsTopItem[];
+  top_genres: StatsTopItem[];
+  /** Unix-second timestamps of every in-range, non-excluded play, for
+   * client-side local-time listening-clock bucketing. */
+  play_timestamps: number[];
+}
+
 export interface ArtistItem {
   name: string | null;
   sort_artist?: string | null;

--- a/src/lib/utils/listeningClock.ts
+++ b/src/lib/utils/listeningClock.ts
@@ -1,0 +1,20 @@
+import { getDaypartBucket, type DaypartBucket } from "./daypart";
+
+/** Buckets raw unix-second play timestamps into local-time Morning/
+ * Afternoon/Evening/Late Night counts, reusing the same `DaypartBucket`
+ * hour boundaries as the Home greeting and the "Late Night Mix" auto-
+ * playlist (#223) so the Personal Stats (#130) listening clock always
+ * agrees with "what part of the day is it" elsewhere in the app.
+ *
+ * Bucketing happens entirely client-side (`Date.getHours()` uses the
+ * browser's timezone) rather than via a server-side UTC-offset param
+ * passed to the backend — simpler, no DST logic, and immune to
+ * stale-offset bugs if the user's timezone changes between listen-time
+ * and view-time. */
+export function bucketListeningClock(timestamps: number[]): Record<DaypartBucket, number> {
+  const counts: Record<DaypartBucket, number> = { morning: 0, afternoon: 0, evening: 0, latenight: 0 };
+  for (const ts of timestamps) {
+    counts[getDaypartBucket(new Date(ts * 1000))]++;
+  }
+  return counts;
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -133,6 +133,10 @@
       {#await import("../lib/components/LyricsView.svelte") then { default: LyricsView }}
         <LyricsView />
       {/await}
+    {:else if navigationStore.activeTab === "stats"}
+      {#await import("../lib/components/StatsView.svelte") then { default: StatsView }}
+        <StatsView />
+      {/await}
     {:else if navigationStore.activeTab === "help"}
       {#await import("../lib/components/HelpView.svelte") then { default: HelpView }}
         <HelpView />


### PR DESCRIPTION
## 📋 Summary
Addresses #130 — adds a private, on-device "Stats" tab (sidebar, between Lyrics and Settings) showing Top 10 artists/albums/songs/genres and a Time of Day listening chart for the past 7 days / 28 days / year, plus a "Don't Include in Stats" exclusion flag.
Out of scope for this PR (per discussion on the issue): the share-card/social-export part of #130 depends on `ShareModal.svelte` from #97, which doesn't exist yet — that'll be a separate follow-up issue once #97 lands. Monthly/annual "Wrapped" summaries and Top-10 badges on Album/Artist detail pages are noted as compatible future extensions but not built here.

## 🔍 Implementation Notes
- **Live from `play_history`, not `album_chart_history`.** The existing weekly Top Albums chart table only keeps the top 10 albums per week — using it here would silently undercount anything that never cracked a weekly top 10. All Stats queries aggregate `play_history` + `songs` directly for the requested range (new `src-tauri/src/stats_summary.rs`).
- **Album play count = `MIN` across its tracks, not `SUM`.** A completionist metric ("how many full front-to-back listens"), deliberately different from the Home "Top Albums" chart's `SUM`-based engagement metric — the two numbers will legitimately disagree for the same album, which is expected.
- **One generic `stats_exclusions(entity_type, entity_key)` table** (migration 27), not per-entity boolean columns — there's no real `albums`/`artists` table to hang a column on, so exclusions are keyed the same way `album_ratings`/`artist_profiles` already key by raw text.
- **Time of Day bucketing happens client-side** (`Date.getHours()`), reusing the app's existing `DaypartBucket` helper/boundaries (same as the Home greeting and "Late Night Mix" auto-playlist) rather than a server-side UTC-offset param — simpler, no DST logic, immune to stale-offset bugs.
- Clicking a Top Artists/Albums/Genres row navigates to that item's detail page; a Top Songs row navigates to its album (songs have no detail page of their own).
- If a song/album is later deleted and cleaned up via "Clean Up Missing Songs", its `play_history` rows cascade-delete with it (`ON DELETE CASCADE`) — confirmed with the reporter this is the desired behavior (deleted content shouldn't linger in stats either), so no change made there.

**Unrelated fixes bundled in at the reporter's request** (found/requested while testing this feature):
- `HomeRowList.svelte` — Top 10 Albums / Recently Added rows no longer vertically justify-spread with large gaps when there are fewer than the max row count; the rank-badge column (rising/falling/new/steady) is now a fixed width so rows stay aligned and longer translations like "Nouveau" don't wrap.
- `HomeView.svelte` — removed the "Top Artists" carousel from the Home page.

## 🧪 Test Plan
- [x] `bun run check` (svelte-check + knip) — clean, 0 errors/warnings.
- [x] `bun run test -- --run` (frontend) — 671 passed, 0 failed.
- [x] `cargo test` (src-tauri) — 319 passed, 0 failed.
- [x] Manually verified in the app — reporter ran `bun run tauri dev` and confirmed the Stats tab, range switching, Top 10 lists, click-through navigation, exclusion toggles (song/album/genre/artist), French translations, and the Home page fixes all worked as expected.

## ✅ Checklist
- [ ] No unrelated changes bundled in — see note above; the Home page fixes were explicitly requested to ship in this PR rather than split out.
- [x] Docs/screenshots updated if user-facing behavior changed — n/a, no docs reference this area.
