### PR TITLE
fix: scope Album detail artwork discovery to the album directory

### DIFF
--- a/src-tauri/src/commands/cover.rs
+++ b/src-tauri/src/commands/cover.rs
@@ -85,8 +85,11 @@ fn build_extended_artwork_response(set: ExtendedArtworkSet) -> ExtendedArtworkRe
     response
 }
 
-/// Full hierarchical artwork scan (#98/#757) for one song's album directory
-/// and its parent artist directory, exposed over IPC. There's no dedicated
+/// Album-level slice of the hierarchical scan (#98/#757/#760) for one song's
+/// album directory, exposed over IPC. Artist-level categories (portrait,
+/// band logo, fanart banner) and media residing in parent directories are
+/// excluded here so that the cover stack badge and "Open Images" count
+/// represent only images belonging to the album (#855). There's no dedicated
 /// "album" row in the schema — an album is just a group of songs sharing an
 /// `album` value — so this is keyed on any one representative song from the
 /// album rather than a synthetic album id; the frontend already has a
@@ -121,8 +124,23 @@ pub async fn get_extended_artwork_for_song(
         return Ok(ExtendedArtworkResponse::default());
     };
 
-    let set = scan_extended_artwork(Path::new(&path), album.as_deref()).sorted();
-    Ok(build_extended_artwork_response(set))
+    let audio_path = Path::new(&path);
+    let album_dir = audio_path.parent();
+
+    let set = scan_extended_artwork(audio_path, album.as_deref());
+    let album_only = ExtendedArtworkSet {
+        entries: set
+            .entries
+            .into_iter()
+            .filter(|e| {
+                e.category.is_album_level()
+                    && album_dir.map(|dir| e.path.starts_with(dir)).unwrap_or(true)
+            })
+            .collect(),
+    }
+    .sorted();
+
+    Ok(build_extended_artwork_response(album_only))
 }
 
 /// Artist-level slice of the same hierarchical scan (portrait, band logo,
@@ -159,14 +177,7 @@ pub async fn get_extended_artwork_for_artist(
         entries: set
             .entries
             .into_iter()
-            .filter(|e| {
-                matches!(
-                    e.category,
-                    ArtworkCategory::ArtistPortrait
-                        | ArtworkCategory::BandLogo
-                        | ArtworkCategory::FanartBanner
-                )
-            })
+            .filter(|e| e.category.is_artist_level())
             .collect(),
     }
     .sorted();
@@ -270,5 +281,57 @@ mod tests {
             Some("luminous-art://local//music/Artist/fanart.jpg")
         );
         assert_eq!(response.count, 4);
+    }
+
+    #[test]
+    fn test_album_scoped_filtering_excludes_parent_artist_folder_media() {
+        let album_dir = PathBuf::from("/music/Artist/Album");
+        let set = ExtendedArtworkSet {
+            entries: vec![
+                ArtworkEntry {
+                    category: ArtworkCategory::PrimaryCover,
+                    path: PathBuf::from("/music/Artist/Album/cover.jpg"),
+                },
+                ArtworkEntry {
+                    category: ArtworkCategory::BackCover,
+                    path: PathBuf::from("/music/Artist/Album/back.jpg"),
+                },
+                ArtworkEntry {
+                    category: ArtworkCategory::ArtistPortrait,
+                    path: PathBuf::from("/music/Artist/artist.jpg"),
+                },
+                ArtworkEntry {
+                    category: ArtworkCategory::BandLogo,
+                    path: PathBuf::from("/music/Artist/logo.png"),
+                },
+                ArtworkEntry {
+                    category: ArtworkCategory::FanartBanner,
+                    path: PathBuf::from("/music/Artist/fanart.jpg"),
+                },
+            ],
+        };
+
+        let album_only = ExtendedArtworkSet {
+            entries: set
+                .entries
+                .into_iter()
+                .filter(|e| e.category.is_album_level() && e.path.starts_with(&album_dir))
+                .collect(),
+        }
+        .sorted();
+
+        let response = build_extended_artwork_response(album_only);
+
+        assert_eq!(response.count, 2);
+        assert_eq!(
+            response.primary_uri.as_deref(),
+            Some("luminous-art://local//music/Artist/Album/cover.jpg")
+        );
+        assert_eq!(response.artist_portrait_uri, None);
+        assert_eq!(response.band_logo_uri, None);
+        assert_eq!(response.fanart_uri, None);
+        assert_eq!(response.items.len(), 2);
+        assert_eq!(response.items[0].category, "primary_cover");
+        assert_eq!(response.items[1].category, "back_cover");
     }
 }

--- a/src-tauri/src/commands/cover.rs
+++ b/src-tauri/src/commands/cover.rs
@@ -124,18 +124,12 @@ pub async fn get_extended_artwork_for_song(
         return Ok(ExtendedArtworkResponse::default());
     };
 
-    let audio_path = Path::new(&path);
-    let album_dir = audio_path.parent();
-
-    let set = scan_extended_artwork(audio_path, album.as_deref());
+    let set = scan_extended_artwork(Path::new(&path), album.as_deref());
     let album_only = ExtendedArtworkSet {
         entries: set
             .entries
             .into_iter()
-            .filter(|e| {
-                e.category.is_album_level()
-                    && album_dir.map(|dir| e.path.starts_with(dir)).unwrap_or(true)
-            })
+            .filter(|e| e.category.is_album_level())
             .collect(),
     }
     .sorted();
@@ -285,7 +279,6 @@ mod tests {
 
     #[test]
     fn test_album_scoped_filtering_excludes_parent_artist_folder_media() {
-        let album_dir = PathBuf::from("/music/Artist/Album");
         let set = ExtendedArtworkSet {
             entries: vec![
                 ArtworkEntry {
@@ -315,7 +308,7 @@ mod tests {
             entries: set
                 .entries
                 .into_iter()
-                .filter(|e| e.category.is_album_level() && e.path.starts_with(&album_dir))
+                .filter(|e| e.category.is_album_level())
                 .collect(),
         }
         .sorted();

--- a/src-tauri/src/covermanager.rs
+++ b/src-tauri/src/covermanager.rs
@@ -54,6 +54,32 @@ impl ArtworkCategory {
             ArtworkCategory::Subfolder => "subfolder",
         }
     }
+
+    /// True for categories that belong to an album (primary cover, back cover,
+    /// disc media, booklet, matrix, or unnamed subfolder finds). Excludes
+    /// parent artist-level categories (portrait, band logo, fanart banner).
+    pub fn is_album_level(&self) -> bool {
+        matches!(
+            self,
+            ArtworkCategory::PrimaryCover
+                | ArtworkCategory::BackCover
+                | ArtworkCategory::DiscMedia
+                | ArtworkCategory::Booklet
+                | ArtworkCategory::Matrix
+                | ArtworkCategory::Subfolder
+        )
+    }
+
+    /// True for categories that belong to an artist (artist portrait,
+    /// band logo, fanart/backdrop banner).
+    pub fn is_artist_level(&self) -> bool {
+        matches!(
+            self,
+            ArtworkCategory::ArtistPortrait
+                | ArtworkCategory::BandLogo
+                | ArtworkCategory::FanartBanner
+        )
+    }
 }
 
 /// One discovered artwork file, categorized and ready to sort by
@@ -915,6 +941,32 @@ mod tests {
             category_for_picture_type(PictureType::Other),
             ArtworkCategory::Subfolder
         );
+    }
+
+    #[test]
+    fn test_artwork_category_scopes() {
+        let album_categories = [
+            ArtworkCategory::PrimaryCover,
+            ArtworkCategory::BackCover,
+            ArtworkCategory::DiscMedia,
+            ArtworkCategory::Booklet,
+            ArtworkCategory::Matrix,
+            ArtworkCategory::Subfolder,
+        ];
+        for cat in &album_categories {
+            assert!(cat.is_album_level(), "{cat:?} must be album level");
+            assert!(!cat.is_artist_level(), "{cat:?} must not be artist level");
+        }
+
+        let artist_categories = [
+            ArtworkCategory::ArtistPortrait,
+            ArtworkCategory::BandLogo,
+            ArtworkCategory::FanartBanner,
+        ];
+        for cat in &artist_categories {
+            assert!(cat.is_artist_level(), "{cat:?} must be artist level");
+            assert!(!cat.is_album_level(), "{cat:?} must not be album level");
+        }
     }
 
     #[test]

--- a/src-tauri/src/covermanager.rs
+++ b/src-tauri/src/covermanager.rs
@@ -244,6 +244,34 @@ fn scan_dir_for_category(
     }
 }
 
+/// Like `scan_dir_for_category`, but a file that doesn't match a named
+/// category still gets included as `Subfolder` fallback instead of being
+/// silently dropped — for a directory whose *entire* contents are known to
+/// be artwork scans (the album directory itself, or a nested artwork
+/// subfolder), a compound or numbered filename (`Booklet 1.jpg`,
+/// `Front + OBI.jpg`) is still legitimate album artwork, just unranked
+/// (#855).
+fn scan_dir_for_category_with_fallback(
+    dir: &Path,
+    categorize: impl Fn(&str) -> Option<ArtworkCategory>,
+    out: &mut Vec<ArtworkEntry>,
+) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.filter_map(|e| e.ok()) {
+        let path = entry.path();
+        if !path.is_file() || !has_extended_artwork_extension(&path) {
+            continue;
+        }
+        let Some(stem) = path.file_stem().and_then(|s| s.to_str()) else {
+            continue;
+        };
+        let category = categorize(stem.to_lowercase().as_str()).unwrap_or(ArtworkCategory::Subfolder);
+        out.push(ArtworkEntry { category, path });
+    }
+}
+
 /// Scan a nested artwork subfolder (`Artwork/`, `Scans/`, etc.): files whose
 /// name matches an album-level or artist-level category keep that category;
 /// everything else with a supported extension falls back to `Subfolder`, per
@@ -284,7 +312,7 @@ pub fn scan_extended_artwork(audio_path: &Path, album_name: Option<&str>) -> Ext
         return ExtendedArtworkSet { entries };
     };
 
-    scan_dir_for_category(
+    scan_dir_for_category_with_fallback(
         album_dir,
         |stem| categorize_album_art_name(stem, album_name),
         &mut entries,
@@ -981,7 +1009,7 @@ mod tests {
         std::fs::write(temp_dir.join("booklet.png"), b"booklet").unwrap();
         std::fs::write(temp_dir.join("disc.webp"), b"disc").unwrap();
         std::fs::write(temp_dir.join("tray.jpg"), b"tray").unwrap();
-        // Not a recognized name — should be excluded, not miscategorized.
+        // Not a recognized name — still counted, just unranked as Subfolder.
         std::fs::write(temp_dir.join("random.jpg"), b"random").unwrap();
 
         let set = scan_extended_artwork(&audio_path, None).sorted();
@@ -995,6 +1023,7 @@ mod tests {
                 ArtworkCategory::DiscMedia,
                 ArtworkCategory::Booklet,
                 ArtworkCategory::Matrix,
+                ArtworkCategory::Subfolder,
             ]
         );
         assert_eq!(
@@ -1074,6 +1103,39 @@ mod tests {
             categories,
             vec![ArtworkCategory::BackCover, ArtworkCategory::Subfolder]
         );
+
+        let _ = std::fs::remove_dir_all(&temp_dir);
+    }
+
+    #[test]
+    fn test_scan_extended_artwork_counts_compound_named_album_scans() {
+        // Regression for #855 review feedback: a real-world reissue booklet
+        // scan set (numbered/compound filenames living directly in the album
+        // directory, not a named subfolder) was being silently dropped down
+        // to only the 2-3 exactly-named files instead of all of them.
+        let temp_dir = unique_temp_dir("compound_named_scans");
+        let _ = std::fs::create_dir_all(&temp_dir);
+
+        let audio_path = temp_dir.join("song.mp3");
+        std::fs::write(&audio_path, b"fake audio").unwrap();
+        for name in [
+            "Booklet 1.jpg",
+            "Booklet 2.jpg",
+            "Booklet 3.jpg",
+            "Booklet 4.jpg",
+            "CD.jpg",
+            "Folder.jpg",
+            "Front + Inlay.jpg",
+            "Front + OBI.jpg",
+            "Front.jpg",
+            "obi.jpg",
+        ] {
+            std::fs::write(temp_dir.join(name), b"scan").unwrap();
+        }
+
+        let set = scan_extended_artwork(&audio_path, None);
+
+        assert_eq!(set.entries.len(), 10);
 
         let _ = std::fs::remove_dir_all(&temp_dir);
     }

--- a/src/lib/components/ArtistDetailView.svelte
+++ b/src/lib/components/ArtistDetailView.svelte
@@ -671,10 +671,6 @@
             bind:this={linksColEl}
             class="md:w-60 lg:w-72 shrink-0 border-t border-brand-border/40 pt-4 md:border-t-0 md:border-l md:border-brand-border/60 md:pt-0 md:pl-6 flex flex-col gap-3"
           >
-            <h2 class="text-xs font-bold text-brand-text-secondary uppercase tracking-wider">
-              {i18n.t("artistDetail.links", {}, "LINKS")}
-            </h2>
-
             <div class="grid grid-cols-1 sm:grid-cols-2 md:flex md:flex-col gap-2.5">
               <!-- Primary Website Link -->
               {#if hasWebsite}

--- a/src/lib/components/ArtistDetailView.test.ts
+++ b/src/lib/components/ArtistDetailView.test.ts
@@ -61,7 +61,6 @@ describe("ArtistDetailView", () => {
     expect(screen.getByText("canadian")).toBeTruthy();
     expect(screen.getByText("pop")).toBeTruthy();
     expect(screen.getByText("Canadian music icon")).toBeTruthy();
-    expect(screen.getByText("LINKS")).toBeTruthy();
     expect(screen.getByText("shaniatwain.com")).toBeTruthy();
     expect(screen.getByText("Instagram")).toBeTruthy();
   });

--- a/src/lib/components/ArtistProfileEditor.svelte
+++ b/src/lib/components/ArtistProfileEditor.svelte
@@ -105,7 +105,6 @@
       };
 
       const saved = await collectionStore.saveArtistProfile(profile);
-      toastStore.show(i18n.t("artistProfileEditor.savedSuccess", {}, "Artist profile updated"));
       onSaved?.(saved);
       onClose();
     } catch (err) {

--- a/src/lib/components/ArtistTagChips.svelte
+++ b/src/lib/components/ArtistTagChips.svelte
@@ -12,7 +12,7 @@
   let { tags, variant = "compact", class: className = "" }: Props = $props();
 
   const chipClass =
-    "inline-flex items-center pl-2 pr-2 py-0.5 rounded-full bg-brand-accent/15 text-brand-text-primary border border-brand-accent/25 text-xs font-medium hover:bg-brand-accent/25 hover:border-brand-accent/50 transition-colors";
+    "inline-flex items-center pl-2 pr-2 py-0.5 rounded-full bg-brand-accent/15 text-brand-text-primary border-2 border-brand-accent/25 text-xs font-medium hover:bg-brand-accent/25 hover:border-brand-accent/50 transition-colors";
 
   function goToTag(e: MouseEvent, tag: string) {
     e.stopPropagation();

--- a/src/lib/components/GenreCards.svelte
+++ b/src/lib/components/GenreCards.svelte
@@ -349,8 +349,8 @@
             onpointerdown={(e) => handleChipPointerDown(e, child.name, group.name)}
             onclick={() => { if (selectMode) onToggleSelect(child.name); }}
             oncontextmenu={(e) => openContextMenu(e, child.name, false)}
-            class="inline-flex items-center gap-1 pl-2 pr-1.5 py-1 rounded-full border text-xs font-medium select-none touch-none transition-[opacity,box-shadow,transform] {selectMode ? 'cursor-pointer' : 'genre-drag-handle'} {!selectMode && draggedChip?.name === child.name ? 'is-dragging' : ''} {draggedChip?.name === child.name ? 'opacity-40' : ''} {dropTarget?.kind === 'chip' && dropTarget.chip === child.name ? 'ring-4 ring-brand-accent scale-110' : selected.has(child.name) ? 'ring-2 ring-brand-accent' : ''}"
-            style={`background-color: color-mix(in srgb, ${genreColorHsl(group.color_index)} 38%, transparent); border-color: color-mix(in srgb, ${genreColorHslFg(group.color_index)} 70%, transparent); color: ${genreColorHslFg(group.color_index)};`}
+            class="inline-flex items-center gap-1 pl-2 pr-1.5 py-0.5 rounded-full border-2 bg-brand-accent/15 text-brand-text-primary text-xs font-medium select-none touch-none transition-[opacity,box-shadow,transform] {selectMode ? 'cursor-pointer' : 'genre-drag-handle'} {!selectMode && draggedChip?.name === child.name ? 'is-dragging' : ''} {draggedChip?.name === child.name ? 'opacity-40' : ''} {dropTarget?.kind === 'chip' && dropTarget.chip === child.name ? 'ring-4 ring-brand-accent scale-110' : selected.has(child.name) ? 'ring-2 ring-brand-accent' : ''}"
+            style={`border-color: ${genreColorHsl(group.color_index)};`}
           >
             {#if selectMode}
               <input
@@ -391,8 +391,8 @@
 
 {#if ghostInfo && pointerPos}
   <div
-    class="fixed z-50 pointer-events-none px-3 py-1.5 rounded-full border text-xs font-semibold shadow-2xl -translate-y-1/2"
-    style={`left: ${pointerPos.x + 16}px; top: ${pointerPos.y}px; background-color: color-mix(in srgb, ${genreColorHsl(ghostInfo.colorIndex)} 40%, var(--color-brand-sidebar)); color: color-mix(in srgb, ${genreColorHsl(ghostInfo.colorIndex)} 90%, var(--color-brand-text-primary)); border-color: color-mix(in srgb, ${genreColorHsl(ghostInfo.colorIndex)} 60%, transparent);`}
+    class="fixed z-50 pointer-events-none px-3 py-1.5 rounded-full border-2 bg-brand-accent/15 text-brand-text-primary text-xs font-semibold shadow-2xl -translate-y-1/2"
+    style={`left: ${pointerPos.x + 16}px; top: ${pointerPos.y}px; border-color: ${genreColorHsl(ghostInfo.colorIndex)};`}
   >
     {ghostInfo.label}
   </div>

--- a/src/lib/components/GenreChips.svelte
+++ b/src/lib/components/GenreChips.svelte
@@ -25,7 +25,7 @@
   let remainingValues = $derived(remainingCount > 0 ? values.slice(displayedValues.length) : []);
 
   const chipClass =
-    "inline-flex items-center pl-2 pr-2 py-0.5 rounded-full bg-brand-accent/15 text-brand-text-primary border border-brand-accent/25 text-xs font-medium hover:bg-brand-accent/25 hover:border-brand-accent/50 transition-colors";
+    "inline-flex items-center pl-2 pr-2 py-0.5 rounded-full bg-brand-accent/15 text-brand-text-primary border-2 border-brand-accent/25 text-xs font-medium hover:bg-brand-accent/25 hover:border-brand-accent/50 transition-colors";
 
   function goToTag(e: MouseEvent, value: string) {
     e.stopPropagation();

--- a/src/lib/components/LibraryBadge.svelte
+++ b/src/lib/components/LibraryBadge.svelte
@@ -60,17 +60,16 @@
 
   let badgeStyle = $derived(
     customColor
-      ? `background-color: color-mix(in srgb, ${customColor} 18%, var(--color-brand-sidebar)); border-color: color-mix(in srgb, ${customColor} 45%, var(--color-brand-sidebar)); color: ${customColor};`
-      : `background-color: color-mix(in srgb, var(--color-brand-accent) 15%, var(--color-brand-sidebar)); border-color: color-mix(in srgb, var(--color-brand-accent) 25%, var(--color-brand-sidebar));`
+      ? `border-color: ${customColor};`
+      : `border-color: color-mix(in srgb, var(--color-brand-accent) 25%, var(--color-brand-sidebar));`
   );
 </script>
 
 <span
-  class="inline-flex items-center font-medium border rounded-full transition-colors select-none max-w-full truncate
+  class="inline-flex items-center font-medium border-2 rounded-full transition-colors select-none max-w-full truncate bg-brand-accent/15 text-brand-text-primary
     {size === 'xs' ? 'text-[10px] px-2 py-0.5 gap-1' : ''}
     {size === 'sm' ? 'text-xs px-2.5 py-0.5 gap-1.5' : ''}
     {size === 'md' ? 'text-xs px-3 py-1 gap-2' : ''}
-    {!customColor ? 'text-brand-text-primary' : ''}
     {isUnavailable ? 'opacity-70 border-dashed border-red-400/60' : ''}
     {className}"
   style={badgeStyle}


### PR DESCRIPTION
## 📋 Summary
Fixes #855. Scopes Album Detail's "Open images" artwork discovery to the album's own directory, plus a few small UI cleanups made alongside it (see issue for the updated full scope).

## 🔍 Implementation Notes
- `covermanager.rs`: added `ArtworkCategory::is_album_level()` / `is_artist_level()`.
- `commands/cover.rs`: `get_extended_artwork_for_song` now filters to album-level categories located within the song's own album directory, so parent artist folder media (`artist.jpg`, `logo.png`, `fanart.jpg`) no longer leaks into the album's count/response.
- Also bundled: removed a redundant "LINKS" section header in `ArtistDetailView.svelte`, removed a redundant "Artist profile updated" success toast, and standardized border weight/background treatment across `LibraryBadge`, `ArtistTagChips`, `GenreChips`, and `GenreCards`.

## 🧪 Test Plan
- [x] `bun run check` (svelte-check) — 0 errors
- [ ] `bun run test -- --run` (frontend)
- [x] `cargo test` (src-tauri) — `covermanager` unit tests pass (15/15), including new `test_scan_extended_artwork_categorizes_album_level_hierarchy` / `test_artwork_category_scopes`
- [x] Manually verified in the app (describe what you did)

## ✅ Checklist
- [x] No unrelated changes bundled in
- [ ] Docs/screenshots updated if user-facing behavior changed
