### PR TITLE
fix: only show bio Show more button when text is truncated (#819)

### DIFF
--- a/src/lib/components/ArtistDetailView.svelte
+++ b/src/lib/components/ArtistDetailView.svelte
@@ -121,6 +121,23 @@
   let hasBio = $derived(!!effectiveBio);
   let hasProfileContent = $derived(hasWebsite || hasBio || hasSocials);
 
+  let bioParagraphEl = $state<HTMLParagraphElement | undefined>();
+  let bioIsTruncated = $state(false);
+
+  // Only show "Show more" when the clamp actually hides text — measured
+  // once per bio while still clamped (isBioExpanded resets to false on every
+  // artist load), since a fixed character threshold would be wrong for
+  // responsive widths.
+  $effect(() => {
+    const text = effectiveBio;
+    const el = bioParagraphEl;
+    if (!text || !el) {
+      bioIsTruncated = false;
+      return;
+    }
+    bioIsTruncated = el.scrollHeight > el.clientHeight + 1;
+  });
+
   // Locally-discovered artist visuals (#98/#761) — portrait/logo/fanart,
   // fetched on demand per artist since scanning every artist's folder
   // eagerly would be far too expensive (see #758's design notes).
@@ -262,6 +279,7 @@
 
   $effect(() => {
     const requested = artistName;
+    isBioExpanded = false;
     // Track collectionStore.songs so artist details update when the library changes (e.g. new albums added)
     const _libraryVersion = collectionStore.songs;
     loading = true;
@@ -562,7 +580,6 @@
           <!-- Bio -->
           {#if hasBio}
             {@const bioText = effectiveBio ?? ""}
-            {@const isLongBio = bioText.length > 200}
             <div class="text-xs text-brand-text-secondary leading-relaxed">
               {#if bioIsFromWikipedia}
                 <button
@@ -574,10 +591,10 @@
                   <ExternalLink class="w-3 h-3 opacity-0 group-hover:opacity-100 transition-opacity" />
                 </button>
               {/if}
-              <p class="{!isBioExpanded && isLongBio ? 'line-clamp-2 sm:line-clamp-3' : ''} whitespace-pre-line">
+              <p bind:this={bioParagraphEl} class="{!isBioExpanded ? 'line-clamp-2 sm:line-clamp-3' : ''} whitespace-pre-line">
                 {bioText}
               </p>
-              {#if isLongBio}
+              {#if bioIsTruncated || isBioExpanded}
                 <button
                   type="button"
                   onclick={() => { isBioExpanded = !isBioExpanded; }}

--- a/src/lib/components/ArtistDetailView.test.ts
+++ b/src/lib/components/ArtistDetailView.test.ts
@@ -251,4 +251,101 @@ describe("ArtistDetailView", () => {
       expect(await screen.findByText("Fanart.tv")).toBeTruthy();
     });
   });
+
+  describe("biography 'Show more' truncation", () => {
+    const longBio = "Shania Twain is a Canadian singer and songwriter. She has sold over 100 million records, making her the best-selling female artist in country music history and one of the best-selling music artists of all time. Her success garnered her several titles including the Queen of Country Pop.";
+
+    it("does not show 'Show more' when the bio text is not truncated even if length > 200", async () => {
+      const invokeMock = vi.mocked(invoke);
+      invokeMock.mockImplementation((cmd: string, args?: any) => {
+        if (cmd === "get_songs_by_artist") return Promise.resolve([]);
+        if (cmd === "get_playlists_by_artist") return Promise.resolve([]);
+        if (cmd === "get_compilations_by_artist") return Promise.resolve([]);
+        if (cmd === "get_artist_profile") {
+          return Promise.resolve({
+            artist_key: "Shania Twain",
+            website: "https://www.shaniatwain.com",
+            tags: ["country"],
+            social_links: [],
+            bio: longBio,
+          });
+        }
+        return Promise.resolve();
+      });
+      collectionStore.artistProfiles = {
+        "shania twain": {
+          artist_key: "Shania Twain",
+          website: "https://www.shaniatwain.com",
+          tags: ["country"],
+          social_links: [],
+          bio: longBio,
+        },
+      };
+
+      render(ArtistDetailView, { props: { artistName: "Shania Twain" } });
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(screen.getByText(longBio)).toBeTruthy();
+      expect(screen.queryByRole("button", { name: "Show more" })).toBeNull();
+      expect(screen.queryByRole("button", { name: "Show less" })).toBeNull();
+    });
+
+    it("shows 'Show more' when bio text is truncated, and toggles expansion on click", async () => {
+      const invokeMock = vi.mocked(invoke);
+      invokeMock.mockImplementation((cmd: string, args?: any) => {
+        if (cmd === "get_songs_by_artist") return Promise.resolve([]);
+        if (cmd === "get_playlists_by_artist") return Promise.resolve([]);
+        if (cmd === "get_compilations_by_artist") return Promise.resolve([]);
+        if (cmd === "get_artist_profile") {
+          return Promise.resolve({
+            artist_key: "Shania Twain",
+            website: "https://www.shaniatwain.com",
+            tags: ["country"],
+            social_links: [],
+            bio: longBio,
+          });
+        }
+        return Promise.resolve();
+      });
+      collectionStore.artistProfiles = {
+        "shania twain": {
+          artist_key: "Shania Twain",
+          website: "https://www.shaniatwain.com",
+          tags: ["country"],
+          social_links: [],
+          bio: longBio,
+        },
+      };
+
+      // In the DOM spec, scrollHeight/clientHeight are on Element.prototype.
+      // Mocking on HTMLParagraphElement.prototype targets <p> without affecting container elements.
+      Object.defineProperty(HTMLParagraphElement.prototype, "scrollHeight", {
+        configurable: true,
+        get: () => 120,
+      });
+      Object.defineProperty(HTMLParagraphElement.prototype, "clientHeight", {
+        configurable: true,
+        get: () => 60,
+      });
+
+      try {
+        render(ArtistDetailView, { props: { artistName: "Shania Twain" } });
+        await new Promise((resolve) => setTimeout(resolve, 50));
+
+        const showMoreBtn = screen.getByRole("button", { name: "Show more" });
+        expect(showMoreBtn).toBeTruthy();
+
+        await fireEvent.click(showMoreBtn);
+
+        const showLessBtn = screen.getByRole("button", { name: "Show less" });
+        expect(showLessBtn).toBeTruthy();
+
+        await fireEvent.click(showLessBtn);
+        expect(screen.getByRole("button", { name: "Show more" })).toBeTruthy();
+      } finally {
+        delete (HTMLParagraphElement.prototype as any).scrollHeight;
+        delete (HTMLParagraphElement.prototype as any).clientHeight;
+      }
+    });
+  });
 });


### PR DESCRIPTION
## 📋 Summary
Fixes #819. Resolves an issue where a "Show more" button appeared under biographies (e.g. Wikipedia extracts) on the Artist Detail page even when the biography was not actually truncated and already fully fit within the visible lines.

## 🔍 Implementation Notes
- Replaced the character-length heuristic (`isLongBio = bioText.length > 200`) in `src/lib/components/ArtistDetailView.svelte` with actual DOM truncation measurement (`bioIsTruncated = el.scrollHeight > el.clientHeight + 1`) mirroring the solution in `RightPanel.svelte`.
- Bound the bio `<p>` element with `bind:this={bioParagraphEl}`.
- Ensured the paragraph is clamped with `line-clamp-2 sm:line-clamp-3` while `!isBioExpanded`.
- Updated the toggle button to only appear when `bioIsTruncated || isBioExpanded`.
- Reset `isBioExpanded = false` when `artistName` changes.
- Added automated unit tests in `src/lib/components/ArtistDetailView.test.ts` covering non-truncated and truncated biography scenarios.

## 🧪 Test Plan
- [x] `bun run check` (svelte-check + knip: 0 errors, 0 warnings)
- [x] `bun run test:run src/lib/components/ArtistDetailView.test.ts` (12 passing tests)
- [x] `bun run test:run` (all 79 test files, 674 tests passing)

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed
