### PR TITLE
Consolidate playbar controls: Menu/Lyrics/Queue/Info/Miniplayer row

### DIFF
--- a/src/lib/components/PlayerBar.svelte
+++ b/src/lib/components/PlayerBar.svelte
@@ -16,6 +16,10 @@
   import WaveformSeekBar from "./WaveformSeekBar.svelte";
   import SpectrumVisualizer from "./SpectrumVisualizer.svelte";
   import LinkButton from "./LinkButton.svelte";
+  import SongContextMenu from "./SongContextMenu.svelte";
+  import TagEditor from "./TagEditor.svelte";
+  import { tagsStore } from "../stores/tags.svelte";
+  import { openInPicard } from "../utils/picard";
   import { isLinux } from "../platform";
 
   // Responsive control trimming (issue #413, refined against real usage,
@@ -49,7 +53,10 @@
     MicrophoneStageIcon as Mic2,
     PlaylistIcon as ListMusic,
     MusicNotesIcon as Music,
-    InfoIcon as Info
+    InfoIcon as Info,
+    ListIcon as Menu,
+    SubtitlesIcon as Lyrics,
+    StackIcon as Layers
   } from "phosphor-svelte";
 
 
@@ -169,35 +176,32 @@
     }
   }
 
-  // True only when the user is already looking at the Queue itself (not
-  // immersive, on the Playlists tab's custom-playlists sub-tab, with the
-  // Queue playlist selected) — distinguishes "viewing the Queue" from
-  // "viewing any other collection/playlist", which the cover-art click
-  // handler below needs in order to pick the right next state (#523).
-  let isViewingQueue = $derived.by(() => {
-    if (windowLayoutStore.immersiveMode) return false;
-    const queuePl = playlistsStore.queuePlaylist;
-    if (!queuePl) return false;
-    return (
-      navigationStore.activeTab === 'playlists' &&
-      navigationStore.playlistsSubTab === 'custom' &&
-      navigationStore.selectedPlaylistId === queuePl.id
-    );
-  });
-
-  // Nudge users toward the Details pane when there's live enrichment content
-  // to fetch for the current track (#23) — matches the two IDs get_song_context
-  // actually reads (musicbrainz_release_group_id / musicbrainz_artist_id).
-  let hasContextEnrichmentSource = $derived(
-    !!(playerStore.currentSong?.musicbrainz_release_group_id || playerStore.currentSong?.musicbrainz_artist_id)
+  let coverTitle = $derived(
+    playerStore.currentSong ? i18n.t('playerBar.immersiveTitle', {}, 'Immersive Mode') : ""
   );
 
-  let coverTitle = $derived.by(() => {
-    if (!playerStore.currentSong) return "";
-    return isViewingQueue
-      ? i18n.t('playerBar.immersiveTitle', {}, 'Immersive Mode')
-      : i18n.t('playerBar.queueTitle', {}, 'Queue');
-  });
+  // Cover art now only toggles Immersive View (#876) — navigating to the
+  // Queue is the dedicated Queue button's job.
+  function handleCoverClick(e: MouseEvent) {
+    if (!playerStore.currentSong) return;
+    e.stopPropagation();
+
+    // While the window is too narrow to show the front face at all
+    // (isImmersiveForced), immersive is already engaged regardless of what
+    // this toggles, so leave it alone until the window widens back out.
+    if (windowLayoutStore.isImmersiveForced) return;
+
+    windowLayoutStore.toggleImmersiveMode();
+  }
+
+  // New playbar button row (#876): Menu/Lyrics/Queue/Info/Miniplayer.
+  let contextMenuState = $state<{ x: number; y: number } | null>(null);
+  let editingSongId = $state<number | null>(null);
+
+  function openCurrentSongMenu(e: MouseEvent) {
+    const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+    contextMenuState = { x: rect.left, y: rect.top };
+  }
 
   async function navigateToQueue() {
     const queuePl = await playlistsStore.requireQueue();
@@ -205,28 +209,9 @@
     navigationStore.viewPlaylist(queuePl.id);
   }
 
-  // Three-state navigation flow (#523): from any collection/playlist view,
-  // clicking goes to the Queue; from the Queue, it flips into Immersive
-  // Mode; from Immersive Mode, it flips back to the Queue.
-  async function handleCoverClick(e: MouseEvent) {
-    if (!playerStore.currentSong) return;
-    e.stopPropagation();
-
-    // While the window is too narrow to show the front face at all
-    // (isImmersiveForced), immersive is engaged regardless of what this
-    // toggles — clicking through to "exit and view Queue" would silently
-    // clear the user's own immersiveMode preference for a screen they can't
-    // actually reach yet, so leave it alone until the window widens back out.
-    if (windowLayoutStore.isImmersiveForced) return;
-
-    if (windowLayoutStore.immersiveMode) {
-      windowLayoutStore.exitImmersiveMode();
-      await navigateToQueue();
-    } else if (isViewingQueue) {
-      windowLayoutStore.toggleImmersiveMode();
-    } else {
-      await navigateToQueue();
-    }
+  function handleTagEditorSaved() {
+    collectionStore.refreshLibrary();
+    tagsStore.load();
   }
 </script>
 
@@ -393,37 +378,34 @@
     </div>
   </div>
 
-  <div class="hidden min-[700px]:flex items-center justify-end gap-1.5 min-[700px]:gap-3 w-1/3 min-w-[50px] min-[700px]:min-w-[200px] max-w-xs">
-    <div class="w-24 h-7 mr-2 hidden md:block">
-      <SpectrumVisualizer />
-    </div>
-    <button onclick={toggleMute} class="text-brand-text-secondary hover:text-brand-text-primary transition-colors" title={i18n.t('playerBar.volume')}>
-      {#if isMuted || playerStore.volume === 0}
-        <VolumeX class="w-4 h-4" />
-      {:else}
-        <Volume2 class="w-4 h-4" />
-      {/if}
-    </button>
-    <input
-      type="range"
-      min="0"
-      max="1"
-      step="0.01"
-      value={playerStore.volume}
-      oninput={handleVolumeChange}
-      onchange={releaseVolumeFocus}
-      onpointerup={releaseVolumeFocus}
-      onkeyup={releaseVolumeFocus}
-      class="volume-slider hidden min-[700px]:block w-20 h-1 rounded-lg outline-none"
-      style={volumeSliderStyle}
-      aria-label={i18n.t('playerBar.volumeSlider')}
-      title={i18n.t('playerBar.volumeWithValue', { value: Math.round(volumePercent) })}
-    />
-    <div class="hidden min-[700px]:flex flex-col items-center justify-center gap-1 flex-shrink-0">
+  <div class="hidden min-[700px]:flex flex-col items-center gap-1.5 w-1/3 min-w-[50px] min-[700px]:min-w-[200px] max-w-xs">
+    <div class="flex items-center gap-3 min-[700px]:gap-5">
+      <button
+        onclick={openCurrentSongMenu}
+        disabled={!playerStore.currentSong}
+        class="text-brand-text-secondary hover:text-brand-text-primary transition-colors disabled:opacity-40 disabled:pointer-events-none"
+        title={i18n.t('playerBar.menuTooltip', {}, 'Song menu')}
+      >
+        <Menu class="w-5 h-5" />
+      </button>
+      <button
+        onclick={() => { navigationStore.activeTab = "lyrics"; }}
+        class="transition-colors {navigationStore.activeTab === 'lyrics' ? 'text-brand-accent-text' : 'text-brand-text-secondary hover:text-brand-text-primary'}"
+        title={i18n.t('sidebar.lyrics')}
+      >
+        <Lyrics class="w-5 h-5" />
+      </button>
+      <button
+        onclick={navigateToQueue}
+        class="text-brand-text-secondary hover:text-brand-text-primary transition-colors"
+        title={i18n.t('playerBar.queueTitle', {}, 'Queue')}
+      >
+        <Layers class="w-5 h-5" />
+      </button>
       {#if !windowLayoutStore.isRightPanelAutoHidden}
         <button
           onclick={() => windowLayoutStore.toggleRightPanel()}
-          class="text-brand-text-secondary hover:text-brand-accent-text transition-colors p-1.5 rounded-full hover:bg-brand-main/60 {windowLayoutStore.rightPanelOpen ? 'text-brand-accent-text' : ''} {!windowLayoutStore.rightPanelOpen && hasContextEnrichmentSource ? 'ring-1 ring-brand-accent' : ''}"
+          class="transition-colors {windowLayoutStore.rightPanelOpen ? 'text-brand-accent-text' : 'text-brand-text-secondary hover:text-brand-text-primary'}"
           title={i18n.t('topNav.toggleRightPanel')}
         >
           <Info class="w-5 h-5" />
@@ -431,14 +413,66 @@
       {/if}
       <button
         onclick={() => windowLayoutStore.toggleMiniplayerMode()}
-        class="text-brand-text-secondary hover:text-brand-accent-text transition-colors p-1.5 rounded hover:bg-brand-main/60"
+        class="text-brand-text-secondary hover:text-brand-text-primary transition-colors"
         title={i18n.t('miniplayer.toggleTooltip', {}, 'Picture-in-Picture Mode (Ctrl+M)')}
       >
-        <PictureInPicture class="w-4.5 h-4.5" />
+        <PictureInPicture class="w-5 h-5" />
       </button>
+    </div>
+
+    <div class="flex items-center gap-2">
+      <div class="w-24 h-7 hidden md:block">
+        <SpectrumVisualizer />
+      </div>
+      <button onclick={toggleMute} class="text-brand-text-secondary hover:text-brand-text-primary transition-colors" title={i18n.t('playerBar.volume')}>
+        {#if isMuted || playerStore.volume === 0}
+          <VolumeX class="w-4 h-4" />
+        {:else}
+          <Volume2 class="w-4 h-4" />
+        {/if}
+      </button>
+      <input
+        type="range"
+        min="0"
+        max="1"
+        step="0.01"
+        value={playerStore.volume}
+        oninput={handleVolumeChange}
+        onchange={releaseVolumeFocus}
+        onpointerup={releaseVolumeFocus}
+        onkeyup={releaseVolumeFocus}
+        class="volume-slider w-20 h-1 rounded-lg outline-none"
+        style={volumeSliderStyle}
+        aria-label={i18n.t('playerBar.volumeSlider')}
+        title={i18n.t('playerBar.volumeWithValue', { value: Math.round(volumePercent) })}
+      />
     </div>
   </div>
 </footer>
+
+{#if contextMenuState && playerStore.currentSong}
+  {@const song = playerStore.currentSong}
+  <SongContextMenu
+    x={contextMenuState.x}
+    y={contextMenuState.y}
+    {song}
+    onPlay={() => playerStore.playSong(song.id)}
+    onAddToPlaylist={() => playlistsStore.addSongsToActiveTarget([song.id], song.title || "Song")}
+    onGoToArtist={song.artist ? () => navigationStore.viewArtist(song.album_artist?.trim() || song.artist || "") : undefined}
+    onGoToAlbum={song.album ? () => navigationStore.viewAlbum(song.album || "") : undefined}
+    onEditTags={() => { editingSongId = song.id; }}
+    onOpenInPicard={() => openInPicard([song.id])}
+    onClose={() => { contextMenuState = null; }}
+  />
+{/if}
+
+{#if editingSongId !== null}
+  <TagEditor
+    songId={editingSongId}
+    onClose={() => { editingSongId = null; }}
+    onSave={handleTagEditorSaved}
+  />
+{/if}
 
 <style>
   /* Accent glow: only the PlayDock gets it, not the other glass panels —

--- a/src/lib/components/PlayerBar.test.ts
+++ b/src/lib/components/PlayerBar.test.ts
@@ -117,37 +117,15 @@ describe("PlayerBar.svelte", () => {
     is_queue: true,
   };
 
-  // #523: the three-state PlayerBar cover-art click flow — collection/
-  // playlist view -> Queue -> Immersive Mode -> back to Queue.
+  // #876: cover art now only toggles Immersive View — navigating to the
+  // Queue is the dedicated Queue button's job (see the "playbar button row"
+  // tests below).
 
-  it("navigates to the Queue when the album cover is clicked from a collection/playlist view", async () => {
+  it("toggles Immersive Mode when the album cover is clicked, regardless of the current view", async () => {
     playerStore.currentSong = mockSong;
     playerStore.state = "playing";
     windowLayoutStore.immersiveMode = false;
     navigationStore.activeTab = "collection";
-
-    vi.spyOn(playlistsStore, "requireQueue").mockResolvedValue(mockQueue);
-    const selectPlaylistSpy = vi.spyOn(playlistsStore, "selectPlaylist").mockImplementation(async () => {});
-    const viewPlaylistSpy = vi.spyOn(navigationStore, "viewPlaylist").mockImplementation(() => {});
-    const toggleImmersiveModeSpy = vi.spyOn(windowLayoutStore, "toggleImmersiveMode");
-
-    const { getByTitle } = render(PlayerBar);
-    const coverButton = getByTitle("Queue");
-    await fireEvent.click(coverButton);
-
-    expect(selectPlaylistSpy).toHaveBeenCalledWith(mockQueue.id);
-    expect(viewPlaylistSpy).toHaveBeenCalledWith(mockQueue.id);
-    expect(toggleImmersiveModeSpy).not.toHaveBeenCalled();
-  });
-
-  it("flips into Immersive Mode when the album cover is clicked while already viewing the Queue", async () => {
-    playerStore.currentSong = mockSong;
-    playerStore.state = "playing";
-    windowLayoutStore.immersiveMode = false;
-    playlistsStore.playlists = [mockQueue];
-    navigationStore.activeTab = "playlists";
-    navigationStore.playlistsSubTab = "custom";
-    navigationStore.selectedPlaylistId = mockQueue.id;
 
     const toggleImmersiveModeSpy = vi.spyOn(windowLayoutStore, "toggleImmersiveMode");
     const viewPlaylistSpy = vi.spyOn(navigationStore, "viewPlaylist").mockImplementation(() => {});
@@ -161,24 +139,19 @@ describe("PlayerBar.svelte", () => {
     expect(viewPlaylistSpy).not.toHaveBeenCalled();
   });
 
-  it("exits Immersive Mode and navigates to the Queue when the album cover is clicked", async () => {
+  it("exits Immersive Mode when the album cover is clicked while immersive", async () => {
     playerStore.currentSong = mockSong;
     playerStore.state = "playing";
     windowLayoutStore.immersiveMode = true;
 
-    vi.spyOn(playlistsStore, "requireQueue").mockResolvedValue(mockQueue);
-    const selectPlaylistSpy = vi.spyOn(playlistsStore, "selectPlaylist").mockImplementation(async () => {});
-    const exitImmersiveModeSpy = vi.spyOn(windowLayoutStore, "exitImmersiveMode");
-    const viewPlaylistSpy = vi.spyOn(navigationStore, "viewPlaylist").mockImplementation(() => {});
+    const toggleImmersiveModeSpy = vi.spyOn(windowLayoutStore, "toggleImmersiveMode");
 
     const { getByTitle } = render(PlayerBar);
-    const coverButton = getByTitle("Queue");
+    const coverButton = getByTitle("Immersive Mode");
     await fireEvent.click(coverButton);
 
-    expect(exitImmersiveModeSpy).toHaveBeenCalled();
+    expect(toggleImmersiveModeSpy).toHaveBeenCalled();
     expect(windowLayoutStore.immersiveMode).toBe(false);
-    expect(selectPlaylistSpy).toHaveBeenCalledWith(mockQueue.id);
-    expect(viewPlaylistSpy).toHaveBeenCalledWith(mockQueue.id);
   });
 
   it("calls playerStore.resume() when play button is clicked in paused/stopped state", async () => {
@@ -281,7 +254,7 @@ describe("PlayerBar.svelte", () => {
 
     const { getByTitle } = render(PlayerBar);
     expect(windowLayoutStore.isImmersiveForced).toBe(true);
-    const coverButton = getByTitle("Queue");
+    const coverButton = getByTitle("Immersive Mode");
     await fireEvent.click(coverButton);
 
     expect(toggleImmersiveModeSpy).not.toHaveBeenCalled();
@@ -312,11 +285,11 @@ describe("PlayerBar.svelte", () => {
     expect(shuffleBtn.closest(".hidden")).toHaveClass("min-[700px]:block");
     expect(repeatBtn.closest(".hidden")).toHaveClass("min-[700px]:block");
     const volumeSlider = container.querySelector('input[type="range"]');
-    expect(volumeSlider).toHaveClass("hidden", "min-[700px]:block");
+    expect(volumeSlider?.closest(".hidden")).toHaveClass("min-[700px]:flex");
     const [transportToggle, rightColumnToggle] = getAllByTitle(/picture-in-picture/i);
     expect(transportToggle).toHaveClass("min-[700px]:hidden");
     expect(rightColumnToggle.closest(".hidden")).toHaveClass("min-[700px]:flex");
-    const rightColumn = Array.from(container.querySelectorAll("div")).find(d => d.className.includes("justify-end"))!;
+    const rightColumn = Array.from(container.querySelectorAll("div")).find(d => d.className.includes("min-w-[50px]"))!;
     expect(rightColumn).toHaveClass("hidden", "min-[700px]:flex");
     const seekRow = Array.from(container.querySelectorAll("div")).find(d => d.className.includes("gap-2.5"))!;
     expect(seekRow).toHaveClass("hidden", "min-[700px]:flex");
@@ -325,7 +298,7 @@ describe("PlayerBar.svelte", () => {
     expect(getByTitle(/previous song/i)).toHaveClass("hidden", "min-[400px]:block");
 
     // Never hidden (the constant core): cover art, play/pause, skip-next.
-    const coverButton = getByTitle("Queue");
+    const coverButton = getByTitle("Immersive Mode");
     expect(coverButton.closest(".hidden")).toBeNull();
     expect(getByTitle(/^pause$/i)).not.toHaveClass("hidden");
     expect(getByTitle(/next song/i)).not.toHaveClass("hidden");
@@ -355,6 +328,47 @@ describe("PlayerBar.svelte", () => {
     const infoBtn = getByTitle("Show Info Panel (Ctrl+I)");
     await fireEvent.click(infoBtn);
     expect(windowLayoutStore.rightPanelOpen).toBe(true);
+  });
+
+  // #876: the playbar's Menu/Lyrics/Queue button row.
+
+  it("switches to the Lyrics tab when the Lyrics button is clicked", async () => {
+    playerStore.currentSong = mockSong;
+    navigationStore.activeTab = "collection";
+    const { getByTitle } = render(PlayerBar);
+
+    await fireEvent.click(getByTitle("Lyrics"));
+
+    expect(navigationStore.activeTab).toBe("lyrics");
+  });
+
+  it("navigates to the Queue when the Queue button is clicked", async () => {
+    playerStore.currentSong = mockSong;
+    vi.spyOn(playlistsStore, "requireQueue").mockResolvedValue(mockQueue);
+    const selectPlaylistSpy = vi.spyOn(playlistsStore, "selectPlaylist").mockImplementation(async () => {});
+    const viewPlaylistSpy = vi.spyOn(navigationStore, "viewPlaylist").mockImplementation(() => {});
+
+    const { getByTitle } = render(PlayerBar);
+    await fireEvent.click(getByTitle("Queue"));
+
+    expect(selectPlaylistSpy).toHaveBeenCalledWith(mockQueue.id);
+    expect(viewPlaylistSpy).toHaveBeenCalledWith(mockQueue.id);
+  });
+
+  it("opens the current song's context menu from the Menu button", async () => {
+    playerStore.currentSong = mockSong;
+    const { getByTitle, getByText } = render(PlayerBar);
+
+    await fireEvent.click(getByTitle("Song menu"));
+
+    expect(getByText(/add to queue/i)).toBeInTheDocument();
+  });
+
+  it("disables the Menu button when nothing is playing", () => {
+    playerStore.currentSong = undefined;
+    const { getByTitle } = render(PlayerBar);
+
+    expect(getByTitle("Song menu")).toBeDisabled();
   });
 
   it("hides the info-panel toggle at the same breakpoint that auto-hides the panel itself", () => {

--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -12,7 +12,6 @@
     PlaylistIcon as ListMusic,
     SparkleIcon as Sparkles,
     GearIcon as Settings,
-    FileTextIcon as FileText,
     ChartBarIcon as BarChart2,
     HouseIcon as Home,
     MicrophoneStageIcon as Mic2,
@@ -233,17 +232,6 @@
         </div>
       {/if}
     </div>
-
-    <button
-      onclick={() => { navigationStore.activeTab = "lyrics"; }}
-      class="flex items-center gap-3 transition-all duration-150 {navigationStore.activeTab === 'lyrics' ? 'bg-brand-accent text-brand-accent-contrast shadow-lg shadow-brand-accent/20' : 'text-brand-text-secondary hover:bg-brand-accent/10 hover:text-brand-accent-text-hover'} {isCollapsed ? 'justify-center w-10 h-10 rounded-xl p-0' : 'w-full px-3 py-1.5 rounded-lg text-sm font-medium'}"
-      title={i18n.t('sidebar.lyrics')}
-    >
-      <FileText class={isCollapsed ? "w-5 h-5" : "w-4 h-4"} />
-      {#if !isCollapsed}
-        <span class="truncate whitespace-nowrap">{i18n.t('sidebar.lyrics')}</span>
-      {/if}
-    </button>
 
     <button
       onclick={() => { navigationStore.activeTab = "stats"; }}


### PR DESCRIPTION
## 📋 Summary
Addresses #876 — consolidates the playbar's controls into one horizontal button row (Menu, Lyrics, Queue, Info, Miniplayer) above the volume slider, sized to match the transport buttons, and simplifies cover art click to only toggle Immersive View.

## 🔍 Implementation Notes
- Cover art click (`PlayerBar.svelte`'s `handleCoverClick`) no longer implements the old 3-state Queue/Immersive cycle — it now only calls `windowLayoutStore.toggleImmersiveMode()` (still guarded by `isImmersiveForced`).
- New Menu button (hamburger icon) opens the current song's context menu by reusing `SongContextMenu.svelte` as-is — no duplicated menu logic, so future context-menu items automatically show up here too.
- New Queue button performs the navigation the old cover-art click used to do (`requireQueue` → `selectPlaylist` → `viewPlaylist`).
- Lyrics moved off the Sidebar nav onto the playbar, using a Subtitles (captions) icon rather than the Sidebar's FileText icon, since Luminous's lyrics feature is timed/synced (LRCLIB), not just static text.
- Sidebar's existing Queue row is untouched — Queue stays reachable from both places.
- Miniplayer/narrow layout is unaffected — this new row only applies to the full playbar.

## 🧪 Test Plan
- [x] `bun run check` (svelte-check + knip) — clean, 0 errors/warnings
- [x] `bun run test -- --run` (frontend) — 708/708 passing, including updated/new `PlayerBar.test.ts` coverage for the new cover-art behavior and the Menu/Lyrics/Queue buttons
- [ ] `cargo test` (src-tauri, if Rust changed) — no Rust changes in this PR
- [x] Manually verified in the app by the user

## ✅ Checklist
- [x] No unrelated changes bundled in
- [ ] Docs/screenshots updated if user-facing behavior changed — not yet done, follow-up if needed
