### PR TITLE
fix: exclude Moment Mix from Custom Smart Playlist detection

### DIFF
--- a/src/lib/utils/filterParser.test.ts
+++ b/src/lib/utils/filterParser.test.ts
@@ -18,6 +18,11 @@ describe("isSmartPlaylistSpec", () => {
     expect(isSmartPlaylistSpec("artisttag:canadian")).toBe(false);
   });
 
+  it("returns false for the Moment Mix (daypart) auto-playlist spec (#223)", () => {
+    expect(isSmartPlaylistSpec("daypart:afternoon:2026-09-09:Indie")).toBe(false);
+    expect(isSmartPlaylistSpec("daypart:morning:2026-09-09:")).toBe(false);
+  });
+
   it("returns false for a null/undefined/empty spec", () => {
     expect(isSmartPlaylistSpec(null)).toBe(false);
     expect(isSmartPlaylistSpec(undefined)).toBe(false);

--- a/src/lib/utils/filterParser.ts
+++ b/src/lib/utils/filterParser.ts
@@ -105,10 +105,12 @@ export function hasAdvancedSearchTerms(query: string): boolean {
 /**
  * True if a playlist's `dynamic_spec` is a user-authored Smart Playlist rule
  * spec (e.g. "genre:rock", "artist:Miles Davis; rating:>=4"), as opposed to a
- * system genre/decade/BPM/artist-tag auto-playlist. Smart Playlist specs always contain
+ * system genre/decade/BPM/artist-tag/daypart auto-playlist. Smart Playlist specs always contain
  * a "field:value" rule; system genre auto-playlists use a "tag:" prefix
  * (#548), decade auto-playlists use "decade:", BPM auto-playlists use
- * "bpmrange:", and artist tag auto-playlists use "artisttag:". Mirrors the categorization in playlist.rs.
+ * "bpmrange:", artist tag auto-playlists use "artisttag:", and the Moment
+ * Mix (formerly Daypart Mix, #223) auto-playlist uses "daypart:". Mirrors
+ * the categorization in playlist.rs.
  */
 export function isSmartPlaylistSpec(spec: string | null | undefined): boolean {
   return (
@@ -117,6 +119,7 @@ export function isSmartPlaylistSpec(spec: string | null | undefined): boolean {
     !spec.startsWith("decade:") &&
     !spec.startsWith("bpmrange:") &&
     !spec.startsWith("tag:") &&
-    !spec.startsWith("artisttag:")
+    !spec.startsWith("artisttag:") &&
+    !spec.startsWith("daypart:")
   );
 }


### PR DESCRIPTION
## 📋 Summary
Fixes #846. The Moment Mix auto-playlist ("daypart:<bucket>:<date>:<resolved-name>") was misclassified as a user-authored Smart Playlist by `isSmartPlaylistSpec()`, which excluded every other system auto-playlist prefix (`tag:`, `decade:`, `bpmrange:`, `artisttag:`) but not `daypart:`. That leaked it into the Custom playlists grid as a duplicate card, with its internal spec rendered as a garbled `equals afternoon:2026-09-09:Indie` rule in the Edit Smart Playlist dialog.

## 🔍 Implementation Notes
- `src/lib/utils/filterParser.ts` — added `!spec.startsWith("daypart:")` to `isSmartPlaylistSpec()`'s exclusions, mirroring the existing system-prefix exclusions and the categorization already in `playlist.rs`.
- No backend changes — the `daypart:` spec shape itself (`src-tauri/src/playlist/auto_sync.rs`) is unchanged; this is purely a frontend classification fix.

## 🧪 Test Plan
- [x] `bun run check` (svelte-check) — 0 errors/warnings, knip clean
- [x] `bun run test -- --run` (frontend) — added regression coverage in `filterParser.test.ts` for the `daypart:` spec shape; also ran the full set of components consuming `isSmartPlaylistSpec` (PlaylistsCollectionView, PlaylistView, PlaylistCard, PlaylistRowCard, TopNavigation, Sidebar, PlayerBar, HomeRowList, ArtistDetailView) — 73/73 pass
- [ ] `cargo test` (src-tauri, if Rust changed) — n/a, no Rust changed
- [x] Manually verified in the app — confirmed on dev server

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed — n/a, this is a bug fix restoring the originally-intended behavior, no new user-facing surface
