### PR TITLE
chore: fail CI on svelte-check warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "preview": "vite preview",
     "prepare": "svelte-kit sync",
     "install:git-hooks": "git config core.hooksPath .githooks",
-    "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --tsgo && bun run knip",
+    "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --tsgo --fail-on-warnings && bun run knip",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --tsgo --watch",
     "knip": "knip",
     "tauri": "NO_STRIP=true tauri",


### PR DESCRIPTION
## 📋 Summary
Fixes #885. Adds `--fail-on-warnings` to the `check` script so `bun run check` (svelte-check) fails on any warning, matching clippy's `-D warnings` gate in CI.

## 🔍 Implementation Notes
Single-line change in `package.json`. There are currently 0 svelte-check warnings in the codebase, so this closes the gap before any accumulate — no other code changes needed.

## 🧪 Test Plan
- [x] `bun run check` (svelte-check) — ran locally on `next`, 0 errors/0 warnings, exits 0 with the new flag

## 📸 Screenshots
N/A — CI config change only.

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed — N/A, no user-facing behavior changed
