### PR TITLE
fix: align Home greeting and detail header layout, unify genre chip styling

### DIFF
--- a/src/lib/components/AlbumDetailView.svelte
+++ b/src/lib/components/AlbumDetailView.svelte
@@ -487,7 +487,7 @@
         </div>
         {/if}
 
-        <div class="flex flex-wrap items-center gap-3 mt-3 select-none">
+        <div class="flex flex-wrap items-center gap-3 {windowLayoutStore.isDetailHeaderCollapsed ? '' : 'mt-3'} select-none">
           <PlayShuffleButtons
             onPlayAll={handlePlayAll}
             onShufflePlay={handleShufflePlay}

--- a/src/lib/components/AlbumDetailView.svelte
+++ b/src/lib/components/AlbumDetailView.svelte
@@ -437,7 +437,7 @@
           {albumName}
         </h1>
 
-        <div class="flex items-center gap-2 text-base font-semibold text-brand-accent-text">
+        <div class="flex items-center gap-2 text-base font-semibold text-brand-text-primary">
           {#if artistName}
             <LinkButton
               onclick={() => navigationStore.viewArtist(artistName)}
@@ -446,19 +446,19 @@
               {artistName}
             </LinkButton>
           {:else}
-            <span class="text-brand-text-secondary">{i18n.t('collection.unknownArtist')}</span>
+            <span class="text-brand-text-primary">{i18n.t('collection.unknownArtist')}</span>
           {/if}
         </div>
 
         {#if rawGenre}
           <GenreChips genre={rawGenre} variant="full" limit={4} />
         {:else}
-          <div class="text-xs text-brand-text-secondary font-medium">
+          <div class="text-xs text-brand-text-primary font-medium">
             <span>{genreLabel}</span>
           </div>
         {/if}
 
-        <div class="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-brand-text-secondary font-medium">
+        <div class="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-brand-text-primary font-medium">
           {#if yearLabel}
             <span>{yearLabel}</span>
             <span>•</span>

--- a/src/lib/components/ArtistDetailView.svelte
+++ b/src/lib/components/ArtistDetailView.svelte
@@ -514,15 +514,15 @@
 </script>
 
 <div class="flex-1 flex flex-col overflow-y-auto bg-brand-main text-brand-text-secondary h-full" use:rememberScroll={`artist-detail:${artistName}`}>
-  <div class="relative z-30 w-full border-b border-brand-border/60 bg-brand-main/60 backdrop-blur-md px-6 {windowLayoutStore.isDetailHeaderCollapsed ? 'py-3' : 'pt-6 pb-6 min-h-48'} overflow-hidden">
+  <div class="relative z-30 w-full border-b border-brand-border/60 bg-brand-main/60 backdrop-blur-md px-6 {windowLayoutStore.isDetailHeaderCollapsed ? 'py-3' : 'pt-6 pb-6 min-h-48'}">
     {#if fanartBannerUrl && !windowLayoutStore.isDetailHeaderCollapsed}
-      <div class="absolute inset-0 z-0 pointer-events-none" aria-hidden="true">
+      <div class="absolute inset-0 z-0 overflow-hidden pointer-events-none" aria-hidden="true">
         <img src={fanartBannerUrl} alt="" class="w-full h-full object-cover opacity-25" />
         <div class="absolute inset-0 bg-gradient-to-t from-brand-main via-brand-main/70 to-brand-main/30"></div>
       </div>
     {/if}
     <div class="flex items-start justify-between gap-6 relative z-10">
-      <div class="flex flex-col justify-end gap-1.5 max-w-xl">
+      <div class="flex flex-col justify-end gap-1.5 min-w-0 max-w-xl">
         {#if !windowLayoutStore.isDetailHeaderCollapsed}
         {#if bandLogoUrl}
           <img
@@ -549,7 +549,7 @@
         </div>
         {/if}
 
-        <div class="flex flex-wrap items-center gap-3 mt-3">
+        <div class="flex flex-wrap items-center gap-3 {windowLayoutStore.isDetailHeaderCollapsed ? '' : 'mt-3'} select-none">
           <PlayShuffleButtons
             onPlayAll={handlePlayAll}
             onShufflePlay={handleShufflePlay}
@@ -605,7 +605,7 @@
   <div class="px-6 pt-6 flex flex-col gap-8">
     <!-- Tags Pills — kept outside/above the profile card so they read as
          top-level artist identity, not a sub-item of "About". -->
-    {#if hasTags}
+    {#if hasTags && !windowLayoutStore.isDetailHeaderCollapsed}
       <div class="flex flex-wrap gap-1.5 sm:gap-2">
         {#each artistProfile?.tags ?? [] as tag (tag)}
           <button
@@ -621,7 +621,7 @@
     {/if}
 
     <!-- Artist Profile Card (About & Links) -->
-    {#if hasProfileContent}
+    {#if hasProfileContent && !windowLayoutStore.isDetailHeaderCollapsed}
       {@const profile = artistProfile}
       <div
         bind:this={profileCardEl}

--- a/src/lib/components/ArtistDetailView.svelte
+++ b/src/lib/components/ArtistDetailView.svelte
@@ -514,7 +514,7 @@
 </script>
 
 <div class="flex-1 flex flex-col overflow-y-auto bg-brand-main text-brand-text-secondary h-full" use:rememberScroll={`artist-detail:${artistName}`}>
-  <div class="relative z-30 w-full border-b border-brand-border/60 bg-brand-main/60 backdrop-blur-md px-6 {windowLayoutStore.isDetailHeaderCollapsed ? 'py-3' : 'pt-6 pb-6 min-h-48'}">
+  <div class="relative z-30 w-full border-b border-brand-border/60 bg-brand-main/60 backdrop-blur-md px-6 {windowLayoutStore.isDetailHeaderCollapsed ? 'py-3' : 'pt-6 pb-6'}">
     {#if fanartBannerUrl && !windowLayoutStore.isDetailHeaderCollapsed}
       <div class="absolute inset-0 z-0 overflow-hidden pointer-events-none" aria-hidden="true">
         <img src={fanartBannerUrl} alt="" class="w-full h-full object-cover opacity-25" />

--- a/src/lib/components/ArtistDetailView.svelte
+++ b/src/lib/components/ArtistDetailView.svelte
@@ -537,12 +537,12 @@
         {#if rawGenre}
           <GenreChips genre={rawGenre} variant="full" limit={4} />
         {:else}
-          <div class="text-xs text-brand-text-secondary font-medium">
+          <div class="text-xs text-brand-text-primary font-medium">
             <span>{genreLabel}</span>
           </div>
         {/if}
 
-        <div class="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-brand-text-secondary font-medium">
+        <div class="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-brand-text-primary font-medium">
           <span>{songsText}</span>
           <span>•</span>
           <span>{totalDurationLabel}</span>

--- a/src/lib/components/ArtistDetailView.test.ts
+++ b/src/lib/components/ArtistDetailView.test.ts
@@ -4,6 +4,7 @@ import ArtistDetailView from "./ArtistDetailView.svelte";
 import { collectionStore } from "../stores/collection.svelte";
 import { navigationStore } from "../stores/navigation.svelte";
 import { picardStore } from "../stores/picard.svelte";
+import { windowLayoutStore } from "../stores/windowLayout.svelte";
 import { invoke } from "@tauri-apps/api/core";
 
 vi.mock("@tauri-apps/api/core", () => ({
@@ -436,7 +437,33 @@ describe("ArtistDetailView", () => {
       } finally {
         delete (HTMLParagraphElement.prototype as any).scrollHeight;
         delete (HTMLDivElement.prototype as any).clientWidth;
-        delete (HTMLDivElement.prototype as any).offsetHeight;
+      }
+    });
+
+    it("hides tags and bio/profile section while keeping action buttons visible when detail header is collapsed", async () => {
+      const originalHeight = windowLayoutStore.viewportHeight;
+      try {
+        // Set viewportHeight to less than DETAIL_HEADER_COLLAPSE_HEIGHT_PX (600)
+        windowLayoutStore.viewportHeight = 500;
+        expect(windowLayoutStore.isDetailHeaderCollapsed).toBe(true);
+
+        render(ArtistDetailView, { props: { artistName: "Shania Twain" } });
+        await new Promise((resolve) => setTimeout(resolve, 50));
+
+        // Action buttons remain visible
+        expect(screen.getByRole("button", { name: /^Play$/i })).toBeTruthy();
+        expect(screen.getByRole("button", { name: /Shuffle Play/i })).toBeTruthy();
+        expect(screen.getByTitle("More actions")).toBeTruthy();
+
+        // Artist name, tags, and bio profile section are hidden
+        expect(screen.queryByText("Shania Twain")).toBeNull();
+        expect(screen.queryByText("country")).toBeNull();
+        expect(screen.queryByText("canadian")).toBeNull();
+        expect(screen.queryByText("pop")).toBeNull();
+        expect(screen.queryByText("Canadian music icon")).toBeNull();
+        expect(screen.queryByText("LINKS")).toBeNull();
+      } finally {
+        windowLayoutStore.viewportHeight = originalHeight;
       }
     });
   });

--- a/src/lib/components/AutoPlaylistDetailView.svelte
+++ b/src/lib/components/AutoPlaylistDetailView.svelte
@@ -559,7 +559,7 @@
           {displayName}
         </h1>
 
-        <div class="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-brand-text-secondary font-medium">
+        <div class="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-brand-text-primary font-medium">
           <span>{songs.length === 1 ? i18n.t('playlists.oneSong') : i18n.t('playlists.songsCount', { count: songs.length })}</span>
           <span>•</span>
           <span>{totalDurationLabel}</span>

--- a/src/lib/components/GenreChips.svelte
+++ b/src/lib/components/GenreChips.svelte
@@ -78,7 +78,7 @@
       {/if}
     </button>
   {:else}
-    <div class="flex flex-wrap gap-1.5 {className}">
+    <div class="flex flex-wrap gap-1 {className}">
       {#each displayedValues as value (value)}
         <button
           type="button"

--- a/src/lib/components/GenreChips.svelte
+++ b/src/lib/components/GenreChips.svelte
@@ -1,8 +1,16 @@
 <script lang="ts">
   import { parseMultiValue } from "../utils/multiValue";
-  import { collectionStore } from "../stores/collection.svelte";
   import { navigationStore } from "../stores/navigation.svelte";
   import { i18n } from "../stores/i18n.svelte";
+  import { tagsStore } from "../stores/tags.svelte";
+  import { themeStore } from "../stores/theme.svelte";
+  import { isLightColor } from "../utils/colorUtils";
+  import {
+    genreColorHsl,
+    genreColorHslBright,
+    genreColorHslDark,
+    resolveGenreColorIndex,
+  } from "../utils/genrePalette";
 
   interface Props {
     /** Raw `; `-delimited `genre` column value (song, album, or otherwise). */
@@ -24,8 +32,30 @@
   let remainingCount = $derived(values.length - displayedValues.length);
   let remainingValues = $derived(remainingCount > 0 ? values.slice(displayedValues.length) : []);
 
-  const chipClass =
-    "inline-flex items-center pl-2 pr-2 py-0.5 rounded-full bg-brand-accent/15 text-brand-text-primary border border-brand-accent/25 text-xs font-medium hover:bg-brand-accent/25 hover:border-brand-accent/50 transition-colors";
+  $effect(() => {
+    if (!tagsStore.hierarchy || tagsStore.hierarchy.length === 0) {
+      tagsStore.loadHierarchy().catch((e) => console.error("Failed to load tag hierarchy:", e));
+    }
+  });
+
+  let isLightTheme = $derived(isLightColor(themeStore.resolvedColors["bg-main"]));
+  let genreColorHslFg = $derived(isLightTheme ? genreColorHslDark : genreColorHslBright);
+
+  function getChipStyle(value: string): string | undefined {
+    const colorIndex = resolveGenreColorIndex(tagsStore.hierarchy, value);
+    if (colorIndex === undefined) return undefined;
+    return `background-color: color-mix(in srgb, ${genreColorHsl(colorIndex)} 38%, transparent); border-color: color-mix(in srgb, ${genreColorHslFg(colorIndex)} 70%, transparent); color: ${genreColorHslFg(colorIndex)};`;
+  }
+
+  function getChipClass(value: string): string {
+    const colorIndex = resolveGenreColorIndex(tagsStore.hierarchy, value);
+    const padding = variant === "compact" ? "px-2 py-0.5" : "px-2.5 py-1";
+    const base = `inline-flex items-center rounded-full border text-xs font-medium select-none transition-[opacity,box-shadow,transform,filter,colors] hover:brightness-110 active:scale-[0.98] ${padding}`;
+    if (colorIndex !== undefined) {
+      return base;
+    }
+    return `${base} bg-brand-accent/15 text-brand-text-primary border-brand-accent/25 hover:bg-brand-accent/25 hover:border-brand-accent/50`;
+  }
 
   function goToTag(e: MouseEvent, value: string) {
     e.stopPropagation();
@@ -39,28 +69,30 @@
       type="button"
       onclick={(e) => goToTag(e, values[0])}
       title={i18n.t('songTags.goToGenreTooltip', { genre: values[0] }, `Browse ${values[0]}`)}
-      class="{chipClass} gap-1 min-w-0 max-w-full {className}"
+      class="{getChipClass(values[0])} gap-1 min-w-0 max-w-full {className}"
+      style={getChipStyle(values[0])}
     >
       <span class="truncate min-w-0">{values[0]}</span>
       {#if values.length > 1}
-        <span class="text-brand-text-secondary shrink-0">+{values.length - 1}</span>
+        <span class="opacity-70 shrink-0 text-[0.85em]">+{values.length - 1}</span>
       {/if}
     </button>
   {:else}
-    <div class="flex flex-wrap gap-1 {className}">
+    <div class="flex flex-wrap gap-1.5 {className}">
       {#each displayedValues as value (value)}
         <button
           type="button"
           onclick={(e) => goToTag(e, value)}
           title={i18n.t('songTags.goToGenreTooltip', { genre: value }, `Browse ${value}`)}
-          class="{chipClass} max-w-64"
+          class="{getChipClass(value)} max-w-64"
+          style={getChipStyle(value)}
         >
           <span class="truncate">{value}</span>
         </button>
       {/each}
       {#if remainingCount > 0}
         <span
-          class="inline-flex items-center px-2 py-0.5 rounded-full bg-brand-sidebar/80 text-brand-text-secondary border border-brand-border/60 text-xs font-medium select-none shrink-0"
+          class="inline-flex items-center px-2 py-1 rounded-full bg-brand-sidebar/80 text-brand-text-secondary border border-brand-border/60 text-xs font-medium select-none shrink-0"
           title={remainingValues.join(", ")}
         >
           +{remainingCount}

--- a/src/lib/components/GenreChips.svelte
+++ b/src/lib/components/GenreChips.svelte
@@ -33,9 +33,7 @@
   let remainingValues = $derived(remainingCount > 0 ? values.slice(displayedValues.length) : []);
 
   $effect(() => {
-    if (!tagsStore.hierarchy || tagsStore.hierarchy.length === 0) {
-      tagsStore.loadHierarchy().catch((e) => console.error("Failed to load tag hierarchy:", e));
-    }
+    tagsStore.ensureHierarchyLoaded();
   });
 
   let isLightTheme = $derived(isLightColor(themeStore.resolvedColors["bg-main"]));

--- a/src/lib/components/GenreChips.test.ts
+++ b/src/lib/components/GenreChips.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, vi } from "vitest";
 import { render, fireEvent } from "@testing-library/svelte";
 import GenreChips from "./GenreChips.svelte";
 import { navigationStore } from "../stores/navigation.svelte";
+import { tagsStore } from "../stores/tags.svelte";
 
 describe("GenreChips.svelte", () => {
   it("renders nothing when genre is null or empty", () => {
@@ -116,6 +117,36 @@ describe("GenreChips.svelte", () => {
 
       expect(viewSpy).toHaveBeenCalledWith("Symphonic Metal");
       viewSpy.mockRestore();
+    });
+
+    it("applies curated genre hierarchy styling when genre is found in hierarchy", () => {
+      tagsStore.hierarchy = [
+        {
+          name: "Rock",
+          color_index: 3,
+          song_count: 50,
+          children: [{ name: "Indie Rock", song_count: 10 }],
+        },
+      ];
+
+      const { getByTitle } = render(GenreChips, {
+        props: {
+          genre: "Rock; Indie Rock; Synthwave",
+          variant: "full",
+        },
+      });
+
+      const rockChip = getByTitle("Browse Rock");
+      const indieChip = getByTitle("Browse Indie Rock");
+      const synthwaveChip = getByTitle("Browse Synthwave");
+
+      // Curated chips have inline style with color-mix
+      expect(rockChip.getAttribute("style")).toContain("background-color: color-mix");
+      expect(rockChip.getAttribute("style")).toContain("border-color: color-mix");
+      expect(indieChip.getAttribute("style")).toContain("background-color: color-mix");
+
+      // Unknown chip falls back to no inline style (using default class colors)
+      expect(synthwaveChip.getAttribute("style")).toBeNull();
     });
   });
 });

--- a/src/lib/components/HomeView.svelte
+++ b/src/lib/components/HomeView.svelte
@@ -89,7 +89,7 @@
 
 <div class="flex flex-col h-full w-full bg-brand-main overflow-hidden">
   <div class="flex-1 overflow-y-auto {playerStore.currentSong ? 'pb-28' : 'pb-6'}" use:rememberScroll={"home"}>
-    <div class="px-6 pt-8">
+    <div class="px-6 pt-4">
       <h1 class="text-3xl font-heading font-bold text-brand-text-primary">
         {timeOfDayGreeting}
       </h1>

--- a/src/lib/components/HomeView.svelte
+++ b/src/lib/components/HomeView.svelte
@@ -89,8 +89,8 @@
 
 <div class="flex flex-col h-full w-full bg-brand-main overflow-hidden">
   <div class="flex-1 overflow-y-auto {playerStore.currentSong ? 'pb-28' : 'pb-6'}" use:rememberScroll={"home"}>
-    <div class="px-6 pt-2">
-      <h1 class="text-3xl font-heading font-bold text-brand-text-primary">
+    <div class="px-6 pt-6">
+      <h1 class="text-3xl sm:text-4xl font-heading font-bold text-brand-text-primary leading-snug py-0.5">
         {timeOfDayGreeting}
       </h1>
     </div>

--- a/src/lib/components/HomeView.svelte
+++ b/src/lib/components/HomeView.svelte
@@ -89,7 +89,7 @@
 
 <div class="flex flex-col h-full w-full bg-brand-main overflow-hidden">
   <div class="flex-1 overflow-y-auto {playerStore.currentSong ? 'pb-28' : 'pb-6'}" use:rememberScroll={"home"}>
-    <div class="px-6 pt-4">
+    <div class="px-6 pt-2">
       <h1 class="text-3xl font-heading font-bold text-brand-text-primary">
         {timeOfDayGreeting}
       </h1>

--- a/src/lib/components/HomeView.test.ts
+++ b/src/lib/components/HomeView.test.ts
@@ -176,11 +176,11 @@ describe("HomeView.svelte", () => {
     }
   });
 
-  it("aligns the greeting header with the sidebar Home nav button using pt-4", () => {
+  it("optically aligns the greeting header with the sidebar Home nav button using pt-2", () => {
     const { container } = render(HomeView);
     const greetingHeading = container.querySelector("h1");
     expect(greetingHeading).toBeInTheDocument();
-    expect(greetingHeading?.parentElement).toHaveClass("pt-4");
+    expect(greetingHeading?.parentElement).toHaveClass("pt-2");
     expect(greetingHeading?.parentElement).not.toHaveClass("pt-8");
   });
 });

--- a/src/lib/components/HomeView.test.ts
+++ b/src/lib/components/HomeView.test.ts
@@ -176,11 +176,11 @@ describe("HomeView.svelte", () => {
     }
   });
 
-  it("optically aligns the greeting header with the sidebar Home nav button using pt-2", () => {
+  it("matches detail view header top whitespace using pt-6", () => {
     const { container } = render(HomeView);
     const greetingHeading = container.querySelector("h1");
     expect(greetingHeading).toBeInTheDocument();
-    expect(greetingHeading?.parentElement).toHaveClass("pt-2");
+    expect(greetingHeading?.parentElement).toHaveClass("pt-6");
     expect(greetingHeading?.parentElement).not.toHaveClass("pt-8");
   });
 });

--- a/src/lib/components/HomeView.test.ts
+++ b/src/lib/components/HomeView.test.ts
@@ -38,7 +38,9 @@ function makeTopAlbum(overrides: Partial<TopAlbumItem> = {}): TopAlbumItem {
 
 // Captures listen() callbacks by event name so tests can fire them directly,
 // mirroring how the real backend would emit scan-progress/library-changed.
-const listenCallbacks: Record<string, (event: { payload: unknown }) => void> = {};
+const { listenCallbacks } = vi.hoisted(() => ({
+  listenCallbacks: {} as Record<string, (event: { payload: unknown }) => void>,
+}));
 
 vi.mock("@tauri-apps/api/event", () => ({
   listen: vi.fn((event: string, callback: (e: { payload: unknown }) => void) => {
@@ -172,5 +174,13 @@ describe("HomeView.svelte", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("aligns the greeting header with the sidebar Home nav button using pt-4", () => {
+    const { container } = render(HomeView);
+    const greetingHeading = container.querySelector("h1");
+    expect(greetingHeading).toBeInTheDocument();
+    expect(greetingHeading?.parentElement).toHaveClass("pt-4");
+    expect(greetingHeading?.parentElement).not.toHaveClass("pt-8");
   });
 });

--- a/src/lib/components/PlaylistView.svelte
+++ b/src/lib/components/PlaylistView.svelte
@@ -685,13 +685,13 @@
             {#if rawGenre}
               <GenreChips genre={rawGenre} variant="full" limit={4} />
             {:else}
-              <div class="text-xs text-brand-text-secondary font-medium">
+              <div class="text-xs text-brand-text-primary font-medium">
                 <span>{genreLabel}</span>
               </div>
             {/if}
           {/if}
 
-          <div class="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-brand-text-secondary font-medium">
+          <div class="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-brand-text-primary font-medium">
             <span>
               {playlistsStore.activePlaylistTracks.length === 1
                 ? i18n.t("playlists.oneSong")

--- a/src/lib/components/PlaylistView.svelte
+++ b/src/lib/components/PlaylistView.svelte
@@ -702,7 +702,7 @@
           </div>
           {/if}
 
-          <div class="flex flex-wrap items-center gap-3 mt-3">
+          <div class="flex flex-wrap items-center gap-3 {windowLayoutStore.isDetailHeaderCollapsed ? '' : 'mt-3'}">
             <Button
               onclick={handlePlayAll}
               disabled={playlistsStore.activePlaylistTracks.length === 0}

--- a/src/lib/stores/tags.svelte.ts
+++ b/src/lib/stores/tags.svelte.ts
@@ -34,7 +34,7 @@ class TagsStore {
   }
 
   async loadHierarchy() {
-    this.hierarchy = await invoke<TagGroup[]>("get_tag_hierarchy");
+    this.hierarchy = (await invoke<TagGroup[]>("get_tag_hierarchy")) ?? [];
   }
 
   async setGroupColor(name: string, colorIndex: number) {

--- a/src/lib/stores/tags.svelte.ts
+++ b/src/lib/stores/tags.svelte.ts
@@ -22,6 +22,7 @@ class TagsStore {
 
   /** The persisted Genres curation hierarchy — one card per primary genre. */
   hierarchy = $state<TagGroup[]>([]);
+  private hierarchyLoadStarted = false;
 
   /** Call from the Genres tab's onMount (and unlisten on unmount, same as
    * its existing "library-changed" listener) to keep `hierarchy` in sync
@@ -36,6 +37,18 @@ class TagsStore {
   async loadHierarchy() {
     const result = await invoke<TagGroup[]>("get_tag_hierarchy");
     this.hierarchy = Array.isArray(result) ? result : [];
+  }
+
+  /** Kick off the initial hierarchy load at most once per session — genre
+   * chips across many widely-reused components (AlbumCard, PlaylistView,
+   * ArtistDetailView, ...) call this from an $effect on every mount, and an
+   * empty result (no genres curated yet) is a legitimate steady state, not
+   * a signal to keep retrying; live updates already flow through
+   * `listenForHierarchyChanges`'s "tags-changed" listener instead. */
+  ensureHierarchyLoaded() {
+    if (this.hierarchyLoadStarted) return;
+    this.hierarchyLoadStarted = true;
+    this.loadHierarchy().catch((e) => console.error("Failed to load tag hierarchy:", e));
   }
 
   async setGroupColor(name: string, colorIndex: number) {

--- a/src/lib/stores/tags.svelte.ts
+++ b/src/lib/stores/tags.svelte.ts
@@ -34,7 +34,8 @@ class TagsStore {
   }
 
   async loadHierarchy() {
-    this.hierarchy = (await invoke<TagGroup[]>("get_tag_hierarchy")) ?? [];
+    const result = await invoke<TagGroup[]>("get_tag_hierarchy");
+    this.hierarchy = Array.isArray(result) ? result : [];
   }
 
   async setGroupColor(name: string, colorIndex: number) {

--- a/src/lib/utils/genrePalette.test.ts
+++ b/src/lib/utils/genrePalette.test.ts
@@ -26,6 +26,12 @@ describe("resolveGenreColorIndex", () => {
     expect(resolveGenreColorIndex(hierarchy, "Progressive Metal")).toBe(3);
   });
 
+  it("resolves names with different casing (case-insensitive fallback)", () => {
+    expect(resolveGenreColorIndex(hierarchy, "metal")).toBe(3);
+    expect(resolveGenreColorIndex(hierarchy, "progressive metal")).toBe(3);
+    expect(resolveGenreColorIndex(hierarchy, "AMBIENT")).toBe(7);
+  });
+
   it("returns undefined for a name not present anywhere in the hierarchy", () => {
     expect(resolveGenreColorIndex(hierarchy, "Unknown Genre")).toBeUndefined();
   });

--- a/src/lib/utils/genrePalette.ts
+++ b/src/lib/utils/genrePalette.ts
@@ -13,11 +13,20 @@ export const GENRE_PALETTE_HUES = [226, 262, 298, 334, 10, 46, 82, 118, 154, 190
  * threshold, or a stale reference), letting the caller fall back to a
  * default color rather than crashing.
  */
-export function resolveGenreColorIndex(hierarchy: TagGroup[], name: string): number | undefined {
+export function resolveGenreColorIndex(
+  hierarchy: TagGroup[] | undefined | null,
+  name: string | undefined | null
+): number | undefined {
+  if (!hierarchy || !name) return undefined;
   const direct = hierarchy.find((g) => g.name === name);
   if (direct) return direct.color_index;
-  const parent = hierarchy.find((g) => g.children.some((c) => c.name === name));
-  return parent?.color_index;
+  const parent = hierarchy.find((g) => g.children?.some((c) => c.name === name));
+  if (parent) return parent.color_index;
+  const lower = name.toLowerCase();
+  const directCi = hierarchy.find((g) => g.name.toLowerCase() === lower);
+  if (directCi) return directCi.color_index;
+  const parentCi = hierarchy.find((g) => g.children?.some((c) => c.name.toLowerCase() === lower));
+  return parentCi?.color_index;
 }
 
 export function genreColorHsl(colorIndex: number): string {

--- a/src/lib/utils/genrePalette.ts
+++ b/src/lib/utils/genrePalette.ts
@@ -17,7 +17,7 @@ export function resolveGenreColorIndex(
   hierarchy: TagGroup[] | undefined | null,
   name: string | undefined | null
 ): number | undefined {
-  if (!hierarchy || !name) return undefined;
+  if (!Array.isArray(hierarchy) || !name) return undefined;
   const direct = hierarchy.find((g) => g.name === name);
   if (direct) return direct.color_index;
   const parent = hierarchy.find((g) => g.children?.some((c) => c.name === name));


### PR DESCRIPTION
## 📋 Summary
Fixes #854. Aligns the Home greeting's typography and top whitespace with Album/Artist detail headers, and fixes several related consistency/accessibility issues across detail view headers and genre chip styling.

## 🔍 Implementation Notes
- `HomeView.svelte`: greeting now uses `px-6 pt-6` and `text-3xl sm:text-4xl font-heading font-bold text-brand-text-primary leading-snug py-0.5`, matching `AlbumDetailView`/`ArtistDetailView`.
- `AlbumDetailView.svelte`, `ArtistDetailView.svelte`, `PlaylistView.svelte`, `AutoPlaylistDetailView.svelte`: header metadata switched to `text-brand-text-primary` for contrast.
- `ArtistDetailView.svelte`: tags and bio now guarded with `!windowLayoutStore.isDetailHeaderCollapsed`; removed the extraneous `min-h-48` that was compressing bottom padding.
- Action button rows drop `mt-3` when the detail header is collapsed.
- `GenreChips.svelte`: chip colors now resolve from `tagsStore.hierarchy` via `resolveGenreColorIndex()`, matching `GenreCards.svelte`'s palette, with a case-insensitive fallback lookup added to `resolveGenreColorIndex()`.

## 🧪 Test Plan
- [x] `bun run check` (svelte-check) — 0 errors
- [x] `bun run test -- --run` (frontend) — relevant suites pass
- [ ] `cargo test` (src-tauri, if Rust changed) — no Rust changes
- [ ] Manually verified in the app (describe what you did)

## ✅ Checklist
- [x] No unrelated changes bundled in
- [ ] Docs/screenshots updated if user-facing behavior changed
