### PR TITLE
fix: use tempfile::tempdir() for test DB paths to fix flaky pins test

### DIFF
--- a/src-tauri/src/pins.rs
+++ b/src-tauri/src/pins.rs
@@ -347,13 +347,7 @@ mod tests {
     use crate::db::Database;
 
     fn test_db() -> (Database, std::path::PathBuf) {
-        let temp_dir = std::env::temp_dir().join(format!(
-            "luminous_pins_test_{}",
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
-        ));
+        let temp_dir = tempfile::tempdir().unwrap().keep();
         (Database::new(temp_dir.clone()).unwrap(), temp_dir)
     }
 

--- a/src-tauri/src/playlist/auto_sync.rs
+++ b/src-tauri/src/playlist/auto_sync.rs
@@ -898,13 +898,7 @@ mod tests {
     use crate::db::Database;
 
     fn setup_test_db() -> (Database, std::path::PathBuf) {
-        let temp_dir = std::env::temp_dir().join(format!(
-            "luminous_playlist_auto_sync_test_{}",
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
-        ));
+        let temp_dir = tempfile::tempdir().unwrap().keep();
         let db = Database::new(temp_dir.clone()).unwrap();
         (db, temp_dir)
     }

--- a/src-tauri/src/playlist/dynamic.rs
+++ b/src-tauri/src/playlist/dynamic.rs
@@ -346,13 +346,7 @@ mod tests {
     use crate::db::Database;
 
     fn setup_test_db() -> (Database, std::path::PathBuf) {
-        let temp_dir = std::env::temp_dir().join(format!(
-            "luminous_playlist_dynamic_test_{}",
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
-        ));
+        let temp_dir = tempfile::tempdir().unwrap().keep();
         let db = Database::new(temp_dir.clone()).unwrap();
         (db, temp_dir)
     }


### PR DESCRIPTION
## 📋 Summary
Fixes #736. `pins::tests::pin_unpin_round_trip_for_each_item_type` (and latently the analogous `setup_test_db` helpers in `playlist/dynamic.rs` and `playlist/auto_sync.rs`) intermittently failed under `cargo test`'s default parallel execution because their temp DB paths were derived from `SystemTime::now().duration_since(UNIX_EPOCH).as_nanos()`. Windows' actual timer resolution is coarser than nanoseconds, so two test threads could land on the same temp path and race each other's schema migrations, producing `duplicate column name: replaygain_track_gain`.

## 🔍 Implementation Notes
Replaced the hand-rolled nanosecond-timestamp path in all three `test_db`/`setup_test_db` helpers with `tempfile::tempdir().unwrap().keep()` (already a dev-dependency), which guarantees a unique path regardless of timer resolution. `.keep()` converts the `TempDir` guard into a plain `PathBuf` without deleting it immediately, so the existing manual `remove_dir_all(dir)` cleanup at each call site keeps working unchanged — minimal diff, no other behavior touched.

## 🧪 Test Plan
- [x] `cargo test` (src-tauri)
- [ ] `bun run check` (svelte-check) — no frontend changes
- [ ] `bun run test -- --run` (frontend) — no frontend changes
- [ ] Manually verified in the app — not applicable; change is test-infrastructure only, no app behavior affected

Ran `cargo test --lib pins::tests` 5x back-to-back under default parallelism with no failures (previously flaky), plus the full `cargo test --lib` suite (313 tests) passing.

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed — not applicable, no user-facing behavior changed
