### PR TITLE
fix: adapt artist detail bio clamping to available card room

### DIFF
--- a/src/lib/components/ArtistDetailView.svelte
+++ b/src/lib/components/ArtistDetailView.svelte
@@ -121,21 +121,67 @@
   let hasBio = $derived(!!effectiveBio);
   let hasProfileContent = $derived(hasWebsite || hasBio || hasSocials);
 
+  let profileCardEl = $state<HTMLDivElement | undefined>();
+  let linksColEl = $state<HTMLDivElement | undefined>();
   let bioParagraphEl = $state<HTMLParagraphElement | undefined>();
-  let bioIsTruncated = $state(false);
+  let bioNeedsClamp = $state(false);
+  let clampedLines = $state(6);
 
-  // Only show "Show more" when the clamp actually hides text — measured
-  // once per bio while still clamped (isBioExpanded resets to false on every
-  // artist load), since a fixed character threshold would be wrong for
-  // responsive widths.
-  $effect(() => {
+  function measureBio() {
     const text = effectiveBio;
     const el = bioParagraphEl;
     if (!text || !el) {
-      bioIsTruncated = false;
+      bioNeedsClamp = false;
       return;
     }
-    bioIsTruncated = el.scrollHeight > el.clientHeight + 1;
+
+    // Baseline height is ~6 lines of text-xs leading-relaxed (~130px)
+    const baselineHeight = 130;
+    const lineHeight = 20;
+
+    // Available height in profile card: when rendered side-by-side in md:flex-row (>= 768px),
+    // the card already expands to the height of the Links column, so the bio can occupy
+    // that height without taking any extra vertical space.
+    const cardEl = profileCardEl;
+    const linksEl = linksColEl;
+    const isSideBySide = !!cardEl && cardEl.clientWidth >= 768 && !!linksEl;
+    const linksHeight = isSideBySide && linksEl ? linksEl.offsetHeight : 0;
+    const availableHeight = Math.max(baselineHeight, linksHeight);
+
+    // scrollHeight reflects the full natural height of the text content even when clamped
+    const naturalHeight = el.scrollHeight;
+
+    // Only clamp if the bio genuinely overflows the available height
+    if (naturalHeight > availableHeight + 10) {
+      bioNeedsClamp = true;
+      clampedLines = Math.max(3, Math.floor(availableHeight / lineHeight));
+    } else {
+      bioNeedsClamp = false;
+    }
+  }
+
+  $effect(() => {
+    const _bio = effectiveBio;
+    const _el = bioParagraphEl;
+    const _links = linksColEl;
+    const _card = profileCardEl;
+    if (!_bio || !_el) {
+      bioNeedsClamp = false;
+      return;
+    }
+
+    measureBio();
+
+    if (typeof ResizeObserver !== "undefined" && _card) {
+      const observer = new ResizeObserver(() => {
+        measureBio();
+      });
+      observer.observe(_card);
+      if (_links) observer.observe(_links);
+      return () => {
+        observer.disconnect();
+      };
+    }
   });
 
   // Locally-discovered artist visuals (#98/#761) — portrait/logo/fanart,
@@ -574,7 +620,10 @@
     <!-- Artist Profile Card (About & Links) -->
     {#if hasProfileContent}
       {@const profile = artistProfile}
-      <div class="border border-brand-border rounded-xl bg-brand-sidebar/40 backdrop-blur-md p-4 sm:p-5 md:p-6 shadow-xs flex flex-col md:flex-row gap-5 md:gap-6 justify-between transition-all">
+      <div
+        bind:this={profileCardEl}
+        class="border border-brand-border rounded-xl bg-brand-sidebar/40 backdrop-blur-md p-4 sm:p-5 md:p-6 shadow-xs flex flex-col md:flex-row gap-5 md:gap-6 justify-between transition-all"
+      >
         <!-- About Column (Left) -->
         <div class="flex-1 flex flex-col gap-3 min-w-0">
           <!-- Bio -->
@@ -591,10 +640,16 @@
                   <ExternalLink class="w-3 h-3 opacity-0 group-hover:opacity-100 transition-opacity" />
                 </button>
               {/if}
-              <p bind:this={bioParagraphEl} class="{!isBioExpanded ? 'line-clamp-2 sm:line-clamp-3' : ''} whitespace-pre-line">
+              <p
+                bind:this={bioParagraphEl}
+                style={bioNeedsClamp && !isBioExpanded
+                  ? `display: -webkit-box; -webkit-box-orient: vertical; -webkit-line-clamp: ${clampedLines}; overflow: hidden;`
+                  : undefined}
+                class="whitespace-pre-line"
+              >
                 {bioText}
               </p>
-              {#if bioIsTruncated || isBioExpanded}
+              {#if bioNeedsClamp}
                 <button
                   type="button"
                   onclick={() => { isBioExpanded = !isBioExpanded; }}
@@ -609,7 +664,10 @@
 
         <!-- Links Column (Right) -->
         {#if hasWebsite || hasSocials}
-          <div class="md:w-60 lg:w-72 shrink-0 border-t border-brand-border/40 pt-4 md:border-t-0 md:border-l md:border-brand-border/60 md:pt-0 md:pl-6 flex flex-col gap-3">
+          <div
+            bind:this={linksColEl}
+            class="md:w-60 lg:w-72 shrink-0 border-t border-brand-border/40 pt-4 md:border-t-0 md:border-l md:border-brand-border/60 md:pt-0 md:pl-6 flex flex-col gap-3"
+          >
             <h2 class="text-xs font-bold text-brand-text-secondary uppercase tracking-wider">
               {i18n.t("artistDetail.links", {}, "LINKS")}
             </h2>

--- a/src/lib/components/ArtistDetailView.test.ts
+++ b/src/lib/components/ArtistDetailView.test.ts
@@ -317,15 +317,10 @@ describe("ArtistDetailView", () => {
         },
       };
 
-      // In the DOM spec, scrollHeight/clientHeight are on Element.prototype.
-      // Mocking on HTMLParagraphElement.prototype targets <p> without affecting container elements.
+      // Mock scrollHeight to exceed the available room baseline (~140px)
       Object.defineProperty(HTMLParagraphElement.prototype, "scrollHeight", {
         configurable: true,
-        get: () => 120,
-      });
-      Object.defineProperty(HTMLParagraphElement.prototype, "clientHeight", {
-        configurable: true,
-        get: () => 60,
+        get: () => 300,
       });
 
       try {
@@ -344,8 +339,73 @@ describe("ArtistDetailView", () => {
         expect(screen.getByRole("button", { name: "Show more" })).toBeTruthy();
       } finally {
         delete (HTMLParagraphElement.prototype as any).scrollHeight;
-        delete (HTMLParagraphElement.prototype as any).clientHeight;
+      }
+    });
+
+    it("does not show 'Show more' when bio fits within the available height of the Links column", async () => {
+      const invokeMock = vi.mocked(invoke);
+      invokeMock.mockImplementation((cmd: string, args?: any) => {
+        if (cmd === "get_songs_by_artist") return Promise.resolve([]);
+        if (cmd === "get_playlists_by_artist") return Promise.resolve([]);
+        if (cmd === "get_compilations_by_artist") return Promise.resolve([]);
+        if (cmd === "get_artist_profile") {
+          return Promise.resolve({
+            artist_key: "Shania Twain",
+            website: "https://www.shaniatwain.com",
+            tags: ["country"],
+            social_links: [
+              { platform: "threads", handle_or_url: "shaniatwain" },
+              { platform: "instagram", handle_or_url: "shaniatwain" },
+            ],
+            bio: longBio,
+          });
+        }
+        return Promise.resolve();
+      });
+      collectionStore.artistProfiles = {
+        "shania twain": {
+          artist_key: "Shania Twain",
+          website: "https://www.shaniatwain.com",
+          tags: ["country"],
+          social_links: [
+            { platform: "threads", handle_or_url: "shaniatwain" },
+            { platform: "instagram", handle_or_url: "shaniatwain" },
+          ],
+          bio: longBio,
+        },
+      };
+
+      // Bio is 160px, but card width is >= 768 and links column is 220px tall
+      Object.defineProperty(HTMLParagraphElement.prototype, "scrollHeight", {
+        configurable: true,
+        get: () => 160,
+      });
+      Object.defineProperty(HTMLDivElement.prototype, "clientWidth", {
+        configurable: true,
+        get() {
+          return 800;
+        },
+      });
+      Object.defineProperty(HTMLDivElement.prototype, "offsetHeight", {
+        configurable: true,
+        get() {
+          return 220;
+        },
+      });
+
+      try {
+        render(ArtistDetailView, { props: { artistName: "Shania Twain" } });
+        await new Promise((resolve) => setTimeout(resolve, 50));
+
+        expect(screen.queryByRole("button", { name: "Show more" })).toBeNull();
+        expect(screen.queryByRole("button", { name: "Show less" })).toBeNull();
+      } finally {
+        delete (HTMLParagraphElement.prototype as any).scrollHeight;
+        delete (HTMLDivElement.prototype as any).clientWidth;
+        delete (HTMLDivElement.prototype as any).offsetHeight;
       }
     });
   });
 });
+
+


### PR DESCRIPTION
## 📋 Summary
Fixes #824 by making artist biography clamping in the Artist Detail view aware of available card room rather than arbitrarily hardcoding `line-clamp-2 sm:line-clamp-3`.

## 🔍 Implementation Notes
- Bound `profileCardEl` and `linksColEl` in `src/lib/components/ArtistDetailView.svelte`.
- Implemented `measureBio()` which computes available vertical height: `Math.max(130, isSideBySide ? linksHeight : 130)` (with 130px baseline representing ~6 lines of text and `linksHeight` measured from the adjacent Links column when side-by-side in `md:flex-row`).
- If the biography's natural scroll height fits within this available room, clamping is disabled and neither "Show more" nor "Show less" is rendered.
- If the biography genuinely overflows the available room, dynamic line clamping is applied via `-webkit-line-clamp: ${clampedLines}` with an ellipsis and the toggle button is rendered.
- Configured a `ResizeObserver` to re-measure when resizing the window or upon layout shifts.
- Updated and expanded tests in `src/lib/components/ArtistDetailView.test.ts`.

## 🧪 Test Plan
- [x] `bun run check` (svelte-check) - 0 errors, 0 warnings
- [x] `bun run test:run` (frontend) - 79 test files passed, 675 tests passed
- [x] Manually verified in the app: verified with Shania Twain (4 lines of bio next to 3 links) that the bio is not clipped and no toggle appears, and verified dynamic window resizing behavior.

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Base branch is `next` for milestone 2.0 issue
