### PR TITLE
chore: add clippy/svelte-check PostToolUse hook

### DIFF
--- a/.claude/hooks/post-edit-check.sh
+++ b/.claude/hooks/post-edit-check.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -uo pipefail
+
+file=$(jq -r '.tool_input.file_path // .tool_response.filePath // empty')
+
+case "$file" in
+  *.rs)
+    (cd "$CLAUDE_PROJECT_DIR/src-tauri" && cargo clippy --all-targets -- -D warnings) 2>&1 | tail -30
+    ;;
+  *.ts|*.svelte)
+    (cd "$CLAUDE_PROJECT_DIR" && bun run check) 2>&1 | tail -20
+    ;;
+esac
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,6 +9,17 @@
           }
         ]
       }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/post-edit-check.sh"
+          }
+        ]
+      }
     ]
   }
 }


### PR DESCRIPTION
## 📋 Summary
Adds a PostToolUse hook that runs `cargo clippy` (for `.rs` files) or `bun run check` (for `.ts`/`.svelte` files) after every Edit/Write, surfacing type/lint breakage immediately instead of after manual verification.

## 🔍 Implementation Notes
`.claude/hooks/post-edit-check.sh` reads the touched file path from the hook's stdin JSON and dispatches by extension: `cargo clippy --all-targets -- -D warnings` (run from `src-tauri/`) for Rust, `bun run check` for TS/Svelte. Output is tailed to keep it readable. Registered in `.claude/settings.json` under `hooks.PostToolUse` matching `Edit|Write`. Note `cargo clippy` recompiles the workspace, so it's slow (~60s) on a cold cache though fast once warm — flagging in case that's too noisy for rapid Rust-editing sessions.

## 🧪 Test Plan
- [x] Piped synthetic hook-input JSON for both a `.rs` and a `.ts` file directly into the script and confirmed each ran the right check and reported real errors/success
- [x] Verified end-to-end firing by temporarily prefixing the hook command with a sentinel write, triggering a real Edit on `src-tauri/src/lib.rs`, and confirming the sentinel appeared before reverting both
- [ ] `bun run test -- --run` (frontend) — not applicable, no frontend code changed
- [ ] `cargo test` (src-tauri) — not applicable, no Rust code changed

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed — not applicable, dev-tooling only
