### PR TITLE
refactor: shared playlist card presentation, remove library badge from album views

### DIFF
--- a/src/lib/components/AlbumCard.svelte
+++ b/src/lib/components/AlbumCard.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { invoke } from "@tauri-apps/api/core";
   import type { AlbumItem } from "../types";
-  import { collectionStore } from "../stores/collection.svelte";
   import { navigationStore } from "../stores/navigation.svelte";
   import CoverStack, { type CoverItem } from "./CoverStack.svelte";
   import LinkButton from "./LinkButton.svelte";
@@ -11,8 +10,7 @@
   import FavouriteCornerFlag from "./FavouriteCornerFlag.svelte";
   import BoxSetDiscIcons from "./BoxSetDiscIcons.svelte";
   import GenreChips from "./GenreChips.svelte";
-  import LibraryBadge from "./LibraryBadge.svelte";
- 
+
   interface Props {
     album: AlbumItem;
     covers?: CoverItem[];
@@ -53,8 +51,6 @@
     if (!album.album) return;
     album.rating = await invoke<number>("set_album_rating", { album: album.album, rating });
   }
-
-  let albumDirectory = $derived(collectionStore.getDirectoryForAlbum(album));
 </script>
 
 <!-- svelte-ignore a11y_no_static_element_interactions -->
@@ -77,11 +73,6 @@
     {/if}
     {#if album.disc_count > 1}
       <BoxSetDiscIcons discCount={album.disc_count} size="md" />
-    {/if}
-    {#if albumDirectory}
-      <div class="absolute top-2 left-2 z-10 opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none max-w-[calc(100%-1rem)]">
-        <LibraryBadge directory={albumDirectory} size="xs" />
-      </div>
     {/if}
   </div>
   <div class="p-3.5 flex flex-col flex-1">

--- a/src/lib/components/AlbumDetailView.svelte
+++ b/src/lib/components/AlbumDetailView.svelte
@@ -25,7 +25,6 @@
   import LinkButton from "./LinkButton.svelte";
   import ColumnSelector from "./ColumnSelector.svelte";
   import SongTable, { type SongTableRow } from "./SongTable.svelte";
-  import LibraryBadge from "./LibraryBadge.svelte";
   import ContextMenu from "./ContextMenu.svelte";
   import ContextMenuItem from "./ContextMenuItem.svelte";
   import {
@@ -34,11 +33,10 @@
     ArrowsClockwiseIcon as RefreshCw,
     PushPinIcon as Pin,
     PushPinSlashIcon as PinOff,
-    FoldersIcon as Folders,
     DotsThreeIcon as MoreHorizontal,
     ArrowSquareOutIcon as OpenInPicard
   } from "phosphor-svelte";
-  import type { Song, AlbumItem, PlayContext, MusicDirectory } from "../types";
+  import type { Song, AlbumItem, PlayContext } from "../types";
   import { getCoverArtUrl, resolveArtUrl } from "../types";
   import { i18n } from "../stores/i18n.svelte";
   import { picardStore } from "../stores/picard.svelte";
@@ -117,17 +115,6 @@
   /** Bumped by handleRefreshAlbum (#867) to force CoverStack's extended-
    * artwork lookup for {@link representativeSongId} to bypass its cache. */
   let artworkRefreshToken = $state(0);
-
-  let albumDirectories = $derived.by(() => {
-    const map = new Map<number, MusicDirectory>();
-    for (const song of songs) {
-      if (song.path) {
-        const dir = collectionStore.getDirectoryForPath(song.path);
-        if (dir) map.set(dir.id, dir);
-      }
-    }
-    return Array.from(map.values());
-  });
 
   let artistName = $derived.by(() => {
     if (albumItem?.artist) return albumItem.artist;
@@ -435,13 +422,13 @@
 
   <div class="relative z-30 w-full border-b border-brand-border/60 bg-brand-main/60 backdrop-blur-md px-6 {windowLayoutStore.isDetailHeaderCollapsed ? 'py-3' : 'pt-6 pb-6'}">
     <div class="flex items-start justify-between gap-6 relative z-10">
-      <div class="flex flex-col justify-end gap-1.5 min-w-0 max-w-xl">
+      <div class="flex flex-col justify-end min-w-0 max-w-xl">
         {#if !windowLayoutStore.isDetailHeaderCollapsed}
         <h1 class="text-3xl sm:text-4xl font-heading font-bold text-brand-text-primary leading-snug truncate py-0.5" title={albumName}>
           {albumName}
         </h1>
 
-        <div class="flex items-center gap-2 text-base font-semibold text-brand-text-primary">
+        <div class="flex items-center gap-2 text-base font-semibold text-brand-text-primary mt-0.5">
           {#if artistName}
             <LinkButton
               onclick={() => navigationStore.viewArtist(artistName)}
@@ -454,15 +441,7 @@
           {/if}
         </div>
 
-        {#if rawGenre}
-          <GenreChips genre={rawGenre} variant="full" limit={4} />
-        {:else}
-          <div class="text-xs text-brand-text-primary font-medium">
-            <span>{genreLabel}</span>
-          </div>
-        {/if}
-
-        <div class="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-brand-text-primary font-medium">
+        <div class="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-brand-text-primary font-medium mt-1.5">
           {#if yearLabel}
             <span>{yearLabel}</span>
             <span>•</span>
@@ -474,21 +453,15 @@
             <span>•</span>
             <SongRating rating={albumItem.rating} onRate={rateAlbum} size="sm" />
           {/if}
-          {#if albumDirectories.length === 1}
-            <span>•</span>
-            <LibraryBadge directory={albumDirectories[0]} size="sm" />
-          {:else if albumDirectories.length > 1}
-            <span>•</span>
-            <span
-              class="inline-flex items-center gap-1.5 px-2.5 py-0.5 rounded-full text-xs font-medium text-brand-text-primary border select-none"
-              style="background-color: color-mix(in srgb, var(--color-brand-accent) 15%, var(--color-brand-sidebar)); border-color: color-mix(in srgb, var(--color-brand-accent) 25%, var(--color-brand-sidebar));"
-              title={albumDirectories.map((d) => d.nickname || d.path).join(", ")}
-            >
-              <Folders class="w-3.5 h-3.5 text-brand-accent-text" />
-              <span>{i18n.t('albumDetail.multiLibraries', { count: albumDirectories.length }, `${albumDirectories.length} Libraries`)}</span>
-            </span>
-          {/if}
         </div>
+
+        {#if rawGenre}
+          <GenreChips genre={rawGenre} variant="full" limit={4} class="mt-1.5" />
+        {:else}
+          <div class="text-xs text-brand-text-primary font-medium mt-1.5">
+            <span>{genreLabel}</span>
+          </div>
+        {/if}
         {/if}
 
         <div class="flex flex-wrap items-center gap-3 {windowLayoutStore.isDetailHeaderCollapsed ? '' : 'mt-3'} select-none">

--- a/src/lib/components/ArtistDetailView.svelte
+++ b/src/lib/components/ArtistDetailView.svelte
@@ -567,6 +567,12 @@
           <h1 class="text-3xl sm:text-4xl font-heading font-bold text-brand-text-primary leading-snug truncate py-0.5">{artistName}</h1>
         {/if}
 
+        <div class="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-brand-text-primary font-medium">
+          <span>{songsText}</span>
+          <span>•</span>
+          <span>{totalDurationLabel}</span>
+        </div>
+
         {#if rawGenre}
           <GenreChips genre={rawGenre} variant="full" limit={4} />
         {:else}
@@ -574,12 +580,6 @@
             <span>{genreLabel}</span>
           </div>
         {/if}
-
-        <div class="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-brand-text-primary font-medium">
-          <span>{songsText}</span>
-          <span>•</span>
-          <span>{totalDurationLabel}</span>
-        </div>
         {/if}
 
         <div class="flex flex-wrap items-center gap-3 {windowLayoutStore.isDetailHeaderCollapsed ? '' : 'mt-3'} select-none">

--- a/src/lib/components/AutoPlaylistCard.svelte
+++ b/src/lib/components/AutoPlaylistCard.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { invoke } from "@tauri-apps/api/core";
   import {
-    PlaylistIcon as ListMusic,
     HeartIcon as Heart,
     ClockIcon as Clock,
     HourglassIcon as Hourglass,
@@ -13,12 +12,14 @@
     WarningIcon as AlertTriangle,
     SunHorizonIcon as SunHorizon
   } from "phosphor-svelte";
-  import CardBadge from "./CardBadge.svelte";
   import type { PlaylistItem, Song } from "../types";
   import { songsToCoverStack } from "../utils/covers";
   import { i18n } from "../stores/i18n.svelte";
   import { formatRelativeDate } from "../utils/date";
   import CoverStack from "./CoverStack.svelte";
+  import PlaylistCardShell from "./PlaylistCardShell.svelte";
+  import PlaylistCoverFrame from "./PlaylistCoverFrame.svelte";
+  import { getPlaylistCardTheme } from "../utils/playlistCardTheme";
   import { playlistsStore } from "../stores/playlists.svelte";
   import { getPlaylistDisplayName } from "../utils/playlist";
   import { toTitleCase } from "../utils/formatters";
@@ -146,22 +147,6 @@
     kind === "genre" || kind === "decade" || kind === "bpm" || kind === "artist_tag" || kind === "daypart" ? songsToCoverStack(songs) : []
   );
 
-  let badgeColorClass = $derived.by(() => {
-    switch (kind) {
-      case "decade": return "bg-[#2563EB] text-white";
-      case "genre": return "bg-[#059669] text-white";
-      case "artist_tag": return "bg-[#EA580C] text-white";
-      case "bpm": return "bg-[#C026D3] text-white";
-      case "favourites": return "bg-[#DB2777] text-white";
-      case "recently_added": return "bg-[#CA8A04] text-white";
-      case "most_played": return "bg-[#DC2626] text-white";
-      case "history": return "bg-[#8B5CF6] text-white";
-      case "missing_metadata": return "bg-amber-600 text-white";
-      case "missing_musicbrainz": return "bg-indigo-600 text-white";
-      case "daypart": return "bg-[#0D9488] text-white";
-    }
-  });
-
   let updatedLabel = $derived.by(() => {
     if (
       (kind !== "genre" && kind !== "decade" && kind !== "bpm" && kind !== "artist_tag" && kind !== "missing_metadata" && kind !== "missing_musicbrainz" && kind !== "daypart") ||
@@ -172,81 +157,50 @@
   });
 </script>
 
-<!-- svelte-ignore a11y_no_static_element_interactions -->
-<!-- svelte-ignore a11y_click_events_have_key_events -->
-<div
-  onclick={onClick}
-  oncontextmenu={(e) => { (oncontextmenu || onContextMenu)?.(e); }}
-  class="{widthClass} h-full bg-brand-sidebar border border-brand-border/60 rounded-xl p-4 flex flex-col text-left outline-2 -outline-offset-2 outline-transparent hover:outline-brand-accent transition-[outline-color,border-color] duration-200 group"
->
-  <div class="aspect-square w-full mb-3 bg-brand-main relative flex items-center justify-center">
-    {#if (kind === "genre" || kind === "decade" || kind === "bpm" || kind === "artist_tag" || kind === "daypart") && topCovers.length > 0}
-      <div class="w-full h-full bg-brand-main bg-gradient-to-br {kind === 'decade' ? 'from-[#2563EB]/25 to-[#38BDF8]/15 border-[#38BDF8]/30 shadow-[0_0_20px_2px_rgba(56,189,248,0.35)]' : kind === 'bpm' ? 'from-[#C026D3]/25 to-[#E879F9]/15 border-[#E879F9]/30 shadow-[0_0_20px_2px_rgba(232,121,249,0.35)]' : kind === 'artist_tag' ? 'from-[#EA580C]/25 to-[#FB923C]/15 border-[#FB923C]/30 shadow-[0_0_20px_2px_rgba(251,146,60,0.35)]' : kind === 'daypart' ? 'from-[#0D9488]/25 to-[#2DD4BF]/15 border-[#2DD4BF]/30 shadow-[0_0_20px_2px_rgba(45,212,191,0.35)]' : 'from-[#059669]/25 to-[#34D399]/15 border-[#34D399]/30 shadow-[0_0_20px_2px_rgba(52,211,153,0.35)]'} flex items-center justify-center overflow-hidden border relative">
-        <CoverStack covers={topCovers} hoverEffect={true} sizeClass="w-[82%] h-[82%]" />
-      </div>
-    {:else if kind === "favourites"}
-      <div class="w-full h-full bg-brand-main bg-gradient-to-br from-[#DB2777]/25 to-[#F43F5E]/15 flex items-center justify-center overflow-hidden border border-[#F43F5E]/30 shadow-[0_0_20px_2px_rgba(244,63,94,0.35)]">
-        <Heart class="w-10 h-10 text-[#F43F5E] fill-current" />
-      </div>
-    {:else if kind === "recently_added"}
-      <div class="w-full h-full bg-brand-main bg-gradient-to-br from-[#CA8A04]/25 to-[#FACC15]/15 flex items-center justify-center overflow-hidden border border-[#FACC15]/30 shadow-[0_0_20px_2px_rgba(250,204,21,0.35)]">
-        <Clock class="w-10 h-10 text-[#CA8A04]" />
-      </div>
-    {:else if kind === "most_played"}
-      <div class="w-full h-full bg-brand-main bg-gradient-to-br from-[#DC2626]/25 to-[#F87171]/15 flex items-center justify-center overflow-hidden border border-[#F87171]/30 shadow-[0_0_20px_2px_rgba(248,113,113,0.35)]">
-        <TrendingUp class="w-10 h-10 text-[#DC2626]" />
-      </div>
-    {:else if kind === "history"}
-      <div class="w-full h-full bg-brand-main bg-gradient-to-br from-[#8B5CF6]/25 to-[#A78BFA]/15 flex items-center justify-center overflow-hidden border border-[#A78BFA]/30 shadow-[0_0_20px_2px_rgba(167,139,250,0.35)]">
-        <Hourglass class="w-10 h-10 text-[#8B5CF6]" />
-      </div>
-    {:else if kind === "decade"}
-      <div class="w-full h-full bg-brand-main bg-gradient-to-br from-[#2563EB]/25 to-[#38BDF8]/15 flex items-center justify-center overflow-hidden border border-[#38BDF8]/30 shadow-[0_0_20px_2px_rgba(56,189,248,0.35)]">
-        <Calendar class="w-10 h-10 text-[#38BDF8]" />
-      </div>
-    {:else if kind === "genre"}
-      <div class="w-full h-full bg-brand-main bg-gradient-to-br from-[#059669]/25 to-[#34D399]/15 flex items-center justify-center overflow-hidden border border-[#34D399]/30 shadow-[0_0_20px_2px_rgba(52,211,153,0.35)]">
-        <Music class="w-10 h-10 text-[#34D399]" />
-      </div>
-    {:else if kind === "artist_tag"}
-      <div class="w-full h-full bg-brand-main bg-gradient-to-br from-[#EA580C]/25 to-[#FB923C]/15 flex items-center justify-center overflow-hidden border border-[#FB923C]/30 shadow-[0_0_20px_2px_rgba(251,146,60,0.35)]">
-        <Tag class="w-10 h-10 text-[#FB923C]" />
-      </div>
-    {:else if kind === "bpm"}
-      <div class="w-full h-full bg-brand-main bg-gradient-to-br from-[#C026D3]/25 to-[#E879F9]/15 flex items-center justify-center overflow-hidden border border-[#E879F9]/30 shadow-[0_0_20px_2px_rgba(232,121,249,0.35)]">
-        <Gauge class="w-10 h-10 text-[#E879F9]" />
-      </div>
-    {:else if kind === "missing_metadata"}
-      <div class="w-full h-full bg-brand-main bg-gradient-to-br from-amber-600/25 to-amber-400/15 flex items-center justify-center overflow-hidden border border-amber-400/30 shadow-[0_0_20px_2px_rgba(245,158,11,0.35)]">
-        <AlertTriangle class="w-10 h-10 text-amber-500" />
-      </div>
-    {:else if kind === "missing_musicbrainz"}
-      <div class="w-full h-full bg-brand-main bg-gradient-to-br from-indigo-600/25 to-indigo-400/15 flex items-center justify-center overflow-hidden border border-indigo-400/30 shadow-[0_0_20px_2px_rgba(99,102,241,0.35)]">
-        <AlertTriangle class="w-10 h-10 text-indigo-400" />
-      </div>
-    {:else if kind === "daypart"}
-      <div class="w-full h-full bg-brand-main bg-gradient-to-br from-[#0D9488]/25 to-[#2DD4BF]/15 flex items-center justify-center overflow-hidden border border-[#2DD4BF]/30 shadow-[0_0_20px_2px_rgba(45,212,191,0.35)]">
-        <SunHorizon class="w-10 h-10 text-[#2DD4BF]" />
-      </div>
-    {:else}
-      <div class="w-full h-full bg-brand-main bg-gradient-to-br from-slate-700/40 to-slate-900/30 flex items-center justify-center overflow-hidden border border-slate-400/20 shadow-[0_0_20px_2px_rgba(100,116,139,0.25)]">
-        <ListMusic class="w-10 h-10 text-slate-300" />
-      </div>
-    {/if}
-  </div>
+{#snippet cover()}
+  {#if (kind === "genre" || kind === "decade" || kind === "bpm" || kind === "artist_tag" || kind === "daypart") && topCovers.length > 0}
+    {@const t = getPlaylistCardTheme(kind)}
+    <PlaylistCoverFrame gradientClass={t.gradientClass}>
+      <CoverStack covers={topCovers} hoverEffect={true} sizeClass="w-[82%] h-[82%]" />
+    </PlaylistCoverFrame>
+  {:else}
+    {@const t = getPlaylistCardTheme(kind)}
+    <PlaylistCoverFrame gradientClass={t.gradientClass}>
+      {#if kind === "favourites"}
+        <Heart class="w-10 h-10 {t.iconColorClass} fill-current" />
+      {:else if kind === "recently_added"}
+        <Clock class="w-10 h-10 {t.iconColorClass}" />
+      {:else if kind === "most_played"}
+        <TrendingUp class="w-10 h-10 {t.iconColorClass}" />
+      {:else if kind === "history"}
+        <Hourglass class="w-10 h-10 {t.iconColorClass}" />
+      {:else if kind === "decade"}
+        <Calendar class="w-10 h-10 {t.iconColorClass}" />
+      {:else if kind === "genre"}
+        <Music class="w-10 h-10 {t.iconColorClass}" />
+      {:else if kind === "artist_tag"}
+        <Tag class="w-10 h-10 {t.iconColorClass}" />
+      {:else if kind === "bpm"}
+        <Gauge class="w-10 h-10 {t.iconColorClass}" />
+      {:else if kind === "missing_metadata"}
+        <AlertTriangle class="w-10 h-10 {t.iconColorClass}" />
+      {:else if kind === "missing_musicbrainz"}
+        <AlertTriangle class="w-10 h-10 {t.iconColorClass}" />
+      {:else}
+        <SunHorizon class="w-10 h-10 {t.iconColorClass}" />
+      {/if}
+    </PlaylistCoverFrame>
+  {/if}
+{/snippet}
 
-  <button
-    onclick={(e) => { e.stopPropagation(); onClick(); }}
-    class="font-semibold text-sm text-brand-text-primary group-hover:text-brand-accent-text group-hover:underline transition-all duration-150 text-left truncate w-full"
-    title={displayLabel}
-  >
-    {displayLabel}
-  </button>
-  <div class="text-xs text-brand-text-secondary truncate w-full mt-0.5 font-medium">
-    {subtitleLabel}
-  </div>
-  <div class="flex items-center justify-between mt-1.5 text-xs leading-[22px] text-brand-text-secondary">
-    <span class="truncate">{updatedLabel ?? ""}</span>
-    <span class="shrink-0">{trackCount === 1 ? i18n.t('playlists.oneSong') : i18n.t("playlists.songsCount", { count: trackCount })}</span>
-  </div>
-</div>
+<PlaylistCardShell
+  {widthClass}
+  {onClick}
+  {oncontextmenu}
+  {onContextMenu}
+  title={displayLabel}
+  {subtitleLabel}
+  updatedLabel={updatedLabel ?? ""}
+  {trackCount}
+  {cover}
+/>

--- a/src/lib/components/PlaylistCard.svelte
+++ b/src/lib/components/PlaylistCard.svelte
@@ -16,6 +16,9 @@
   import { formatRelativeDate } from "../utils/date";
   import { isSmartPlaylistSpec } from "../utils/filterParser";
   import CoverStack from "./CoverStack.svelte";
+  import PlaylistCardShell from "./PlaylistCardShell.svelte";
+  import PlaylistCoverFrame from "./PlaylistCoverFrame.svelte";
+  import { getPlaylistCardTheme } from "../utils/playlistCardTheme";
 
   import { getPlaylistDisplayName } from "../utils/playlist";
 
@@ -32,6 +35,9 @@
     oncontextmenu?: (e: MouseEvent) => void;
     onContextMenu?: (e: MouseEvent) => void;
   } = $props();
+
+  const queueTheme = getPlaylistCardTheme("queue");
+  const smartTheme = getPlaylistCardTheme("smart");
 
   let cardTitle = $derived(getPlaylistDisplayName(playlist));
 
@@ -75,74 +81,44 @@
   let isActive = $derived(playlistsStore.effectivePinnedPlaylistId === playlist.id);
 
   let updatedLabel = $derived(formatRelativeDate(playlist.updated));
-
-  let badgeColorClass = $derived.by(() => {
-    switch (autoKind) {
-      case "decade": return "bg-[#2563EB] text-white";
-      case "genre": return "bg-[#059669] text-white";
-      case "smart": return "bg-[#C2410C] text-white";
-      default: return "bg-brand-accent text-brand-accent-contrast";
-    }
-  });
 </script>
 
-<!-- svelte-ignore a11y_no_static_element_interactions -->
-<!-- svelte-ignore a11y_click_events_have_key_events -->
-<div
-  onclick={onClick}
-  oncontextmenu={(e) => { (oncontextmenu || onContextMenu)?.(e); }}
-  class="{widthClass} h-full bg-brand-sidebar border border-brand-border/60 rounded-xl p-4 flex flex-col text-left outline-2 -outline-offset-2 outline-transparent hover:outline-brand-accent transition-[outline-color,border-color] duration-200 group relative"
->
-  <div class="aspect-square w-full mb-3 bg-brand-main relative flex items-center justify-center overflow-hidden">
-    {#if isQueue}
-      <div class="w-full h-full bg-brand-main bg-gradient-to-br from-[#4338CA]/25 to-[#7C3AED]/15 flex items-center justify-center overflow-hidden border border-[#7C3AED]/30 shadow-[0_0_20px_2px_rgba(124,58,237,0.35)]">
-        <Layers class="w-10 h-10 text-[#7C3AED]" />
-      </div>
-    {:else if topAlbums.length > 0 && autoKind}
-      <div class="w-full h-full bg-brand-main bg-gradient-to-br {autoKind === 'decade' ? 'from-[#2563EB]/25 to-[#38BDF8]/15 border-[#38BDF8]/30 shadow-[0_0_20px_2px_rgba(56,189,248,0.35)]' : autoKind === 'genre' ? 'from-[#059669]/25 to-[#34D399]/15 border-[#34D399]/30 shadow-[0_0_20px_2px_rgba(52,211,153,0.35)]' : 'from-[#C2410C]/25 to-[#F59E0B]/15 border-[#F59E0B]/30 shadow-[0_0_20px_2px_rgba(245,158,11,0.35)]'} flex items-center justify-center overflow-hidden border">
-        <CoverStack covers={topAlbums} hoverEffect={true} sizeClass="w-[82%] h-[82%]" />
-      </div>
-    {:else if topAlbums.length > 0}
+{#snippet cover()}
+  {#if isQueue}
+    <PlaylistCoverFrame gradientClass={queueTheme.gradientClass}>
+      <Layers class="w-10 h-10 {queueTheme.iconColorClass}" />
+    </PlaylistCoverFrame>
+  {:else if topAlbums.length > 0 && autoKind}
+    {@const t = getPlaylistCardTheme(autoKind)}
+    <PlaylistCoverFrame gradientClass={t.gradientClass}>
       <CoverStack covers={topAlbums} hoverEffect={true} sizeClass="w-[82%] h-[82%]" />
-    {:else if autoKind}
-      <div class="w-full h-full bg-brand-main bg-gradient-to-br {autoKind === 'decade' ? 'from-[#2563EB]/25 to-[#38BDF8]/15 border-[#38BDF8]/30 shadow-[0_0_20px_2px_rgba(56,189,248,0.35)]' : autoKind === 'genre' ? 'from-[#059669]/25 to-[#34D399]/15 border-[#34D399]/30 shadow-[0_0_20px_2px_rgba(52,211,153,0.35)]' : 'from-[#C2410C]/25 to-[#F59E0B]/15 border-[#F59E0B]/30 shadow-[0_0_20px_2px_rgba(245,158,11,0.35)]'} flex items-center justify-center overflow-hidden border">
-        {#if autoKind === "decade"}
-          <Calendar class="w-10 h-10 text-[#38BDF8]" />
-        {:else if autoKind === "genre"}
-          <Music class="w-10 h-10 text-[#34D399]" />
-        {:else}
-          <Sparkles class="w-10 h-10 text-[#F59E0B]" />
-        {/if}
-      </div>
-    {:else}
-      <!-- Custom (user-made) playlist with no art yet: flat, no gradient —
-           gradient/frame treatment is reserved for app-generated playlists
-           (see Luminous Playlist Card System). -->
-      <ListMusic class="w-10 h-10 text-brand-text-secondary" />
-    {/if}
-
-    {#if autoKind === "smart"}
-      <CardBadge icon={Sparkles} label={i18n.t("playlists.smartBadgeLabel")} title={i18n.t("playlists.smartRuleBasedTooltip")} colorClass={badgeColorClass} />
-    {/if}
-  </div>
-
-  <button
-    onclick={(e) => { e.stopPropagation(); onClick(); }}
-    class="font-semibold text-sm text-brand-text-primary group-hover:text-brand-accent-text group-hover:underline transition-all duration-150 text-left truncate w-full"
-    title={cardTitle}
-  >
-    {cardTitle}
-  </button>
-  {#if subtitleLabel}
-    <div class="text-xs text-brand-text-secondary truncate w-full mt-0.5 font-medium">
-      {subtitleLabel}
-    </div>
+    </PlaylistCoverFrame>
+  {:else if topAlbums.length > 0}
+    <CoverStack covers={topAlbums} hoverEffect={true} sizeClass="w-[82%] h-[82%]" />
+  {:else if autoKind}
+    {@const t = getPlaylistCardTheme(autoKind)}
+    <PlaylistCoverFrame gradientClass={t.gradientClass}>
+      {#if autoKind === "decade"}
+        <Calendar class="w-10 h-10 {t.iconColorClass}" />
+      {:else if autoKind === "genre"}
+        <Music class="w-10 h-10 {t.iconColorClass}" />
+      {:else}
+        <Sparkles class="w-10 h-10 {t.iconColorClass}" />
+      {/if}
+    </PlaylistCoverFrame>
+  {:else}
+    <!-- Custom (user-made) playlist with no art yet: flat, no gradient —
+         gradient/frame treatment is reserved for app-generated playlists
+         (see Luminous Playlist Card System). -->
+    <ListMusic class="w-10 h-10 text-brand-text-secondary" />
   {/if}
-  <div class="flex items-center justify-between mt-1.5 text-xs leading-[22px] text-brand-text-secondary">
-    <span class="truncate">{updatedLabel}</span>
-    <span class="shrink-0">{playlist.track_count === 1 ? i18n.t('playlists.oneSong') : i18n.t("playlists.songsCount", { count: playlist.track_count })}</span>
-  </div>
 
+  {#if autoKind === "smart"}
+    <CardBadge icon={Sparkles} label={i18n.t("playlists.smartBadgeLabel")} title={i18n.t("playlists.smartRuleBasedTooltip")} colorClass={smartTheme.badgeColorClass} />
+  {/if}
+{/snippet}
+
+{#snippet footer()}
   {#if !playlist.dynamic_enabled}
     {#if !isActive}
       <button
@@ -160,4 +136,17 @@
       </div>
     {/if}
   {/if}
-</div>
+{/snippet}
+
+<PlaylistCardShell
+  {widthClass}
+  {onClick}
+  {oncontextmenu}
+  {onContextMenu}
+  title={cardTitle}
+  {subtitleLabel}
+  {updatedLabel}
+  trackCount={playlist.track_count}
+  {cover}
+  {footer}
+/>

--- a/src/lib/components/PlaylistCardShell.svelte
+++ b/src/lib/components/PlaylistCardShell.svelte
@@ -1,0 +1,61 @@
+<script lang="ts">
+  import type { Snippet } from "svelte";
+  import { i18n } from "../stores/i18n.svelte";
+
+  let {
+    widthClass = "w-full",
+    onClick,
+    oncontextmenu,
+    onContextMenu,
+    title,
+    subtitleLabel = null,
+    updatedLabel,
+    trackCount,
+    cover,
+    footer,
+  }: {
+    widthClass?: string;
+    onClick: () => void;
+    oncontextmenu?: (e: MouseEvent) => void;
+    onContextMenu?: (e: MouseEvent) => void;
+    title: string;
+    subtitleLabel?: string | null;
+    updatedLabel: string;
+    trackCount: number;
+    cover: Snippet;
+    footer?: Snippet;
+  } = $props();
+</script>
+
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<!-- svelte-ignore a11y_click_events_have_key_events -->
+<div
+  onclick={onClick}
+  oncontextmenu={(e) => { (oncontextmenu || onContextMenu)?.(e); }}
+  class="{widthClass} h-full bg-brand-sidebar border border-brand-border/60 rounded-xl p-4 flex flex-col text-left outline-2 -outline-offset-2 outline-transparent hover:outline-brand-accent transition-[outline-color,border-color] duration-200 group relative"
+>
+  <div class="aspect-square w-full mb-3 bg-brand-main relative flex items-center justify-center overflow-hidden">
+    {@render cover()}
+  </div>
+
+  <button
+    onclick={(e) => { e.stopPropagation(); onClick(); }}
+    class="font-semibold text-sm text-brand-text-primary group-hover:text-brand-accent-text group-hover:underline transition-all duration-150 text-left truncate w-full"
+    {title}
+  >
+    {title}
+  </button>
+  {#if subtitleLabel}
+    <div class="text-xs text-brand-text-secondary truncate w-full mt-0.5 font-medium">
+      {subtitleLabel}
+    </div>
+  {/if}
+  <div class="flex items-center justify-between mt-1.5 text-xs leading-[22px] text-brand-text-secondary">
+    <span class="truncate">{updatedLabel}</span>
+    <span class="shrink-0">{trackCount === 1 ? i18n.t('playlists.oneSong') : i18n.t("playlists.songsCount", { count: trackCount })}</span>
+  </div>
+
+  {#if footer}
+    {@render footer()}
+  {/if}
+</div>

--- a/src/lib/components/PlaylistCoverFrame.svelte
+++ b/src/lib/components/PlaylistCoverFrame.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  import type { Snippet } from "svelte";
+
+  let {
+    gradientClass,
+    children,
+  }: {
+    gradientClass?: string | null;
+    children: Snippet;
+  } = $props();
+</script>
+
+{#if gradientClass}
+  <div class="w-full h-full bg-brand-main bg-gradient-to-br {gradientClass} flex items-center justify-center overflow-hidden border">
+    {@render children()}
+  </div>
+{:else}
+  {@render children()}
+{/if}

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -986,7 +986,6 @@ export const en = {
     refreshTooltip: "Rescan metadata and artwork for this album",
     refreshSuccess: "Album metadata and artwork refreshed",
     refreshError: "Failed to refresh album metadata",
-    multiLibraries: "{count} Libraries",
   },
   immersive: {
     emptyStateText: "Select a song from your collection to start playing."

--- a/src/lib/locales/fr.ts
+++ b/src/lib/locales/fr.ts
@@ -1017,8 +1017,7 @@ export const fr = {
     editInfoTooltip: "Modifier les infos de l'album",
     refreshTooltip: "Actualiser les métadonnées et la pochette de cet album",
     refreshSuccess: "Métadonnées et pochette de l'album actualisées",
-    refreshError: "Échec de l'actualisation de l'album",
-    multiLibraries: "{count} bibliothèques"
+    refreshError: "Échec de l'actualisation de l'album"
   },
   immersive: {
     emptyStateText: "Sélectionnez une chanson de votre collection pour commencer la lecture."

--- a/src/lib/utils/playlistCardTheme.ts
+++ b/src/lib/utils/playlistCardTheme.ts
@@ -1,0 +1,93 @@
+export type PlaylistCardThemeKind =
+  | "queue"
+  | "genre"
+  | "decade"
+  | "smart"
+  | "bpm"
+  | "artist_tag"
+  | "favourites"
+  | "recently_added"
+  | "most_played"
+  | "history"
+  | "missing_metadata"
+  | "missing_musicbrainz"
+  | "daypart";
+
+export interface PlaylistCardTheme {
+  /** Gradient/border/shadow classes for the cover-art frame (Tailwind `bg-gradient-to-br {gradientClass}`). */
+  gradientClass: string;
+  iconColorClass: string;
+  badgeColorClass: string;
+}
+
+const THEMES: Record<PlaylistCardThemeKind, PlaylistCardTheme> = {
+  queue: {
+    gradientClass: "from-[#4338CA]/25 to-[#7C3AED]/15 border-[#7C3AED]/30 shadow-[0_0_20px_2px_rgba(124,58,237,0.35)]",
+    iconColorClass: "text-[#7C3AED]",
+    badgeColorClass: "bg-[#7C3AED] text-white",
+  },
+  decade: {
+    gradientClass: "from-[#2563EB]/25 to-[#38BDF8]/15 border-[#38BDF8]/30 shadow-[0_0_20px_2px_rgba(56,189,248,0.35)]",
+    iconColorClass: "text-[#38BDF8]",
+    badgeColorClass: "bg-[#2563EB] text-white",
+  },
+  genre: {
+    gradientClass: "from-[#059669]/25 to-[#34D399]/15 border-[#34D399]/30 shadow-[0_0_20px_2px_rgba(52,211,153,0.35)]",
+    iconColorClass: "text-[#34D399]",
+    badgeColorClass: "bg-[#059669] text-white",
+  },
+  smart: {
+    gradientClass: "from-[#C2410C]/25 to-[#F59E0B]/15 border-[#F59E0B]/30 shadow-[0_0_20px_2px_rgba(245,158,11,0.35)]",
+    iconColorClass: "text-[#F59E0B]",
+    badgeColorClass: "bg-[#C2410C] text-white",
+  },
+  bpm: {
+    gradientClass: "from-[#C026D3]/25 to-[#E879F9]/15 border-[#E879F9]/30 shadow-[0_0_20px_2px_rgba(232,121,249,0.35)]",
+    iconColorClass: "text-[#E879F9]",
+    badgeColorClass: "bg-[#C026D3] text-white",
+  },
+  artist_tag: {
+    gradientClass: "from-[#EA580C]/25 to-[#FB923C]/15 border-[#FB923C]/30 shadow-[0_0_20px_2px_rgba(251,146,60,0.35)]",
+    iconColorClass: "text-[#FB923C]",
+    badgeColorClass: "bg-[#EA580C] text-white",
+  },
+  favourites: {
+    gradientClass: "from-[#DB2777]/25 to-[#F43F5E]/15 border-[#F43F5E]/30 shadow-[0_0_20px_2px_rgba(244,63,94,0.35)]",
+    iconColorClass: "text-[#F43F5E]",
+    badgeColorClass: "bg-[#DB2777] text-white",
+  },
+  recently_added: {
+    gradientClass: "from-[#CA8A04]/25 to-[#FACC15]/15 border-[#FACC15]/30 shadow-[0_0_20px_2px_rgba(250,204,21,0.35)]",
+    iconColorClass: "text-[#CA8A04]",
+    badgeColorClass: "bg-[#CA8A04] text-white",
+  },
+  most_played: {
+    gradientClass: "from-[#DC2626]/25 to-[#F87171]/15 border-[#F87171]/30 shadow-[0_0_20px_2px_rgba(248,113,113,0.35)]",
+    iconColorClass: "text-[#DC2626]",
+    badgeColorClass: "bg-[#DC2626] text-white",
+  },
+  history: {
+    gradientClass: "from-[#8B5CF6]/25 to-[#A78BFA]/15 border-[#A78BFA]/30 shadow-[0_0_20px_2px_rgba(167,139,250,0.35)]",
+    iconColorClass: "text-[#8B5CF6]",
+    badgeColorClass: "bg-[#8B5CF6] text-white",
+  },
+  missing_metadata: {
+    gradientClass: "from-amber-600/25 to-amber-400/15 border-amber-400/30 shadow-[0_0_20px_2px_rgba(245,158,11,0.35)]",
+    iconColorClass: "text-amber-500",
+    badgeColorClass: "bg-amber-600 text-white",
+  },
+  missing_musicbrainz: {
+    gradientClass: "from-indigo-600/25 to-indigo-400/15 border-indigo-400/30 shadow-[0_0_20px_2px_rgba(99,102,241,0.35)]",
+    iconColorClass: "text-indigo-400",
+    badgeColorClass: "bg-indigo-600 text-white",
+  },
+  daypart: {
+    gradientClass: "from-[#0D9488]/25 to-[#2DD4BF]/15 border-[#2DD4BF]/30 shadow-[0_0_20px_2px_rgba(45,212,191,0.35)]",
+    iconColorClass: "text-[#2DD4BF]",
+    badgeColorClass: "bg-[#0D9488] text-white",
+  },
+};
+
+export function getPlaylistCardTheme(kind: PlaylistCardThemeKind): PlaylistCardTheme {
+  return THEMES[kind];
+}


### PR DESCRIPTION
## 📋 Summary
Two related cleanups to playlist/album/artist card presentation, done in one pass since they touch overlapping files.
1. Extract the duplicated presentation between `PlaylistCard` and `AutoPlaylistCard` into shared pieces, so the per-kind gradient/icon/badge colors only live in one place.
2. Remove the "Library" badge shown on album covers/detail headers, and reorder the Album/Artist Detail headers so Genre comes after the Details row.

## 🔍 Implementation Notes
**Card refactor (`f17a2000`)**
- `src/lib/utils/playlistCardTheme.ts` — single source of truth for the gradient/border/shadow, icon color, and badge color per playlist kind (queue, genre, decade, smart, bpm, artist_tag, favourites, recently_added, most_played, history, missing_metadata, missing_musicbrainz, daypart). Colors are unchanged from before — this only consolidates two parallel switch/ternary chains.
- `PlaylistCoverFrame.svelte` — the gradient cover-art frame wrapper.
- `PlaylistCardShell.svelte` — shared card chrome: outer container, cover slot, title button, subtitle, updated/track-count row, and an optional `footer` slot (used only by `PlaylistCard` for the make-active button).
- `PlaylistCard.svelte` / `AutoPlaylistCard.svelte` now only own their data-fetching and kind-discrimination, rendering into the shared shell via `cover`/`footer` snippets.
- Incidental cleanup while touching this code: `AutoPlaylistCard` had a dead `CardBadge` import and unused `badgeColorClass` derived (the badge is a `PlaylistCard`-only feature), and an unreachable slate/`ListMusic` fallback branch (its `kind` union is exhaustively covered by the preceding branches). Both removed.

**Header cleanup (`1d4edf6c`)**
- `AlbumCard.svelte`: removed the hover-only `LibraryBadge` overlay on the album cover art, and the now-unused `albumDirectory` derived/`collectionStore` import it needed.
- `AlbumDetailView.svelte`: removed the library/multi-library indicator from the header meta row entirely, along with the now-dead `albumDirectories` derived, `LibraryBadge`/`Folders` imports, and the orphaned `albumDetail.multiLibraries` locale key (`en.ts`/`fr.ts`).
- `AlbumDetailView.svelte` / `ArtistDetailView.svelte`: reordered the header to Title/Artist → Details → Genre (genre chips previously came before the song count/duration row); tightened the whitespace between the album title and artist name.
- `LibraryBadge.svelte` itself is untouched — it's still used in Settings, the folder edit/WebDAV modals, and the song table.

Base branch is `next` rather than `main` because this branch builds on the playlist/auto-playlist/artist card height-alignment change (#873), which is only merged into `next` so far.

## 🧪 Test Plan
- [x] `bun run check` (svelte-check) — 0 errors, 0 warnings; knip clean
- [x] `bun run test -- --run` (frontend) — 705/705 passing
- [ ] `cargo test` (src-tauri, if Rust changed) — no Rust changed
- [x] Manually verified in the app — not yet done; this is a visual-only change (card colors should be pixel-identical, header changes are new) and should be eyeballed in `bun run tauri dev` before merge

## 📸 Screenshots
Not captured — recommend a quick before/after look at a Playlists grid (queue/custom/smart/genre/decade/bpm/artist-tag cards) and an Album/Artist Detail header in the running app.

## ✅ Checklist
- [x] No unrelated changes bundled in
- [ ] Docs/screenshots updated if user-facing behavior changed — n/a (no docs reference these strings/badges)
