### PR TITLE
refactor: derive songs.source SQL filters from SongSource enum

### DIFF
--- a/src-tauri/src/collection.rs
+++ b/src-tauri/src/collection.rs
@@ -5,7 +5,7 @@ use crate::{
     db::Database,
     models::{
         self, FileType, MusicDirectory, PruneResult, QueuePopulationMode, ScanPhase, ScanProgress,
-        Song, SongSource,
+        Song, SongSource, LOCAL_SOURCES_SQL,
     },
 };
 use anyhow::{Context, Result};
@@ -91,8 +91,11 @@ impl CollectionScanner {
         // Mark all songs under this directory as unavailable
         let mut to_mark = Vec::new();
         {
-            let mut stmt = tx
-                .prepare("SELECT id, path FROM songs WHERE source IN (1, 2) AND unavailable = 0")?;
+            let sql = format!(
+                "SELECT id, path FROM songs WHERE source IN ({lib}) AND unavailable = 0",
+                lib = *LOCAL_SOURCES_SQL
+            );
+            let mut stmt = tx.prepare(&sql)?;
             let rows = stmt.query_map([], |row| {
                 let id: i64 = row.get(0)?;
                 let p: String = row.get(1)?;
@@ -561,7 +564,7 @@ impl CollectionScanner {
         log::info!("Starting artwork resolution for missing albums...");
         let mut albums_to_resolve = Vec::new();
         if let Ok(conn) = self.db.pool.get() {
-            if let Ok(mut stmt) = conn.prepare(
+            let sql = format!(
                 "SELECT
                     id,
                     path,
@@ -569,11 +572,13 @@ impl CollectionScanner {
                     album,
                     art_embedded
                  FROM songs
-                 WHERE source IN (1, 2)
+                 WHERE source IN ({lib})
                    AND album IS NOT NULL
                    AND (art_unset = 1 OR (art_automatic IS NULL AND art_manual IS NULL))
                  GROUP BY effective_artist, album",
-            ) {
+                lib = *LOCAL_SOURCES_SQL
+            );
+            if let Ok(mut stmt) = conn.prepare(&sql) {
                 if let Ok(mut rows) = stmt.query([]) {
                     while let Ok(Some(row)) = rows.next() {
                         if let (

--- a/src-tauri/src/collection/query.rs
+++ b/src-tauri/src/collection/query.rs
@@ -10,7 +10,7 @@ use super::{
 };
 use crate::models::{
     AlbumItem, ArtistProfile, ArtistSocialLink, HomeItem, LibraryStats, Playlist,
-    QueuePopulationMode, Song, TopAlbumItem,
+    QueuePopulationMode, Song, TopAlbumItem, LIBRARY_SOURCES_SQL,
 };
 use anyhow::Result;
 use rusqlite::{params, ToSql};
@@ -157,10 +157,11 @@ impl CollectionScanner {
         let conn = self.db.pool.get()?;
         let sql = format!(
             "SELECT {} FROM songs
-             WHERE source IN (1, 2, 11) AND unavailable = 0
+             WHERE source IN ({lib}) AND unavailable = 0
              ORDER BY COALESCE(album_artist_sort, album_artist), COALESCE(albumsort, album), disc, track
              LIMIT ?1 OFFSET ?2",
-            SONG_SELECT_COLS
+            SONG_SELECT_COLS,
+            lib = *LIBRARY_SOURCES_SQL
         );
         let mut stmt = conn.prepare(&sql)?;
         let songs = stmt
@@ -175,10 +176,11 @@ impl CollectionScanner {
         let sql = format!(
             "SELECT {} FROM songs
              WHERE album = ?1
-               AND source IN (1, 2, 11)
+               AND source IN ({lib})
                AND unavailable = 0
              ORDER BY disc, track",
-            SONG_SELECT_COLS
+            SONG_SELECT_COLS,
+            lib = *LIBRARY_SOURCES_SQL
         );
         let mut stmt = conn.prepare(&sql)?;
         let songs = stmt
@@ -217,12 +219,13 @@ impl CollectionScanner {
         let sql = format!(
             "SELECT {} FROM songs
              WHERE ({} OR {})
-               AND source IN (1, 2, 11)
+               AND source IN ({lib})
                AND unavailable = 0
              ORDER BY COALESCE(albumsort, album), disc, track",
             SONG_SELECT_COLS,
             multi_value_contains_sql("COALESCE(artist, '')", "?1"),
-            multi_value_contains_sql("COALESCE(album_artist, '')", "?1")
+            multi_value_contains_sql("COALESCE(album_artist, '')", "?1"),
+            lib = *LIBRARY_SOURCES_SQL
         );
         let mut stmt = conn.prepare(&sql)?;
         let songs = stmt
@@ -258,7 +261,7 @@ impl CollectionScanner {
                 (
                     SELECT genre
                     FROM songs g
-                    WHERE g.album = songs.album AND g.source IN (1, 2, 11) AND g.unavailable = 0
+                    WHERE g.album = songs.album AND g.source IN ({lib}) AND g.unavailable = 0
                       AND g.genre IS NOT NULL AND g.genre != ''
                     GROUP BY genre
                     ORDER BY COUNT(*) DESC, COALESCE(genresort, genre) ASC
@@ -271,14 +274,14 @@ impl CollectionScanner {
                 MAX(added) AS added,
                 COALESCE(SUM(length_nanosec), 0) AS total_duration_nanosec
              FROM songs
-             WHERE source IN (1, 2, 11) AND unavailable = 0 AND album IS NOT NULL AND album != ''
+             WHERE source IN ({lib}) AND unavailable = 0 AND album IS NOT NULL AND album != ''
                AND album IN (
                  SELECT album FROM songs s2
-                 WHERE s2.source IN (1, 2, 11) AND s2.unavailable = 0 AND {}
+                 WHERE s2.source IN ({lib}) AND s2.unavailable = 0 AND {}
                )
                AND album IN (
                  SELECT album FROM songs s3
-                 WHERE s3.source IN (1, 2, 11) AND s3.unavailable = 0
+                 WHERE s3.source IN ({lib}) AND s3.unavailable = 0
                  GROUP BY album
                  -- Mirrors get_albums()'s various-artists fallback: a compilation
                  -- either has TCMP set, is explicitly credited to Various
@@ -297,7 +300,8 @@ impl CollectionScanner {
                )
              GROUP BY album
              ORDER BY COALESCE(MAX(albumsort), album)",
-            multi_value_contains_sql("s2.artist", "?1")
+            multi_value_contains_sql("s2.artist", "?1"),
+            lib = *LIBRARY_SOURCES_SQL
         );
         let mut stmt = conn.prepare(&sql)?;
         let albums: Vec<serde_json::Value> = stmt
@@ -328,11 +332,12 @@ impl CollectionScanner {
         let sql = format!(
             "SELECT {} FROM songs
              WHERE rating = 5
-               AND source IN (1, 2, 11)
+               AND source IN ({lib})
                AND unavailable = 0
                AND not_included = 0
              ORDER BY COALESCE(album_artist_sort, album_artist), COALESCE(albumsort, album), disc, track",
-            SONG_SELECT_COLS
+            SONG_SELECT_COLS,
+            lib = *LIBRARY_SOURCES_SQL
         );
         let mut stmt = conn.prepare(&sql)?;
         let songs = stmt
@@ -347,13 +352,14 @@ impl CollectionScanner {
         let conn = self.db.pool.get()?;
         let sql = format!(
             "SELECT {} FROM songs
-             WHERE source IN (1, 2, 11)
+             WHERE source IN ({lib})
                AND unavailable = 0
                AND not_included = 0
                AND added IS NOT NULL
              ORDER BY added DESC
              LIMIT ?1",
-            SONG_SELECT_COLS
+            SONG_SELECT_COLS,
+            lib = *LIBRARY_SOURCES_SQL
         );
         let mut stmt = conn.prepare(&sql)?;
         let songs = stmt
@@ -378,9 +384,10 @@ impl CollectionScanner {
                  FROM play_history
                  GROUP BY song_id
              ) ph ON ph.song_id = s.id
-             WHERE s.source IN (1, 2, 11) AND s.unavailable = 0 AND s.not_included = 0
+             WHERE s.source IN ({lib}) AND s.unavailable = 0 AND s.not_included = 0
              ORDER BY ph.play_count DESC, s.added DESC
-             LIMIT ?1"
+             LIMIT ?1",
+            lib = *LIBRARY_SOURCES_SQL
         );
         let mut stmt = conn.prepare(&sql)?;
         let songs = stmt
@@ -394,15 +401,17 @@ impl CollectionScanner {
     /// auto-playlist per genre.
     pub fn get_library_genres(&self) -> Result<Vec<String>> {
         let conn = self.db.pool.get()?;
-        let mut stmt = conn.prepare(
+        let sql = format!(
             "SELECT DISTINCT genre FROM songs
-             WHERE source IN (1, 2, 11)
+             WHERE source IN ({lib})
                AND unavailable = 0
                AND not_included = 0
                AND genre IS NOT NULL
                AND genre != ''
              ORDER BY COALESCE(genresort, genre)",
-        )?;
+            lib = *LIBRARY_SOURCES_SQL
+        );
+        let mut stmt = conn.prepare(&sql)?;
         let genres = stmt
             .query_map([], |row| row.get::<_, String>(0))?
             .filter_map(|r| r.ok())
@@ -414,17 +423,19 @@ impl CollectionScanner {
     /// auto-playlist per decade.
     pub fn get_library_decades(&self) -> Result<Vec<String>> {
         let conn = self.db.pool.get()?;
-        let mut stmt = conn.prepare(
+        let sql = format!(
             "SELECT DISTINCT (COALESCE(year, originalyear) / 10 * 10) AS decade_start
              FROM songs
-             WHERE source IN (1, 2, 11)
+             WHERE source IN ({lib})
                AND unavailable = 0
                AND not_included = 0
                AND COALESCE(year, originalyear) IS NOT NULL
                AND COALESCE(year, originalyear) >= 1000
                AND COALESCE(year, originalyear) <= 9999
              ORDER BY decade_start ASC",
-        )?;
+            lib = *LIBRARY_SOURCES_SQL
+        );
+        let mut stmt = conn.prepare(&sql)?;
         let decades = stmt
             .query_map([], |row| {
                 let start: i32 = row.get(0)?;
@@ -453,13 +464,14 @@ impl CollectionScanner {
             "SELECT {} FROM songs
              WHERE COALESCE(year, originalyear) >= ?1
                AND COALESCE(year, originalyear) <= ?2
-               AND source IN (1, 2, 11)
+               AND source IN ({lib})
                AND unavailable = 0
                AND not_included = 0
                {extra_where}
              ORDER BY {order_by}
              LIMIT ?3",
-            SONG_SELECT_COLS
+            SONG_SELECT_COLS,
+            lib = *LIBRARY_SOURCES_SQL
         );
         let mut stmt = conn.prepare(&sql)?;
         let songs = stmt
@@ -489,13 +501,14 @@ impl CollectionScanner {
             "SELECT {} FROM songs
              WHERE bpm >= ?1
                {upper_bound}
-               AND source IN (1, 2, 11)
+               AND source IN ({lib})
                AND unavailable = 0
                AND not_included = 0
                {extra_where}
              ORDER BY {order_by}
              LIMIT ?3",
-            SONG_SELECT_COLS
+            SONG_SELECT_COLS,
+            lib = *LIBRARY_SOURCES_SQL
         );
         let mut stmt = conn.prepare(&sql)?;
         let songs = stmt
@@ -521,13 +534,14 @@ impl CollectionScanner {
                  SELECT artist_key FROM artist_profiles, json_each(artist_profiles.tags)
                  WHERE json_each.value = ?1 COLLATE NOCASE
              )
-               AND source IN (1, 2, 11)
+               AND source IN ({lib})
                AND unavailable = 0
                AND not_included = 0
                {extra_where}
              ORDER BY {order_by}
              LIMIT ?2",
-            SONG_SELECT_COLS
+            SONG_SELECT_COLS,
+            lib = *LIBRARY_SOURCES_SQL
         );
         let mut stmt = conn.prepare(&sql)?;
         let songs = stmt
@@ -556,13 +570,14 @@ impl CollectionScanner {
                  OR artist IS NULL OR TRIM(artist) = ''
                  OR album IS NULL OR TRIM(album) = ''
              )
-               AND source IN (1, 2, 11)
+               AND source IN ({lib})
                AND unavailable = 0
                AND not_included = 0
                {extra_where}
              ORDER BY {order_by}
              LIMIT ?1",
-            SONG_SELECT_COLS
+            SONG_SELECT_COLS,
+            lib = *LIBRARY_SOURCES_SQL
         );
         let mut stmt = conn.prepare(&sql)?;
         let songs = stmt
@@ -587,13 +602,14 @@ impl CollectionScanner {
              WHERE (
                  musicbrainz_recording_id IS NULL OR TRIM(musicbrainz_recording_id) = ''
              )
-               AND source IN (1, 2, 11)
+               AND source IN ({lib})
                AND unavailable = 0
                AND not_included = 0
                {extra_where}
              ORDER BY {order_by}
              LIMIT ?1",
-            SONG_SELECT_COLS
+            SONG_SELECT_COLS,
+            lib = *LIBRARY_SOURCES_SQL
         );
         let mut stmt = conn.prepare(&sql)?;
         let songs = stmt
@@ -614,12 +630,13 @@ impl CollectionScanner {
         let conn = self.db.pool.get()?;
         let sql = format!(
             "SELECT {} FROM songs
-             WHERE source IN (1, 2, 11)
+             WHERE source IN ({lib})
                AND unavailable = 0
                AND not_included = 0
              ORDER BY RANDOM()
              LIMIT ?1",
-            SONG_SELECT_COLS
+            SONG_SELECT_COLS,
+            lib = *LIBRARY_SOURCES_SQL
         );
         let mut stmt = conn.prepare(&sql)?;
         let songs = stmt
@@ -654,7 +671,7 @@ impl CollectionScanner {
         // but the same album title are consolidated into a single entry.
         // album_artist is taken as the shared value when all tracks agree on it;
         // if they differ (true various-artist albums), it comes back as NULL.
-        let mut stmt = conn.prepare(
+        let sql = format!(
             "SELECT
                 CASE
                     WHEN COUNT(DISTINCT NULLIF(album_artist, '')) = 1 THEN MAX(NULLIF(album_artist, ''))
@@ -671,7 +688,7 @@ impl CollectionScanner {
                 (
                     SELECT genre
                     FROM songs g
-                    WHERE g.album = songs.album AND g.source IN (1, 2, 11) AND g.unavailable = 0
+                    WHERE g.album = songs.album AND g.source IN ({lib}) AND g.unavailable = 0
                       AND g.genre IS NOT NULL AND g.genre != ''
                     GROUP BY genre
                     ORDER BY COUNT(*) DESC, COALESCE(genresort, genre) ASC
@@ -686,10 +703,12 @@ impl CollectionScanner {
                 COALESCE(MAX(NULLIF(album_artist_sort, '')), MAX(NULLIF(artistsort, ''))) AS artist_sort,
                 MAX(NULLIF(albumsort, '')) AS albumsort
              FROM songs
-             WHERE source IN (1, 2, 11) AND album IS NOT NULL AND album != '' AND unavailable = 0
+             WHERE source IN ({lib}) AND album IS NOT NULL AND album != '' AND unavailable = 0
              GROUP BY album
              ORDER BY COALESCE(MAX(album_artist_sort), MAX(artistsort), MAX(album_artist), MAX(artist)), COALESCE(MAX(albumsort), album)",
-        )?;
+            lib = *LIBRARY_SOURCES_SQL
+        );
+        let mut stmt = conn.prepare(&sql)?;
         let albums: Vec<serde_json::Value> = stmt
             .query_map([], |row| {
                 Ok(serde_json::json!({
@@ -725,11 +744,11 @@ impl CollectionScanner {
         // drift across files/albums for the same real-world artist (e.g. "The War On
         // Drugs" vs "The War on Drugs") doesn't show up as two separate cards — see
         // issue #295. `MIN(...)` picks one deterministic casing per group to display.
-        let mut stmt = conn.prepare(
+        let sql = format!(
             "WITH album_counts AS (
                 SELECT album, COUNT(*) AS track_count
                 FROM songs
-                WHERE source IN (1, 2, 11) AND album IS NOT NULL AND album != '' AND unavailable = 0
+                WHERE source IN ({lib}) AND album IS NOT NULL AND album != '' AND unavailable = 0
                 GROUP BY album
              ),
              base AS (
@@ -737,7 +756,7 @@ impl CollectionScanner {
                        COALESCE(NULLIF(s.album_artist, ''), s.artist, '') AS effective_artist,
                        COALESCE(NULLIF(s.album_artist_sort, ''), NULLIF(s.album_artist, ''), NULLIF(s.artistsort, ''), s.artist, '') AS sort_artist
                 FROM songs s
-                WHERE s.source IN (1, 2, 11) AND s.unavailable = 0
+                WHERE s.source IN ({lib}) AND s.unavailable = 0
              ),
              grouped AS (
                 SELECT MIN(effective_artist) AS effective_artist,
@@ -760,7 +779,7 @@ impl CollectionScanner {
                     SELECT genre
                     FROM songs sg
                     WHERE COALESCE(NULLIF(sg.album_artist, ''), sg.artist, '') = g.effective_artist COLLATE NOCASE
-                      AND sg.source IN (1, 2, 11) AND sg.unavailable = 0 AND sg.genre IS NOT NULL AND sg.genre != ''
+                      AND sg.source IN ({lib}) AND sg.unavailable = 0 AND sg.genre IS NOT NULL AND sg.genre != ''
                     GROUP BY sg.genre
                     ORDER BY COUNT(*) DESC, COALESCE(sg.genresort, sg.genre) ASC
                     LIMIT 1
@@ -769,7 +788,9 @@ impl CollectionScanner {
                 g.total_playcount
              FROM grouped g
              ORDER BY g.sort_artist COLLATE NOCASE",
-        )?;
+            lib = *LIBRARY_SOURCES_SQL
+        );
+        let mut stmt = conn.prepare(&sql)?;
         let artists: Vec<serde_json::Value> = stmt
             .query_map([], |row| {
                 Ok(serde_json::json!({
@@ -795,11 +816,11 @@ impl CollectionScanner {
     pub fn get_top_artists(&self, limit: i64) -> Result<Vec<serde_json::Value>> {
         let conn = self.db.pool.get()?;
         // See get_artists() for why grouping is case-insensitive (issue #295).
-        let mut stmt = conn.prepare(
+        let sql = format!(
             "WITH album_counts AS (
                 SELECT album, COUNT(*) AS track_count
                 FROM songs
-                WHERE source IN (1, 2, 11) AND album IS NOT NULL AND album != '' AND unavailable = 0
+                WHERE source IN ({lib}) AND album IS NOT NULL AND album != '' AND unavailable = 0
                 GROUP BY album
              ),
              base AS (
@@ -807,7 +828,7 @@ impl CollectionScanner {
                        COALESCE(NULLIF(s.album_artist, ''), s.artist, '') AS effective_artist,
                        COALESCE(NULLIF(s.album_artist_sort, ''), NULLIF(s.album_artist, ''), NULLIF(s.artistsort, ''), s.artist, '') AS sort_artist
                 FROM songs s
-                WHERE s.source IN (1, 2, 11) AND s.unavailable = 0
+                WHERE s.source IN ({lib}) AND s.unavailable = 0
              ),
              totals AS (
                 SELECT SUM(COALESCE(playcount, 0)) AS lib_total_playcount FROM base
@@ -835,7 +856,7 @@ impl CollectionScanner {
                     SELECT genre
                     FROM songs sg
                     WHERE COALESCE(NULLIF(sg.album_artist, ''), sg.artist, '') = g.effective_artist COLLATE NOCASE
-                      AND sg.source IN (1, 2, 11) AND sg.unavailable = 0 AND sg.genre IS NOT NULL AND sg.genre != ''
+                      AND sg.source IN ({lib}) AND sg.unavailable = 0 AND sg.genre IS NOT NULL AND sg.genre != ''
                     GROUP BY sg.genre
                     ORDER BY COUNT(*) DESC, COALESCE(sg.genresort, sg.genre) ASC
                     LIMIT 1
@@ -846,7 +867,9 @@ impl CollectionScanner {
                 CASE WHEN t.lib_total_playcount = 0 THEN g.song_count END DESC,
                 g.sort_artist COLLATE NOCASE
              LIMIT ?1",
-        )?;
+            lib = *LIBRARY_SOURCES_SQL
+        );
+        let mut stmt = conn.prepare(&sql)?;
         let artists: Vec<serde_json::Value> = stmt
             .query_map(params![limit], |row| {
                 Ok(serde_json::json!({
@@ -883,25 +906,25 @@ impl CollectionScanner {
 
     pub fn get_library_stats(&self) -> Result<LibraryStats> {
         let conn = self.db.pool.get()?;
-        let stats = conn.query_row(
+        let sql = format!(
             "SELECT
                 COUNT(*) as total_songs,
                 COUNT(DISTINCT COALESCE(NULLIF(album_artist,''), artist)) as total_artists,
                 COUNT(DISTINCT album) as total_albums,
                 COALESCE(SUM(length_nanosec), 0) as total_duration,
                 COALESCE(SUM(filesize), 0) as total_filesize
-             FROM songs WHERE source IN (1, 2, 11) AND unavailable = 0",
-            [],
-            |row| {
-                Ok(LibraryStats {
-                    total_songs: row.get(0)?,
-                    total_artists: row.get(1)?,
-                    total_albums: row.get(2)?,
-                    total_duration_nanosec: row.get(3)?,
-                    total_filesize_bytes: row.get(4)?,
-                })
-            },
-        )?;
+             FROM songs WHERE source IN ({lib}) AND unavailable = 0",
+            lib = *LIBRARY_SOURCES_SQL
+        );
+        let stats = conn.query_row(&sql, [], |row| {
+            Ok(LibraryStats {
+                total_songs: row.get(0)?,
+                total_artists: row.get(1)?,
+                total_albums: row.get(2)?,
+                total_duration_nanosec: row.get(3)?,
+                total_filesize_bytes: row.get(4)?,
+            })
+        })?;
         Ok(stats)
     }
 
@@ -921,9 +944,10 @@ impl CollectionScanner {
                  FROM play_history
                  GROUP BY song_id
              ) ph ON s.id = ph.song_id
-             WHERE s.source IN (1, 2, 11) AND s.unavailable = 0
+             WHERE s.source IN ({lib}) AND s.unavailable = 0
              ORDER BY ph.last_played_at DESC
-             LIMIT ?1"
+             LIMIT ?1",
+            lib = *LIBRARY_SOURCES_SQL
         );
         let mut stmt = conn.prepare(&sql)?;
         let songs = stmt
@@ -956,7 +980,7 @@ impl CollectionScanner {
             "SELECT {home_item_select_cols}, ph.context_type, ph.playlist_id
              FROM play_history ph
              JOIN songs s ON s.id = ph.song_id
-             WHERE s.source IN (1, 2, 11) AND s.unavailable = 0
+             WHERE s.source IN ({lib}) AND s.unavailable = 0
                AND NOT (
                    ph.context_type = 'playlist'
                    AND ph.playlist_id IN (
@@ -964,7 +988,8 @@ impl CollectionScanner {
                    )
                )
              ORDER BY ph.played_at DESC
-             LIMIT ?1"
+             LIMIT ?1",
+            lib = *LIBRARY_SOURCES_SQL
         );
         let mut stmt = conn.prepare(&sql)?;
         let rows: Vec<(Song, i64, i64, String, Option<i64>)> = stmt
@@ -1016,9 +1041,10 @@ impl CollectionScanner {
         let sql = format!(
             "SELECT {home_item_select_cols}
              FROM songs s
-             WHERE s.source IN (1, 2, 11) AND s.unavailable = 0 AND s.added IS NOT NULL
+             WHERE s.source IN ({lib}) AND s.unavailable = 0 AND s.added IS NOT NULL
              ORDER BY s.added DESC
-             LIMIT ?1"
+             LIMIT ?1",
+            lib = *LIBRARY_SOURCES_SQL
         );
         let mut stmt = conn.prepare(&sql)?;
         let songs_with_counts: Vec<(Song, i64, i64)> = stmt
@@ -1048,10 +1074,11 @@ impl CollectionScanner {
         let sql = format!(
             "SELECT {home_item_select_cols}
              FROM songs s
-             WHERE s.source IN (1, 2, 11) AND s.unavailable = 0
+             WHERE s.source IN ({lib}) AND s.unavailable = 0
                AND s.album IS NOT NULL AND s.album != ''
              ORDER BY RANDOM()
-             LIMIT ?1"
+             LIMIT ?1",
+            lib = *LIBRARY_SOURCES_SQL
         );
         let mut stmt = conn.prepare(&sql)?;
         let songs_with_counts: Vec<(Song, i64, i64)> = stmt
@@ -1109,13 +1136,14 @@ impl CollectionScanner {
                  FROM play_history ph
                  JOIN songs s2 ON s2.id = ph.song_id
                  WHERE ph.played_at >= ?1
-                   AND s2.source IN (1, 2, 11) AND s2.unavailable = 0
+                   AND s2.source IN ({lib}) AND s2.unavailable = 0
                    AND s2.album IS NOT NULL AND s2.album != ''
                  GROUP BY s2.album
              ) wc ON wc.album = s.album
-             WHERE s.source IN (1, 2, 11) AND s.unavailable = 0
+             WHERE s.source IN ({lib}) AND s.unavailable = 0
              ORDER BY wc.week_plays DESC, s.added DESC
-             LIMIT ?2"
+             LIMIT ?2",
+            lib = *LIBRARY_SOURCES_SQL
         );
         let mut stmt = conn.prepare(&sql)?;
         let rows: Vec<(Song, i64, i64, i64)> = stmt
@@ -1561,13 +1589,14 @@ fn multi_value_contains_pattern(value: &str) -> String {
 /// (`get_recently_played`, `get_recently_added`),
 /// which all join on `songs s`.
 fn home_item_select_cols() -> String {
+    let lib = &*LIBRARY_SOURCES_SQL;
     format!(
         "{SONG_SELECT_COLS_QUALIFIED},
     (SELECT COUNT(*) FROM songs s2
-     WHERE s2.source IN (1, 2, 11) AND s2.unavailable = 0 AND s2.album = s.album
+     WHERE s2.source IN ({lib}) AND s2.unavailable = 0 AND s2.album = s.album
     ) AS album_track_count,
     (SELECT COALESCE(MAX(COALESCE(s2.disc, 1)), 1) FROM songs s2
-     WHERE s2.source IN (1, 2, 11) AND s2.unavailable = 0 AND s2.album = s.album
+     WHERE s2.source IN ({lib}) AND s2.unavailable = 0 AND s2.album = s.album
     ) AS album_disc_count"
     )
 }

--- a/src-tauri/src/commands/loudness.rs
+++ b/src-tauri/src/commands/loudness.rs
@@ -1,4 +1,4 @@
-use crate::models::LoudnessSettings;
+use crate::models::{LoudnessSettings, LOCAL_SOURCES_SQL};
 use crate::AppState;
 use tauri::State;
 
@@ -28,9 +28,12 @@ pub async fn set_loudness_settings(
 pub async fn get_loudness_analysis_remaining(state: State<'_, AppState>) -> Result<i64, String> {
     let conn = state.db.pool.get().map_err(|e| e.to_string())?;
     conn.query_row(
-        "SELECT COUNT(*) FROM songs
-         WHERE source IN (1, 2) AND unavailable = 0 AND path IS NOT NULL
+        &format!(
+            "SELECT COUNT(*) FROM songs
+         WHERE source IN ({lib}) AND unavailable = 0 AND path IS NOT NULL
            AND ebur128_integrated_loudness_lufs IS NULL",
+            lib = *LOCAL_SOURCES_SQL
+        ),
         [],
         |row| row.get(0),
     )

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -918,10 +918,12 @@ CREATE TABLE IF NOT EXISTS tag_assignments (
 fn seed_tag_hierarchy(conn: &rusqlite::Connection) -> Result<()> {
     use std::collections::HashMap;
 
-    let mut stmt = conn.prepare(
+    let sql = format!(
         "SELECT genre FROM songs
-         WHERE source IN (1, 2, 11) AND unavailable = 0 AND genre IS NOT NULL AND genre != ''",
-    )?;
+         WHERE source IN ({lib}) AND unavailable = 0 AND genre IS NOT NULL AND genre != ''",
+        lib = *crate::models::LIBRARY_SOURCES_SQL
+    );
+    let mut stmt = conn.prepare(&sql)?;
     let lists: Vec<Vec<String>> = stmt
         .query_map([], |row| row.get::<_, String>(0))?
         .filter_map(|r| r.ok())

--- a/src-tauri/src/loudness.rs
+++ b/src-tauri/src/loudness.rs
@@ -11,7 +11,7 @@
 //! DSP chain by #47.
 
 use crate::db::Database;
-use crate::models::{LoudnessGainSource, LoudnessMode, LoudnessSettings};
+use crate::models::{LoudnessGainSource, LoudnessMode, LoudnessSettings, LOCAL_SOURCES_SQL};
 use anyhow::{anyhow, Context, Result};
 use rusqlite::{params, OptionalExtension};
 use std::path::Path;
@@ -266,10 +266,13 @@ pub fn spawn_background_analyzer(app: AppHandle, db: Arc<Database>) {
                 let next: Option<(i64, String)> = match db.pool.get() {
                     Ok(conn) => conn
                         .query_row(
-                            "SELECT id, path FROM songs
-                         WHERE source IN (1, 2) AND unavailable = 0 AND path IS NOT NULL
+                            &format!(
+                                "SELECT id, path FROM songs
+                         WHERE source IN ({lib}) AND unavailable = 0 AND path IS NOT NULL
                            AND ebur128_integrated_loudness_lufs IS NULL
                          ORDER BY added DESC, id DESC LIMIT 1",
+                                lib = *LOCAL_SOURCES_SQL
+                            ),
                             [],
                             |row| Ok((row.get(0)?, row.get(1)?)),
                         )
@@ -305,9 +308,12 @@ pub fn spawn_background_analyzer(app: AppHandle, db: Arc<Database>) {
                         )
                         .ok()?;
                         conn.query_row(
-                            "SELECT COUNT(*) FROM songs
-                         WHERE source IN (1, 2) AND unavailable = 0 AND path IS NOT NULL
+                            &format!(
+                                "SELECT COUNT(*) FROM songs
+                         WHERE source IN ({lib}) AND unavailable = 0 AND path IS NOT NULL
                            AND ebur128_integrated_loudness_lufs IS NULL",
+                                lib = *LOCAL_SOURCES_SQL
+                            ),
                             [],
                             |row| row.get(0),
                         )

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -5,6 +5,7 @@
 
 use serde::{Deserialize, Serialize};
 use std::fmt;
+use std::sync::LazyLock;
 use uuid::Uuid;
 
 // ---------------------------------------------------------------------------
@@ -55,6 +56,33 @@ impl From<i64> for SongSource {
         }
     }
 }
+
+/// SQL `IN (...)` fragment listing the source IDs that make up the browsable
+/// library (local files, managed collection folders, and WebDAV mounts).
+/// Derived from `SongSource` discriminants so it can't silently drift from
+/// the enum. Interpolate into query strings, e.g. `format!("source IN ({})",
+/// *LIBRARY_SOURCES_SQL)`.
+pub(crate) static LIBRARY_SOURCES_SQL: LazyLock<String> = LazyLock::new(|| {
+    format!(
+        "{}, {}, {}",
+        SongSource::LocalFile as i32,
+        SongSource::Collection as i32,
+        SongSource::WebDav as i32,
+    )
+});
+
+/// SQL `IN (...)` fragment listing the source IDs backed by a local
+/// filesystem path (local files and managed collection folders). Excludes
+/// WebDAV — remote files can't be moved/renamed by filesystem operations
+/// like the Organize feature. Derived from `SongSource` discriminants so it
+/// can't silently drift from the enum.
+pub(crate) static LOCAL_SOURCES_SQL: LazyLock<String> = LazyLock::new(|| {
+    format!(
+        "{}, {}",
+        SongSource::LocalFile as i32,
+        SongSource::Collection as i32,
+    )
+});
 
 // ---------------------------------------------------------------------------
 // File type enum

--- a/src-tauri/src/organizer.rs
+++ b/src-tauri/src/organizer.rs
@@ -6,7 +6,7 @@
 use crate::collection::is_audio_file;
 use crate::covermanager::CoverManager;
 use crate::db::Database;
-use crate::models::{self, Song};
+use crate::models::{self, Song, LOCAL_SOURCES_SQL};
 use anyhow::{anyhow, Result};
 use rusqlite::params;
 use serde::{Deserialize, Serialize};
@@ -473,10 +473,12 @@ pub fn compute_preview(
         .collect();
 
     let songs: Vec<Song> = if song_ids.is_empty() {
-        let mut stmt = conn.prepare(
+        let sql = format!(
             "SELECT id, path, title, artist, album, album_artist, track, disc, year, genre
-             FROM songs WHERE path IS NOT NULL AND TRIM(path) != '' AND source IN (1, 2) AND unavailable = 0",
-        )?;
+             FROM songs WHERE path IS NOT NULL AND TRIM(path) != '' AND source IN ({lib}) AND unavailable = 0",
+            lib = *LOCAL_SOURCES_SQL
+        );
+        let mut stmt = conn.prepare(&sql)?;
         let rows = stmt.query_map([], |row| {
             Ok(Song {
                 id: row.get(0)?,
@@ -535,10 +537,12 @@ pub fn compute_preview(
     let casing_basis_songs: Vec<Song> = if song_ids.is_empty() {
         songs.clone()
     } else {
-        let mut stmt = conn.prepare(
+        let sql = format!(
             "SELECT id, path, title, artist, album, album_artist, track, disc, year, genre
-             FROM songs WHERE path IS NOT NULL AND TRIM(path) != '' AND source IN (1, 2) AND unavailable = 0",
-        )?;
+             FROM songs WHERE path IS NOT NULL AND TRIM(path) != '' AND source IN ({lib}) AND unavailable = 0",
+            lib = *LOCAL_SOURCES_SQL
+        );
+        let mut stmt = conn.prepare(&sql)?;
         let rows = stmt.query_map([], |row| {
             Ok(Song {
                 id: row.get(0)?,

--- a/src-tauri/src/scrobbler.rs
+++ b/src-tauri/src/scrobbler.rs
@@ -5,7 +5,7 @@
 //! ensuring listens survive offline sessions and application restarts.
 
 use crate::db::Database;
-use crate::models::{Song, SongSource};
+use crate::models::{Song, SongSource, LIBRARY_SOURCES_SQL};
 use anyhow::Result;
 use reqwest::Client;
 use rusqlite::params;
@@ -501,10 +501,11 @@ impl ScrobblerManager {
             let sql = format!(
                 "SELECT {} FROM songs
                  WHERE rating >= 4
-                   AND source IN (1, 2, 11)
+                   AND source IN ({lib})
                    AND unavailable = 0
                    AND not_included = 0",
-                crate::collection::SONG_SELECT_COLS
+                crate::collection::SONG_SELECT_COLS,
+                lib = *LIBRARY_SOURCES_SQL
             );
             let mut stmt = conn.prepare(&sql).map_err(|e| e.to_string())?;
             let rows = stmt

--- a/src-tauri/src/stats_summary.rs
+++ b/src-tauri/src/stats_summary.rs
@@ -6,7 +6,7 @@
 //! summing across weeks would silently undercount anything that never
 //! cracked a weekly top 10. See issue #130's comment thread.
 
-use crate::models::{parse_multi_value, StatsSummary, StatsTopItem};
+use crate::models::{parse_multi_value, StatsSummary, StatsTopItem, LIBRARY_SOURCES_SQL};
 use anyhow::Result;
 use rusqlite::{params, Connection};
 
@@ -76,12 +76,12 @@ fn get_summary_at(conn: &Connection, range: StatsRange, now: i64) -> Result<Stat
 }
 
 fn top_songs(conn: &Connection, range_start: i64) -> Result<Vec<StatsTopItem>> {
-    let mut stmt = conn.prepare(
+    let sql = format!(
         "SELECT CAST(s.id AS TEXT), s.title, s.artist, COUNT(*) AS play_count, s.album
          FROM play_history ph
          JOIN songs s ON s.id = ph.song_id
          WHERE ph.played_at >= ?1
-           AND s.source IN (1, 2, 11) AND s.unavailable = 0
+           AND s.source IN ({lib}) AND s.unavailable = 0
            AND NOT EXISTS (
                SELECT 1 FROM stats_exclusions se
                WHERE se.entity_type = 'song' AND se.entity_key = CAST(s.id AS TEXT)
@@ -89,7 +89,9 @@ fn top_songs(conn: &Connection, range_start: i64) -> Result<Vec<StatsTopItem>> {
          GROUP BY s.id
          ORDER BY play_count DESC, s.title COLLATE NOCASE ASC
          LIMIT ?2",
-    )?;
+        lib = *LIBRARY_SOURCES_SQL
+    );
+    let mut stmt = conn.prepare(&sql)?;
     let rows = stmt
         .query_map(params![range_start, TOP_N], |row| {
             Ok(StatsTopItem {
@@ -112,7 +114,7 @@ fn top_songs(conn: &Connection, range_start: i64) -> Result<Vec<StatsTopItem>> {
 /// metric (`CollectionScanner::get_top_albums`). The two numbers will
 /// legitimately disagree for the same album/range — see #130's discussion.
 fn top_albums(conn: &Connection, range_start: i64) -> Result<Vec<StatsTopItem>> {
-    let mut stmt = conn.prepare(
+    let sql = format!(
         "SELECT s.album, MIN(COALESCE(s.album_artist, s.artist)), MIN(track_plays.plays) AS min_plays
          FROM songs s
          JOIN (
@@ -122,7 +124,7 @@ fn top_albums(conn: &Connection, range_start: i64) -> Result<Vec<StatsTopItem>> 
              WHERE ph.played_at >= ?1
              GROUP BY s2.id
          ) track_plays ON track_plays.song_id = s.id
-         WHERE s.source IN (1, 2, 11) AND s.unavailable = 0
+         WHERE s.source IN ({lib}) AND s.unavailable = 0
            AND s.album IS NOT NULL AND s.album != ''
            AND NOT EXISTS (
                SELECT 1 FROM stats_exclusions se
@@ -131,7 +133,9 @@ fn top_albums(conn: &Connection, range_start: i64) -> Result<Vec<StatsTopItem>> 
          GROUP BY s.album
          ORDER BY min_plays DESC, s.album COLLATE NOCASE ASC
          LIMIT ?2",
-    )?;
+        lib = *LIBRARY_SOURCES_SQL
+    );
+    let mut stmt = conn.prepare(&sql)?;
     let rows = stmt
         .query_map(params![range_start, TOP_N], |row| {
             Ok(StatsTopItem {
@@ -149,13 +153,13 @@ fn top_albums(conn: &Connection, range_start: i64) -> Result<Vec<StatsTopItem>> 
 }
 
 fn top_artists(conn: &Connection, range_start: i64) -> Result<Vec<StatsTopItem>> {
-    let mut stmt = conn.prepare(
+    let sql = format!(
         "SELECT COALESCE(NULLIF(s.album_artist, ''), s.artist, '') AS effective_artist,
                 COUNT(*) AS play_count
          FROM play_history ph
          JOIN songs s ON s.id = ph.song_id
          WHERE ph.played_at >= ?1
-           AND s.source IN (1, 2, 11) AND s.unavailable = 0
+           AND s.source IN ({lib}) AND s.unavailable = 0
            AND COALESCE(NULLIF(s.album_artist, ''), s.artist, '') != ''
            AND NOT EXISTS (
                SELECT 1 FROM stats_exclusions se
@@ -165,7 +169,9 @@ fn top_artists(conn: &Connection, range_start: i64) -> Result<Vec<StatsTopItem>>
          GROUP BY effective_artist COLLATE NOCASE
          ORDER BY play_count DESC, effective_artist COLLATE NOCASE ASC
          LIMIT ?2",
-    )?;
+        lib = *LIBRARY_SOURCES_SQL
+    );
+    let mut stmt = conn.prepare(&sql)?;
     let rows = stmt
         .query_map(params![range_start, TOP_N], |row| {
             Ok(StatsTopItem {
@@ -187,14 +193,16 @@ fn top_artists(conn: &Connection, range_start: i64) -> Result<Vec<StatsTopItem>>
 /// counting can't be a plain SQL `GROUP BY` — each play is attributed to
 /// every genre tag on its song, then tallied and ranked in Rust.
 fn top_genres(conn: &Connection, range_start: i64) -> Result<Vec<StatsTopItem>> {
-    let mut stmt = conn.prepare(
+    let sql = format!(
         "SELECT s.genre
          FROM play_history ph
          JOIN songs s ON s.id = ph.song_id
          WHERE ph.played_at >= ?1
-           AND s.source IN (1, 2, 11) AND s.unavailable = 0
+           AND s.source IN ({lib}) AND s.unavailable = 0
            AND s.genre IS NOT NULL AND s.genre != ''",
-    )?;
+        lib = *LIBRARY_SOURCES_SQL
+    );
+    let mut stmt = conn.prepare(&sql)?;
     let genre_lists: Vec<String> = stmt
         .query_map(params![range_start], |row| row.get(0))?
         .filter_map(|r| r.ok())
@@ -249,17 +257,19 @@ fn excluded_keys(
 /// stale-offset bugs if the user's timezone changes between listen-time and
 /// view-time.
 fn play_timestamps(conn: &Connection, range_start: i64) -> Result<Vec<i64>> {
-    let mut stmt = conn.prepare(
+    let sql = format!(
         "SELECT ph.played_at
          FROM play_history ph
          JOIN songs s ON s.id = ph.song_id
          WHERE ph.played_at >= ?1
-           AND s.source IN (1, 2, 11) AND s.unavailable = 0
+           AND s.source IN ({lib}) AND s.unavailable = 0
            AND NOT EXISTS (
                SELECT 1 FROM stats_exclusions se
                WHERE se.entity_type = 'song' AND se.entity_key = CAST(s.id AS TEXT)
            )",
-    )?;
+        lib = *LIBRARY_SOURCES_SQL
+    );
+    let mut stmt = conn.prepare(&sql)?;
     let rows = stmt
         .query_map(params![range_start], |row| row.get(0))?
         .filter_map(|r| r.ok())

--- a/src-tauri/src/tags.rs
+++ b/src-tauri/src/tags.rs
@@ -15,7 +15,7 @@ use crate::{
     db::Database,
     models::{
         join_multi_value, parse_multi_value, GenreGroup, QueuePopulationMode, Song, Tag, TagCount,
-        TagGroup, TagGroupChild,
+        TagGroup, TagGroupChild, LIBRARY_SOURCES_SQL,
     },
 };
 use anyhow::Result;
@@ -69,13 +69,15 @@ impl TagManager {
     /// for scanned/local songs that are currently available.
     fn all_song_genre_lists(&self) -> Result<Vec<Vec<String>>> {
         let conn = self.db.pool.get()?;
-        let mut stmt = conn.prepare(
+        let sql = format!(
             "SELECT genre FROM songs
-             WHERE source IN (1, 2, 11)
+             WHERE source IN ({lib})
                AND unavailable = 0
                AND genre IS NOT NULL
                AND genre != ''",
-        )?;
+            lib = *LIBRARY_SOURCES_SQL
+        );
+        let mut stmt = conn.prepare(&sql)?;
         let lists = stmt
             .query_map([], |row| row.get::<_, String>(0))?
             .filter_map(|r| r.ok())
@@ -185,14 +187,14 @@ impl TagManager {
     /// from `all_song_genre_lists` entirely, so tracked separately.
     fn count_songs_without_genre(&self) -> Result<i64> {
         let conn = self.db.pool.get()?;
-        let count = conn.query_row(
+        let sql = format!(
             "SELECT COUNT(*) FROM songs
-             WHERE source IN (1, 2, 11)
+             WHERE source IN ({lib})
                AND unavailable = 0
                AND (genre IS NULL OR genre = '')",
-            [],
-            |row| row.get(0),
-        )?;
+            lib = *LIBRARY_SOURCES_SQL
+        );
+        let count = conn.query_row(&sql, [], |row| row.get(0))?;
         Ok(count)
     }
 
@@ -207,12 +209,13 @@ impl TagManager {
         let sql = format!(
             "SELECT {} FROM songs
              WHERE (genre IS NULL OR genre = '')
-               AND source IN (1, 2, 11)
+               AND source IN ({lib})
                AND unavailable = 0
                {extra_where}
              ORDER BY {order_by}
              LIMIT ?1",
-            SONG_SELECT_COLS
+            SONG_SELECT_COLS,
+            lib = *LIBRARY_SOURCES_SQL
         );
         let mut stmt = conn.prepare(&sql)?;
         let songs = stmt
@@ -238,12 +241,13 @@ impl TagManager {
         let sql = format!(
             "SELECT {} FROM songs
              WHERE genre LIKE '%' || ?1 || '%'
-               AND source IN (1, 2, 11)
+               AND source IN ({lib})
                AND unavailable = 0
                AND not_included = 0
                {extra_where}
              ORDER BY {order_by}",
-            SONG_SELECT_COLS
+            SONG_SELECT_COLS,
+            lib = *LIBRARY_SOURCES_SQL
         );
         let mut stmt = conn.prepare(&sql)?;
         let candidates: Vec<Song> = stmt
@@ -309,14 +313,15 @@ impl TagManager {
         let (extra_where, order_by) = mode_query_fragments(mode);
         let sql = format!(
             "SELECT {} FROM songs
-             WHERE source IN (1, 2, 11)
+             WHERE source IN ({lib})
                AND unavailable = 0
                AND not_included = 0
                AND genre IS NOT NULL
                AND genre != ''
                {extra_where}
              ORDER BY {order_by}",
-            SONG_SELECT_COLS
+            SONG_SELECT_COLS,
+            lib = *LIBRARY_SOURCES_SQL
         );
         let mut stmt = conn.prepare(&sql)?;
         let songs = stmt
@@ -796,10 +801,12 @@ impl TagManager {
     /// [`delete_tags`]: crate::commands::tags::delete_tags
     pub fn songs_containing_any(&self, names: &[String]) -> Result<Vec<(i64, String, String)>> {
         let conn = self.db.pool.get()?;
-        let mut stmt = conn.prepare(
+        let sql = format!(
             "SELECT id, path, genre FROM songs
-             WHERE source IN (1, 2, 11) AND unavailable = 0 AND genre IS NOT NULL AND genre != ''",
-        )?;
+             WHERE source IN ({lib}) AND unavailable = 0 AND genre IS NOT NULL AND genre != ''",
+            lib = *LIBRARY_SOURCES_SQL
+        );
+        let mut stmt = conn.prepare(&sql)?;
         let targets: Vec<String> = names.iter().map(|n| n.to_lowercase()).collect();
         let rows: Vec<(i64, String, String)> = stmt
             .query_map([], |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)))?


### PR DESCRIPTION
## 📋 Summary
Addresses #843. The `songs.source` column was filtered in ~55 raw SQL query strings using bare integer literals like `source IN (1, 2, 11)` or `source IN (1, 2)`, where 1=`SongSource::LocalFile`, 2=`SongSource::Collection`, 11=`SongSource::WebDav`. These literals had no compiler-enforced link back to `SongSource`, so they could silently drift if a discriminant ever changed.

## 🔍 Implementation Notes
Added two `pub(crate)` `LazyLock<String>` constants next to `SongSource` in `src-tauri/src/models.rs`, built from the enum discriminants via `as i32` casts rather than hand-copied literals:
- `LIBRARY_SOURCES_SQL` — local + collection + webdav (`"1, 2, 11"`), used everywhere the browsable library is queried.
- `LOCAL_SOURCES_SQL` — local + collection only (`"1, 2"`), used in filesystem-specific contexts that can't touch WebDAV: the Organize feature (`organizer.rs`), the R128 loudness background analyzer (`loudness.rs` / `commands/loudness.rs`), directory removal, and the scan-time artwork resolution pass in `collection.rs`.

All ~55 call sites across `collection.rs`, `collection/query.rs`, `loudness.rs`, `db.rs`, `organizer.rs`, `scrobbler.rs`, `stats_summary.rs`, `tags.rs`, and `commands/loudness.rs` now interpolate one of these constants instead of hand-copied literals. Pure internal refactor — no behavior change, no new dependency.

## 🧪 Test Plan
- [x] `cargo check` (src-tauri)
- [x] `cargo test --lib` (src-tauri) — 335 passed, 1 ignored (pre-existing)
- [ ] `bun run check` (svelte-check) — not applicable, no frontend changes
- [ ] Manually verified in the app — not applicable, no user-facing behavior change

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed — not applicable, no user-facing change
