### PR TITLE
fix: resolve Wikipedia context race condition and error cache poisoning

### DIFF
--- a/src-tauri/src/commands/context.rs
+++ b/src-tauri/src/commands/context.rs
@@ -4,7 +4,10 @@
 //! (see `db.rs` migration 28) with a 30-day TTL. Each source degrades
 //! independently on failure — see `context::ContextManager`'s doc comment.
 
-use crate::context::{is_cache_fresh, ContextManager};
+use crate::context::{
+    is_cache_fresh, ContextManager, ARTIST_FLIGHT, RELEASE_GROUP_FLIGHT,
+};
+use crate::db::Database;
 use crate::AppState;
 use rusqlite::params;
 use serde::Serialize;
@@ -58,14 +61,25 @@ pub async fn get_song_context(
         if !context_enrichment_enabled(&conn) {
             return Ok(SongContextEnrichment::default());
         }
-        let (rg, artist): (Option<String>, Option<String>) = conn
+        let (rg, artist, album_artist): (Option<String>, Option<String>, Option<String>) = conn
             .query_row(
-                "SELECT musicbrainz_release_group_id, musicbrainz_artist_id FROM songs WHERE id = ?1",
+                "SELECT musicbrainz_release_group_id, musicbrainz_artist_id, musicbrainz_album_artist_id FROM songs WHERE id = ?1",
                 params![song_id],
-                |row| Ok((row.get(0)?, row.get(1)?)),
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
             )
-            .unwrap_or((None, None));
-        (rg, artist)
+            .unwrap_or((None, None, None));
+        let resolved_artist = artist
+            .filter(|a| !a.trim().is_empty())
+            .or_else(|| album_artist.filter(|a| !a.trim().is_empty()))
+            .map(|a| {
+                a.split(&[';', '/'][..])
+                    .next()
+                    .unwrap_or(&a)
+                    .trim()
+                    .to_string()
+            })
+            .filter(|a| !a.is_empty());
+        (rg, resolved_artist)
     };
 
     if release_group_id.is_none() && artist_id.is_none() {
@@ -75,9 +89,10 @@ pub async fn get_song_context(
     let now = now_unix();
     let mut result = SongContextEnrichment::default();
     let context_manager = ContextManager::new();
+    let db = state.db.clone();
 
     if let Some(ref rg_id) = release_group_id {
-        let cached = read_release_group_cache(&state, rg_id)?;
+        let cached = read_release_group_cache(&db, rg_id)?;
         let fresh = cached
             .as_ref()
             .map(|c| is_cache_fresh(c.fetched_at, now))
@@ -86,31 +101,74 @@ pub async fn get_song_context(
         if fresh && !force_refresh {
             apply_release_group_cache(&mut result, cached.unwrap());
         } else {
-            let mb = context_manager
-                .fetch_musicbrainz_release_group(rg_id)
-                .await
-                .ok();
-            let cb = context_manager
-                .fetch_critiquebrainz_reviews(rg_id)
-                .await
-                .ok();
-            write_release_group_cache(&state, rg_id, &mb, &cb, now)?;
-            if let Some(mb) = mb {
+            let db_clone = db.clone();
+            let rg_id_clone = rg_id.clone();
+            let cm = context_manager.clone();
+            let (mb_res, cb_res) = RELEASE_GROUP_FLIGHT
+                .work(rg_id, move || async move {
+                    let mb = cm
+                        .fetch_musicbrainz_release_group(&rg_id_clone)
+                        .await
+                        .map_err(|e| e.to_string());
+                    let cb = cm
+                        .fetch_critiquebrainz_reviews(&rg_id_clone)
+                        .await
+                        .map_err(|e| e.to_string());
+
+                    let mb_ok = mb.as_ref().ok().cloned();
+                    let cb_ok = cb.as_ref().ok().cloned();
+
+                    if mb.is_ok() || cb.is_ok() {
+                        let _ = write_release_group_cache(
+                            &db_clone,
+                            &rg_id_clone,
+                            &mb_ok,
+                            &cb_ok,
+                            now,
+                        );
+                    }
+                    (mb, cb)
+                })
+                .await;
+
+            if let Ok(ref mb) = mb_res {
                 result.mb_rating = mb.rating;
                 result.mb_rating_votes = mb.rating_votes;
-                result.mb_tags = mb.tags;
+                result.mb_tags = mb.tags.clone();
+            } else if let Some(ref cached_row) = cached {
+                result.mb_rating = cached_row.mb_rating;
+                result.mb_rating_votes = cached_row.mb_rating_votes;
+                result.mb_tags = cached_row
+                    .mb_tags
+                    .as_ref()
+                    .and_then(|t| serde_json::from_str(t).ok())
+                    .unwrap_or_default();
             }
-            if let Some(cb) = cb {
+
+            if let Ok(ref cb) = cb_res {
                 result.critiquebrainz_rating = cb.average_rating;
                 result.critiquebrainz_review_count = Some(cb.review_count);
-                result.critiquebrainz_review_links = cb.review_links;
+                result.critiquebrainz_review_links = cb.review_links.clone();
+            } else if let Some(ref cached_row) = cached {
+                result.critiquebrainz_rating = cached_row.critiquebrainz_rating;
+                result.critiquebrainz_review_count = cached_row.critiquebrainz_review_count;
+                result.critiquebrainz_review_links = cached_row
+                    .critiquebrainz_review_links
+                    .as_ref()
+                    .and_then(|l| serde_json::from_str(l).ok())
+                    .unwrap_or_default();
             }
-            result.fetched_at = Some(now);
+
+            if mb_res.is_ok() || cb_res.is_ok() {
+                result.fetched_at = Some(now);
+            } else if let Some(ref cached_row) = cached {
+                result.fetched_at = Some(cached_row.fetched_at);
+            }
         }
     }
 
     if let Some(ref artist_id) = artist_id {
-        let cached = read_artist_cache(&state, artist_id)?;
+        let cached = read_artist_cache(&db, artist_id)?;
         let fresh = cached
             .as_ref()
             .map(|c| is_cache_fresh(c.3, now))
@@ -123,18 +181,55 @@ pub async fn get_song_context(
                 result.wikipedia_thumbnail_url = thumbnail_url;
             }
         } else {
-            let bio = context_manager
-                .fetch_wikipedia_bio_for_artist(artist_id)
-                .await
-                .ok()
-                .flatten();
-            write_artist_cache(&state, artist_id, &bio, now)?;
-            if let Some(bio) = bio {
-                result.wikipedia_extract = Some(bio.extract);
-                result.wikipedia_page_url = bio.page_url;
-                result.wikipedia_thumbnail_url = bio.thumbnail_url;
+            let db_clone = db.clone();
+            let artist_id_clone = artist_id.clone();
+            let bio_res = ARTIST_FLIGHT
+                .work(artist_id, move || async move {
+                    let res = context_manager
+                        .fetch_wikipedia_bio_for_artist(&artist_id_clone)
+                        .await
+                        .map_err(|e| e.to_string());
+
+                    match &res {
+                        Ok(bio) => {
+                            let _ = write_artist_cache(
+                                &db_clone,
+                                &artist_id_clone,
+                                bio,
+                                now,
+                            );
+                        }
+                        Err(err) => {
+                            log::warn!(
+                                "Failed to fetch Wikipedia bio for artist {}: {}",
+                                artist_id_clone,
+                                err
+                            );
+                        }
+                    }
+                    res
+                })
+                .await;
+
+            match bio_res {
+                Ok(Some(bio)) => {
+                    result.wikipedia_extract = Some(bio.extract);
+                    result.wikipedia_page_url = bio.page_url;
+                    result.wikipedia_thumbnail_url = bio.thumbnail_url;
+                    result.fetched_at = Some(now);
+                }
+                Ok(None) => {
+                    result.fetched_at = Some(now);
+                }
+                Err(_) => {
+                    if let Some((extract, page_url, thumbnail_url, fetched_at)) = cached {
+                        result.wikipedia_extract = extract;
+                        result.wikipedia_page_url = page_url;
+                        result.wikipedia_thumbnail_url = thumbnail_url;
+                        result.fetched_at = Some(fetched_at);
+                    }
+                }
             }
-            result.fetched_at = Some(now);
         }
     }
 
@@ -152,10 +247,10 @@ struct ReleaseGroupCacheRow {
 }
 
 fn read_release_group_cache(
-    state: &State<'_, AppState>,
+    db: &Database,
     release_group_id: &str,
 ) -> Result<Option<ReleaseGroupCacheRow>, String> {
-    let conn = state.db.pool.get().map_err(|e| e.to_string())?;
+    let conn = db.pool.get().map_err(|e| e.to_string())?;
     conn.query_row(
         "SELECT mb_rating, mb_rating_votes, mb_tags, critiquebrainz_rating, critiquebrainz_review_count, critiquebrainz_review_links, fetched_at
          FROM context_enrichment WHERE release_group_id = ?1",
@@ -196,13 +291,13 @@ fn apply_release_group_cache(result: &mut SongContextEnrichment, cached: Release
 }
 
 fn write_release_group_cache(
-    state: &State<'_, AppState>,
+    db: &Database,
     release_group_id: &str,
     mb: &Option<crate::context::MusicBrainzReleaseGroupData>,
     cb: &Option<crate::context::CritiqueBrainzData>,
     fetched_at: i64,
 ) -> Result<(), String> {
-    let conn = state.db.pool.get().map_err(|e| e.to_string())?;
+    let conn = db.pool.get().map_err(|e| e.to_string())?;
     let mb_tags_json = serde_json::to_string(&mb.as_ref().map(|m| m.tags.clone()).unwrap_or_default())
         .unwrap_or_else(|_| "[]".to_string());
     let cb_links_json =
@@ -238,10 +333,10 @@ fn write_release_group_cache(
 type ArtistCacheRow = (Option<String>, Option<String>, Option<String>, i64);
 
 fn read_artist_cache(
-    state: &State<'_, AppState>,
+    db: &Database,
     artist_id: &str,
 ) -> Result<Option<ArtistCacheRow>, String> {
-    let conn = state.db.pool.get().map_err(|e| e.to_string())?;
+    let conn = db.pool.get().map_err(|e| e.to_string())?;
     conn.query_row(
         "SELECT wikipedia_extract, wikipedia_page_url, wikipedia_thumbnail_url, fetched_at
          FROM artist_context_enrichment WHERE artist_id = ?1",
@@ -263,12 +358,12 @@ fn read_artist_cache(
 }
 
 fn write_artist_cache(
-    state: &State<'_, AppState>,
+    db: &Database,
     artist_id: &str,
     bio: &Option<crate::context::WikipediaSummary>,
     fetched_at: i64,
 ) -> Result<(), String> {
-    let conn = state.db.pool.get().map_err(|e| e.to_string())?;
+    let conn = db.pool.get().map_err(|e| e.to_string())?;
     conn.execute(
         "INSERT INTO artist_context_enrichment
             (artist_id, wikidata_id, wikipedia_extract, wikipedia_page_url, wikipedia_thumbnail_url, fetched_at)

--- a/src-tauri/src/context.rs
+++ b/src-tauri/src/context.rs
@@ -14,8 +14,95 @@ use parking_lot::Mutex;
 use reqwest::Client;
 use serde::Deserialize;
 use std::collections::HashMap;
-use std::sync::LazyLock;
+use std::sync::{Arc, LazyLock};
 use std::time::{Duration, Instant};
+use tokio::sync::watch;
+
+// ---------------------------------------------------------------------------
+// In-flight request coalescer (SingleFlight) — ensures that concurrent
+// calls for the same artist or release group share a single in-flight operation
+// rather than duplicating network requests or racing writes.
+// ---------------------------------------------------------------------------
+
+struct FlightGuard<T: Clone> {
+    in_flight: Arc<Mutex<HashMap<String, watch::Receiver<Option<T>>>>>,
+    key: String,
+}
+
+impl<T: Clone> Drop for FlightGuard<T> {
+    fn drop(&mut self) {
+        let mut map = self.in_flight.lock();
+        map.remove(&self.key);
+    }
+}
+
+#[derive(Clone, Default)]
+pub struct FlightGroup<T: Clone> {
+    in_flight: Arc<Mutex<HashMap<String, watch::Receiver<Option<T>>>>>,
+}
+
+impl<T: Clone + Send + 'static> FlightGroup<T> {
+    pub fn new() -> Self {
+        Self {
+            in_flight: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    pub async fn work<F, Fut>(&self, key: &str, f: F) -> T
+    where
+        F: FnOnce() -> Fut,
+        Fut: std::future::Future<Output = T>,
+    {
+        enum FlightAction<T> {
+            Wait(watch::Receiver<Option<T>>),
+            Leader(watch::Sender<Option<T>>),
+        }
+
+        let action = {
+            let mut map = self.in_flight.lock();
+            if let Some(rx) = map.get(key) {
+                FlightAction::Wait(rx.clone())
+            } else {
+                let (tx, rx) = watch::channel(None);
+                map.insert(key.to_string(), rx);
+                FlightAction::Leader(tx)
+            }
+        };
+
+        match action {
+            FlightAction::Leader(tx) => {
+                let _guard = FlightGuard {
+                    in_flight: self.in_flight.clone(),
+                    key: key.to_string(),
+                };
+                let result = f().await;
+                let _ = tx.send(Some(result.clone()));
+                result
+            }
+            FlightAction::Wait(mut rx) => {
+                while rx.borrow().is_none() {
+                    if rx.changed().await.is_err() {
+                        break;
+                    }
+                }
+                if let Some(val) = rx.borrow().clone() {
+                    return val;
+                }
+                f().await
+            }
+        }
+    }
+}
+
+pub static ARTIST_FLIGHT: LazyLock<FlightGroup<Result<Option<WikipediaSummary>, String>>> =
+    LazyLock::new(FlightGroup::new);
+
+pub static RELEASE_GROUP_FLIGHT: LazyLock<
+    FlightGroup<(
+        Result<MusicBrainzReleaseGroupData, String>,
+        Result<CritiqueBrainzData, String>,
+    )>,
+> = LazyLock::new(FlightGroup::new);
 
 // ---------------------------------------------------------------------------
 // MusicBrainz rate limiting — MetaBrainz asks for roughly one request per
@@ -224,6 +311,7 @@ pub fn is_cache_fresh(fetched_at: i64, now: i64) -> bool {
 /// Holds the shared HTTP client used for every source. Cheap to construct
 /// (no state beyond the client), so callers can create one per-lookup rather
 /// than needing to share an instance — matches `LyricsManager`.
+#[derive(Clone)]
 pub struct ContextManager {
     client: Client,
 }
@@ -592,5 +680,41 @@ mod tests {
                 "https://critiquebrainz.org/review/22222222-2222-2222-2222-222222222222",
             ]
         );
+    }
+
+    #[tokio::test]
+    async fn test_flight_group_deduplicates_concurrent_calls() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let group: FlightGroup<String> = FlightGroup::new();
+        let counter = Arc::new(AtomicUsize::new(0));
+
+        let g1 = group.clone();
+        let c1 = counter.clone();
+        let t1 = tokio::spawn(async move {
+            g1.work("key1", move || async move {
+                tokio::time::sleep(Duration::from_millis(50)).await;
+                c1.fetch_add(1, Ordering::SeqCst);
+                "result_val".to_string()
+            })
+            .await
+        });
+
+        let g2 = group.clone();
+        let c2 = counter.clone();
+        let t2 = tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+            g2.work("key1", move || async move {
+                c2.fetch_add(1, Ordering::SeqCst);
+                "result_val".to_string()
+            })
+            .await
+        });
+
+        let (r1, r2) = tokio::join!(t1, t2);
+        assert_eq!(r1.unwrap(), "result_val");
+        assert_eq!(r2.unwrap(), "result_val");
+        // Only one worker should have actually executed the inner work future
+        assert_eq!(counter.load(Ordering::SeqCst), 1);
     }
 }

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -232,6 +232,7 @@ impl Database {
                 "PRAGMA journal_mode=WAL;
                      PRAGMA synchronous=NORMAL;
                      PRAGMA foreign_keys=ON;
+                     PRAGMA busy_timeout=5000;
                      PRAGMA cache_size=-32000;  -- 32 MB page cache
                      PRAGMA temp_store=MEMORY;",
             )

--- a/src/lib/components/ArtistDetailView.svelte
+++ b/src/lib/components/ArtistDetailView.svelte
@@ -90,12 +90,14 @@
   let hasTags = $derived((artistProfile?.tags?.length ?? 0) > 0);
   let hasSocials = $derived((artistProfile?.social_links?.length ?? 0) > 0);
 
-  // Fetched MusicBrainz/Wikipedia context (#23), keyed off any one track by
-  // this artist — neither ArtistProfile nor a dedicated artist entity carry
-  // a MusicBrainz ID of their own, so the backend resolves it from a song row.
+  // Fetched MusicBrainz/Wikipedia context (#23), keyed off a track by
+  // this artist with a MusicBrainz ID (or first song) — neither ArtistProfile
+  // nor a dedicated artist entity carry a MusicBrainz ID of their own,
+  // so the backend resolves it from a song row.
   let contextData = $state<SongContextEnrichment | null>(null);
   $effect(() => {
-    const id = songs[0]?.id;
+    const songWithMb = songs.find((s) => s.musicbrainz_artist_id || s.musicbrainz_album_artist_id);
+    const id = songWithMb?.id || songs[0]?.id;
     if (!id) {
       contextData = null;
       return;
@@ -262,6 +264,7 @@
 
   $effect(() => {
     const requested = artistName;
+    contextData = null;
     // Track collectionStore.songs so artist details update when the library changes (e.g. new albums added)
     const _libraryVersion = collectionStore.songs;
     loading = true;


### PR DESCRIPTION
## 📋 Summary
Fixes #818

Addresses intermittent and missing Wikipedia artist bio display in both the sidebar (`RightPanel.svelte`) and the artist detail view (`ArtistDetailView.svelte`).

The root cause was a combination of:
1. Concurrent duplicate requests (cache stampede) when navigating to an artist view while playing that artist, causing parallel calls to MusicBrainz / Wikipedia.
2. Error masking where network rate-limiting or timeouts were converted to `Ok(None)` and cached as `NULL` for 30 days, poisoning the cache on race conditions.
3. Lack of SQLite `busy_timeout`, leading to `database is locked` concurrency errors.
4. Artist view selecting `songs[0]` which could lack MusicBrainz tags even if other tracks had them.

## 🔍 Implementation Notes
- **SingleFlight Coalescing**: Added `FlightGroup<T>` in `src-tauri/src/context.rs` using `tokio::sync::watch` to deduplicate and coalesce simultaneous in-flight requests for artist and release-group context lookups across threads.
- **Cache Poisoning Prevention**: In `src-tauri/src/commands/context.rs`, network and rate-limiting errors (`Err`) are no longer treated as empty bios (`Ok(None)`) and will not overwrite cached entries with `NULL`. Previously cached data is retained on error.
- **MusicBrainz ID Normalization & Fallbacks**: Support multiple semicolon/slash-separated MBIDs by taking the primary UUID, and fall back to `musicbrainz_album_artist_id` if `musicbrainz_artist_id` is empty.
- **SQLite Concurrency**: Added `PRAGMA busy_timeout=5000;` during database connection pool initialization in `src-tauri/src/db.rs`.
- **Artist Track Selection**: Updated `ArtistDetailView.svelte` to find the first song with a MusicBrainz artist or album artist ID, and clear `contextData` on artist change.

## 🧪 Test Plan
- [x] `bun run check` (svelte-check + knip: 0 errors, 0 warnings)
- [x] `bun run test:run` (79 passed test files, 672 passed unit tests)
- [x] `cargo check` (0 errors)
- [x] `cargo test --lib -- context` (14 passed, including `test_flight_group_deduplicates_concurrent_calls`)

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed
