### PR TITLE
docs: clarify wry Windows custom protocol workaround in uri handlers (#715)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -589,6 +589,10 @@ pub fn run() {
 
             let uri_str = request.uri().to_string();
             let mut trimmed = &uri_str[..];
+            // On Windows WebView2, requests are made to `http://luminous-art.localhost/`
+            // via the frontend rewrite in `getCoverArtUrl()`. wry intercepts the HTTP request
+            // and runs `revert_uri_work_around` which rewrites the URI to `luminous-art://localhost/`
+            // before calling this handler (see #715). We strip either prefix here.
             if let Some(t) = uri_str.strip_prefix("http://luminous-art.localhost/") {
                 trimmed = t;
             } else if let Some(t) = uri_str.strip_prefix("luminous-art://") {

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -471,6 +471,13 @@ export function getCoverArtUrl(uri: string | null | undefined): string | null {
       }
       return `/fixtures/${cleanPath}`;
     }
+    // On Windows, WebView2 does not intercept non-standard URI schemes (like luminous-art://)
+    // directly. Instead, wry sets up an AddWebResourceRequestedFilter for `http://luminous-art.*`
+    // (see custom_protocol_workaround.rs in wry). The webview must therefore request
+    // `http://luminous-art.localhost/...`. wry's handler intercepts this and internally
+    // reverts the URI back to `luminous-art://localhost/...` before invoking the Tauri
+    // protocol handler (which is why backend logs display `URI = luminous-art://...`).
+    // Do not remove this rewrite (see #715).
     if (isWindows) {
       return uri.replace("luminous-art://", "http://luminous-art.localhost/");
     }


### PR DESCRIPTION
## 📋 Summary
Addresses #715. Investigated and verified the Windows-specific URI rewrite in `getCoverArtUrl()` (`luminous-art://...` → `http://luminous-art.localhost/...`). Confirmed that the rewrite is load-bearing in Tauri's webview engine (`wry`) on Windows WebView2, and added explanatory comments in both `src/lib/types/index.ts` and `src-tauri/src/lib.rs` to document why the rewrite is required and why backend logs show `luminous-art://localhost/...`.

## 🔍 Implementation Notes
- On Windows WebView2, `wry` v0.55.1 uses `AddWebResourceRequestedFilter` exclusively for `http://<protocol>.*` (the workaround URI prefix) and does not register a filter for custom schemes like `luminous-art://*`. The webview must request `http://luminous-art.localhost/...` for the request to be intercepted.
- When the request is intercepted by `wry`, `wry::prepare_request()` calls `custom_protocol_workaround::revert_uri_work_around()`, converting `http://luminous-art.` back into `luminous-art://` before invoking Tauri's registered protocol handler. That is why backend logs in `src-tauri/src/lib.rs` display `URI = luminous-art://localhost/...`.
- Preserved the rewrite as-is and added in-code documentation to prevent future confusion.

## 🧪 Test Plan
- [x] `bun run check` (svelte-check)
- [x] `bun run test:run` (frontend)
- [x] `cargo test` (src-tauri, if Rust changed)

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed (see `.claude/CLAUDE.md` for the screenshot harness)
