### PR TITLE
feat: Windows taskbar thumbnail toolbar with album art preview

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "aligned"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee4508988c62edf04abd8d92897fca0c2995d907ce1dfeaf369dac3716a40685"
+dependencies = [
+ "as-slice",
+]
+
+[[package]]
+name = "aligned-vec"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b"
+dependencies = [
+ "equator",
+]
+
+[[package]]
 name = "alloc-no-stdlib"
 version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -126,6 +144,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 dependencies = [
  "derive_arbitrary",
+]
+
+[[package]]
+name = "arg_enum_proc_macro"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "arrayvec"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
+
+[[package]]
+name = "as-slice"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "516b6b4f0e40d50dcda9365d53964ec74560ad4284da2e7fc97122cd83174516"
+dependencies = [
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -316,6 +360,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "av-scenechange"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f321d77c20e19b92c39e7471cf986812cbb46659d2af674adc4331ef3f18394"
+dependencies = [
+ "aligned",
+ "anyhow",
+ "arg_enum_proc_macro",
+ "arrayvec",
+ "log",
+ "num-rational",
+ "num-traits",
+ "pastey",
+ "rayon",
+ "thiserror 2.0.20",
+ "v_frame",
+ "y4m",
+]
+
+[[package]]
+name = "av1-grain"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cfddb07216410377231960af4fcab838eaa12e013417781b78bd95ee22077f8"
+dependencies = [
+ "anyhow",
+ "arrayvec",
+ "log",
+ "nom",
+ "num-rational",
+ "v_frame",
+]
+
+[[package]]
+name = "avif-serialize"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7178fe5f7d460b13895ebb9dcb28a3a6216d2df2574a0806cb51b555d297f38"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
 name = "aws-lc-rs"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -366,6 +453,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
+name = "bit_field"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -378,6 +471,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "bitstream-io"
+version = "4.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eff00be299a18769011411c9def0d827e8f2d7bf0c3dbf53633147a8867fd1f"
+dependencies = [
+ "no_std_io2",
 ]
 
 [[package]]
@@ -456,6 +558,12 @@ dependencies = [
  "memchr",
  "serde_core",
 ]
+
+[[package]]
+name = "built"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c0e531d93d39c34eef561e929e8a7f86d77a5af08aac4f6d6e39976c51858e9"
 
 [[package]]
 name = "bumpalo"
@@ -690,6 +798,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -889,6 +1003,12 @@ name = "crossbeam-utils"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -1400,6 +1520,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "equator"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4711b213838dfee0117e3be6ac926007d7f433d7bbe33595975d4190cb07e6fc"
+dependencies = [
+ "equator-macro",
+]
+
+[[package]]
+name = "equator-macro"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1447,6 +1587,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "exr"
+version = "1.74.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711fe42c9964295e01ee3fba3f9fe0e1d24b98886950d68efe81b1c76e21adf3"
+dependencies = [
+ "bit_field",
+ "half",
+ "lebe",
+ "miniz_oxide",
+ "num-complex",
+ "pulp",
+ "rayon-core",
+ "smallvec",
+ "zune-inflate",
+]
+
+[[package]]
 name = "extended"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1469,6 +1626,12 @@ name = "fastrand"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
+
+[[package]]
+name = "fax"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
 
 [[package]]
 name = "fdeflate"
@@ -1855,6 +2018,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gif"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
+dependencies = [
+ "color_quant",
+ "weezl",
+]
+
+[[package]]
 name = "gio"
 version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2061,6 +2234,17 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2409,10 +2593,37 @@ checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
 dependencies = [
  "bytemuck",
  "byteorder-lite",
+ "color_quant",
+ "exr",
+ "gif",
+ "image-webp",
  "moxcms",
  "num-traits",
  "png 0.18.1",
+ "qoi",
+ "ravif",
+ "rayon",
+ "rgb",
+ "tiff",
+ "zune-core",
+ "zune-jpeg",
 ]
+
+[[package]]
+name = "image-webp"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
+dependencies = [
+ "byteorder-lite",
+ "quick-error",
+]
+
+[[package]]
+name = "imgref"
+version = "1.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89194689a993ab15268672e99e7b0e19da2da3268ac682e8f02d29d4d1434cd7"
 
 [[package]]
 name = "indexmap"
@@ -2470,6 +2681,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c033f80b2c113cdf91ab7a33faa9cbc014726dcad99880c8609af2a370edf37d"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "interpolate_name"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2767,6 +2989,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "lebe"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
+
+[[package]]
 name = "libappindicator"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2806,6 +3034,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libfuzzer-sys"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9fd2f41a1cba099f79a0b6b6c35656cf7c03351a7bae8ff0f28f25270f929d2"
+dependencies = [
+ "arbitrary",
+ "cc",
+]
+
+[[package]]
 name = "libloading"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2814,6 +3052,12 @@ dependencies = [
  "cfg-if",
  "winapi",
 ]
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
@@ -2895,6 +3139,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
+name = "loop9"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062"
+dependencies = [
+ "imgref",
+]
+
+[[package]]
 name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2911,6 +3164,7 @@ dependencies = [
  "cpal",
  "cucumber",
  "env_logger",
+ "image",
  "libc",
  "lofty",
  "log",
@@ -2987,6 +3241,16 @@ dependencies = [
  "log",
  "tendril",
  "web_atoms",
+]
+
+[[package]]
+name = "maybe-rayon"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
+dependencies = [
+ "cfg-if",
+ "rayon",
 ]
 
 [[package]]
@@ -3106,6 +3370,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
+name = "no_std_io2"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418abd1b6d34fbf6cae440dc874771b0525a604428704c76e48b29a5e67b8003"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "nom"
 version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3124,6 +3397,12 @@ dependencies = [
  "memchr",
  "nom",
 ]
+
+[[package]]
+name = "noop_proc_macro"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
 
 [[package]]
 name = "notify"
@@ -3168,11 +3447,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-complex"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
+ "bytemuck",
  "num-traits",
 ]
 
@@ -3199,6 +3489,17 @@ version = "0.1.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
  "num-traits",
 ]
 
@@ -3641,6 +3942,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pastey"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
+
+[[package]]
 name = "peg"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3939,10 +4246,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "profiling"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d595e54a326bc53c1c197b32d295e14b169e3cfeaa8dc82b529f947fba6bcf5"
+dependencies = [
+ "profiling-procmacros",
+]
+
+[[package]]
+name = "profiling-procmacros"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4488a4a36b9a4ba6b9334a32a39971f77c1436ec82c38707bce707699cc3bbcb"
+dependencies = [
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "pulp"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "046aa45b989642ec2e4717c8e72d677b13edd831a4d3b6cf37d9a3e54912496a"
+dependencies = [
+ "bytemuck",
+ "cfg-if",
+ "libm",
+ "num-complex",
+ "paste",
+ "pulp-wasm-simd-flag",
+ "raw-cpuid",
+ "reborrow",
+ "version_check",
+]
+
+[[package]]
+name = "pulp-wasm-simd-flag"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d8f70e07b9c3962945a74e59ca1c511bba65b6419468acc217c457d93f3c740"
+
+[[package]]
 name = "pxfm"
 version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea"
+
+[[package]]
+name = "qoi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
@@ -4110,6 +4474,65 @@ dependencies = [
 ]
 
 [[package]]
+name = "rav1e"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43b6dd56e85d9483277cde964fd1bdb0428de4fec5ebba7540995639a21cb32b"
+dependencies = [
+ "aligned-vec",
+ "arbitrary",
+ "arg_enum_proc_macro",
+ "arrayvec",
+ "av-scenechange",
+ "av1-grain",
+ "bitstream-io",
+ "built",
+ "cfg-if",
+ "interpolate_name",
+ "itertools 0.14.0",
+ "libc",
+ "libfuzzer-sys",
+ "log",
+ "maybe-rayon",
+ "new_debug_unreachable",
+ "noop_proc_macro",
+ "num-derive",
+ "num-traits",
+ "paste",
+ "profiling",
+ "rand 0.9.5",
+ "rand_chacha",
+ "simd_helpers",
+ "thiserror 2.0.20",
+ "v_frame",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "ravif"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e52310197d971b0f5be7fe6b57530dcd27beb35c1b013f29d66c1ad73fbbcc45"
+dependencies = [
+ "avif-serialize",
+ "imgref",
+ "loop9",
+ "quick-error",
+ "rav1e",
+ "rayon",
+ "rgb",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags 2.13.1",
+]
+
+[[package]]
 name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4134,6 +4557,12 @@ dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
 ]
+
+[[package]]
+name = "reborrow"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03251193000f4bd3b042892be858ee50e8b3719f2b08e5833ac4353724632430"
 
 [[package]]
 name = "redox_syscall"
@@ -4286,6 +4715,12 @@ dependencies = [
  "web-sys",
  "windows-sys 0.60.2",
 ]
+
+[[package]]
+name = "rgb"
+version = "0.8.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
 
 [[package]]
 name = "ring"
@@ -4858,6 +5293,15 @@ checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
 dependencies = [
  "rustc_version",
  "simdutf8",
+]
+
+[[package]]
+name = "simd_helpers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
+dependencies = [
+ "quote",
 ]
 
 [[package]]
@@ -5978,6 +6422,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiff"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error",
+ "weezl",
+ "zune-jpeg",
+]
+
+[[package]]
 name = "time"
 version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6490,6 +6948,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "v_frame"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "666b7727c8875d6ab5db9533418d7c764233ac9c0cff1d469aec8fa127597be2"
+dependencies = [
+ "aligned-vec",
+ "num-traits",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6749,6 +7218,12 @@ dependencies = [
  "windows 0.61.3",
  "windows-core 0.61.2",
 ]
+
+[[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "winapi"
@@ -7412,6 +7887,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
+name = "y4m"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448"
+
+[[package]]
 name = "yoke"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7602,6 +8083,30 @@ name = "zmij"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
+
+[[package]]
+name = "zune-core"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56377fd46368984a170bc5aac5567e52ca5da874caa60bea39fcbca78fb658b"
+
+[[package]]
+name = "zune-inflate"
+version = "0.2.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
+]
 
 [[package]]
 name = "zvariant"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -127,7 +127,17 @@ windows = { version = "0.61", features = [
     "Win32_System_WinRT",
     "Win32_System_Recovery",
     "Win32_Storage_Packaging_Appx",
+    # --- Taskbar thumbnail toolbar + iconic (album art) preview (#852) ---
+    "Win32_UI_Shell",
+    "Win32_UI_WindowsAndMessaging",
+    "Win32_Graphics_Dwm",
+    "Win32_Graphics_Gdi",
 ] }
+# Decodes/resizes cover art into the RGBA buffer used for the taskbar's
+# iconic thumbnail (#852). Already pulled in transitively by Tauri's
+# "image-png" feature (see Cargo.lock) — added directly here since taskbar.rs
+# calls into it itself rather than through Tauri.
+image = "0.25"
 # tauri-plugin-notification hardcodes the toast's AppUserModelID to the Tauri
 # `identifier` config value, which Windows only accepts for apps registered
 # under that exact AUMID — an MSIX/Store install's real AUMID is

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -37,6 +37,8 @@ pub mod stats;
 pub mod stats_summary;
 pub mod tageditor;
 pub mod tags;
+#[cfg(target_os = "windows")]
+pub mod taskbar;
 pub mod tray;
 pub mod waveform;
 pub mod webdav;
@@ -889,6 +891,9 @@ pub fn run() {
             if let Err(e) = tray::init(app) {
                 log::warn!("Failed to initialize system tray: {e}");
             }
+
+            #[cfg(target_os = "windows")]
+            taskbar::init(app);
 
             register_media_shortcuts(app);
 

--- a/src-tauri/src/taskbar.rs
+++ b/src-tauri/src/taskbar.rs
@@ -30,8 +30,8 @@ use tauri::{AppHandle, Emitter, Listener, Manager};
 use windows::core::{w, BOOL};
 use windows::Win32::Foundation::{HWND, LPARAM, LRESULT, WPARAM};
 use windows::Win32::Graphics::Dwm::{
-    DwmSetIconicLivePreviewBitmap, DwmSetIconicThumbnail, DwmSetWindowAttribute,
-    DWMWA_FORCE_ICONIC_REPRESENTATION, DWMWA_HAS_ICONIC_BITMAP,
+    DwmInvalidateIconicBitmaps, DwmSetIconicLivePreviewBitmap, DwmSetIconicThumbnail,
+    DwmSetWindowAttribute, DWMWA_FORCE_ICONIC_REPRESENTATION, DWMWA_HAS_ICONIC_BITMAP,
 };
 use windows::Win32::Graphics::Gdi::{
     CreateBitmap, CreateDIBSection, DeleteObject, GetDC, ReleaseDC, BITMAPINFO, BITMAPINFOHEADER,
@@ -109,6 +109,12 @@ struct TaskbarContext {
     now_playing: parking_lot::Mutex<NowPlayingArt>,
     fallback_art: Arc<image::DynamicImage>,
     taskbar_button_created_msg: u32,
+    /// Bumped once per `apply_playback_state` call. Lets an art-decode task
+    /// that's still running when a *newer* track change comes in tell it's
+    /// been superseded and skip writing stale art into `now_playing` —
+    /// otherwise two rapid track changes could race and leave the slower
+    /// (now outdated) decode as the one that "wins".
+    art_request_seq: std::sync::atomic::AtomicU64,
 }
 
 // SAFETY: `taskbar` (an apartment-threaded COM pointer, behind its own
@@ -164,6 +170,7 @@ fn try_init(app: &tauri::App) -> windows::core::Result<()> {
         now_playing: parking_lot::Mutex::new(NowPlayingArt::default()),
         fallback_art: load_fallback_art(),
         taskbar_button_created_msg,
+        art_request_seq: std::sync::atomic::AtomicU64::new(0),
     });
     let ctx_ptr = Box::into_raw(ctx) as usize;
 
@@ -357,6 +364,11 @@ fn apply_playback_state(app: AppHandle, ctx_ptr: usize, state: PlaybackState) {
     // Slower: resolve and decode cover art off the main thread, caching it
     // for the next WM_DWMSENDICONICTHUMBNAIL/LIVEPREVIEWBITMAP request.
     let song_id = state.current_song.as_ref().map(|s| s.id);
+    let ctx = unsafe { &*(ctx_ptr as *const TaskbarContext) };
+    let my_seq = ctx
+        .art_request_seq
+        .fetch_add(1, std::sync::atomic::Ordering::SeqCst)
+        + 1;
     tauri::async_runtime::spawn(async move {
         // SAFETY: same as above.
         let ctx = unsafe { &*(ctx_ptr as *const TaskbarContext) };
@@ -373,9 +385,35 @@ fn apply_playback_state(app: AppHandle, ctx_ptr: usize, state: PlaybackState) {
         });
         let decoded = cover_path.and_then(|p| image::open(p).ok()).map(Arc::new);
 
-        let mut now_playing = ctx.now_playing.lock();
-        now_playing.song_id = song_id;
-        now_playing.image = decoded;
+        // A newer track change may have started (and possibly already
+        // finished) while this decode was running — if so, don't let this
+        // now-stale result clobber it.
+        if ctx
+            .art_request_seq
+            .load(std::sync::atomic::Ordering::SeqCst)
+            != my_seq
+        {
+            return;
+        }
+
+        {
+            let mut now_playing = ctx.now_playing.lock();
+            now_playing.song_id = song_id;
+            now_playing.image = decoded;
+        }
+
+        // The art just changed — tell DWM its cached thumbnail/live-preview
+        // bitmaps are stale so it re-requests them (via
+        // WM_DWMSENDICONICTHUMBNAIL/LIVEPREVIEWBITMAP) instead of continuing
+        // to show whatever was last handed to it, which could otherwise
+        // persist until some unrelated event happens to invalidate it.
+        // `HWND` wraps a raw pointer and isn't `Send`; it's just an opaque
+        // handle value here; reconstructed on the main thread it's actually
+        // used on.
+        let hwnd_value = ctx.hwnd.0 as isize;
+        let _ = app.run_on_main_thread(move || unsafe {
+            let _ = DwmInvalidateIconicBitmaps(HWND(hwnd_value as *mut core::ffi::c_void));
+        });
     });
 }
 

--- a/src-tauri/src/taskbar.rs
+++ b/src-tauri/src/taskbar.rs
@@ -27,7 +27,7 @@ use crate::models::{PlayState, PlaybackState};
 use crate::AppState;
 use std::sync::Arc;
 use tauri::{AppHandle, Emitter, Listener, Manager};
-use windows::core::BOOL;
+use windows::core::{w, BOOL};
 use windows::Win32::Foundation::{HWND, LPARAM, LRESULT, WPARAM};
 use windows::Win32::Graphics::Dwm::{
     DwmSetIconicLivePreviewBitmap, DwmSetIconicThumbnail, DwmSetWindowAttribute,
@@ -43,7 +43,8 @@ use windows::Win32::UI::Shell::{
     THBN_CLICKED, THB_FLAGS, THB_ICON, THB_TOOLTIP, THUMBBUTTON,
 };
 use windows::Win32::UI::WindowsAndMessaging::{
-    CreateIconIndirect, GetClientRect, GetSystemMetrics, HICON, ICONINFO, SM_CXSMICON, WM_COMMAND,
+    CreateIconIndirect, GetClientRect, GetSystemMetrics, RegisterWindowMessageW, HICON, ICONINFO,
+    SM_CXSMICON, WM_COMMAND,
 };
 
 /// Not currently exported by the `windows` crate's `Win32_Graphics_Dwm`
@@ -93,18 +94,30 @@ struct NowPlayingArt {
 struct TaskbarContext {
     app: AppHandle,
     hwnd: HWND,
-    taskbar: ITaskbarList3,
+    /// `None` until a taskbar button actually exists for our window (see
+    /// `try_register_thumbbar`) — `ThumbBarAddButtons` is a no-op if called
+    /// before that, which is exactly what a window created hidden
+    /// (`"visible": false`, shown later from the frontend) hits if it's
+    /// called eagerly at `.setup()` time.
+    taskbar: parking_lot::Mutex<Option<ITaskbarList3>>,
     icons: ButtonIcons,
+    /// The most recently applied (playing, has_song) pair, so a taskbar
+    /// button created *after* playback already started (or after Explorer
+    /// restarts and re-broadcasts `TaskbarButtonCreated`) can be seeded
+    /// correctly instead of starting from "no track loaded".
+    last_known_state: parking_lot::Mutex<(bool, bool)>,
     now_playing: parking_lot::Mutex<NowPlayingArt>,
     fallback_art: Arc<image::DynamicImage>,
+    taskbar_button_created_msg: u32,
 }
 
-// SAFETY: `taskbar` (an apartment-threaded COM pointer) and `icons` (raw
-// HICON handles) are only ever touched from the main thread — the thread
-// that created them in `try_init` below, and the only thread the window's
-// message pump (and therefore every `SetWindowSubclass` callback) runs on.
-// Code on other threads reaches this struct only to read/write
-// `now_playing`, which is guarded by its own `Mutex`, or to hand work back
+// SAFETY: `taskbar` (an apartment-threaded COM pointer, behind its own
+// Mutex) and `icons` (raw HICON handles) are only ever touched from the
+// main thread — the thread that created them in `try_init`/
+// `try_register_thumbbar`, and the only thread the window's message pump
+// (and therefore every `SetWindowSubclass` callback) runs on. Code on other
+// threads reaches this struct only to read/write `now_playing`/
+// `last_known_state`, each guarded by its own `Mutex`, or to hand work back
 // to the main thread via `AppHandle::run_on_main_thread`.
 unsafe impl Send for TaskbarContext {}
 unsafe impl Sync for TaskbarContext {}
@@ -127,10 +140,6 @@ fn try_init(app: &tauri::App) -> windows::core::Result<()> {
     };
     let hwnd = HWND(raw_hwnd.0);
 
-    let taskbar: ITaskbarList3 =
-        unsafe { CoCreateInstance(&TaskbarList, None, CLSCTX_INPROC_SERVER) }?;
-    unsafe { taskbar.HrInit() }?;
-
     let icon_size = (unsafe { GetSystemMetrics(SM_CXSMICON) }).max(16) as u32;
     let icons = ButtonIcons {
         previous: build_icon(ButtonGlyph::Previous, icon_size)?,
@@ -139,30 +148,60 @@ fn try_init(app: &tauri::App) -> windows::core::Result<()> {
         next: build_icon(ButtonGlyph::Next, icon_size)?,
     };
 
-    let initial_buttons = [
-        thumb_button(BTN_PREVIOUS, icons.previous, "Previous", false),
-        thumb_button(BTN_PLAY_PAUSE, icons.play, "Play", false),
-        thumb_button(BTN_NEXT, icons.next, "Next", false),
-    ];
-    unsafe { taskbar.ThumbBarAddButtons(hwnd, &initial_buttons) }?;
-
     force_iconic_representation(hwnd)?;
+
+    // Registered once here (rather than hardcoding WM_APP+N) so Explorer can
+    // tell every top-level window when a taskbar button becomes available
+    // for it — see `try_register_thumbbar`.
+    let taskbar_button_created_msg = unsafe { RegisterWindowMessageW(w!("TaskbarButtonCreated")) };
 
     let ctx = Box::new(TaskbarContext {
         app: app.handle().clone(),
         hwnd,
-        taskbar,
+        taskbar: parking_lot::Mutex::new(None),
         icons,
+        last_known_state: parking_lot::Mutex::new((false, false)),
         now_playing: parking_lot::Mutex::new(NowPlayingArt::default()),
         fallback_art: load_fallback_art(),
+        taskbar_button_created_msg,
     });
     let ctx_ptr = Box::into_raw(ctx) as usize;
 
     unsafe { SetWindowSubclass(hwnd, Some(subclass_proc), SUBCLASS_ID, ctx_ptr) }.ok()?;
 
+    // Covers the (unlikely, given the window starts hidden) case where a
+    // taskbar button already exists by the time we get here; the normal
+    // path is via `TaskbarButtonCreated` in `subclass_proc`.
+    let ctx = unsafe { &*(ctx_ptr as *const TaskbarContext) };
+    register_thumbbar(ctx);
+
     listen_playback_state(app, ctx_ptr);
     seed_playback_state(app.handle().clone(), ctx_ptr);
 
+    Ok(())
+}
+
+/// (Re-)creates the `ITaskbarList3` for our window and registers the
+/// thumbbar buttons, seeded with whatever playback state was last applied.
+/// Called once a taskbar button actually exists for the window — see the
+/// `TaskbarButtonCreated` handling in `subclass_proc` — and, in principle,
+/// again if Explorer restarts and rebroadcasts that message.
+fn register_thumbbar(ctx: &TaskbarContext) {
+    if let Err(e) = try_register_thumbbar(ctx) {
+        log::warn!("Failed to register taskbar thumbbar buttons: {e:?}");
+    }
+}
+
+fn try_register_thumbbar(ctx: &TaskbarContext) -> windows::core::Result<()> {
+    let taskbar: ITaskbarList3 =
+        unsafe { CoCreateInstance(&TaskbarList, None, CLSCTX_INPROC_SERVER) }?;
+    unsafe { taskbar.HrInit() }?;
+
+    let (playing, has_song) = *ctx.last_known_state.lock();
+    let buttons = build_buttons(ctx, playing, has_song);
+    unsafe { taskbar.ThumbBarAddButtons(ctx.hwnd, &buttons) }?;
+
+    *ctx.taskbar.lock() = Some(taskbar);
     Ok(())
 }
 
@@ -209,6 +248,14 @@ unsafe extern "system" fn subclass_proc(
     ref_data: usize,
 ) -> LRESULT {
     let ctx = &*(ref_data as *const TaskbarContext);
+
+    if msg == ctx.taskbar_button_created_msg {
+        register_thumbbar(ctx);
+        // Not a message with a meaningful return value or default handling
+        // of its own, but fall through to `DefSubclassProc` anyway rather
+        // than swallowing a registered message other subclasses might care
+        // about.
+    }
 
     match msg {
         WM_COMMAND => {
@@ -332,18 +379,30 @@ fn apply_playback_state(app: AppHandle, ctx_ptr: usize, state: PlaybackState) {
     });
 }
 
-fn sync_thumbbar_buttons(ctx: &TaskbarContext, playing: bool, has_song: bool) {
+fn build_buttons(ctx: &TaskbarContext, playing: bool, has_song: bool) -> [THUMBBUTTON; 3] {
     let (play_pause_icon, play_pause_tip) = if playing {
         (ctx.icons.pause, "Pause")
     } else {
         (ctx.icons.play, "Play")
     };
-    let buttons = [
+    [
         thumb_button(BTN_PREVIOUS, ctx.icons.previous, "Previous", has_song),
         thumb_button(BTN_PLAY_PAUSE, play_pause_icon, play_pause_tip, has_song),
         thumb_button(BTN_NEXT, ctx.icons.next, "Next", has_song),
-    ];
-    if let Err(e) = unsafe { ctx.taskbar.ThumbBarUpdateButtons(ctx.hwnd, &buttons) } {
+    ]
+}
+
+fn sync_thumbbar_buttons(ctx: &TaskbarContext, playing: bool, has_song: bool) {
+    *ctx.last_known_state.lock() = (playing, has_song);
+
+    let taskbar_guard = ctx.taskbar.lock();
+    let Some(taskbar) = taskbar_guard.as_ref() else {
+        // No taskbar button yet — `register_thumbbar` will apply
+        // `last_known_state` once `TaskbarButtonCreated` arrives.
+        return;
+    };
+    let buttons = build_buttons(ctx, playing, has_song);
+    if let Err(e) = unsafe { taskbar.ThumbBarUpdateButtons(ctx.hwnd, &buttons) } {
         log::warn!("Failed to update taskbar thumbbar buttons: {e:?}");
     }
 }

--- a/src-tauri/src/taskbar.rs
+++ b/src-tauri/src/taskbar.rs
@@ -1,0 +1,659 @@
+//! Windows taskbar thumbnail toolbar (`ITaskbarList3`) — #852.
+//!
+//! Adds Previous/Play-Pause/Next buttons beneath the taskbar thumbnail
+//! preview of the main window, and replaces that preview (and the larger
+//! hover flyout) with the current track's cover art via DWM's "iconic
+//! bitmap" mechanism, so hovering the taskbar icon reads as a "now playing"
+//! card rather than a screenshot of whatever tab happens to be open.
+//!
+//! Both pieces are best-effort, mirroring `media_session::windows` (SMTC):
+//! if COM/DWM setup fails, this logs a warning and Luminous just runs
+//! without the feature. Button clicks are dispatched through the same
+//! `state.player` command paths as the tray menu (`tray.rs`) and global
+//! media-key shortcuts (`lib.rs::register_media_shortcuts`).
+//!
+//! `ITaskbarList3` is an apartment-threaded COM object: it's created here in
+//! `.setup()` (the main/UI thread, which owns the window's message pump) and
+//! must only ever be called from that same thread again. The window is
+//! subclassed via `SetWindowSubclass` (comctl32) rather than replacing its
+//! `WNDPROC` outright, since that's the additive, chaining-safe way to hook
+//! messages without clobbering tao's own window procedure — the same
+//! consideration that led `media_session::windows` to run SMTC on its own
+//! dedicated COM thread instead. Any code that isn't already running on the
+//! main thread (e.g. the async task that decodes cover art) hands taskbar
+//! button/icon updates back to it via `AppHandle::run_on_main_thread`.
+
+use crate::models::{PlayState, PlaybackState};
+use crate::AppState;
+use std::sync::Arc;
+use tauri::{AppHandle, Emitter, Listener, Manager};
+use windows::core::BOOL;
+use windows::Win32::Foundation::{HWND, LPARAM, LRESULT, WPARAM};
+use windows::Win32::Graphics::Dwm::{
+    DwmSetIconicLivePreviewBitmap, DwmSetIconicThumbnail, DwmSetWindowAttribute,
+    DWMWA_FORCE_ICONIC_REPRESENTATION, DWMWA_HAS_ICONIC_BITMAP,
+};
+use windows::Win32::Graphics::Gdi::{
+    CreateBitmap, CreateDIBSection, DeleteObject, GetDC, ReleaseDC, BITMAPINFO, BITMAPINFOHEADER,
+    BI_RGB, DIB_RGB_COLORS, HBITMAP,
+};
+use windows::Win32::System::Com::{CoCreateInstance, CLSCTX_INPROC_SERVER};
+use windows::Win32::UI::Shell::{
+    DefSubclassProc, ITaskbarList3, SetWindowSubclass, TaskbarList, THBF_DISABLED, THBF_ENABLED,
+    THBN_CLICKED, THB_FLAGS, THB_ICON, THB_TOOLTIP, THUMBBUTTON,
+};
+use windows::Win32::UI::WindowsAndMessaging::{
+    CreateIconIndirect, GetClientRect, GetSystemMetrics, HICON, ICONINFO, SM_CXSMICON, WM_COMMAND,
+};
+
+/// Not currently exported by the `windows` crate's `Win32_Graphics_Dwm`
+/// bindings — values are stable Win32 constants from `dwmapi.h`.
+const WM_DWMSENDICONICTHUMBNAIL: u32 = 0x0323;
+const WM_DWMSENDICONICLIVEPREVIEWBITMAP: u32 = 0x0326;
+
+const BTN_PREVIOUS: u32 = 100;
+const BTN_PLAY_PAUSE: u32 = 101;
+const BTN_NEXT: u32 = 102;
+
+/// Arbitrary but stable id identifying our subclass among any others chained
+/// on the same window (comctl32 requires each subclass to register a unique
+/// id) — the issue number doubles as a memorable, collision-unlikely value.
+const SUBCLASS_ID: usize = 852;
+
+#[derive(Clone, Copy)]
+enum ButtonAction {
+    Previous,
+    PlayPause,
+    Next,
+}
+
+fn button_action(id: u32) -> Option<ButtonAction> {
+    match id {
+        BTN_PREVIOUS => Some(ButtonAction::Previous),
+        BTN_PLAY_PAUSE => Some(ButtonAction::PlayPause),
+        BTN_NEXT => Some(ButtonAction::Next),
+        _ => None,
+    }
+}
+
+#[derive(Clone, Copy)]
+struct ButtonIcons {
+    previous: HICON,
+    play: HICON,
+    pause: HICON,
+    next: HICON,
+}
+
+#[derive(Default)]
+struct NowPlayingArt {
+    song_id: Option<i64>,
+    image: Option<Arc<image::DynamicImage>>,
+}
+
+struct TaskbarContext {
+    app: AppHandle,
+    hwnd: HWND,
+    taskbar: ITaskbarList3,
+    icons: ButtonIcons,
+    now_playing: parking_lot::Mutex<NowPlayingArt>,
+    fallback_art: Arc<image::DynamicImage>,
+}
+
+// SAFETY: `taskbar` (an apartment-threaded COM pointer) and `icons` (raw
+// HICON handles) are only ever touched from the main thread — the thread
+// that created them in `try_init` below, and the only thread the window's
+// message pump (and therefore every `SetWindowSubclass` callback) runs on.
+// Code on other threads reaches this struct only to read/write
+// `now_playing`, which is guarded by its own `Mutex`, or to hand work back
+// to the main thread via `AppHandle::run_on_main_thread`.
+unsafe impl Send for TaskbarContext {}
+unsafe impl Sync for TaskbarContext {}
+
+/// Best-effort: adds the thumbnail toolbar and iconic (cover art) preview to
+/// the main window. Logs and returns on any failure — Luminous runs fine
+/// without this, the same way it does when SMTC/MPRIS init fails.
+pub fn init(app: &tauri::App) {
+    if let Err(e) = try_init(app) {
+        log::warn!("Failed to initialize taskbar thumbnail toolbar: {e:?}");
+    }
+}
+
+fn try_init(app: &tauri::App) -> windows::core::Result<()> {
+    let Some(window) = app.get_webview_window("main") else {
+        return Ok(());
+    };
+    let Ok(raw_hwnd) = window.hwnd() else {
+        return Ok(());
+    };
+    let hwnd = HWND(raw_hwnd.0);
+
+    let taskbar: ITaskbarList3 =
+        unsafe { CoCreateInstance(&TaskbarList, None, CLSCTX_INPROC_SERVER) }?;
+    unsafe { taskbar.HrInit() }?;
+
+    let icon_size = (unsafe { GetSystemMetrics(SM_CXSMICON) }).max(16) as u32;
+    let icons = ButtonIcons {
+        previous: build_icon(ButtonGlyph::Previous, icon_size)?,
+        play: build_icon(ButtonGlyph::Play, icon_size)?,
+        pause: build_icon(ButtonGlyph::Pause, icon_size)?,
+        next: build_icon(ButtonGlyph::Next, icon_size)?,
+    };
+
+    let initial_buttons = [
+        thumb_button(BTN_PREVIOUS, icons.previous, "Previous", false),
+        thumb_button(BTN_PLAY_PAUSE, icons.play, "Play", false),
+        thumb_button(BTN_NEXT, icons.next, "Next", false),
+    ];
+    unsafe { taskbar.ThumbBarAddButtons(hwnd, &initial_buttons) }?;
+
+    force_iconic_representation(hwnd)?;
+
+    let ctx = Box::new(TaskbarContext {
+        app: app.handle().clone(),
+        hwnd,
+        taskbar,
+        icons,
+        now_playing: parking_lot::Mutex::new(NowPlayingArt::default()),
+        fallback_art: load_fallback_art(),
+    });
+    let ctx_ptr = Box::into_raw(ctx) as usize;
+
+    unsafe { SetWindowSubclass(hwnd, Some(subclass_proc), SUBCLASS_ID, ctx_ptr) }.ok()?;
+
+    listen_playback_state(app, ctx_ptr);
+    seed_playback_state(app.handle().clone(), ctx_ptr);
+
+    Ok(())
+}
+
+fn force_iconic_representation(hwnd: HWND) -> windows::core::Result<()> {
+    let enabled = BOOL(1);
+    unsafe {
+        DwmSetWindowAttribute(
+            hwnd,
+            DWMWA_HAS_ICONIC_BITMAP,
+            &enabled as *const _ as *const core::ffi::c_void,
+            std::mem::size_of::<BOOL>() as u32,
+        )?;
+        DwmSetWindowAttribute(
+            hwnd,
+            DWMWA_FORCE_ICONIC_REPRESENTATION,
+            &enabled as *const _ as *const core::ffi::c_void,
+            std::mem::size_of::<BOOL>() as u32,
+        )?;
+    }
+    Ok(())
+}
+
+fn thumb_button(id: u32, icon: HICON, tip: &str, enabled: bool) -> THUMBBUTTON {
+    let mut sz_tip = [0u16; 260];
+    for (dst, c) in sz_tip.iter_mut().zip(tip.encode_utf16()) {
+        *dst = c;
+    }
+    THUMBBUTTON {
+        dwMask: THB_ICON | THB_TOOLTIP | THB_FLAGS,
+        iId: id,
+        iBitmap: 0,
+        hIcon: icon,
+        szTip: sz_tip,
+        dwFlags: if enabled { THBF_ENABLED } else { THBF_DISABLED },
+    }
+}
+
+unsafe extern "system" fn subclass_proc(
+    hwnd: HWND,
+    msg: u32,
+    wparam: WPARAM,
+    lparam: LPARAM,
+    _subclass_id: usize,
+    ref_data: usize,
+) -> LRESULT {
+    let ctx = &*(ref_data as *const TaskbarContext);
+
+    match msg {
+        WM_COMMAND => {
+            let notification = ((wparam.0 >> 16) & 0xFFFF) as u32;
+            let button_id = (wparam.0 & 0xFFFF) as u32;
+            if notification == THBN_CLICKED {
+                if let Some(action) = button_action(button_id) {
+                    dispatch_button_action(&ctx.app, action);
+                }
+                return LRESULT(0);
+            }
+        }
+        WM_DWMSENDICONICTHUMBNAIL => {
+            let width = ((lparam.0 >> 16) & 0xFFFF) as u32;
+            let height = (lparam.0 & 0xFFFF) as u32;
+            if width > 0 && height > 0 {
+                send_iconic_thumbnail(ctx, hwnd, width, height);
+            }
+            return LRESULT(0);
+        }
+        WM_DWMSENDICONICLIVEPREVIEWBITMAP => {
+            send_live_preview(ctx, hwnd);
+            return LRESULT(0);
+        }
+        _ => {}
+    }
+
+    DefSubclassProc(hwnd, msg, wparam, lparam)
+}
+
+/// Mirrors `tray::handle_menu_event` / `lib.rs::register_media_shortcuts`:
+/// lock the player, run the command, then propagate the result the same way
+/// every other playback-control entry point does.
+fn dispatch_button_action(app: &AppHandle, action: ButtonAction) {
+    let app = app.clone();
+    tauri::async_runtime::spawn(async move {
+        let state = app.state::<AppState>();
+        let mut player = state.player.lock().await;
+
+        let result = match action {
+            ButtonAction::PlayPause => {
+                if player.get_state().await.state == PlayState::Playing {
+                    player.pause().await
+                } else {
+                    player.resume().await
+                }
+            }
+            ButtonAction::Next => {
+                if let Some(stats) = player.note_manual_skip() {
+                    let _ = app.emit("song-stats-changed", stats);
+                }
+                player.next_track().await
+            }
+            ButtonAction::Previous => player.previous_track().await,
+        };
+
+        if result.is_ok() {
+            let playback_state = player.get_state().await;
+            crate::media_session::mirror_state(&app, &playback_state).await;
+            let _ = app.emit("playback-state", playback_state);
+        }
+    });
+}
+
+fn listen_playback_state(app: &tauri::App, ctx_ptr: usize) {
+    let app_handle = app.handle().clone();
+    app.listen("playback-state", move |event| {
+        if let Ok(state) = serde_json::from_str::<PlaybackState>(event.payload()) {
+            apply_playback_state(app_handle.clone(), ctx_ptr, state);
+        }
+    });
+}
+
+/// The listener above only fires on playback-state *changes*, so a session
+/// restored with a track already loaded wouldn't show buttons/art until the
+/// next play/pause — seed it once up front, the same way
+/// `tray::seed_tooltip` seeds the tray tooltip.
+fn seed_playback_state(app: AppHandle, ctx_ptr: usize) {
+    tauri::async_runtime::spawn(async move {
+        let state = app.state::<AppState>();
+        let snapshot = state.player.lock().await.get_state().await;
+        apply_playback_state(app, ctx_ptr, snapshot);
+    });
+}
+
+fn apply_playback_state(app: AppHandle, ctx_ptr: usize, state: PlaybackState) {
+    let has_song = state.current_song.is_some();
+    let playing = state.state == PlayState::Playing;
+
+    // Fast, no I/O: sync the thumbbar buttons on the main thread, since
+    // `ITaskbarList3` may only be called from the thread that created it.
+    let _ = app.run_on_main_thread(move || {
+        // SAFETY: `ctx_ptr` was leaked from a `Box<TaskbarContext>` in
+        // `try_init` and lives for the rest of the process.
+        let ctx = unsafe { &*(ctx_ptr as *const TaskbarContext) };
+        sync_thumbbar_buttons(ctx, playing, has_song);
+    });
+
+    // Slower: resolve and decode cover art off the main thread, caching it
+    // for the next WM_DWMSENDICONICTHUMBNAIL/LIVEPREVIEWBITMAP request.
+    let song_id = state.current_song.as_ref().map(|s| s.id);
+    tauri::async_runtime::spawn(async move {
+        // SAFETY: same as above.
+        let ctx = unsafe { &*(ctx_ptr as *const TaskbarContext) };
+        if ctx.now_playing.lock().song_id == song_id {
+            return;
+        }
+
+        let cover_path = song_id.and_then(|id| {
+            app.state::<AppState>()
+                .cover_manager
+                .get_cover_art_path(id)
+                .ok()
+                .flatten()
+        });
+        let decoded = cover_path.and_then(|p| image::open(p).ok()).map(Arc::new);
+
+        let mut now_playing = ctx.now_playing.lock();
+        now_playing.song_id = song_id;
+        now_playing.image = decoded;
+    });
+}
+
+fn sync_thumbbar_buttons(ctx: &TaskbarContext, playing: bool, has_song: bool) {
+    let (play_pause_icon, play_pause_tip) = if playing {
+        (ctx.icons.pause, "Pause")
+    } else {
+        (ctx.icons.play, "Play")
+    };
+    let buttons = [
+        thumb_button(BTN_PREVIOUS, ctx.icons.previous, "Previous", has_song),
+        thumb_button(BTN_PLAY_PAUSE, play_pause_icon, play_pause_tip, has_song),
+        thumb_button(BTN_NEXT, ctx.icons.next, "Next", has_song),
+    ];
+    if let Err(e) = unsafe { ctx.taskbar.ThumbBarUpdateButtons(ctx.hwnd, &buttons) } {
+        log::warn!("Failed to update taskbar thumbbar buttons: {e:?}");
+    }
+}
+
+fn send_iconic_thumbnail(ctx: &TaskbarContext, hwnd: HWND, width: u32, height: u32) {
+    match build_iconic_bitmap(ctx, width, height) {
+        Ok(hbitmap) => unsafe {
+            let _ = DwmSetIconicThumbnail(hwnd, hbitmap, 0);
+            let _ = DeleteObject(hbitmap.into());
+        },
+        Err(e) => log::warn!("Failed to build taskbar iconic thumbnail: {e:?}"),
+    }
+}
+
+fn send_live_preview(ctx: &TaskbarContext, hwnd: HWND) {
+    let mut rect = Default::default();
+    let (width, height) = if unsafe { GetClientRect(hwnd, &mut rect) }.is_ok() {
+        (
+            (rect.right - rect.left).max(1) as u32,
+            (rect.bottom - rect.top).max(1) as u32,
+        )
+    } else {
+        (320, 320)
+    };
+
+    match build_iconic_bitmap(ctx, width, height) {
+        Ok(hbitmap) => unsafe {
+            let _ = DwmSetIconicLivePreviewBitmap(hwnd, hbitmap, None, 0);
+            let _ = DeleteObject(hbitmap.into());
+        },
+        Err(e) => log::warn!("Failed to build taskbar live preview bitmap: {e:?}"),
+    }
+}
+
+fn build_iconic_bitmap(
+    ctx: &TaskbarContext,
+    box_w: u32,
+    box_h: u32,
+) -> windows::core::Result<HBITMAP> {
+    let image = {
+        let now_playing = ctx.now_playing.lock();
+        now_playing
+            .image
+            .clone()
+            .unwrap_or_else(|| ctx.fallback_art.clone())
+    };
+    render_premultiplied_bitmap(&image, box_w, box_h)
+}
+
+/// Scales `(src_w, src_h)` down (or up) to fit within `(max_w, max_h)`
+/// while preserving aspect ratio. Returns `(0, 0)` for degenerate input.
+fn fit_within(src_w: u32, src_h: u32, max_w: u32, max_h: u32) -> (u32, u32) {
+    if src_w == 0 || src_h == 0 || max_w == 0 || max_h == 0 {
+        return (0, 0);
+    }
+    let scale = (max_w as f64 / src_w as f64).min(max_h as f64 / src_h as f64);
+    let w = ((src_w as f64 * scale).round() as u32).clamp(1, max_w);
+    let h = ((src_h as f64 * scale).round() as u32).clamp(1, max_h);
+    (w, h)
+}
+
+/// Builds a `box_w x box_h` 32bpp premultiplied-alpha DIB with `image`
+/// letterboxed (aspect-preserving, centered) inside it — the format
+/// `DwmSetIconicThumbnail`/`DwmSetIconicLivePreviewBitmap` require.
+fn render_premultiplied_bitmap(
+    image: &image::DynamicImage,
+    box_w: u32,
+    box_h: u32,
+) -> windows::core::Result<HBITMAP> {
+    let (target_w, target_h) = fit_within(image.width(), image.height(), box_w, box_h);
+    let x_off = box_w.saturating_sub(target_w) / 2;
+    let y_off = box_h.saturating_sub(target_h) / 2;
+
+    let (hbitmap, bits) = create_argb_dib(box_w, box_h)?;
+    // SAFETY: `bits` points to a freshly allocated, zero-initialized
+    // `box_w * box_h * 4`-byte DIB section owned by `hbitmap`.
+    let buf = unsafe { std::slice::from_raw_parts_mut(bits, (box_w * box_h * 4) as usize) };
+
+    if target_w > 0 && target_h > 0 {
+        let resized = image::imageops::resize(
+            image,
+            target_w,
+            target_h,
+            image::imageops::FilterType::Triangle,
+        );
+        for y in 0..target_h {
+            for x in 0..target_w {
+                let px = resized.get_pixel(x, y).0;
+                let a = px[3] as u32;
+                let idx = (((y + y_off) * box_w + (x + x_off)) * 4) as usize;
+                buf[idx] = ((px[2] as u32 * a) / 255) as u8;
+                buf[idx + 1] = ((px[1] as u32 * a) / 255) as u8;
+                buf[idx + 2] = ((px[0] as u32 * a) / 255) as u8;
+                buf[idx + 3] = a as u8;
+            }
+        }
+    }
+
+    Ok(hbitmap)
+}
+
+/// Allocates a top-down, 32bpp, zero-initialized BGRA DIB section of the
+/// given size. The returned pointer stays valid for the lifetime of the
+/// returned `HBITMAP`.
+fn create_argb_dib(width: u32, height: u32) -> windows::core::Result<(HBITMAP, *mut u8)> {
+    let mut bmi = BITMAPINFO::default();
+    bmi.bmiHeader.biSize = std::mem::size_of::<BITMAPINFOHEADER>() as u32;
+    bmi.bmiHeader.biWidth = width as i32;
+    bmi.bmiHeader.biHeight = -(height as i32);
+    bmi.bmiHeader.biPlanes = 1;
+    bmi.bmiHeader.biBitCount = 32;
+    bmi.bmiHeader.biCompression = BI_RGB.0;
+
+    let mut bits: *mut core::ffi::c_void = std::ptr::null_mut();
+    let hdc = unsafe { GetDC(None) };
+    let result = unsafe { CreateDIBSection(Some(hdc), &bmi, DIB_RGB_COLORS, &mut bits, None, 0) };
+    unsafe {
+        ReleaseDC(None, hdc);
+    }
+    result.map(|hbitmap| (hbitmap, bits as *mut u8))
+}
+
+#[derive(Clone, Copy)]
+enum ButtonGlyph {
+    Previous,
+    Play,
+    Pause,
+    Next,
+}
+
+/// Renders a flat, filled glyph (no external icon assets) into an `HICON`
+/// at `size x size` — straight (non-premultiplied) alpha, which is what a
+/// 32bpp icon bitmap expects (unlike the DWM iconic bitmaps above).
+fn build_icon(glyph: ButtonGlyph, size: u32) -> windows::core::Result<HICON> {
+    let (color_bitmap, bits) = create_argb_dib(size, size)?;
+    {
+        // SAFETY: see `render_premultiplied_bitmap` — same allocation shape.
+        let buf = unsafe { std::slice::from_raw_parts_mut(bits, (size * size * 4) as usize) };
+        draw_glyph(glyph, size, buf);
+    }
+    // A 32bpp color bitmap with a real alpha channel only needs a blank
+    // (all-zero) 1bpp mask — the alpha channel alone drives transparency.
+    let mask_bitmap = unsafe { CreateBitmap(size as i32, size as i32, 1, 1, None) };
+
+    let icon_info = ICONINFO {
+        fIcon: BOOL(1),
+        xHotspot: 0,
+        yHotspot: 0,
+        hbmMask: mask_bitmap,
+        hbmColor: color_bitmap,
+    };
+    let result = unsafe { CreateIconIndirect(&icon_info) };
+    unsafe {
+        let _ = DeleteObject(color_bitmap.into());
+        let _ = DeleteObject(mask_bitmap.into());
+    }
+    result
+}
+
+fn draw_glyph(glyph: ButtonGlyph, size: u32, buf: &mut [u8]) {
+    let s = size as f32;
+    let margin = s * 0.28;
+    match glyph {
+        ButtonGlyph::Play => {
+            fill_triangle(
+                buf,
+                size,
+                (margin, margin),
+                (margin, s - margin),
+                (s - margin, s / 2.0),
+            );
+        }
+        ButtonGlyph::Pause => {
+            let bar_w = s * 0.16;
+            let gap = s * 0.14;
+            let left1 = s / 2.0 - gap / 2.0 - bar_w;
+            let left2 = s / 2.0 + gap / 2.0;
+            fill_rect(buf, size, left1, margin, left1 + bar_w, s - margin);
+            fill_rect(buf, size, left2, margin, left2 + bar_w, s - margin);
+        }
+        ButtonGlyph::Next => {
+            let mid = s / 2.0;
+            fill_triangle(
+                buf,
+                size,
+                (margin, margin),
+                (margin, s - margin),
+                (mid, s / 2.0),
+            );
+            let bar_w = s * 0.12;
+            fill_rect(buf, size, mid, margin, mid + bar_w, s - margin);
+        }
+        ButtonGlyph::Previous => {
+            let mid = s / 2.0;
+            fill_triangle(
+                buf,
+                size,
+                (s - margin, margin),
+                (s - margin, s - margin),
+                (mid, s / 2.0),
+            );
+            let bar_w = s * 0.12;
+            fill_rect(buf, size, mid - bar_w, margin, mid, s - margin);
+        }
+    }
+}
+
+fn set_pixel_opaque(buf: &mut [u8], size: u32, x: i64, y: i64) {
+    if x < 0 || y < 0 || x as u32 >= size || y as u32 >= size {
+        return;
+    }
+    let idx = ((y as u32 * size + x as u32) * 4) as usize;
+    buf[idx] = 255;
+    buf[idx + 1] = 255;
+    buf[idx + 2] = 255;
+    buf[idx + 3] = 255;
+}
+
+fn fill_rect(buf: &mut [u8], size: u32, x0: f32, y0: f32, x1: f32, y1: f32) {
+    let (x0, x1) = (x0.min(x1).round() as i64, x0.max(x1).round() as i64);
+    let (y0, y1) = (y0.min(y1).round() as i64, y0.max(y1).round() as i64);
+    for y in y0..y1 {
+        for x in x0..x1 {
+            set_pixel_opaque(buf, size, x, y);
+        }
+    }
+}
+
+fn fill_triangle(buf: &mut [u8], size: u32, p0: (f32, f32), p1: (f32, f32), p2: (f32, f32)) {
+    let min_x = p0.0.min(p1.0).min(p2.0).floor() as i64;
+    let max_x = p0.0.max(p1.0).max(p2.0).ceil() as i64;
+    let min_y = p0.1.min(p1.1).min(p2.1).floor() as i64;
+    let max_y = p0.1.max(p1.1).max(p2.1).ceil() as i64;
+    for y in min_y..=max_y {
+        for x in min_x..=max_x {
+            let p = (x as f32 + 0.5, y as f32 + 0.5);
+            if point_in_triangle(p, p0, p1, p2) {
+                set_pixel_opaque(buf, size, x, y);
+            }
+        }
+    }
+}
+
+fn triangle_sign(p1: (f32, f32), p2: (f32, f32), p3: (f32, f32)) -> f32 {
+    (p1.0 - p3.0) * (p2.1 - p3.1) - (p2.0 - p3.0) * (p1.1 - p3.1)
+}
+
+fn point_in_triangle(pt: (f32, f32), v0: (f32, f32), v1: (f32, f32), v2: (f32, f32)) -> bool {
+    let d1 = triangle_sign(pt, v0, v1);
+    let d2 = triangle_sign(pt, v1, v2);
+    let d3 = triangle_sign(pt, v2, v0);
+    let has_neg = d1 < 0.0 || d2 < 0.0 || d3 < 0.0;
+    let has_pos = d1 > 0.0 || d2 > 0.0 || d3 > 0.0;
+    !(has_neg && has_pos)
+}
+
+fn load_fallback_art() -> Arc<image::DynamicImage> {
+    const FALLBACK_ART_BYTES: &[u8] = include_bytes!("../icons/128x128.png");
+    Arc::new(
+        image::load_from_memory(FALLBACK_ART_BYTES)
+            .unwrap_or_else(|_| image::DynamicImage::new_rgba8(1, 1)),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn button_action_maps_known_ids() {
+        assert!(matches!(
+            button_action(BTN_PREVIOUS),
+            Some(ButtonAction::Previous)
+        ));
+        assert!(matches!(
+            button_action(BTN_PLAY_PAUSE),
+            Some(ButtonAction::PlayPause)
+        ));
+        assert!(matches!(button_action(BTN_NEXT), Some(ButtonAction::Next)));
+    }
+
+    #[test]
+    fn button_action_ignores_unknown_ids() {
+        assert!(button_action(0).is_none());
+        assert!(button_action(999).is_none());
+    }
+
+    #[test]
+    fn fit_within_downscales_preserving_aspect_ratio() {
+        assert_eq!(fit_within(1000, 1000, 64, 64), (64, 64));
+        assert_eq!(fit_within(1000, 500, 64, 64), (64, 32));
+        assert_eq!(fit_within(500, 1000, 64, 64), (32, 64));
+    }
+
+    #[test]
+    fn fit_within_upscales_small_art_to_fill_the_box() {
+        assert_eq!(fit_within(10, 10, 64, 64), (64, 64));
+    }
+
+    #[test]
+    fn fit_within_handles_degenerate_input() {
+        assert_eq!(fit_within(0, 100, 64, 64), (0, 0));
+        assert_eq!(fit_within(100, 0, 64, 64), (0, 0));
+        assert_eq!(fit_within(100, 100, 0, 64), (0, 0));
+    }
+
+    #[test]
+    fn point_in_triangle_matches_expected_containment() {
+        let tri = ((0.0, 0.0), (10.0, 0.0), (0.0, 10.0));
+        assert!(point_in_triangle((1.0, 1.0), tri.0, tri.1, tri.2));
+        assert!(!point_in_triangle((9.0, 9.0), tri.0, tri.1, tri.2));
+    }
+}


### PR DESCRIPTION
## 📋 Summary
Addresses #852. Adds Previous/Play-Pause/Next buttons to the Windows taskbar thumbnail preview via `ITaskbarList3`, and — per follow-up feedback with a screenshot of Spotify's taskbar hover card — replaces the taskbar's live window thumbnail/hover flyout with the current track's album art via DWM iconic bitmaps, so hovering the Luminous taskbar icon reads as a "now playing" card.

## 🔍 Implementation Notes
- New `src-tauri/src/taskbar.rs` (Windows-only, `#[cfg(target_os = "windows")]`), wired into `.setup()` in `lib.rs` right after `tray::init`.
- Button clicks route through the same `state.player` command paths as the tray menu (`tray.rs`) and global media-key shortcuts (`lib.rs::register_media_shortcuts`) — pause/resume, next/previous with manual-skip stat tracking, SMTC mirroring, and the `playback-state` event all behave identically regardless of which control the user used.
- Buttons are disabled when no track is loaded and enabled otherwise; the middle button's icon/tooltip swap between Play and Pause based on current state.
- Button icons are rendered programmatically (flat triangle/bar glyphs into a DIB, wrapped as an `HICON`) rather than shipped as new asset files.
- Cover art is resolved via the existing `CoverManager::get_cover_art_path`, decoded with a newly-added `image` crate dependency (Windows-only; already present transitively via Tauri's `image-png` feature), and cached per-track so a taskbar hover only does a cheap resize of the already-decoded image rather than a fresh decode. Falls back to the app icon when a track has no art or nothing is playing.
- `ITaskbarList3` is an apartment-threaded COM object — created/called only from the main thread. `ThumbBarAddButtons` is registered lazily in response to the `TaskbarButtonCreated` broadcast message rather than eagerly at `.setup()` time, since the main window starts hidden (`"visible": false`, shown later from the frontend) and calling it before a taskbar button exists for the window silently no-ops (this was caught during manual testing — the album art showed but the buttons didn't, since the DWM iconic-bitmap path doesn't have this dependency).
- The window is subclassed via `SetWindowSubclass` (comctl32) rather than replacing its `WNDPROC` outright, to avoid clobbering tao's own window procedure.
- DWM caches whatever iconic bitmap it was last handed and only re-queries a new one when told the cache is stale — `DwmInvalidateIconicBitmaps` is called whenever the cached cover art actually changes (also caught during manual testing: the very first track's art showed, but switching tracks didn't update it). Art decoding is also guarded against a race where two rapid track changes could otherwise let a slower, now-stale decode overwrite a newer one.
- Out of scope for this pass: the issue's optional Favorite/heart button — left out to keep the change scoped; straightforward to add later as a 4th thumbbar button using the same mechanism.

## 🧪 Test Plan
- [x] `cargo test` (src-tauri) — full suite passes, including 6 new unit tests (letterbox/fit-into-box math, button-id → player-command mapping)
- [x] `cargo clippy` / `cargo fmt` — clean
- [ ] `bun run check` / `bun run test -- --run` — no frontend changes in this PR
- [x] Manually verified in the app (`bun run tauri dev`) by @esoltys: taskbar hover shows the album art with working Previous/Pause/Next underneath; buttons control playback and the Play/Pause icon flips correctly; switching tracks/albums now updates the art; no-art and fully-idle states fall back to the app icon.

## 📸 Screenshots
<!-- @esoltys: please attach the taskbar-hover screenshot from your manual test here. -->

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed — screenshot added above; no docs reference this OS-shell-only feature
