### PR TITLE
feat: dynamically update window title with Now Playing track (#29)

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -6,6 +6,7 @@
   "permissions": [
     "core:default",
     "core:window:allow-show",
+    "core:window:allow-set-title",
     "opener:default",
     "dialog:default",
     "window-state:default",

--- a/src/lib/utils/formatters.test.ts
+++ b/src/lib/utils/formatters.test.ts
@@ -1,5 +1,14 @@
-import { describe, it, expect } from "vitest";
-import { toTitleCase, formatDuration, formatFileSize, formatSampleRate, formatBitDepth, formatChannels } from "./formatters";
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  toTitleCase,
+  formatDuration,
+  formatFileSize,
+  formatSampleRate,
+  formatBitDepth,
+  formatChannels,
+  formatWindowTitle,
+} from "./formatters";
+import { i18n } from "../stores/i18n.svelte";
 
 describe("toTitleCase", () => {
   it("capitalizes single-word lowercase tags", () => {
@@ -32,3 +41,43 @@ describe("formatters", () => {
     expect(formatDuration(65_000_000_000)).toBe("1:05");
   });
 });
+
+describe("formatWindowTitle", () => {
+  beforeEach(() => {
+    i18n.currentLocale = "en";
+  });
+
+  it("returns 'Luminous' when stopped or paused, even with a song", () => {
+    const song = { title: "Anti-Hero", artist: "Taylor Swift" };
+    expect(formatWindowTitle(song, "stopped")).toBe("Luminous");
+    expect(formatWindowTitle(song, "paused")).toBe("Luminous");
+  });
+
+  it("returns 'Luminous' when song is missing, even if state is playing", () => {
+    expect(formatWindowTitle(null, "playing")).toBe("Luminous");
+    expect(formatWindowTitle(undefined, "playing")).toBe("Luminous");
+  });
+
+  it("formats title and artist when both are present and playing", () => {
+    const song = { title: "Starboy", artist: "The Weeknd" };
+    expect(formatWindowTitle(song, "playing")).toBe("Starboy - The Weeknd - Luminous");
+  });
+
+  it("formats title only when artist is absent or whitespace", () => {
+    expect(formatWindowTitle({ title: "Prelude", artist: null }, "playing")).toBe("Prelude - Luminous");
+    expect(formatWindowTitle({ title: "Prelude", artist: "" }, "playing")).toBe("Prelude - Luminous");
+    expect(formatWindowTitle({ title: "Prelude", artist: "   " }, "playing")).toBe("Prelude - Luminous");
+  });
+
+  it("falls back to localized Unknown Song when title is absent or whitespace", () => {
+    expect(formatWindowTitle({ title: "", artist: "Queen" }, "playing")).toBe("Unknown Song - Queen - Luminous");
+    expect(formatWindowTitle({ title: "   ", artist: null }, "playing")).toBe("Unknown Song - Luminous");
+  });
+
+  it("respects French locale for fallback title", () => {
+    i18n.currentLocale = "fr";
+    expect(formatWindowTitle({ title: "", artist: "Daft Punk" }, "playing")).toBe("Chanson inconnue - Daft Punk - Luminous");
+    expect(formatWindowTitle({ title: "", artist: "" }, "playing")).toBe("Chanson inconnue - Luminous");
+  });
+});
+

--- a/src/lib/utils/formatters.ts
+++ b/src/lib/utils/formatters.ts
@@ -1,3 +1,6 @@
+import type { PlayState } from "../types";
+import { i18n } from "../stores/i18n.svelte";
+
 export function formatDuration(ns: number | undefined): string {
   if (!ns) return "0:00";
   const sec = Math.floor(ns / 1_000_000_000);
@@ -39,5 +42,23 @@ export function formatChannels(ch?: number): string {
 export function toTitleCase(str: string): string {
   if (!str) return "";
   return str.replace(/\b\w+/g, (txt) => txt.charAt(0).toUpperCase() + txt.slice(1).toLowerCase());
+}
+
+export function formatWindowTitle(
+  song?: { title?: string | null; artist?: string | null } | null,
+  state?: PlayState
+): string {
+  if (state !== "playing" || !song) {
+    return "Luminous";
+  }
+
+  const rawTitle = song.title?.trim();
+  const rawArtist = song.artist?.trim();
+
+  const title = rawTitle || i18n.t("collection.unknownSong", {}, "Unknown Song");
+  if (rawArtist) {
+    return `${title} - ${rawArtist} - Luminous`;
+  }
+  return `${title} - Luminous`;
 }
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -26,6 +26,7 @@
   import { isLinux as platformIsLinux } from '../lib/platform';
   import { themeStore } from '../lib/stores/theme.svelte';
   import { generateEllipseGradientSvg } from '../lib/utils/ellipseGradient';
+  import { formatWindowTitle } from '../lib/utils/formatters';
   import { onMount } from 'svelte';
   import { getCurrentWebview } from '@tauri-apps/api/webview';
   import { getCurrentWindow } from '@tauri-apps/api/window';
@@ -64,6 +65,18 @@
     const art = themeStore.artworkColors;
     const colors = art ? [art.vibrant, art.darkVibrant, art.lightVibrant, art.muted].filter((c): c is string => !!c) : undefined;
     return generateEllipseGradientSvg({ colors, seed: playerStore.currentSong?.id ?? 'immersive-empty' });
+  });
+
+  // Dynamically synchronize the OS window title with Now Playing track status (#29).
+  // When playing: "[Song Title] - [Artist] - Luminous" (or "[Song Title] - Luminous").
+  // When stopped/paused: reverts to "Luminous".
+  $effect(() => {
+    void i18n.currentLocale;
+    const title = formatWindowTitle(playerStore.currentSong, playerStore.state);
+    if (typeof document !== 'undefined') {
+      document.title = title;
+    }
+    void getCurrentWindow()?.setTitle?.(title)?.catch(() => {});
   });
 
   onMount(() => {


### PR DESCRIPTION
## 📋 Summary
Dynamically synchronizes the operating system window title with Now Playing track metadata and playback state (`[Song Title] - [Artist] - Luminous` when playing, reverting to `Luminous` when paused/stopped/cleared). Updating the window title also directly updates the Windows taskbar button label and thumbnail preview header when hovered. Closes #29.

## 🔍 Implementation Notes
- **Window Capability**: Added `"core:window:allow-set-title"` permission in `src-tauri/capabilities/default.json` to permit frontend window title updates via `@tauri-apps/api/window`.
- **Formatting Logic**: Implemented `formatWindowTitle(song, state)` in `src/lib/utils/formatters.ts` with localized fallback for untagged songs (`collection.unknownSong`) and missing artist handling.
- **Reactive Synchronization**: Added a Svelte 5 `$effect` in `src/routes/+layout.svelte` observing `playerStore.currentSong`, `playerStore.state`, and `i18n.currentLocale`, safely calling `getCurrentWindow()?.setTitle?.(title)` and updating `document.title`.

## 🧪 Test Plan
- [x] `bun run check` (svelte-check + knip clean, 0 errors, 0 warnings)
- [x] `bun run test -- --run` (all 81 test files, 701 tests passed, including new window title unit tests in `src/lib/utils/formatters.test.ts`)
- [x] `cargo test` (all unit and BDD suites passed)
- [x] Manually verified in the app:
  - Verified window title displays "Luminous" on initial launch.
  - Verified playing a song updates window title and Windows taskbar label/thumbnail header to `[Song Title] - [Artist] - Luminous`.
  - Verified pausing playback reverts the window title to `Luminous`.
  - Verified resuming or advancing to the next song updates the title immediately.

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed
