### PR TITLE
fix: adopt solid background and rounded-full styling for library chips (#820)

### DIFF
--- a/src/lib/components/AlbumDetailView.svelte
+++ b/src/lib/components/AlbumDetailView.svelte
@@ -476,7 +476,8 @@
           {:else if albumDirectories.length > 1}
             <span>•</span>
             <span
-              class="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-lg text-xs font-medium bg-brand-sidebar/80 border border-brand-border/70 text-brand-text-secondary select-none"
+              class="inline-flex items-center gap-1.5 px-2.5 py-0.5 rounded-full text-xs font-medium text-brand-text-primary border select-none"
+              style="background-color: color-mix(in srgb, var(--color-brand-accent) 15%, var(--color-brand-sidebar)); border-color: color-mix(in srgb, var(--color-brand-accent) 25%, var(--color-brand-sidebar));"
               title={albumDirectories.map((d) => d.nickname || d.path).join(", ")}
             >
               <Folders class="w-3.5 h-3.5 text-brand-accent-text" />

--- a/src/lib/components/LibraryBadge.svelte
+++ b/src/lib/components/LibraryBadge.svelte
@@ -60,17 +60,17 @@
 
   let badgeStyle = $derived(
     customColor
-      ? `background-color: color-mix(in srgb, ${customColor} 18%, transparent); border-color: color-mix(in srgb, ${customColor} 45%, transparent); color: ${customColor};`
-      : undefined
+      ? `background-color: color-mix(in srgb, ${customColor} 18%, var(--color-brand-sidebar)); border-color: color-mix(in srgb, ${customColor} 45%, var(--color-brand-sidebar)); color: ${customColor};`
+      : `background-color: color-mix(in srgb, var(--color-brand-accent) 15%, var(--color-brand-sidebar)); border-color: color-mix(in srgb, var(--color-brand-accent) 25%, var(--color-brand-sidebar));`
   );
 </script>
 
 <span
-  class="inline-flex items-center font-medium border backdrop-blur-md transition-colors select-none max-w-full truncate
-    {size === 'xs' ? 'text-[10px] px-1.5 py-0.5 gap-1 rounded-md' : ''}
-    {size === 'sm' ? 'text-xs px-2 py-0.5 gap-1.5 rounded-lg' : ''}
-    {size === 'md' ? 'text-xs px-2.5 py-1 gap-2 rounded-xl' : ''}
-    {!customColor ? 'bg-brand-sidebar/80 border-brand-border/70 text-brand-text-secondary' : ''}
+  class="inline-flex items-center font-medium border rounded-full transition-colors select-none max-w-full truncate
+    {size === 'xs' ? 'text-[10px] px-2 py-0.5 gap-1' : ''}
+    {size === 'sm' ? 'text-xs px-2.5 py-0.5 gap-1.5' : ''}
+    {size === 'md' ? 'text-xs px-3 py-1 gap-2' : ''}
+    {!customColor ? 'text-brand-text-primary' : ''}
     {isUnavailable ? 'opacity-70 border-dashed border-red-400/60' : ''}
     {className}"
   style={badgeStyle}

--- a/src/lib/components/LibraryBadge.test.ts
+++ b/src/lib/components/LibraryBadge.test.ts
@@ -66,4 +66,16 @@ describe("LibraryBadge.svelte", () => {
     });
     expect(queryByText("HighRes")).toBeNull();
   });
+
+  it("applies rounded-full, avoids glass blur, and uses solid genre chip styling by default", () => {
+    const { container } = render(LibraryBadge, {
+      props: { directory: baseDirectory },
+    });
+    const badge = container.querySelector("span");
+    expect(badge).toBeInTheDocument();
+    expect(badge?.classList.contains("rounded-full")).toBe(true);
+    expect(badge?.classList.contains("backdrop-blur-md")).toBe(false);
+    expect(badge?.classList.contains("text-brand-text-primary")).toBe(true);
+    expect(badge?.getAttribute("style")).toContain("var(--color-brand-sidebar)");
+  });
 });


### PR DESCRIPTION
## 📋 Summary
Fixes #820 — updates library chips styling across the application to match the visual language of genre chips. Removes frosted glassmorphism (`backdrop-blur-md` and alpha-blended transparency) in favor of solid, opaque backgrounds and pill-shaped rounded corners (`rounded-full`) for significantly improved contrast and legibility over album artwork.

## 🔍 Implementation Notes
- `src/lib/components/LibraryBadge.svelte`:
  - Removed `backdrop-blur-md` so artwork no longer bleeds through the chip.
  - Replaced size-dependent corner radiuses (`rounded-md`, `rounded-lg`, `rounded-xl`) with `rounded-full` across all size variants (`xs`, `sm`, `md`), aligning with `GenreChips.svelte`.
  - For default folders (`!customColor`): Adopted the solid genre-chip palette (`color-mix(in srgb, var(--color-brand-accent) 15%, var(--color-brand-sidebar))` with `text-brand-text-primary` and matching border). Blending with `var(--color-brand-sidebar)` ensures 100% opacity over cover art.
  - For custom-colored folders (`customColor`): Mixed with `var(--color-brand-sidebar)` rather than `transparent`, guaranteeing 100% opacity and high contrast against underlying art.
- `src/lib/components/AlbumDetailView.svelte`:
  - Updated the multi-libraries indicator badge to `rounded-full` with the solid genre-chip palette.
- `src/lib/components/LibraryBadge.test.ts`:
  - Added unit test asserting `rounded-full`, absence of `backdrop-blur-md`, `text-brand-text-primary`, and solid background mixing with `var(--color-brand-sidebar)`.

## 🧪 Test Plan
- [x] `bun run check` (svelte-check + knip) — 0 errors, 0 warnings
- [x] `bun run test -- --run` (frontend) — 79 files passed, 673 tests passed
- [ ] `cargo test` — N/A, frontend styling only
- [x] Manually verified in the app

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed — N/A, UI polish only
