### PR TITLE
fix: limit genre chips in detail headers to prevent button clipping (#817)

### DIFF
--- a/src/lib/components/AlbumDetailView.svelte
+++ b/src/lib/components/AlbumDetailView.svelte
@@ -451,7 +451,7 @@
         </div>
 
         {#if rawGenre}
-          <GenreChips genre={rawGenre} variant="full" />
+          <GenreChips genre={rawGenre} variant="full" limit={4} />
         {:else}
           <div class="text-xs text-brand-text-secondary font-medium">
             <span>{genreLabel}</span>

--- a/src/lib/components/ArtistDetailView.svelte
+++ b/src/lib/components/ArtistDetailView.svelte
@@ -468,7 +468,7 @@
         {/if}
 
         {#if rawGenre}
-          <GenreChips genre={rawGenre} variant="full" />
+          <GenreChips genre={rawGenre} variant="full" limit={4} />
         {:else}
           <div class="text-xs text-brand-text-secondary font-medium">
             <span>{genreLabel}</span>

--- a/src/lib/components/ArtistDetailView.test.ts
+++ b/src/lib/components/ArtistDetailView.test.ts
@@ -175,6 +175,40 @@ describe("ArtistDetailView", () => {
     expect(await screen.findByText("Unknown genre")).toBeTruthy();
   });
 
+  it("limits header genre chips to 4 and shows overflow badge when artist has many genres (#817)", async () => {
+    const invokeMock = vi.mocked(invoke);
+    invokeMock.mockImplementation((cmd: string, args?: any) => {
+      if (cmd === "get_songs_by_artist") {
+        return Promise.resolve([
+          {
+            id: 1,
+            title: "Song 1",
+            artist: "Nightwish",
+            genre: "Metal; Symphonic Metal; Gothic Metal; Power Metal; Heavy Metal; Pop Rock",
+            length_nanosec: 180_000_000_000,
+          } as any,
+        ]);
+      }
+      if (cmd === "get_playlists_by_artist") return Promise.resolve([]);
+      if (cmd === "get_compilations_by_artist") return Promise.resolve([]);
+      if (cmd === "get_artist_profile") return Promise.resolve(null as any);
+      return Promise.resolve();
+    });
+
+    render(ArtistDetailView, { props: { artistName: "Nightwish" } });
+
+    expect(await screen.findByTitle("Browse Metal")).toBeTruthy();
+    expect(screen.getByTitle("Browse Symphonic Metal")).toBeTruthy();
+    expect(screen.getByTitle("Browse Gothic Metal")).toBeTruthy();
+    expect(screen.getByTitle("Browse Power Metal")).toBeTruthy();
+
+    expect(screen.queryByTitle("Browse Heavy Metal")).toBeNull();
+    expect(screen.queryByTitle("Browse Pop Rock")).toBeNull();
+    const badge = screen.getByText("+2");
+    expect(badge).toBeTruthy();
+    expect(badge.getAttribute("title")).toBe("Heavy Metal, Pop Rock");
+  });
+
   describe("extended artist artwork (#98/#761)", () => {
     it("renders a discovered artist portrait and band logo instead of the album-art composite and text heading", async () => {
       const invokeMock = vi.mocked(invoke);

--- a/src/lib/components/ArtistDetailView.test.ts
+++ b/src/lib/components/ArtistDetailView.test.ts
@@ -197,16 +197,16 @@ describe("ArtistDetailView", () => {
 
     render(ArtistDetailView, { props: { artistName: "Nightwish" } });
 
-    expect(await screen.findByTitle("Browse Metal")).toBeTruthy();
-    expect(screen.getByTitle("Browse Symphonic Metal")).toBeTruthy();
-    expect(screen.getByTitle("Browse Gothic Metal")).toBeTruthy();
-    expect(screen.getByTitle("Browse Power Metal")).toBeTruthy();
+    expect(await screen.findByTitle("Browse Gothic Metal")).toBeTruthy();
+    expect(screen.getByTitle("Browse Heavy Metal")).toBeTruthy();
+    expect(screen.getByTitle("Browse Metal")).toBeTruthy();
+    expect(screen.getByTitle("Browse Pop Rock")).toBeTruthy();
 
-    expect(screen.queryByTitle("Browse Heavy Metal")).toBeNull();
-    expect(screen.queryByTitle("Browse Pop Rock")).toBeNull();
+    expect(screen.queryByTitle("Browse Power Metal")).toBeNull();
+    expect(screen.queryByTitle("Browse Symphonic Metal")).toBeNull();
     const badge = screen.getByText("+2");
     expect(badge).toBeTruthy();
-    expect(badge.getAttribute("title")).toBe("Heavy Metal, Pop Rock");
+    expect(badge.getAttribute("title")).toBe("Power Metal, Symphonic Metal");
   });
 
   describe("extended artist artwork (#98/#761)", () => {

--- a/src/lib/components/GenreChips.svelte
+++ b/src/lib/components/GenreChips.svelte
@@ -11,12 +11,18 @@
         indicator, for narrow contexts like table columns. "full" shows every
         value as its own chip, for wide contexts like detail-view headers. */
     variant?: "compact" | "full";
+    /** Optional maximum number of chips to display when variant is "full".
+        When specified and genres exceed this limit, a "+N" overflow badge is shown. */
+    limit?: number;
     class?: string;
   }
 
-  let { genre, variant = "compact", class: className = "" }: Props = $props();
+  let { genre, variant = "compact", limit, class: className = "" }: Props = $props();
 
   let values = $derived(parseMultiValue(genre || ""));
+  let displayedValues = $derived(limit && limit > 0 ? values.slice(0, limit) : values);
+  let remainingCount = $derived(values.length - displayedValues.length);
+  let remainingValues = $derived(remainingCount > 0 ? values.slice(displayedValues.length) : []);
 
   const chipClass =
     "inline-flex items-center pl-2 pr-2 py-0.5 rounded-full bg-brand-accent/15 text-brand-text-primary border border-brand-accent/25 text-xs font-medium hover:bg-brand-accent/25 hover:border-brand-accent/50 transition-colors";
@@ -42,7 +48,7 @@
     </button>
   {:else}
     <div class="flex flex-wrap gap-1 {className}">
-      {#each values as value (value)}
+      {#each displayedValues as value (value)}
         <button
           type="button"
           onclick={(e) => goToTag(e, value)}
@@ -52,6 +58,14 @@
           <span class="truncate">{value}</span>
         </button>
       {/each}
+      {#if remainingCount > 0}
+        <span
+          class="inline-flex items-center px-2 py-0.5 rounded-full bg-brand-sidebar/80 text-brand-text-secondary border border-brand-border/60 text-xs font-medium select-none shrink-0"
+          title={remainingValues.join(", ")}
+        >
+          +{remainingCount}
+        </span>
+      {/if}
     </div>
   {/if}
 {/if}

--- a/src/lib/components/GenreChips.test.ts
+++ b/src/lib/components/GenreChips.test.ts
@@ -1,0 +1,121 @@
+import "@testing-library/jest-dom";
+import { describe, it, expect, vi } from "vitest";
+import { render, fireEvent } from "@testing-library/svelte";
+import GenreChips from "./GenreChips.svelte";
+import { navigationStore } from "../stores/navigation.svelte";
+
+describe("GenreChips.svelte", () => {
+  it("renders nothing when genre is null or empty", () => {
+    const { container: container1 } = render(GenreChips, { props: { genre: null } });
+    expect(container1.textContent?.trim()).toBe("");
+
+    const { container: container2 } = render(GenreChips, { props: { genre: "" } });
+    expect(container2.textContent?.trim()).toBe("");
+  });
+
+  describe("compact variant (default)", () => {
+    it("renders single genre without overflow count", () => {
+      const { getByText, queryByText } = render(GenreChips, {
+        props: { genre: "Metal" },
+      });
+
+      expect(getByText("Metal")).toBeInTheDocument();
+      expect(queryByText("+")).toBeNull();
+    });
+
+    it("renders primary genre with +N overflow count when multiple genres exist", () => {
+      const { getByText } = render(GenreChips, {
+        props: { genre: "Metal; Symphonic Metal; Gothic Metal" },
+      });
+
+      expect(getByText("Metal")).toBeInTheDocument();
+      expect(getByText("+2")).toBeInTheDocument();
+    });
+
+    it("navigates to genre tag on click", async () => {
+      const viewSpy = vi.spyOn(navigationStore, "viewGenreTag");
+      const { getByRole } = render(GenreChips, {
+        props: { genre: "Rock; Pop" },
+      });
+
+      const button = getByRole("button");
+      await fireEvent.click(button);
+
+      expect(viewSpy).toHaveBeenCalledWith("Rock");
+      viewSpy.mockRestore();
+    });
+  });
+
+  describe("full variant", () => {
+    it("renders all genre chips when no limit is specified", () => {
+      const { getByText, queryByText } = render(GenreChips, {
+        props: {
+          genre: "Metal; Symphonic Metal; Gothic Metal; Power Metal; Heavy Metal",
+          variant: "full",
+        },
+      });
+
+      expect(getByText("Metal")).toBeInTheDocument();
+      expect(getByText("Symphonic Metal")).toBeInTheDocument();
+      expect(getByText("Gothic Metal")).toBeInTheDocument();
+      expect(getByText("Power Metal")).toBeInTheDocument();
+      expect(getByText("Heavy Metal")).toBeInTheDocument();
+      expect(queryByText(/^\+/)).toBeNull();
+    });
+
+    it("renders all chips without overflow badge when count <= limit", () => {
+      const { getByText, queryByText } = render(GenreChips, {
+        props: {
+          genre: "Rock; Pop; Jazz",
+          variant: "full",
+          limit: 4,
+        },
+      });
+
+      expect(getByText("Rock")).toBeInTheDocument();
+      expect(getByText("Pop")).toBeInTheDocument();
+      expect(getByText("Jazz")).toBeInTheDocument();
+      expect(queryByText(/^\+/)).toBeNull();
+    });
+
+    it("limits displayed chips and renders +N badge when count > limit", () => {
+      const { getByText, queryByText } = render(GenreChips, {
+        props: {
+          genre: "Metal; Symphonic Metal; Gothic Metal; Power Metal; Heavy Metal; Pop Rock",
+          variant: "full",
+          limit: 4,
+        },
+      });
+
+      expect(getByText("Metal")).toBeInTheDocument();
+      expect(getByText("Symphonic Metal")).toBeInTheDocument();
+      expect(getByText("Gothic Metal")).toBeInTheDocument();
+      expect(getByText("Power Metal")).toBeInTheDocument();
+
+      // Exceeded chips should NOT be individual buttons
+      expect(queryByText("Heavy Metal")).toBeNull();
+      expect(queryByText("Pop Rock")).toBeNull();
+
+      // Overflow badge with +2 and title showing hidden genres
+      const overflowBadge = getByText("+2");
+      expect(overflowBadge).toBeInTheDocument();
+      expect(overflowBadge.getAttribute("title")).toBe("Heavy Metal, Pop Rock");
+    });
+
+    it("navigates to specific genre tag when an individual chip is clicked", async () => {
+      const viewSpy = vi.spyOn(navigationStore, "viewGenreTag");
+      const { getByTitle } = render(GenreChips, {
+        props: {
+          genre: "Metal; Symphonic Metal",
+          variant: "full",
+        },
+      });
+
+      const symphonicChip = getByTitle("Browse Symphonic Metal");
+      await fireEvent.click(symphonicChip);
+
+      expect(viewSpy).toHaveBeenCalledWith("Symphonic Metal");
+      viewSpy.mockRestore();
+    });
+  });
+});

--- a/src/lib/components/PlaylistView.svelte
+++ b/src/lib/components/PlaylistView.svelte
@@ -683,7 +683,7 @@
 
           {#if !isSpecialPlaylist}
             {#if rawGenre}
-              <GenreChips genre={rawGenre} variant="full" />
+              <GenreChips genre={rawGenre} variant="full" limit={4} />
             {:else}
               <div class="text-xs text-brand-text-secondary font-medium">
                 <span>{genreLabel}</span>


### PR DESCRIPTION
## 📋 Summary
Fixes #817. Limits the number of genre chips displayed in detail view headers to a single row (up to 4 chips) plus an overflow `+N` badge with hover tooltip for additional genres. This prevents multi-line wrapping in the header that previously caused the action buttons row (Play, Shuffle Play, Pin, Column Selector, etc.) to get cut off by the header container boundary.

## 🔍 Implementation Notes
- Added an optional `limit?: number` prop to `GenreChips.svelte`. When `variant="full"` and genres exceed `limit`, the component renders the first `limit` chips and groups remaining genres into a neutral `+N` pill displaying all hidden genre names on hover (`title={remainingValues.join(", ")}`).
- If `limit` is omitted, all chips continue to render without truncation.
- Configured `limit={4}` in `ArtistDetailView.svelte`, `AlbumDetailView.svelte`, and `PlaylistView.svelte`. Because artists and playlists sort genres by frequency descending (with alphabetical tie-breaker), the most prominent 4 genres are always prioritized as visible chips.
- Retained the existing `compact` variant behavior for table and card views.

## 🧪 Test Plan
- [x] `bun run check` (svelte-check + knip clean with 0 errors and 0 warnings)
- [x] Added unit tests in `src/lib/components/GenreChips.test.ts` covering compact mode, full mode without limit, full mode with `limit` (both count $\le$ limit and count > limit), genre navigation click events, and null/empty genres.
- [x] Added test case in `src/lib/components/ArtistDetailView.test.ts` verifying that an artist with 6 genres renders 4 chips and a `+2` badge with remaining genres in the title.
- [x] Manually verified in the app by user confirming genre chips stay on a single line and action buttons remain fully visible and clickable.

## 📸 Screenshots
*(See issue #817 for before screenshot)*

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed
