### PR TITLE
feat: album social share cards (#97)

### DIFF
--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -11,6 +11,7 @@ pub mod player;
 pub mod playlist;
 pub mod scrobbler;
 pub mod settings;
+pub mod share;
 pub mod stats;
 pub mod tageditor;
 pub mod tags;

--- a/src-tauri/src/commands/share.rs
+++ b/src-tauri/src/commands/share.rs
@@ -1,0 +1,14 @@
+//! Backend half of the social share card export (#97). The card image itself
+//! is rasterized entirely in the frontend (SVG -> canvas -> PNG blob); this
+//! command just writes the resulting bytes to a path the user already chose
+//! via the save dialog, since there's no `@tauri-apps/plugin-fs` dependency
+//! for the frontend to write files directly (see `playlist::import_export`
+//! for the same pattern used by playlist export).
+
+use base64::{engine::general_purpose::STANDARD, Engine as _};
+
+#[tauri::command]
+pub async fn save_share_card_image(path: String, data_base64: String) -> Result<(), String> {
+    let bytes = STANDARD.decode(&data_base64).map_err(|e| e.to_string())?;
+    std::fs::write(&path, bytes).map_err(|e| e.to_string())
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -982,6 +982,8 @@ pub fn run() {
             commands::pins::unpin_item,
             commands::pins::get_pinned_items,
             commands::pins::reorder_pinned_items,
+            // Social share card export (#97)
+            commands::share::save_share_card_image,
             // Playlist commands
             commands::playlist::validate_playlist_name,
             commands::playlist::create_playlist,

--- a/src/lib/components/AlbumContextMenu.svelte
+++ b/src/lib/components/AlbumContextMenu.svelte
@@ -9,7 +9,8 @@
     PushPinSlashIcon as PinOff,
     PencilSimpleIcon as Edit3,
     ArrowSquareOutIcon as OpenInPicard,
-    ChartBarIcon as BarChart2
+    ChartBarIcon as BarChart2,
+    ShareNetworkIcon as Share
   } from "phosphor-svelte";
   import { i18n } from "../stores/i18n.svelte";
   import { playlistsStore } from "../stores/playlists.svelte";
@@ -24,6 +25,7 @@
   import ContextMenu from "./ContextMenu.svelte";
   import ContextMenuItem from "./ContextMenuItem.svelte";
   import ContextMenuDivider from "./ContextMenuDivider.svelte";
+  import ShareModal from "./ShareModal.svelte";
 
   let {
     x,
@@ -50,6 +52,8 @@
     onOpenInPicard?: () => void;
     onClose: () => void;
   } = $props();
+
+  let showShareModal = $state(false);
 
   async function handleDefaultAddToQueue() {
     try {
@@ -158,6 +162,11 @@
       disabled={!picardStore.available}
       title={picardStore.available ? undefined : i18n.t("picard.notFoundTooltip")}
     />
+    <ContextMenuItem
+      icon={Share}
+      label={i18n.t("shareModal.menuItem")}
+      onclick={() => { showShareModal = true; }}
+    />
     <ContextMenuDivider />
     <ContextMenuItem
       icon={pinnedStore.isPinned("album", albumName) ? PinOff : Pin}
@@ -175,3 +184,7 @@
     />
   {/if}
 </ContextMenu>
+
+{#if showShareModal}
+  <ShareModal {albumName} onClose={() => { showShareModal = false; }} />
+{/if}

--- a/src/lib/components/AlbumDetailView.svelte
+++ b/src/lib/components/AlbumDetailView.svelte
@@ -34,8 +34,10 @@
     PushPinIcon as Pin,
     PushPinSlashIcon as PinOff,
     DotsThreeIcon as MoreHorizontal,
-    ArrowSquareOutIcon as OpenInPicard
+    ArrowSquareOutIcon as OpenInPicard,
+    ShareNetworkIcon as Share
   } from "phosphor-svelte";
+  import ShareModal from "./ShareModal.svelte";
   import type { Song, AlbumItem, PlayContext } from "../types";
   import { getCoverArtUrl, resolveArtUrl } from "../types";
   import { i18n } from "../stores/i18n.svelte";
@@ -53,6 +55,7 @@
   let editingSongId = $state<number | null>(null);
   let showAlbumTagEditor = $state(false);
   let contextMenuState = $state<{ x: number; y: number; song: Song } | null>(null);
+  let showShareModal = $state(false);
 
   async function handleRefreshAlbum() {
     if (refreshing || collectionStore.isScanning) return;
@@ -500,6 +503,12 @@
               {/if}
             {/snippet}
           </IconActionButton>
+          <IconActionButton
+            onclick={() => { showShareModal = true; }}
+            title={i18n.t("shareModal.menuItem")}
+          >
+            {#snippet icon()}<Share class="w-4 h-4" />{/snippet}
+          </IconActionButton>
           <ColumnSelector align="left" iconOnly />
           <button
             onclick={toggleOverflowMenu}
@@ -647,5 +656,9 @@
     onAddToPlaylist={handleBulkAddToPlaylist}
     onClear={() => { selectedKeys = new Set(); }}
   />
+{/if}
+
+{#if showShareModal}
+  <ShareModal {albumName} onClose={() => { showShareModal = false; }} />
 {/if}
 

--- a/src/lib/components/ShareModal.svelte
+++ b/src/lib/components/ShareModal.svelte
@@ -9,6 +9,7 @@
     MoonIcon as Moon,
   } from "phosphor-svelte";
   import Modal from "./Modal.svelte";
+  import Button from "./Button.svelte";
   import { i18n } from "../stores/i18n.svelte";
   import { toastStore } from "../stores/toast.svelte";
   import { collectionStore } from "../stores/collection.svelte";
@@ -273,7 +274,7 @@
           <button
             onclick={() => (aspectRatio = ratio.id)}
             class="px-3 py-1.5 rounded-full text-xs font-semibold border transition-colors cursor-pointer {aspectRatio === ratio.id
-              ? 'bg-brand-accent text-brand-accent-text border-brand-accent'
+              ? 'bg-brand-accent text-brand-accent-contrast border-brand-accent'
               : 'border-brand-border text-brand-text-secondary hover:bg-brand-main'}"
           >
             {ratio.id}
@@ -288,7 +289,7 @@
             onclick={() => (theme = "dark")}
             title={i18n.t("shareModal.themeDark")}
             class="flex items-center justify-center w-8 h-8 rounded-full border transition-colors cursor-pointer {theme === 'dark'
-              ? 'bg-brand-accent text-brand-accent-text border-brand-accent'
+              ? 'bg-brand-accent text-brand-accent-contrast border-brand-accent'
               : 'border-brand-border text-brand-text-secondary hover:bg-brand-main'}"
           >
             <Moon class="w-4 h-4" />
@@ -297,7 +298,7 @@
             onclick={() => (theme = "light")}
             title={i18n.t("shareModal.themeLight")}
             class="flex items-center justify-center w-8 h-8 rounded-full border transition-colors cursor-pointer {theme === 'light'
-              ? 'bg-brand-accent text-brand-accent-text border-brand-accent'
+              ? 'bg-brand-accent text-brand-accent-contrast border-brand-accent'
               : 'border-brand-border text-brand-text-secondary hover:bg-brand-main'}"
           >
             <Sun class="w-4 h-4" />
@@ -312,22 +313,14 @@
     </div>
 
     <div class="flex items-center justify-end gap-2 pt-2 border-t border-brand-border">
-      <button
-        onclick={handleCopy}
-        disabled={exporting || rendering}
-        class="flex items-center gap-2 px-4 py-2 rounded-full text-sm font-semibold border border-brand-border text-brand-text-primary hover:bg-brand-main transition-colors disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
-      >
+      <Button variant="secondary" onclick={handleCopy} disabled={exporting || rendering}>
         <Copy class="w-4 h-4" />
         {i18n.t("shareModal.copyButton")}
-      </button>
-      <button
-        onclick={handleSave}
-        disabled={exporting || rendering}
-        class="flex items-center gap-2 px-4 py-2 rounded-full text-sm font-semibold bg-brand-accent text-brand-accent-text hover:bg-brand-accent-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
-      >
+      </Button>
+      <Button variant="primary" onclick={handleSave} disabled={exporting || rendering}>
         <Download class="w-4 h-4" />
         {i18n.t("shareModal.saveButton")}
-      </button>
+      </Button>
     </div>
   </div>
 </Modal>

--- a/src/lib/components/ShareModal.svelte
+++ b/src/lib/components/ShareModal.svelte
@@ -1,0 +1,333 @@
+<script lang="ts">
+  import { invoke } from "@tauri-apps/api/core";
+  import { save } from "@tauri-apps/plugin-dialog";
+  import {
+    XIcon as X,
+    CopySimpleIcon as Copy,
+    DownloadSimpleIcon as Download,
+    SunIcon as Sun,
+    MoonIcon as Moon,
+  } from "phosphor-svelte";
+  import Modal from "./Modal.svelte";
+  import { i18n } from "../stores/i18n.svelte";
+  import { toastStore } from "../stores/toast.svelte";
+  import { collectionStore } from "../stores/collection.svelte";
+  import { extractColorsFromImage } from "../stores/theme.svelte";
+  import { getCoverArtUrl, resolveArtUrl, type Song } from "../types";
+  import {
+    SHARE_ASPECT_RATIOS,
+    rasterizeShareCard,
+    toDataUri,
+    blobToBase64,
+    type ShareAspectRatio,
+    type ShareCardTheme,
+    type ShareCardTrack,
+  } from "../utils/shareCard";
+
+  let { albumName, onClose }: { albumName: string; onClose: () => void } = $props();
+
+  let aspectRatio = $state<ShareAspectRatio>("1:1");
+  let theme = $state<ShareCardTheme>("dark");
+  let includeTrackList = $state(true);
+  let previewUrl = $state<string | null>(null);
+  let rendering = $state(false);
+  let exporting = $state(false);
+  let lastBlob: Blob | null = null;
+
+  let albumItem = $derived(collectionStore.albums.find((a) => a.album === albumName) || null);
+  let songs = $state<Song[]>([]);
+
+  $effect(() => {
+    let cancelled = false;
+    invoke<Song[]>("get_songs_by_album", { album: albumName })
+      .then((fetched) => {
+        if (!cancelled) songs = fetched;
+      })
+      .catch((err) => console.error("Failed to load songs for share card:", err));
+    return () => {
+      cancelled = true;
+    };
+  });
+
+  let artistName = $derived.by(() => {
+    if (albumItem?.artist) return albumItem.artist;
+    if (songs.length > 0) return songs[0].album_artist || songs[0].artist || "";
+    return "";
+  });
+
+  let sortedTracks = $derived.by(() => {
+    return [...songs].sort((a, b) => {
+      if ((a.disc ?? 1) !== (b.disc ?? 1)) return (a.disc ?? 1) - (b.disc ?? 1);
+      return (a.track ?? 0) - (b.track ?? 0);
+    });
+  });
+
+  let trackCards = $derived<ShareCardTrack[]>(
+    sortedTracks.map((s) => ({ number: s.track ?? null, title: s.title || "" }))
+  );
+
+  let totalDurationLabel = $derived.by(() => {
+    const totalNs = songs.reduce((sum, s) => sum + (s.length_nanosec ?? 0), 0);
+    const totalMinutes = Math.round(totalNs / 1_000_000_000 / 60);
+    const h = Math.floor(totalMinutes / 60);
+    const m = totalMinutes % 60;
+    return h > 0 ? `${h}h ${m}m` : `${m}m`;
+  });
+
+  let metadataLine = $derived.by(() => {
+    const parts: string[] = [];
+    if (albumItem?.year) parts.push(String(albumItem.year));
+    parts.push(
+      songs.length === 1
+        ? i18n.t("playlists.oneSong")
+        : i18n.t("playlists.songsCount", { count: songs.length })
+    );
+    if (totalDurationLabel) parts.push(totalDurationLabel);
+    return parts.join(" • ");
+  });
+
+  let coverUrl = $state<string | null>(null);
+
+  $effect(() => {
+    const item = albumItem;
+    const fallbackSongId = item?.sample_song_id ?? songs[0]?.id;
+    let cancelled = false;
+
+    async function resolve() {
+      let url: string | null = null;
+      if (item?.art_manual) {
+        url = resolveArtUrl(item.art_manual);
+      } else if (item?.art_automatic) {
+        url = resolveArtUrl(item.art_automatic);
+      } else if (item?.art_embedded && fallbackSongId !== undefined) {
+        try {
+          const uri = await invoke<string | null>("get_cover_art_uri", { songId: fallbackSongId });
+          if (uri) url = getCoverArtUrl(uri);
+        } catch (e) {
+          console.error("Failed to load album cover for share card:", e);
+        }
+      }
+      if (!cancelled) coverUrl = url;
+    }
+
+    resolve();
+    return () => {
+      cancelled = true;
+    };
+  });
+
+  let coverDataUri = $state<string | null>(null);
+  let backgroundColors = $state<string[] | undefined>(undefined);
+
+  $effect(() => {
+    const url = coverUrl;
+    let cancelled = false;
+    if (!url) {
+      coverDataUri = null;
+      backgroundColors = undefined;
+      return;
+    }
+    Promise.all([toDataUri(url), extractColorsFromImage(url)]).then(([dataUri, colors]) => {
+      if (cancelled) return;
+      coverDataUri = dataUri;
+      backgroundColors = [colors.vibrant, colors.darkVibrant, colors.lightVibrant, colors.muted].filter(
+        (c): c is string => !!c
+      );
+    });
+    return () => {
+      cancelled = true;
+    };
+  });
+
+  $effect(() => {
+    // Track every option the rendered card depends on so this re-runs when any changes.
+    void aspectRatio;
+    void theme;
+    void includeTrackList;
+    void coverDataUri;
+    void backgroundColors;
+    void trackCards;
+    void metadataLine;
+
+    let cancelled = false;
+    rendering = true;
+    rasterizeShareCard(
+      {
+        aspectRatio,
+        theme,
+        seed: albumName,
+        backgroundColors,
+        coverDataUri,
+        title: albumName || i18n.t("collection.unknownAlbum"),
+        subtitle: artistName || i18n.t("collection.unknownArtist"),
+        metadataLine,
+        tracks: trackCards,
+        includeTrackList,
+      },
+      1.5
+    )
+      .then((blob) => {
+        if (cancelled || !blob) return;
+        lastBlob = blob;
+        if (previewUrl) URL.revokeObjectURL(previewUrl);
+        previewUrl = URL.createObjectURL(blob);
+      })
+      .finally(() => {
+        if (!cancelled) rendering = false;
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  });
+
+  async function getExportBlob(): Promise<Blob | null> {
+    if (lastBlob) return lastBlob;
+    return rasterizeShareCard(
+      {
+        aspectRatio,
+        theme,
+        seed: albumName,
+        backgroundColors,
+        coverDataUri,
+        title: albumName || i18n.t("collection.unknownAlbum"),
+        subtitle: artistName || i18n.t("collection.unknownArtist"),
+        metadataLine,
+        tracks: trackCards,
+        includeTrackList,
+      },
+      3
+    );
+  }
+
+  async function handleCopy() {
+    exporting = true;
+    try {
+      const blob = await getExportBlob();
+      if (!blob) throw new Error("render failed");
+      await navigator.clipboard.write([new ClipboardItem({ "image/png": blob })]);
+      toastStore.show(i18n.t("shareModal.copySuccess"));
+    } catch (err) {
+      console.error("Failed to copy share card:", err);
+      toastStore.show(i18n.t("shareModal.copyError"));
+    } finally {
+      exporting = false;
+    }
+  }
+
+  async function handleSave() {
+    exporting = true;
+    try {
+      const blob = await getExportBlob();
+      if (!blob) throw new Error("render failed");
+      const savePath = await save({
+        title: i18n.t("shareModal.saveDialogTitle"),
+        defaultPath: `${albumName || "album"}-share.png`,
+        filters: [{ name: "PNG Image (*.png)", extensions: ["png"] }],
+      });
+      if (savePath && typeof savePath === "string") {
+        const base64 = await blobToBase64(blob);
+        await invoke("save_share_card_image", { path: savePath, dataBase64: base64 });
+        toastStore.show(i18n.t("shareModal.saveSuccess"));
+      }
+    } catch (err) {
+      console.error("Failed to save share card:", err);
+      toastStore.show(i18n.t("shareModal.saveError"));
+    } finally {
+      exporting = false;
+    }
+  }
+</script>
+
+<Modal {onClose} maxWidth="max-w-2xl" ariaLabelledby="share-modal-title">
+  <div class="flex items-center justify-between px-5 py-4 border-b border-brand-border">
+    <h2 id="share-modal-title" class="text-lg font-heading font-bold text-brand-text-primary">
+      {i18n.t("shareModal.title")}
+    </h2>
+    <button
+      onclick={onClose}
+      title={i18n.t("shareModal.closeTooltip")}
+      class="flex items-center justify-center w-8 h-8 rounded-full text-brand-text-secondary hover:text-brand-accent-text hover:bg-brand-main transition-colors cursor-pointer"
+    >
+      <X class="w-4 h-4" />
+    </button>
+  </div>
+
+  <div class="p-5 flex flex-col gap-4">
+    <div class="flex items-center justify-center bg-brand-main rounded-lg border border-brand-border p-4 min-h-[280px]">
+      {#if previewUrl}
+        <img
+          src={previewUrl}
+          alt={i18n.t("shareModal.previewAlt")}
+          class="max-w-full max-h-[50vh] rounded-lg shadow-2xl {rendering ? 'opacity-70' : ''} transition-opacity"
+        />
+      {:else}
+        <div class="text-sm text-brand-text-secondary">{i18n.t("shareModal.rendering")}</div>
+      {/if}
+    </div>
+
+    <div class="flex flex-col gap-3">
+      <div class="flex flex-wrap items-center gap-2">
+        <span class="text-xs font-semibold text-brand-text-secondary mr-1">{i18n.t("shareModal.aspectRatioLabel")}</span>
+        {#each SHARE_ASPECT_RATIOS as ratio (ratio.id)}
+          <button
+            onclick={() => (aspectRatio = ratio.id)}
+            class="px-3 py-1.5 rounded-full text-xs font-semibold border transition-colors cursor-pointer {aspectRatio === ratio.id
+              ? 'bg-brand-accent text-brand-accent-text border-brand-accent'
+              : 'border-brand-border text-brand-text-secondary hover:bg-brand-main'}"
+          >
+            {ratio.id}
+          </button>
+        {/each}
+      </div>
+
+      <div class="flex flex-wrap items-center justify-between gap-3">
+        <div class="flex items-center gap-2">
+          <span class="text-xs font-semibold text-brand-text-secondary mr-1">{i18n.t("shareModal.themeLabel")}</span>
+          <button
+            onclick={() => (theme = "dark")}
+            title={i18n.t("shareModal.themeDark")}
+            class="flex items-center justify-center w-8 h-8 rounded-full border transition-colors cursor-pointer {theme === 'dark'
+              ? 'bg-brand-accent text-brand-accent-text border-brand-accent'
+              : 'border-brand-border text-brand-text-secondary hover:bg-brand-main'}"
+          >
+            <Moon class="w-4 h-4" />
+          </button>
+          <button
+            onclick={() => (theme = "light")}
+            title={i18n.t("shareModal.themeLight")}
+            class="flex items-center justify-center w-8 h-8 rounded-full border transition-colors cursor-pointer {theme === 'light'
+              ? 'bg-brand-accent text-brand-accent-text border-brand-accent'
+              : 'border-brand-border text-brand-text-secondary hover:bg-brand-main'}"
+          >
+            <Sun class="w-4 h-4" />
+          </button>
+        </div>
+
+        <label class="flex items-center gap-2 text-xs font-semibold text-brand-text-secondary cursor-pointer select-none">
+          <input type="checkbox" bind:checked={includeTrackList} class="accent-brand-accent" />
+          {i18n.t("shareModal.trackListToggle")}
+        </label>
+      </div>
+    </div>
+
+    <div class="flex items-center justify-end gap-2 pt-2 border-t border-brand-border">
+      <button
+        onclick={handleCopy}
+        disabled={exporting || rendering}
+        class="flex items-center gap-2 px-4 py-2 rounded-full text-sm font-semibold border border-brand-border text-brand-text-primary hover:bg-brand-main transition-colors disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
+      >
+        <Copy class="w-4 h-4" />
+        {i18n.t("shareModal.copyButton")}
+      </button>
+      <button
+        onclick={handleSave}
+        disabled={exporting || rendering}
+        class="flex items-center gap-2 px-4 py-2 rounded-full text-sm font-semibold bg-brand-accent text-brand-accent-text hover:bg-brand-accent-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
+      >
+        <Download class="w-4 h-4" />
+        {i18n.t("shareModal.saveButton")}
+      </button>
+    </div>
+  </div>
+</Modal>

--- a/src/lib/components/ShareModal.svelte
+++ b/src/lib/components/ShareModal.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { onMount } from "svelte";
   import { invoke } from "@tauri-apps/api/core";
   import { save } from "@tauri-apps/plugin-dialog";
   import {
@@ -27,13 +28,57 @@
 
   let { albumName, onClose }: { albumName: string; onClose: () => void } = $props();
 
+  // Remembered across cards/sessions as app settings — a user who picks
+  // 9:16 + track list once almost always wants the same setup next time.
+  const SETTING_ASPECT_RATIO = "share_card_aspect_ratio";
+  const SETTING_THEME = "share_card_theme";
+  const SETTING_INCLUDE_TRACK_LIST = "share_card_include_track_list";
+
   let aspectRatio = $state<ShareAspectRatio>("1:1");
   let theme = $state<ShareCardTheme>("dark");
   let includeTrackList = $state(true);
+  let settingsLoaded = $state(false);
   let previewUrl = $state<string | null>(null);
   let rendering = $state(false);
   let exporting = $state(false);
   let lastBlob: Blob | null = null;
+
+  onMount(async () => {
+    try {
+      const settings = await invoke<Record<string, string>>("get_all_app_settings");
+      const savedRatio = settings[SETTING_ASPECT_RATIO];
+      if (savedRatio && SHARE_ASPECT_RATIOS.some((r) => r.id === savedRatio)) {
+        aspectRatio = savedRatio as ShareAspectRatio;
+      }
+      const savedTheme = settings[SETTING_THEME];
+      if (savedTheme === "light" || savedTheme === "dark") {
+        theme = savedTheme;
+      }
+      const savedTrackList = settings[SETTING_INCLUDE_TRACK_LIST];
+      if (savedTrackList === "true" || savedTrackList === "false") {
+        includeTrackList = savedTrackList === "true";
+      }
+    } catch (err) {
+      console.error("Failed to load share card settings:", err);
+    } finally {
+      settingsLoaded = true;
+    }
+  });
+
+  $effect(() => {
+    if (!settingsLoaded) return;
+    void invoke("set_app_setting", { key: SETTING_ASPECT_RATIO, value: aspectRatio });
+  });
+
+  $effect(() => {
+    if (!settingsLoaded) return;
+    void invoke("set_app_setting", { key: SETTING_THEME, value: theme });
+  });
+
+  $effect(() => {
+    if (!settingsLoaded) return;
+    void invoke("set_app_setting", { key: SETTING_INCLUDE_TRACK_LIST, value: String(includeTrackList) });
+  });
 
   let albumItem = $derived(collectionStore.albums.find((a) => a.album === albumName) || null);
   let songs = $state<Song[]>([]);

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -990,6 +990,25 @@ export const en = {
   immersive: {
     emptyStateText: "Select a song from your collection to start playing."
   },
+  shareModal: {
+    menuItem: "Share Card...",
+    title: "Share Card",
+    closeTooltip: "Close",
+    previewAlt: "Share card preview",
+    rendering: "Rendering preview...",
+    aspectRatioLabel: "Aspect ratio",
+    themeLabel: "Theme",
+    themeLight: "Light",
+    themeDark: "Dark",
+    trackListToggle: "Show track list",
+    copyButton: "Copy Image",
+    saveButton: "Save Image",
+    copySuccess: "Share card copied to clipboard",
+    copyError: "Failed to copy share card",
+    saveDialogTitle: "Save Share Card",
+    saveSuccess: "Share card saved",
+    saveError: "Failed to save share card"
+  },
   rating: {
     label: "Rating",
     setTooltip: "Rate {value} of 5",

--- a/src/lib/locales/fr.ts
+++ b/src/lib/locales/fr.ts
@@ -1022,6 +1022,25 @@ export const fr = {
   immersive: {
     emptyStateText: "Sélectionnez une chanson de votre collection pour commencer la lecture."
   },
+  shareModal: {
+    menuItem: "Partager la carte...",
+    title: "Partager la carte",
+    closeTooltip: "Fermer",
+    previewAlt: "Aperçu de la carte de partage",
+    rendering: "Génération de l'aperçu...",
+    aspectRatioLabel: "Format",
+    themeLabel: "Thème",
+    themeLight: "Clair",
+    themeDark: "Sombre",
+    trackListToggle: "Afficher la liste des pistes",
+    copyButton: "Copier l'image",
+    saveButton: "Enregistrer l'image",
+    copySuccess: "Carte de partage copiée dans le presse-papiers",
+    copyError: "Échec de la copie de la carte de partage",
+    saveDialogTitle: "Enregistrer la carte de partage",
+    saveSuccess: "Carte de partage enregistrée",
+    saveError: "Échec de l'enregistrement de la carte de partage"
+  },
   rating: {
     label: "Note",
     setTooltip: "Noter {value} sur 5",

--- a/src/lib/utils/shareCard.test.ts
+++ b/src/lib/utils/shareCard.test.ts
@@ -49,6 +49,20 @@ describe("buildShareCardSvg", () => {
     expect(svg).toMatch(/\+\d+ more/);
   });
 
+  it("fans a long track list out into multiple CSS columns, more on wider frames", () => {
+    const tracks = Array.from({ length: 20 }, (_, i) => ({ number: i + 1, title: `Track ${i + 1}` }));
+    const landscape = buildShareCardSvg({ ...baseOptions, aspectRatio: "16:9", tracks });
+    const portrait = buildShareCardSvg({ ...baseOptions, aspectRatio: "9:16", tracks });
+    expect(landscape.svg).toContain("column-count:3");
+    expect(portrait.svg).toContain("column-count:2");
+  });
+
+  it("keeps a short track list to a single column", () => {
+    const tracks = [{ number: 1, title: "Only Track" }];
+    const { svg } = buildShareCardSvg({ ...baseOptions, aspectRatio: "16:9", tracks });
+    expect(svg).toContain("column-count:1");
+  });
+
   it("is deterministic for a given seed", () => {
     const a = buildShareCardSvg({ ...baseOptions, aspectRatio: "1:1" });
     const b = buildShareCardSvg({ ...baseOptions, aspectRatio: "1:1" });

--- a/src/lib/utils/shareCard.test.ts
+++ b/src/lib/utils/shareCard.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import { buildShareCardSvg, SHARE_ASPECT_RATIOS } from "./shareCard";
+
+const baseOptions = {
+  theme: "dark" as const,
+  seed: "album-1",
+  coverDataUri: null,
+  title: "Test Album",
+  subtitle: "Test Artist",
+  metadataLine: "2024 • 10 songs • 42m",
+  includeTrackList: true,
+};
+
+describe("buildShareCardSvg", () => {
+  it("renders each aspect ratio at its declared pixel dimensions", () => {
+    for (const ratio of SHARE_ASPECT_RATIOS) {
+      const { svg, width, height } = buildShareCardSvg({ ...baseOptions, aspectRatio: ratio.id });
+      expect(width).toBe(ratio.width);
+      expect(height).toBe(ratio.height);
+      expect(svg).toContain(`width="${ratio.width}"`);
+      expect(svg).toContain(`height="${ratio.height}"`);
+    }
+  });
+
+  it("escapes title/subtitle text to avoid breaking the embedded HTML", () => {
+    const { svg } = buildShareCardSvg({
+      ...baseOptions,
+      aspectRatio: "1:1",
+      title: '<script>alert("x")</script>',
+    });
+    expect(svg).not.toContain("<script>alert");
+    expect(svg).toContain("&lt;script&gt;");
+  });
+
+  it("omits the track list block when includeTrackList is false", () => {
+    const { svg } = buildShareCardSvg({
+      ...baseOptions,
+      aspectRatio: "1:1",
+      includeTrackList: false,
+      tracks: [{ number: 1, title: "Opening Track" }],
+    });
+    expect(svg).not.toContain("Opening Track");
+  });
+
+  it("caps visible tracks and shows a +N more overflow row", () => {
+    const tracks = Array.from({ length: 20 }, (_, i) => ({ number: i + 1, title: `Track ${i + 1}` }));
+    const { svg } = buildShareCardSvg({ ...baseOptions, aspectRatio: "16:9", tracks });
+    expect(svg).toContain("Track 1<");
+    expect(svg).toMatch(/\+\d+ more/);
+  });
+
+  it("is deterministic for a given seed", () => {
+    const a = buildShareCardSvg({ ...baseOptions, aspectRatio: "1:1" });
+    const b = buildShareCardSvg({ ...baseOptions, aspectRatio: "1:1" });
+    expect(a.svg).toBe(b.svg);
+  });
+});

--- a/src/lib/utils/shareCard.ts
+++ b/src/lib/utils/shareCard.ts
@@ -76,7 +76,13 @@ export function buildShareCardSvg(options: ShareCardOptions): { svg: string; wid
   // landscape frames keep a side-by-side row so the wide aspect isn't mostly
   // empty gradient either side of a narrow text column.
   const isPortrait = height >= width;
-  const coverSize = Math.round(isPortrait ? width * 0.56 : Math.min(width, height) * 0.46);
+  // A very elongated portrait frame (9:16) has a lot more vertical room than
+  // a mild one (3:4) at the same width, so content sized purely off width
+  // reads small and leaves dead space top and bottom. Scale content up
+  // relative to how much taller the frame is than a baseline 3:4 (1.33:1).
+  const elongation = height / width;
+  const contentScale = isPortrait ? Math.min(1.5, Math.max(1, elongation / 1.33)) : 1;
+  const coverSize = Math.round(isPortrait ? width * 0.56 * contentScale : Math.min(width, height) * 0.46);
 
   const background = generateEllipseGradientSvg({
     width,
@@ -92,7 +98,7 @@ export function buildShareCardSvg(options: ShareCardOptions): { svg: string; wid
     const { columns, maxVisible } = trackListLayout(dims, options.tracks.length);
     const visible = options.tracks.slice(0, maxVisible);
     const overflow = options.tracks.length - visible.length;
-    const rowFontSize = Math.round(width * 0.017);
+    const rowFontSize = Math.round(width * 0.017 * contentScale);
 
     const rows = visible.map(
       (track) =>
@@ -109,7 +115,7 @@ export function buildShareCardSvg(options: ShareCardOptions): { svg: string; wid
         : "";
 
     trackListHtml =
-      `<div style="margin-top:${Math.round(width * 0.025)}px;text-align:left;width:100%;column-count:${columns};column-gap:${Math.round(width * 0.03)}px;">` +
+      `<div style="margin-top:${Math.round(width * 0.025 * contentScale)}px;text-align:left;width:100%;column-count:${columns};column-gap:${Math.round(width * 0.03)}px;">` +
         rows.join("") + overflowRow +
       `</div>`;
   }
@@ -121,16 +127,16 @@ export function buildShareCardSvg(options: ShareCardOptions): { svg: string; wid
 
   const contentHtml = `
     <div xmlns="http://www.w3.org/1999/xhtml" style="position:relative;width:100%;height:100%;display:flex;flex-direction:column;align-items:center;justify-content:center;padding:${cardPad}px;box-sizing:border-box;font-family:'Inter','Segoe UI',system-ui,sans-serif;">
-      <div style="display:flex;flex-direction:${groupDirection};align-items:center;gap:${Math.round(width * 0.035)}px;max-width:100%;">
+      <div style="display:flex;flex-direction:${groupDirection};align-items:center;gap:${Math.round(width * 0.035 * contentScale)}px;max-width:100%;">
         ${
           options.coverDataUri
             ? `<img src="${options.coverDataUri}" style="width:${coverSize}px;height:${coverSize}px;object-fit:cover;border-radius:${Math.round(coverSize * 0.06)}px;box-shadow:0 20px 50px rgba(0,0,0,0.4);flex-shrink:0;" />`
             : ""
         }
         <div style="min-width:0;${isPortrait ? "" : "flex:1;"}display:flex;flex-direction:column;gap:2px;align-items:${isPortrait ? "center" : "flex-start"};text-align:${textAlign};${textBlockMaxWidth ? `max-width:${textBlockMaxWidth}px;` : ""}">
-          <div style="font-size:${Math.round(width * 0.046)}px;font-weight:800;color:${textPrimary};line-height:1.14;overflow:hidden;text-overflow:ellipsis;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;">${escapeHtml(options.title)}</div>
-          <div style="font-size:${Math.round(width * 0.026)}px;font-weight:600;color:${textSecondary};margin-top:6px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:100%;">${escapeHtml(options.subtitle)}</div>
-          <div style="font-size:${Math.round(width * 0.019)}px;color:${textSecondary};margin-top:6px;">${escapeHtml(options.metadataLine)}</div>
+          <div style="font-size:${Math.round(width * 0.046 * contentScale)}px;font-weight:800;color:${textPrimary};line-height:1.14;overflow:hidden;text-overflow:ellipsis;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;">${escapeHtml(options.title)}</div>
+          <div style="font-size:${Math.round(width * 0.026 * contentScale)}px;font-weight:600;color:${textSecondary};margin-top:6px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:100%;">${escapeHtml(options.subtitle)}</div>
+          <div style="font-size:${Math.round(width * 0.019 * contentScale)}px;color:${textSecondary};margin-top:6px;">${escapeHtml(options.metadataLine)}</div>
           ${showTrackList ? trackListHtml : ""}
         </div>
       </div>

--- a/src/lib/utils/shareCard.ts
+++ b/src/lib/utils/shareCard.ts
@@ -1,0 +1,190 @@
+// Social share card builder (#97). The card is composed as a single SVG
+// string — the same layered-ellipse gradient used by the immersive view for
+// the background, with an <foreignObject> overlay for the actual HTML/CSS
+// content (cover art, title, metadata, track list) — then rasterized to a
+// PNG by loading that SVG into an <img> and drawing it onto a canvas. This
+// avoids pulling in a DOM-to-image dependency: the whole card only ever
+// exists as markup we generate, never a live component tree we'd need to
+// snapshot.
+
+import { generateEllipseGradientSvg } from "./ellipseGradient";
+
+export type ShareAspectRatio = "1:1" | "9:16" | "16:9" | "4:3" | "3:4";
+
+export const SHARE_ASPECT_RATIOS: { id: ShareAspectRatio; width: number; height: number }[] = [
+  { id: "1:1", width: 1080, height: 1080 },
+  { id: "9:16", width: 1080, height: 1920 },
+  { id: "16:9", width: 1920, height: 1080 },
+  { id: "4:3", width: 1440, height: 1080 },
+  { id: "3:4", width: 1080, height: 1440 },
+];
+
+export type ShareCardTheme = "light" | "dark";
+
+export interface ShareCardTrack {
+  number?: number | null;
+  title: string;
+}
+
+export interface ShareCardOptions {
+  aspectRatio: ShareAspectRatio;
+  theme: ShareCardTheme;
+  seed: string;
+  backgroundColors?: string[];
+  coverDataUri: string | null;
+  title: string;
+  subtitle: string;
+  metadataLine: string;
+  tracks?: ShareCardTrack[];
+  includeTrackList: boolean;
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+/** How many track rows fit before "+N more" overflow, tuned per aspect ratio's usable height. */
+function maxVisibleTracks(dims: { width: number; height: number }): number {
+  const isPortrait = dims.height > dims.width;
+  const isSquareish = Math.abs(dims.width - dims.height) < dims.width * 0.15;
+  if (isPortrait) return 12;
+  if (isSquareish) return 6;
+  return 5;
+}
+
+export function buildShareCardSvg(options: ShareCardOptions): { svg: string; width: number; height: number } {
+  const dims = SHARE_ASPECT_RATIOS.find((r) => r.id === options.aspectRatio) ?? SHARE_ASPECT_RATIOS[0];
+  const { width, height } = dims;
+  const isDark = options.theme === "dark";
+  const textPrimary = isDark ? "#0b0c0f" : "#f5f6f8";
+  const textSecondary = isDark ? "rgba(11,12,15,0.72)" : "rgba(245,246,248,0.78)";
+  const scrimFrom = isDark ? "rgba(255,255,255,0)" : "rgba(0,0,0,0)";
+  const scrimTo = isDark ? "rgba(255,255,255,0.55)" : "rgba(0,0,0,0.55)";
+  const cardPad = Math.round(width * 0.06);
+  const coverSize = Math.round(Math.min(width, height) * 0.34);
+
+  const background = generateEllipseGradientSvg({
+    width,
+    height,
+    colors: options.backgroundColors,
+    seed: options.seed,
+  });
+  // Strip the outer <svg ...> wrapper so it can be inlined as this card's own background layer.
+  const backgroundInner = background.replace(/^<svg[^>]*>/, "").replace(/<\/svg>$/, "");
+
+  const trackRows: string[] = [];
+  if (options.includeTrackList && options.tracks && options.tracks.length > 0) {
+    const limit = maxVisibleTracks(dims);
+    const visible = options.tracks.slice(0, limit);
+    const overflow = options.tracks.length - visible.length;
+    for (const track of visible) {
+      trackRows.push(
+        `<div style="display:flex;gap:10px;align-items:baseline;padding:4px 0;font-size:${Math.round(width * 0.017)}px;color:${textSecondary};">` +
+          (track.number != null
+            ? `<span style="min-width:1.8em;text-align:right;opacity:0.7;">${track.number}</span>`
+            : "") +
+          `<span style="overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">${escapeHtml(track.title)}</span>` +
+        `</div>`
+      );
+    }
+    if (overflow > 0) {
+      trackRows.push(
+        `<div style="padding:4px 0;font-size:${Math.round(width * 0.017)}px;color:${textSecondary};opacity:0.7;">+${overflow} more</div>`
+      );
+    }
+  }
+
+  const showTrackList = trackRows.length > 0;
+
+  const contentHtml = `
+    <div xmlns="http://www.w3.org/1999/xhtml" style="width:100%;height:100%;display:flex;flex-direction:column;justify-content:flex-end;padding:${cardPad}px;box-sizing:border-box;font-family:'Inter','Segoe UI',system-ui,sans-serif;">
+      <div style="display:flex;flex-direction:${showTrackList ? "row" : "column"};align-items:${showTrackList ? "flex-end" : "flex-start"};gap:${Math.round(width * 0.03)}px;">
+        ${
+          options.coverDataUri
+            ? `<img src="${options.coverDataUri}" style="width:${coverSize}px;height:${coverSize}px;object-fit:cover;border-radius:${Math.round(coverSize * 0.06)}px;box-shadow:0 12px 40px rgba(0,0,0,0.35);flex-shrink:0;" />`
+            : ""
+        }
+        <div style="min-width:0;flex:1;display:flex;flex-direction:column;gap:2px;">
+          <div style="font-size:${Math.round(width * 0.042)}px;font-weight:800;color:${textPrimary};line-height:1.12;overflow:hidden;text-overflow:ellipsis;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;">${escapeHtml(options.title)}</div>
+          <div style="font-size:${Math.round(width * 0.024)}px;font-weight:600;color:${textSecondary};margin-top:4px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">${escapeHtml(options.subtitle)}</div>
+          <div style="font-size:${Math.round(width * 0.018)}px;color:${textSecondary};margin-top:4px;">${escapeHtml(options.metadataLine)}</div>
+          ${showTrackList ? `<div style="margin-top:${Math.round(width * 0.02)}px;display:flex;flex-direction:column;">${trackRows.join("")}</div>` : ""}
+        </div>
+      </div>
+      <div style="margin-top:${Math.round(width * 0.02)}px;font-size:${Math.round(width * 0.014)}px;font-weight:700;letter-spacing:0.04em;color:${textSecondary};opacity:0.8;">LUMINOUS</div>
+    </div>
+  `;
+
+  const svg =
+    `<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}">` +
+      `<g>${backgroundInner}</g>` +
+      `<defs><linearGradient id="scrim" x1="0" y1="0" x2="0" y2="1">` +
+        `<stop offset="0%" stop-color="${scrimFrom}"/>` +
+        `<stop offset="100%" stop-color="${scrimTo}"/>` +
+      `</linearGradient></defs>` +
+      `<rect x="0" y="0" width="${width}" height="${height}" fill="url(#scrim)"/>` +
+      `<foreignObject x="0" y="0" width="${width}" height="${height}">${contentHtml}</foreignObject>` +
+    `</svg>`;
+
+  return { svg, width, height };
+}
+
+/** Loads an image, tolerating cross-origin/blocked sources by resolving with `null` instead of rejecting. */
+async function loadImage(src: string): Promise<HTMLImageElement | null> {
+  return new Promise((resolve) => {
+    const img = new Image();
+    img.onload = () => resolve(img);
+    img.onerror = () => resolve(null);
+    img.src = src;
+  });
+}
+
+/** Converts an arbitrary image URL (including Tauri asset URLs) to a data URI so it can be safely embedded in an SVG foreignObject and rasterized without tainting the canvas. */
+export async function toDataUri(url: string): Promise<string | null> {
+  try {
+    const response = await fetch(url);
+    const blob = await response.blob();
+    return await new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => resolve(reader.result as string);
+      reader.onerror = reject;
+      reader.readAsDataURL(blob);
+    });
+  } catch {
+    return null;
+  }
+}
+
+export async function rasterizeShareCard(options: ShareCardOptions, scale = 2): Promise<Blob | null> {
+  const { svg, width, height } = buildShareCardSvg(options);
+  const svgDataUri = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`;
+  const img = await loadImage(svgDataUri);
+  if (!img) return null;
+
+  const canvas = document.createElement("canvas");
+  canvas.width = width * scale;
+  canvas.height = height * scale;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return null;
+  ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+
+  return new Promise((resolve) => {
+    canvas.toBlob((blob) => resolve(blob), "image/png");
+  });
+}
+
+export function blobToBase64(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const result = reader.result as string;
+      resolve(result.slice(result.indexOf(",") + 1));
+    };
+    reader.onerror = reject;
+    reader.readAsDataURL(blob);
+  });
+}

--- a/src/lib/utils/shareCard.ts
+++ b/src/lib/utils/shareCard.ts
@@ -47,13 +47,19 @@ function escapeHtml(value: string): string {
     .replace(/"/g, "&quot;");
 }
 
-/** How many track rows fit before "+N more" overflow, tuned per aspect ratio's usable height. */
-function maxVisibleTracks(dims: { width: number; height: number }): number {
+/**
+ * Track list is laid out as CSS columns so a long tracklist fans out
+ * sideways instead of forcing one tall, mostly-empty-feeling column —
+ * landscape frames have the width to spare for a third column, portrait/
+ * square ones cap out at two.
+ */
+function trackListLayout(dims: { width: number; height: number }, trackCount: number): { columns: number; maxVisible: number } {
   const isPortrait = dims.height > dims.width;
   const isSquareish = Math.abs(dims.width - dims.height) < dims.width * 0.15;
-  if (isPortrait) return 12;
-  if (isSquareish) return 6;
-  return 5;
+  const rowsPerColumn = isPortrait ? 10 : isSquareish ? 7 : 6;
+  const maxColumns = isPortrait || isSquareish ? 2 : 3;
+  const columns = Math.min(maxColumns, Math.max(1, Math.ceil(trackCount / rowsPerColumn)));
+  return { columns, maxVisible: columns * rowsPerColumn };
 }
 
 export function buildShareCardSvg(options: ShareCardOptions): { svg: string; width: number; height: number } {
@@ -81,29 +87,34 @@ export function buildShareCardSvg(options: ShareCardOptions): { svg: string; wid
   // Strip the outer <svg ...> wrapper so it can be inlined as this card's own background layer.
   const backgroundInner = background.replace(/^<svg[^>]*>/, "").replace(/<\/svg>$/, "");
 
-  const trackRows: string[] = [];
+  let trackListHtml = "";
   if (options.includeTrackList && options.tracks && options.tracks.length > 0) {
-    const limit = maxVisibleTracks(dims);
-    const visible = options.tracks.slice(0, limit);
+    const { columns, maxVisible } = trackListLayout(dims, options.tracks.length);
+    const visible = options.tracks.slice(0, maxVisible);
     const overflow = options.tracks.length - visible.length;
-    for (const track of visible) {
-      trackRows.push(
-        `<div style="display:flex;gap:10px;align-items:baseline;padding:4px 0;font-size:${Math.round(width * 0.017)}px;color:${textSecondary};">` +
+    const rowFontSize = Math.round(width * 0.017);
+
+    const rows = visible.map(
+      (track) =>
+        `<div style="display:flex;gap:10px;align-items:baseline;padding:4px 0;font-size:${rowFontSize}px;color:${textSecondary};break-inside:avoid;">` +
           (track.number != null
             ? `<span style="min-width:1.8em;text-align:right;opacity:0.7;">${track.number}</span>`
             : "") +
           `<span style="overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">${escapeHtml(track.title)}</span>` +
         `</div>`
-      );
-    }
-    if (overflow > 0) {
-      trackRows.push(
-        `<div style="padding:4px 0;font-size:${Math.round(width * 0.017)}px;color:${textSecondary};opacity:0.7;">+${overflow} more</div>`
-      );
-    }
+    );
+    const overflowRow =
+      overflow > 0
+        ? `<div style="column-span:all;padding:4px 0;font-size:${rowFontSize}px;color:${textSecondary};opacity:0.7;">+${overflow} more</div>`
+        : "";
+
+    trackListHtml =
+      `<div style="margin-top:${Math.round(width * 0.025)}px;text-align:left;width:100%;column-count:${columns};column-gap:${Math.round(width * 0.03)}px;">` +
+        rows.join("") + overflowRow +
+      `</div>`;
   }
 
-  const showTrackList = trackRows.length > 0;
+  const showTrackList = trackListHtml.length > 0;
   const textAlign = isPortrait ? "center" : "left";
   const groupDirection = isPortrait ? "column" : "row";
   const textBlockMaxWidth = isPortrait ? Math.round(width * 0.82) : undefined;
@@ -120,7 +131,7 @@ export function buildShareCardSvg(options: ShareCardOptions): { svg: string; wid
           <div style="font-size:${Math.round(width * 0.046)}px;font-weight:800;color:${textPrimary};line-height:1.14;overflow:hidden;text-overflow:ellipsis;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;">${escapeHtml(options.title)}</div>
           <div style="font-size:${Math.round(width * 0.026)}px;font-weight:600;color:${textSecondary};margin-top:6px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:100%;">${escapeHtml(options.subtitle)}</div>
           <div style="font-size:${Math.round(width * 0.019)}px;color:${textSecondary};margin-top:6px;">${escapeHtml(options.metadataLine)}</div>
-          ${showTrackList ? `<div style="margin-top:${Math.round(width * 0.025)}px;display:flex;flex-direction:column;text-align:left;width:100%;">${trackRows.join("")}</div>` : ""}
+          ${showTrackList ? trackListHtml : ""}
         </div>
       </div>
       <div style="position:absolute;left:${cardPad}px;bottom:${cardPad}px;font-size:${Math.round(width * 0.014)}px;font-weight:700;letter-spacing:0.04em;color:${textSecondary};opacity:0.8;">LUMINOUS</div>

--- a/src/lib/utils/shareCard.ts
+++ b/src/lib/utils/shareCard.ts
@@ -65,11 +65,14 @@ function trackListLayout(dims: { width: number; height: number }, trackCount: nu
 export function buildShareCardSvg(options: ShareCardOptions): { svg: string; width: number; height: number } {
   const dims = SHARE_ASPECT_RATIOS.find((r) => r.id === options.aspectRatio) ?? SHARE_ASPECT_RATIOS[0];
   const { width, height } = dims;
+  // "Dark" means the card itself reads dark (a darkening scrim, light text);
+  // "light" means the card reads light (a brightening scrim, dark text) —
+  // the opposite pairing looked backwards against the sun/moon icons.
   const isDark = options.theme === "dark";
-  const textPrimary = isDark ? "#0b0c0f" : "#f5f6f8";
-  const textSecondary = isDark ? "rgba(11,12,15,0.72)" : "rgba(245,246,248,0.78)";
-  const scrimFrom = isDark ? "rgba(255,255,255,0)" : "rgba(0,0,0,0)";
-  const scrimTo = isDark ? "rgba(255,255,255,0.55)" : "rgba(0,0,0,0.55)";
+  const textPrimary = isDark ? "#f5f6f8" : "#0b0c0f";
+  const textSecondary = isDark ? "rgba(245,246,248,0.78)" : "rgba(11,12,15,0.72)";
+  const scrimFrom = isDark ? "rgba(0,0,0,0)" : "rgba(255,255,255,0)";
+  const scrimTo = isDark ? "rgba(0,0,0,0.55)" : "rgba(255,255,255,0.55)";
   const cardPad = Math.round(width * 0.06);
   // Portrait/square frames stack cover-then-text centered in the middle of
   // the canvas (a bigger cover, since there's little horizontal room);

--- a/src/lib/utils/shareCard.ts
+++ b/src/lib/utils/shareCard.ts
@@ -114,8 +114,15 @@ export function buildShareCardSvg(options: ShareCardOptions): { svg: string; wid
         ? `<div style="column-span:all;padding:4px 0;font-size:${rowFontSize}px;color:${textSecondary};opacity:0.7;">+${overflow} more</div>`
         : "";
 
+    // Belt-and-suspenders against a pathological combination (a very long,
+    // two-line-wrapped title plus a huge box-set tracklist): even though
+    // trackListLayout already sizes for the expected case, cap the block's
+    // own height and clip it so it can never grow past the LUMINOUS mark
+    // pinned near the bottom of the frame, rather than overlapping it.
+    const trackListMaxHeight = Math.round(height * (isPortrait ? 0.3 : 0.4));
+
     trackListHtml =
-      `<div style="margin-top:${Math.round(width * 0.025 * contentScale)}px;text-align:left;width:100%;column-count:${columns};column-gap:${Math.round(width * 0.03)}px;">` +
+      `<div style="margin-top:${Math.round(width * 0.025 * contentScale)}px;text-align:left;width:100%;column-count:${columns};column-gap:${Math.round(width * 0.03)}px;max-height:${trackListMaxHeight}px;overflow:hidden;">` +
         rows.join("") + overflowRow +
       `</div>`;
   }
@@ -126,7 +133,7 @@ export function buildShareCardSvg(options: ShareCardOptions): { svg: string; wid
   const textBlockMaxWidth = isPortrait ? Math.round(width * 0.82) : undefined;
 
   const contentHtml = `
-    <div xmlns="http://www.w3.org/1999/xhtml" style="position:relative;width:100%;height:100%;display:flex;flex-direction:column;align-items:center;justify-content:center;padding:${cardPad}px;box-sizing:border-box;font-family:'Inter','Segoe UI',system-ui,sans-serif;">
+    <div xmlns="http://www.w3.org/1999/xhtml" style="position:relative;width:100%;height:100%;overflow:hidden;display:flex;flex-direction:column;align-items:center;justify-content:center;padding:${cardPad}px;box-sizing:border-box;font-family:'Inter','Segoe UI',system-ui,sans-serif;">
       <div style="display:flex;flex-direction:${groupDirection};align-items:center;gap:${Math.round(width * 0.035 * contentScale)}px;max-width:100%;">
         ${
           options.coverDataUri
@@ -134,7 +141,7 @@ export function buildShareCardSvg(options: ShareCardOptions): { svg: string; wid
             : ""
         }
         <div style="min-width:0;${isPortrait ? "" : "flex:1;"}display:flex;flex-direction:column;gap:2px;align-items:${isPortrait ? "center" : "flex-start"};text-align:${textAlign};${textBlockMaxWidth ? `max-width:${textBlockMaxWidth}px;` : ""}">
-          <div style="font-size:${Math.round(width * 0.046 * contentScale)}px;font-weight:800;color:${textPrimary};line-height:1.14;overflow:hidden;text-overflow:ellipsis;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;">${escapeHtml(options.title)}</div>
+          <div style="font-size:${Math.round(width * 0.046 * contentScale)}px;font-weight:800;color:${textPrimary};line-height:1.3;padding-bottom:0.08em;overflow:hidden;text-overflow:ellipsis;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;">${escapeHtml(options.title)}</div>
           <div style="font-size:${Math.round(width * 0.026 * contentScale)}px;font-weight:600;color:${textSecondary};margin-top:6px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:100%;">${escapeHtml(options.subtitle)}</div>
           <div style="font-size:${Math.round(width * 0.019 * contentScale)}px;color:${textSecondary};margin-top:6px;">${escapeHtml(options.metadataLine)}</div>
           ${showTrackList ? trackListHtml : ""}

--- a/src/lib/utils/shareCard.ts
+++ b/src/lib/utils/shareCard.ts
@@ -65,7 +65,12 @@ export function buildShareCardSvg(options: ShareCardOptions): { svg: string; wid
   const scrimFrom = isDark ? "rgba(255,255,255,0)" : "rgba(0,0,0,0)";
   const scrimTo = isDark ? "rgba(255,255,255,0.55)" : "rgba(0,0,0,0.55)";
   const cardPad = Math.round(width * 0.06);
-  const coverSize = Math.round(Math.min(width, height) * 0.34);
+  // Portrait/square frames stack cover-then-text centered in the middle of
+  // the canvas (a bigger cover, since there's little horizontal room);
+  // landscape frames keep a side-by-side row so the wide aspect isn't mostly
+  // empty gradient either side of a narrow text column.
+  const isPortrait = height >= width;
+  const coverSize = Math.round(isPortrait ? width * 0.56 : Math.min(width, height) * 0.46);
 
   const background = generateEllipseGradientSvg({
     width,
@@ -99,23 +104,26 @@ export function buildShareCardSvg(options: ShareCardOptions): { svg: string; wid
   }
 
   const showTrackList = trackRows.length > 0;
+  const textAlign = isPortrait ? "center" : "left";
+  const groupDirection = isPortrait ? "column" : "row";
+  const textBlockMaxWidth = isPortrait ? Math.round(width * 0.82) : undefined;
 
   const contentHtml = `
-    <div xmlns="http://www.w3.org/1999/xhtml" style="width:100%;height:100%;display:flex;flex-direction:column;justify-content:flex-end;padding:${cardPad}px;box-sizing:border-box;font-family:'Inter','Segoe UI',system-ui,sans-serif;">
-      <div style="display:flex;flex-direction:${showTrackList ? "row" : "column"};align-items:${showTrackList ? "flex-end" : "flex-start"};gap:${Math.round(width * 0.03)}px;">
+    <div xmlns="http://www.w3.org/1999/xhtml" style="position:relative;width:100%;height:100%;display:flex;flex-direction:column;align-items:center;justify-content:center;padding:${cardPad}px;box-sizing:border-box;font-family:'Inter','Segoe UI',system-ui,sans-serif;">
+      <div style="display:flex;flex-direction:${groupDirection};align-items:center;gap:${Math.round(width * 0.035)}px;max-width:100%;">
         ${
           options.coverDataUri
-            ? `<img src="${options.coverDataUri}" style="width:${coverSize}px;height:${coverSize}px;object-fit:cover;border-radius:${Math.round(coverSize * 0.06)}px;box-shadow:0 12px 40px rgba(0,0,0,0.35);flex-shrink:0;" />`
+            ? `<img src="${options.coverDataUri}" style="width:${coverSize}px;height:${coverSize}px;object-fit:cover;border-radius:${Math.round(coverSize * 0.06)}px;box-shadow:0 20px 50px rgba(0,0,0,0.4);flex-shrink:0;" />`
             : ""
         }
-        <div style="min-width:0;flex:1;display:flex;flex-direction:column;gap:2px;">
-          <div style="font-size:${Math.round(width * 0.042)}px;font-weight:800;color:${textPrimary};line-height:1.12;overflow:hidden;text-overflow:ellipsis;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;">${escapeHtml(options.title)}</div>
-          <div style="font-size:${Math.round(width * 0.024)}px;font-weight:600;color:${textSecondary};margin-top:4px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">${escapeHtml(options.subtitle)}</div>
-          <div style="font-size:${Math.round(width * 0.018)}px;color:${textSecondary};margin-top:4px;">${escapeHtml(options.metadataLine)}</div>
-          ${showTrackList ? `<div style="margin-top:${Math.round(width * 0.02)}px;display:flex;flex-direction:column;">${trackRows.join("")}</div>` : ""}
+        <div style="min-width:0;${isPortrait ? "" : "flex:1;"}display:flex;flex-direction:column;gap:2px;align-items:${isPortrait ? "center" : "flex-start"};text-align:${textAlign};${textBlockMaxWidth ? `max-width:${textBlockMaxWidth}px;` : ""}">
+          <div style="font-size:${Math.round(width * 0.046)}px;font-weight:800;color:${textPrimary};line-height:1.14;overflow:hidden;text-overflow:ellipsis;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;">${escapeHtml(options.title)}</div>
+          <div style="font-size:${Math.round(width * 0.026)}px;font-weight:600;color:${textSecondary};margin-top:6px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:100%;">${escapeHtml(options.subtitle)}</div>
+          <div style="font-size:${Math.round(width * 0.019)}px;color:${textSecondary};margin-top:6px;">${escapeHtml(options.metadataLine)}</div>
+          ${showTrackList ? `<div style="margin-top:${Math.round(width * 0.025)}px;display:flex;flex-direction:column;text-align:left;width:100%;">${trackRows.join("")}</div>` : ""}
         </div>
       </div>
-      <div style="margin-top:${Math.round(width * 0.02)}px;font-size:${Math.round(width * 0.014)}px;font-weight:700;letter-spacing:0.04em;color:${textSecondary};opacity:0.8;">LUMINOUS</div>
+      <div style="position:absolute;left:${cardPad}px;bottom:${cardPad}px;font-size:${Math.round(width * 0.014)}px;font-weight:700;letter-spacing:0.04em;color:${textSecondary};opacity:0.8;">LUMINOUS</div>
     </div>
   `;
 


### PR DESCRIPTION
## 📋 Summary
Adds a "Share Card" action for albums: an interactive modal that generates a custom social preview image (5 aspect ratios, optional track list, light/dark theme), with copy-to-clipboard and save-to-disk export. Addresses #97.

## 🔍 Implementation Notes
- `ShareModal.svelte` is the modal itself, opened from a new "Share Card..." item in `AlbumContextMenu.svelte` and a new Share button in `AlbumDetailView.svelte`'s header actions.
- `shareCard.ts` builds the card as a single SVG string — the layered-ellipse gradient background (`ellipseGradient.ts`, the same generator used by the immersive view, seeded by album name and colored from the album's extracted artwork palette) plus a `foreignObject` HTML overlay for cover art/text/track list — then rasterizes it via canvas. This avoids pulling in a DOM-to-image dependency.
- A long tracklist lays out in CSS columns (up to 3 on landscape frames, 2 on portrait/square) instead of one tall list, with a hard height cap + `overflow:hidden` as a safety net so a pathological case (a very long title plus a 50+ track box set) can't push content past the frame and overlap the branding.
- Portrait frames scale content size relative to how much taller the frame is than a 3:4 baseline, since 9:16 has a lot more vertical room at the same width and looked small/sparse without it.
- Aspect ratio, theme, and track-list toggle are remembered across sessions via `set_app_setting`/`get_all_app_settings`.
- Saving to disk goes through a new `save_share_card_image` Tauri command (`src-tauri/src/commands/share.rs`) since the app has no fs plugin — mirrors the existing playlist-export pattern (dialog picks the path, a command writes the bytes).
- Out of scope, tracked separately: playlist/artist/stats card variants (#880) and direct posting to Bluesky (#879), both targeted at Milestone 3.0.

## 🧪 Test Plan
- [x] `bun run check` (svelte-check + knip)
- [x] `bun run test -- --run` (frontend) — 713/713 pass, plus 7 new tests in `shareCard.test.ts` covering per-ratio dimensions, HTML escaping, track-list toggle/truncation, multi-column layout, and determinism
- [x] `cargo test` (src-tauri) — clean
- [x] Manually verified in the app across all 5 aspect ratios, light/dark theme, with/without track list, short and very long tracklists, and long two-line titles — several rounds of visual fixes included (button contrast, layout centering, multi-column tracklist, portrait content scaling, overflow clipping, title descender clipping, light/dark mapping)

## 📸 Screenshots
See conversation history on the linked branch for before/after captures across all aspect ratios.

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed — n/a, no docs reference this yet
