### PR TITLE
fix: align Playlist/AutoPlaylist/Artist card heights in mixed grids

### DIFF
--- a/src/lib/components/ArtistCard.svelte
+++ b/src/lib/components/ArtistCard.svelte
@@ -58,7 +58,7 @@
   onclick={(e) => customClick?.(e)}
   oncontextmenu={(e) => customContextMenu?.(e)}
   onkeydown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); customClick?.(e as unknown as MouseEvent); } }}
-  class="artist-card group bg-brand-sidebar border border-brand-border/60 rounded-xl p-4 flex flex-col items-start text-left outline-2 -outline-offset-2 outline-transparent hover:outline-brand-accent transition-[outline-color,border-color] duration-200 select-none"
+  class="artist-card group h-full bg-brand-sidebar border border-brand-border/60 rounded-xl p-4 flex flex-col items-start text-left outline-2 -outline-offset-2 outline-transparent hover:outline-brand-accent transition-[outline-color,border-color] duration-200 select-none"
 >
   <div class="aspect-square w-full mb-3 bg-brand-main relative flex items-center justify-center overflow-hidden">
     {#if artistPortraitUrl}

--- a/src/lib/components/AutoPlaylistCard.svelte
+++ b/src/lib/components/AutoPlaylistCard.svelte
@@ -177,7 +177,7 @@
 <div
   onclick={onClick}
   oncontextmenu={(e) => { (oncontextmenu || onContextMenu)?.(e); }}
-  class="{widthClass} bg-brand-sidebar border border-brand-border/60 rounded-xl p-4 flex flex-col text-left outline-2 -outline-offset-2 outline-transparent hover:outline-brand-accent transition-[outline-color,border-color] duration-200 group"
+  class="{widthClass} h-full bg-brand-sidebar border border-brand-border/60 rounded-xl p-4 flex flex-col text-left outline-2 -outline-offset-2 outline-transparent hover:outline-brand-accent transition-[outline-color,border-color] duration-200 group"
 >
   <div class="aspect-square w-full mb-3 bg-brand-main relative flex items-center justify-center">
     {#if (kind === "genre" || kind === "decade" || kind === "bpm" || kind === "artist_tag" || kind === "daypart") && topCovers.length > 0}
@@ -245,7 +245,7 @@
   <div class="text-xs text-brand-text-secondary truncate w-full mt-0.5 font-medium">
     {subtitleLabel}
   </div>
-  <div class="flex items-center justify-between mt-0.5 text-xs text-brand-text-secondary">
+  <div class="flex items-center justify-between mt-1.5 text-xs leading-[22px] text-brand-text-secondary">
     <span class="truncate">{updatedLabel ?? ""}</span>
     <span class="shrink-0">{trackCount === 1 ? i18n.t('playlists.oneSong') : i18n.t("playlists.songsCount", { count: trackCount })}</span>
   </div>

--- a/src/lib/components/PlaylistCard.svelte
+++ b/src/lib/components/PlaylistCard.svelte
@@ -91,7 +91,7 @@
 <div
   onclick={onClick}
   oncontextmenu={(e) => { (oncontextmenu || onContextMenu)?.(e); }}
-  class="{widthClass} bg-brand-sidebar border border-brand-border/60 rounded-xl p-4 flex flex-col text-left outline-2 -outline-offset-2 outline-transparent hover:outline-brand-accent transition-[outline-color,border-color] duration-200 group relative"
+  class="{widthClass} h-full bg-brand-sidebar border border-brand-border/60 rounded-xl p-4 flex flex-col text-left outline-2 -outline-offset-2 outline-transparent hover:outline-brand-accent transition-[outline-color,border-color] duration-200 group relative"
 >
   <div class="aspect-square w-full mb-3 bg-brand-main relative flex items-center justify-center overflow-hidden">
     {#if isQueue}
@@ -138,7 +138,7 @@
       {subtitleLabel}
     </div>
   {/if}
-  <div class="flex items-center justify-between mt-0.5 text-xs text-brand-text-secondary">
+  <div class="flex items-center justify-between mt-1.5 text-xs leading-[22px] text-brand-text-secondary">
     <span class="truncate">{updatedLabel}</span>
     <span class="shrink-0">{playlist.track_count === 1 ? i18n.t('playlists.oneSong') : i18n.t("playlists.songsCount", { count: playlist.track_count })}</span>
   </div>


### PR DESCRIPTION
## 📋 Summary
Fixes #872. Playlist and AutoPlaylist cards rendered shorter than Artist cards in mixed grids/rows (e.g. the Home page's Pinned row), so their bottoms didn't align.

## 🔍 Implementation Notes
Two compounding causes: `GenreChips`' chip padding+border makes Artist cards' 3rd line (genre chips) ~6px taller than Playlist/AutoPlaylist cards' plain-text date/count line, and all three card roots lacked `h-full`, so in a flex row they didn't stretch to fill their cell even when a sibling card was taller. Added `h-full` to the root of `ArtistCard.svelte`, `PlaylistCard.svelte`, and `AutoPlaylistCard.svelte`, and matched Playlist/AutoPlaylist's date/count row spacing (`mt-1.5 leading-[22px]`) to the Artist card's genre-chip row height.

## 🧪 Test Plan
- [x] Manually verified in the app — confirmed via screenshot that all card types in the Home page's Pinned row (Morning Mix, Favourite Songs, Cannons, Eric Soltys, Dua Lipa) now align top and bottom.

## 📸 Screenshots
Before: Playlist/AutoPlaylist cards ~12px shorter than Artist cards, misaligned bottoms in the Pinned row.
After: all card types align evenly top and bottom.

## ✅ Checklist
- [x] No unrelated changes bundled in
- [ ] Docs/screenshots updated if user-facing behavior changed (see `.claude/CLAUDE.md` for the screenshot harness) — N/A, no new screenshot-worthy feature added
