### PR TITLE
feat: add daily listening heatmap to Personal Stats

### DIFF
--- a/src-tauri/src/commands/stats.rs
+++ b/src-tauri/src/commands/stats.rs
@@ -1,4 +1,4 @@
-use crate::models::StatsSummary;
+use crate::models::{ListenEvent, StatsSummary};
 use crate::stats_summary::StatsRange;
 use crate::AppState;
 use tauri::{AppHandle, Emitter, State};
@@ -11,6 +11,18 @@ pub async fn get_stats_summary(
     let conn = state.db.pool.get().map_err(|e| e.to_string())?;
     let range = StatsRange::parse(&range).ok_or_else(|| format!("invalid range: {range}"))?;
     crate::stats_summary::get_summary(&conn, range).map_err(|e| e.to_string())
+}
+
+/// Raw listen events for the past `days` days, for the daily listening
+/// heatmap (#890) to bucket into local calendar days client-side.
+#[tauri::command]
+pub async fn get_listening_activity(
+    days: i64,
+    state: State<'_, AppState>,
+) -> Result<Vec<ListenEvent>, String> {
+    let conn = state.db.pool.get().map_err(|e| e.to_string())?;
+    let since_unix = chrono::Utc::now().timestamp() - days * 86_400;
+    crate::stats_summary::listening_activity(&conn, since_unix).map_err(|e| e.to_string())
 }
 
 #[tauri::command]
@@ -70,8 +82,16 @@ pub async fn set_song_rating(
         Some(s) => Some(s),
         None => {
             if let Ok(conn) = state.db.pool.get() {
-                let sql = format!("SELECT {} FROM songs WHERE id = ?1", crate::collection::SONG_SELECT_COLS);
-                conn.query_row(&sql, rusqlite::params![song_id], crate::collection::row_to_song).ok()
+                let sql = format!(
+                    "SELECT {} FROM songs WHERE id = ?1",
+                    crate::collection::SONG_SELECT_COLS
+                );
+                conn.query_row(
+                    &sql,
+                    rusqlite::params![song_id],
+                    crate::collection::row_to_song,
+                )
+                .ok()
             } else {
                 None
             }

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 pub type DbPool = Pool<SqliteConnectionManager>;
 
 /// Current schema version. Increment when adding migrations.
-pub const CURRENT_SCHEMA_VERSION: i32 = 31;
+pub const CURRENT_SCHEMA_VERSION: i32 = 32;
 
 struct Migration {
     version: i32,
@@ -225,6 +225,19 @@ const MIGRATIONS: &[Migration] = &[
                 .exists([])?;
             if !has_nickname {
                 conn.execute_batch(MIGRATION_31)?;
+            }
+            Ok(())
+        },
+    },
+    Migration {
+        version: 32,
+        description: "duration_secs column on play_history for the daily listening heatmap (#890)",
+        apply: |conn| {
+            let has_duration_secs: bool = conn
+                .prepare("SELECT 1 FROM pragma_table_info('play_history') WHERE name = 'duration_secs'")?
+                .exists([])?;
+            if !has_duration_secs {
+                conn.execute_batch(MIGRATION_32)?;
             }
             Ok(())
         },
@@ -920,6 +933,17 @@ const MIGRATION_31: &str = "
 ALTER TABLE webdav_servers ADD COLUMN nickname TEXT;
 ALTER TABLE webdav_servers ADD COLUMN icon TEXT;
 ALTER TABLE webdav_servers ADD COLUMN color TEXT;
+";
+
+// ---------------------------------------------------------------------------
+// Migration 32: duration_secs column on play_history — the daily listening
+// heatmap (#890) needs each play's length to sum minutes-listened per day,
+// which play_history didn't previously record (only that a play happened).
+// Existing rows default to 0 and are simply undercounted; there's no way to
+// recover their original duration retroactively.
+// ---------------------------------------------------------------------------
+const MIGRATION_32: &str = "
+ALTER TABLE play_history ADD COLUMN duration_secs INTEGER NOT NULL DEFAULT 0;
 ";
 
 // ---------------------------------------------------------------------------

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1095,6 +1095,7 @@ pub fn run() {
             commands::stats::set_song_rating,
             commands::stats::set_album_rating,
             commands::stats::get_stats_summary,
+            commands::stats::get_listening_activity,
             commands::stats::get_stats_exclusions,
             commands::stats::set_stats_excluded,
             // Organizer commands

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -888,6 +888,16 @@ pub struct StatsSummary {
     pub play_timestamps: Vec<i64>,
 }
 
+/// One completed listen's timing, for the daily listening heatmap (#890) to
+/// bucket into local calendar days and sum minutes played. Raw and
+/// unaggregated, same rationale as `StatsSummary::play_timestamps` — bucketing
+/// by calendar day must happen client-side in the viewer's local timezone.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ListenEvent {
+    pub played_at: i64,
+    pub duration_secs: i64,
+}
+
 /// Represents a dynamic item in the Home curation carousels (a Song, an Album, or a Playlist).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "camelCase")]

--- a/src-tauri/src/player.rs
+++ b/src-tauri/src/player.rs
@@ -1735,6 +1735,7 @@ impl Player {
         }
 
         let song_id = self.current_song.as_ref()?.id;
+        let duration_secs = self.current_song.as_ref()?.duration_secs().round() as i64;
         match self._db.pool.get() {
             Ok(conn) => match stats::record_play(&conn, song_id) {
                 Ok(()) => {
@@ -1742,7 +1743,9 @@ impl Player {
                         .current_play_context
                         .clone()
                         .unwrap_or(PlayContext::Song);
-                    if let Err(e) = stats::record_play_context(&conn, &context, song_id) {
+                    if let Err(e) =
+                        stats::record_play_context(&conn, &context, song_id, duration_secs)
+                    {
                         log::warn!("Failed to record play context for song {song_id}: {e}");
                     }
                     Some(stats::stats_payload(&conn, song_id))

--- a/src-tauri/src/stats.rs
+++ b/src-tauri/src/stats.rs
@@ -22,17 +22,23 @@ pub fn record_play(conn: &Connection, song_id: i64) -> Result<()> {
 
 /// Record what the user was inside (album/playlist/standalone song) when a
 /// listen completed, so "Recently Played" can reflect that context instead
-/// of a post-hoc heuristic.
-pub fn record_play_context(conn: &Connection, context: &PlayContext, song_id: i64) -> Result<()> {
+/// of a post-hoc heuristic. `duration_secs` is the song's length at play
+/// time, summed per calendar day by the daily listening heatmap (#890).
+pub fn record_play_context(
+    conn: &Connection,
+    context: &PlayContext,
+    song_id: i64,
+    duration_secs: i64,
+) -> Result<()> {
     let (context_type, playlist_id) = match context {
         PlayContext::Song => ("song", None),
         PlayContext::Album { .. } => ("album", None),
         PlayContext::Playlist { playlist_id } => ("playlist", Some(*playlist_id)),
     };
     conn.execute(
-        "INSERT INTO play_history (context_type, song_id, playlist_id, played_at)
-         VALUES (?1, ?2, ?3, strftime('%s','now'))",
-        params![context_type, song_id, playlist_id],
+        "INSERT INTO play_history (context_type, song_id, playlist_id, played_at, duration_secs)
+         VALUES (?1, ?2, ?3, strftime('%s','now'), ?4)",
+        params![context_type, song_id, playlist_id, duration_secs],
     )?;
     Ok(())
 }
@@ -218,7 +224,7 @@ mod tests {
         .unwrap();
         let playlist_id = conn.last_insert_rowid();
 
-        record_play_context(&conn, &PlayContext::Song, id).unwrap();
+        record_play_context(&conn, &PlayContext::Song, id, 180).unwrap();
         record_play_context(
             &conn,
             &PlayContext::Album {
@@ -226,9 +232,10 @@ mod tests {
                 album_artist: Some("Test Artist".into()),
             },
             id,
+            180,
         )
         .unwrap();
-        record_play_context(&conn, &PlayContext::Playlist { playlist_id }, id).unwrap();
+        record_play_context(&conn, &PlayContext::Playlist { playlist_id }, id, 180).unwrap();
 
         let rows: Vec<(String, Option<i64>)> = conn
             .prepare(
@@ -248,6 +255,26 @@ mod tests {
                 ("playlist".to_string(), Some(playlist_id)),
             ]
         );
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn test_record_play_context_persists_duration_secs() {
+        let (db, dir) = test_db();
+        let conn = db.pool.get().unwrap();
+        let id = insert_song(&conn, "/tmp/duration.flac");
+
+        record_play_context(&conn, &PlayContext::Song, id, 245).unwrap();
+
+        let duration: i64 = conn
+            .query_row(
+                "SELECT duration_secs FROM play_history WHERE song_id = ?1",
+                params![id],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(duration, 245);
 
         let _ = std::fs::remove_dir_all(dir);
     }

--- a/src-tauri/src/stats_summary.rs
+++ b/src-tauri/src/stats_summary.rs
@@ -6,7 +6,9 @@
 //! summing across weeks would silently undercount anything that never
 //! cracked a weekly top 10. See issue #130's comment thread.
 
-use crate::models::{parse_multi_value, StatsSummary, StatsTopItem, LIBRARY_SOURCES_SQL};
+use crate::models::{
+    parse_multi_value, ListenEvent, StatsSummary, StatsTopItem, LIBRARY_SOURCES_SQL,
+};
 use anyhow::Result;
 use rusqlite::{params, Connection};
 
@@ -277,6 +279,36 @@ fn play_timestamps(conn: &Connection, range_start: i64) -> Result<Vec<i64>> {
     Ok(rows)
 }
 
+/// Raw `(played_at, duration_secs)` pairs for every non-excluded play since
+/// `since_unix`, for the daily listening heatmap (#890) to bucket into local
+/// calendar days and sum minutes played client-side — same rationale as
+/// `play_timestamps` above (no server-side UTC-offset day math).
+pub fn listening_activity(conn: &Connection, since_unix: i64) -> Result<Vec<ListenEvent>> {
+    let sql = format!(
+        "SELECT ph.played_at, ph.duration_secs
+         FROM play_history ph
+         JOIN songs s ON s.id = ph.song_id
+         WHERE ph.played_at >= ?1
+           AND s.source IN ({lib}) AND s.unavailable = 0
+           AND NOT EXISTS (
+               SELECT 1 FROM stats_exclusions se
+               WHERE se.entity_type = 'song' AND se.entity_key = CAST(s.id AS TEXT)
+           )",
+        lib = *LIBRARY_SOURCES_SQL
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt
+        .query_map(params![since_unix], |row| {
+            Ok(ListenEvent {
+                played_at: row.get(0)?,
+                duration_secs: row.get(1)?,
+            })
+        })?
+        .filter_map(|r| r.ok())
+        .collect();
+    Ok(rows)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -311,9 +343,18 @@ mod tests {
     }
 
     fn insert_play(conn: &Connection, song_id: i64, played_at: i64) {
+        insert_play_with_duration(conn, song_id, played_at, 0);
+    }
+
+    fn insert_play_with_duration(
+        conn: &Connection,
+        song_id: i64,
+        played_at: i64,
+        duration_secs: i64,
+    ) {
         conn.execute(
-            "INSERT INTO play_history (context_type, song_id, played_at) VALUES ('song', ?1, ?2)",
-            params![song_id, played_at],
+            "INSERT INTO play_history (context_type, song_id, played_at, duration_secs) VALUES ('song', ?1, ?2, ?3)",
+            params![song_id, played_at, duration_secs],
         )
         .unwrap();
     }
@@ -417,6 +458,34 @@ mod tests {
         let genres = top_genres(&conn, range_start).unwrap();
         let labels: Vec<&str> = genres.iter().map(|g| g.label.as_str()).collect();
         assert_eq!(labels, vec!["Metal"]);
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn test_listening_activity_excludes_out_of_range_and_flagged_songs() {
+        let (db, dir) = test_db();
+        let conn = db.pool.get().unwrap();
+        let now = 1_700_000_000;
+        let range_start = range_start_unix(StatsRange::SevenDays, now);
+
+        let in_range = insert_song(&conn, "/d.flac", "In Range", "Artist D", "Album D", "Rock");
+        let out_of_range = insert_song(&conn, "/e.flac", "Out", "Artist E", "Album E", "Pop");
+        let excluded = insert_song(&conn, "/f.flac", "Excluded", "Artist F", "Album F", "Jazz");
+
+        insert_play_with_duration(&conn, in_range, range_start + 10, 200);
+        insert_play_with_duration(&conn, out_of_range, range_start - 10, 200);
+        insert_play_with_duration(&conn, excluded, range_start + 10, 200);
+        conn.execute(
+            "INSERT INTO stats_exclusions (entity_type, entity_key) VALUES ('song', ?1)",
+            params![excluded.to_string()],
+        )
+        .unwrap();
+
+        let events = listening_activity(&conn, range_start).unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].played_at, range_start + 10);
+        assert_eq!(events[0].duration_secs, 200);
 
         let _ = std::fs::remove_dir_all(dir);
     }

--- a/src/lib/components/ListeningHeatmap.svelte
+++ b/src/lib/components/ListeningHeatmap.svelte
@@ -1,0 +1,79 @@
+<script lang="ts">
+  import { invoke } from "@tauri-apps/api/core";
+  import { i18n } from "../stores/i18n.svelte";
+  import { prefs } from "../stores/prefs.svelte";
+  import type { ListenEvent } from "../types";
+  import { bucketDailyMinutes, buildHeatmapGrid, computeStreaks, type HeatmapCell } from "../utils/listeningHeatmap";
+
+  // 14 weeks (~3 months) — "a couple months wide" per #890 — plus enough
+  // history for a meaningful longest-streak calculation without pulling a
+  // user's entire listening history on every Stats view load.
+  const WEEKS = 14;
+  const LOOKBACK_DAYS = WEEKS * 7;
+
+  // Cell background intensity per HeatmapCell.level, expressed as opacity
+  // steps of the active theme's accent color (`--color-brand-accent`) rather
+  // than a fixed palette, so the heatmap reskins correctly across every
+  // color theme and in both light/dark mode (#890).
+  const LEVEL_OPACITY = [0, 25, 45, 70, 100];
+
+  let events = $state<ListenEvent[] | null>(null);
+
+  async function load() {
+    try {
+      events = await invoke<ListenEvent[]>("get_listening_activity", { days: LOOKBACK_DAYS });
+    } catch (err) {
+      console.error("Failed to load listening activity:", err);
+      events = [];
+    }
+  }
+
+  $effect(() => {
+    load();
+  });
+
+  let dailyMinutes = $derived(events ? bucketDailyMinutes(events) : new Map<string, number>());
+  // `buildHeatmapGrid` returns rows (day-of-week) x columns (week); rendered
+  // here as columns of 7 stacked cells, so transpose before drawing.
+  let rows = $derived(buildHeatmapGrid(dailyMinutes, WEEKS, prefs.weekStart));
+  let columns = $derived(Array.from({ length: WEEKS }, (_, col) => rows.map((row) => row[col])));
+  let streaks = $derived(computeStreaks(dailyMinutes));
+
+  function cellStyle(cell: HeatmapCell): string {
+    if (cell.future) return "background-color: transparent;";
+    const opacity = LEVEL_OPACITY[cell.level];
+    if (opacity === 0) return "background-color: color-mix(in srgb, var(--color-brand-accent) 12%, transparent);";
+    return `background-color: color-mix(in srgb, var(--color-brand-accent) ${opacity}%, transparent);`;
+  }
+
+  function cellTitle(cell: HeatmapCell): string {
+    if (cell.future) return "";
+    const [y, m, d] = cell.date.split("-").map(Number);
+    const date = new Date(y, m - 1, d).toLocaleDateString(i18n.currentLocale, { month: "short", day: "numeric" });
+    if (cell.minutes <= 0) return i18n.t("stats.heatmapTooltipNoListening", { date });
+    if (cell.minutes === 1) return i18n.t("stats.heatmapTooltipOneMinute", { date });
+    return i18n.t("stats.heatmapTooltipMinutes", { minutes: cell.minutes, date });
+  }
+
+  function streakLabel(days: number): string {
+    return days === 1 ? i18n.t("stats.heatmapStreakOneDay") : i18n.t("stats.heatmapStreakDays", { count: days });
+  }
+</script>
+
+<div class="flex flex-col items-end gap-2">
+  {#if events}
+    <div class="flex gap-[3px]">
+      {#each columns as column, colIndex (colIndex)}
+        <div class="flex flex-col gap-[3px]">
+          {#each column as cell (cell.date)}
+            <div class="w-[11px] h-[11px] rounded-sm" style={cellStyle(cell)} title={cellTitle(cell)}></div>
+          {/each}
+        </div>
+      {/each}
+    </div>
+    <div class="flex items-center gap-4 text-xs text-brand-text-secondary">
+      <span>{i18n.t("stats.heatmapCurrentStreak", {}, "Current Streak")}: <span class="text-brand-text-primary font-medium">{streakLabel(streaks.current)}</span></span>
+      <span>{i18n.t("stats.heatmapLongestStreak", {}, "Longest Streak")}: <span class="text-brand-text-primary font-medium">{streakLabel(streaks.longest)}</span></span>
+    </div>
+  {/if}
+</div>

--- a/src/lib/components/StatsView.svelte
+++ b/src/lib/components/StatsView.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { invoke } from "@tauri-apps/api/core";
   import LoadingSpinner from "./LoadingSpinner.svelte";
+  import ListeningHeatmap from "./ListeningHeatmap.svelte";
   import { i18n } from "../stores/i18n.svelte";
   import { rememberScroll } from "../utils/scrollMemory";
   import { playerStore } from "../stores/player.svelte";
@@ -95,13 +96,18 @@
 
 <div class="flex-1 flex flex-col h-full bg-brand-main text-brand-text-primary select-none overflow-hidden relative">
   <div class="px-6 pt-8 pb-4 shrink-0">
-    <h1 class="text-3xl font-heading font-bold text-brand-text-primary flex items-center gap-3">
-      <BarChart2 class="w-7 h-7 text-brand-accent" />
-      {i18n.t("stats.title", {}, "Stats")}
-    </h1>
-    <p class="text-sm text-brand-text-secondary mt-1">
-      {i18n.t("stats.subtitle", {}, "Your private listening insights — computed on-device, never shared.")}
-    </p>
+    <div class="flex items-start justify-between gap-6">
+      <div>
+        <h1 class="text-3xl font-heading font-bold text-brand-text-primary flex items-center gap-3">
+          <BarChart2 class="w-7 h-7 text-brand-accent" />
+          {i18n.t("stats.title", {}, "Stats")}
+        </h1>
+        <p class="text-sm text-brand-text-secondary mt-1">
+          {i18n.t("stats.subtitle", {}, "Your private listening insights — computed on-device, never shared.")}
+        </p>
+      </div>
+      <ListeningHeatmap />
+    </div>
 
     <div class="flex items-center gap-2 mt-4">
       {#each RANGES as r (r.value)}

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -662,7 +662,14 @@ export const en = {
     excludeFromStats: "Don't Include in Stats",
     includeInStats: "Include in Stats",
     excludedToast: "Excluded {name} from Stats",
-    includedToast: "Included {name} in Stats again"
+    includedToast: "Included {name} in Stats again",
+    heatmapCurrentStreak: "Current Streak",
+    heatmapLongestStreak: "Longest Streak",
+    heatmapStreakOneDay: "1 day",
+    heatmapStreakDays: "{count} days",
+    heatmapTooltipNoListening: "No listening on {date}",
+    heatmapTooltipOneMinute: "1 minute on {date}",
+    heatmapTooltipMinutes: "{minutes} minutes on {date}"
   },
   help: {
     loading: "Loading user guide..."

--- a/src/lib/locales/fr.ts
+++ b/src/lib/locales/fr.ts
@@ -661,7 +661,14 @@ export const fr = {
     excludeFromStats: "Ne pas inclure dans les statistiques",
     includeInStats: "Inclure dans les statistiques",
     excludedToast: "{name} exclu des statistiques",
-    includedToast: "{name} de nouveau inclus dans les statistiques"
+    includedToast: "{name} de nouveau inclus dans les statistiques",
+    heatmapCurrentStreak: "Série en cours",
+    heatmapLongestStreak: "Plus longue série",
+    heatmapStreakOneDay: "1 jour",
+    heatmapStreakDays: "{count} jours",
+    heatmapTooltipNoListening: "Aucune écoute le {date}",
+    heatmapTooltipOneMinute: "1 minute le {date}",
+    heatmapTooltipMinutes: "{minutes} minutes le {date}"
   },
   help: {
     loading: "Chargement du guide d'utilisation..."

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -353,6 +353,13 @@ export interface StatsSummary {
   play_timestamps: number[];
 }
 
+/** One completed listen's timing, for the daily listening heatmap to bucket
+ * into local calendar days and sum minutes played. */
+export interface ListenEvent {
+  played_at: number;
+  duration_secs: number;
+}
+
 export interface ArtistItem {
   name: string | null;
   sort_artist?: string | null;

--- a/src/lib/utils/listeningHeatmap.test.ts
+++ b/src/lib/utils/listeningHeatmap.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from "vitest";
+import { bucketDailyMinutes, buildHeatmapGrid, computeStreaks } from "./listeningHeatmap";
+import type { ListenEvent } from "../types";
+
+function unixSecondsFor(date: Date): number {
+  return Math.floor(date.getTime() / 1000);
+}
+
+describe("bucketDailyMinutes", () => {
+  it("sums durations within the same local day and floors to whole minutes", () => {
+    const day = new Date(2026, 0, 15, 10, 0);
+    const events: ListenEvent[] = [
+      { played_at: unixSecondsFor(day), duration_secs: 200 },
+      { played_at: unixSecondsFor(new Date(2026, 0, 15, 22, 0)), duration_secs: 100 }
+    ];
+    const result = bucketDailyMinutes(events);
+    expect(result.get("2026-01-15")).toBe(5); // (200 + 100) / 60 = 5
+  });
+
+  it("keeps different days separate", () => {
+    const events: ListenEvent[] = [
+      { played_at: unixSecondsFor(new Date(2026, 0, 15, 10, 0)), duration_secs: 180 },
+      { played_at: unixSecondsFor(new Date(2026, 0, 16, 10, 0)), duration_secs: 60 }
+    ];
+    const result = bucketDailyMinutes(events);
+    expect(result.get("2026-01-15")).toBe(3);
+    expect(result.get("2026-01-16")).toBe(1);
+  });
+});
+
+describe("buildHeatmapGrid", () => {
+  it("produces 7 rows each with `weeks` columns", () => {
+    const grid = buildHeatmapGrid(new Map(), 4, "sunday", new Date(2026, 0, 15));
+    expect(grid).toHaveLength(7);
+    for (const row of grid) expect(row).toHaveLength(4);
+  });
+
+  // `new Date("YYYY-MM-DD")` parses as UTC, not local time, so tests parse
+  // the cell's date key back into a local Date manually instead.
+  function localDayOfWeek(dateKey: string): number {
+    const [y, m, d] = dateKey.split("-").map(Number);
+    return new Date(y, m - 1, d).getDay();
+  }
+
+  it("orders rows Sunday-first when weekStart is sunday", () => {
+    // 2026-01-15 is a Thursday.
+    const grid = buildHeatmapGrid(new Map(), 1, "sunday", new Date(2026, 0, 15));
+    expect(localDayOfWeek(grid[0][0].date)).toBe(0); // Sunday
+  });
+
+  it("orders rows Monday-first when weekStart is monday", () => {
+    const grid = buildHeatmapGrid(new Map(), 1, "monday", new Date(2026, 0, 15));
+    expect(localDayOfWeek(grid[0][0].date)).toBe(1); // Monday
+  });
+
+  it("marks days after today (but still within the current week) as future and excludes them from minutes", () => {
+    // 2026-01-15 is a Thursday, so with a Sunday-first week, Jan 16-17
+    // (Fri/Sat) are still in the grid but haven't happened yet.
+    const dailyMinutes = new Map([["2026-01-17", 45]]);
+    const grid = buildHeatmapGrid(dailyMinutes, 1, "sunday", new Date(2026, 0, 15));
+    const flatCells = grid.flat();
+    const futureCell = flatCells.find((c) => c.date === "2026-01-17");
+    expect(futureCell?.future).toBe(true);
+    expect(futureCell?.minutes).toBe(0);
+  });
+
+  it("maps minutes to intensity levels", () => {
+    const dailyMinutes = new Map([
+      ["2026-01-15", 0],
+      ["2026-01-14", 15],
+      ["2026-01-13", 45],
+      ["2026-01-12", 90],
+      ["2026-01-11", 200]
+    ]);
+    const grid = buildHeatmapGrid(dailyMinutes, 1, "sunday", new Date(2026, 0, 15));
+    const byDate = new Map(grid.flat().map((c) => [c.date, c.level]));
+    expect(byDate.get("2026-01-15")).toBe(0);
+    expect(byDate.get("2026-01-14")).toBe(1);
+    expect(byDate.get("2026-01-13")).toBe(2);
+    expect(byDate.get("2026-01-12")).toBe(3);
+    expect(byDate.get("2026-01-11")).toBe(4);
+  });
+});
+
+describe("computeStreaks", () => {
+  it("returns zero streaks with no listening history", () => {
+    expect(computeStreaks(new Map())).toEqual({ current: 0, longest: 0 });
+  });
+
+  it("counts a consecutive run ending today", () => {
+    const dailyMinutes = new Map([
+      ["2026-01-13", 10],
+      ["2026-01-14", 10],
+      ["2026-01-15", 10]
+    ]);
+    const result = computeStreaks(dailyMinutes, new Date(2026, 0, 15));
+    expect(result.current).toBe(3);
+    expect(result.longest).toBe(3);
+  });
+
+  it("gives one day of grace when today has no listening yet", () => {
+    const dailyMinutes = new Map([
+      ["2026-01-13", 10],
+      ["2026-01-14", 10]
+    ]);
+    const result = computeStreaks(dailyMinutes, new Date(2026, 0, 15));
+    expect(result.current).toBe(2);
+  });
+
+  it("resets current streak after a full missed day", () => {
+    const dailyMinutes = new Map([
+      ["2026-01-10", 10],
+      ["2026-01-15", 10]
+    ]);
+    const result = computeStreaks(dailyMinutes, new Date(2026, 0, 15));
+    expect(result.current).toBe(1);
+  });
+
+  it("tracks the longest streak independently of the current one", () => {
+    const dailyMinutes = new Map([
+      ["2026-01-01", 10],
+      ["2026-01-02", 10],
+      ["2026-01-03", 10],
+      ["2026-01-04", 10],
+      ["2026-01-15", 10]
+    ]);
+    const result = computeStreaks(dailyMinutes, new Date(2026, 0, 15));
+    expect(result.current).toBe(1);
+    expect(result.longest).toBe(4);
+  });
+});

--- a/src/lib/utils/listeningHeatmap.ts
+++ b/src/lib/utils/listeningHeatmap.ts
@@ -1,0 +1,140 @@
+import type { ListenEvent } from "../types";
+import type { WeekStart } from "../stores/prefs.svelte";
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+export interface HeatmapCell {
+  /** Local calendar date, YYYY-MM-DD. */
+  date: string;
+  /** Total minutes of music played on this day. */
+  minutes: number;
+  /** Intensity bucket for cell coloring: 0 = no listening. */
+  level: 0 | 1 | 2 | 3 | 4;
+  /** True for a cell past today, included only to keep every week's column
+   * full-height — always renders empty regardless of `minutes`. */
+  future: boolean;
+}
+
+export interface StreakInfo {
+  current: number;
+  longest: number;
+}
+
+function localDateKey(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
+
+function startOfDay(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate());
+}
+
+function intensityLevel(minutes: number): HeatmapCell["level"] {
+  if (minutes <= 0) return 0;
+  if (minutes < 30) return 1;
+  if (minutes < 60) return 2;
+  if (minutes < 120) return 3;
+  return 4;
+}
+
+/** Sums each listen event's duration into its local calendar day, in whole
+ * minutes. Bucketing happens entirely client-side (`Date` uses the browser's
+ * timezone), mirroring `bucketListeningClock`'s rationale — no server-side
+ * UTC-offset day math, immune to DST/timezone changes between listen-time
+ * and view-time. */
+export function bucketDailyMinutes(events: ListenEvent[]): Map<string, number> {
+  const seconds = new Map<string, number>();
+  for (const event of events) {
+    const key = localDateKey(new Date(event.played_at * 1000));
+    seconds.set(key, (seconds.get(key) ?? 0) + event.duration_secs);
+  }
+  const minutes = new Map<string, number>();
+  for (const [key, secs] of seconds) {
+    minutes.set(key, Math.floor(secs / 60));
+  }
+  return minutes;
+}
+
+/** Builds a `weeks`-wide grid of days ending today, reshaped into 7 rows
+ * (one per day-of-week) x `weeks` columns. Row order follows the
+ * "Start the week with" preference (`weekStart`, Sunday- or Monday-first —
+ * see `prefs.svelte.ts`) rather than a hardcoded Sun-Sat order, matching how
+ * `formatChartWeekRange` already respects this setting elsewhere. */
+export function buildHeatmapGrid(
+  dailyMinutes: Map<string, number>,
+  weeks: number,
+  weekStart: WeekStart,
+  today: Date = new Date()
+): HeatmapCell[][] {
+  const todayStart = startOfDay(today);
+  const todayDow = weekStart === "sunday" ? todayStart.getDay() : (todayStart.getDay() + 6) % 7;
+  // Pad the grid out to full weeks: the last column ends on the
+  // weekStart-aligned last day of the current week (today plus however many
+  // days remain in it), so every column is a complete 7-day week.
+  const daysAfterToday = 6 - todayDow;
+  const gridEnd = new Date(todayStart);
+  gridEnd.setDate(gridEnd.getDate() + daysAfterToday);
+
+  const totalDays = weeks * 7;
+  const cells: HeatmapCell[] = [];
+  for (let i = totalDays - 1; i >= 0; i--) {
+    const date = new Date(gridEnd);
+    date.setDate(date.getDate() - i);
+    const key = localDateKey(date);
+    const future = date.getTime() > todayStart.getTime();
+    const minutes = future ? 0 : (dailyMinutes.get(key) ?? 0);
+    cells.push({ date: key, minutes, level: intensityLevel(minutes), future });
+  }
+
+  // Reshape into rows (day-of-week) x columns (week): `cells` is chronological
+  // starting on a weekStart-aligned day, so index i is (dayOfWeek = i % 7,
+  // week = floor(i / 7)).
+  const rows: HeatmapCell[][] = Array.from({ length: 7 }, () => []);
+  cells.forEach((cell, i) => rows[i % 7].push(cell));
+  return rows;
+}
+
+function countBackwardFrom(activeDays: Set<string>, start: Date): number {
+  let count = 0;
+  const cursor = new Date(start);
+  while (activeDays.has(localDateKey(cursor))) {
+    count++;
+    cursor.setDate(cursor.getDate() - 1);
+  }
+  return count;
+}
+
+/** Current and longest listening streaks (consecutive days with any minutes
+ * played), in whole days. The current streak allows one day of grace: if
+ * today has no listening yet, it counts backward from yesterday instead of
+ * resetting to zero mid-day, matching how most streak trackers behave. */
+export function computeStreaks(dailyMinutes: Map<string, number>, today: Date = new Date()): StreakInfo {
+  const activeDays = new Set(
+    [...dailyMinutes.entries()].filter(([, minutes]) => minutes > 0).map(([key]) => key)
+  );
+  if (activeDays.size === 0) return { current: 0, longest: 0 };
+
+  const todayStart = startOfDay(today);
+  let current = countBackwardFrom(activeDays, todayStart);
+  if (current === 0) {
+    const yesterday = new Date(todayStart);
+    yesterday.setDate(yesterday.getDate() - 1);
+    current = countBackwardFrom(activeDays, yesterday);
+  }
+
+  const sortedDays = [...activeDays].sort();
+  let longest = 0;
+  let run = 0;
+  let prevDate: Date | null = null;
+  for (const key of sortedDays) {
+    const [y, m, d] = key.split("-").map(Number);
+    const date = new Date(y, m - 1, d);
+    run = prevDate && date.getTime() - prevDate.getTime() === MS_PER_DAY ? run + 1 : 1;
+    longest = Math.max(longest, run);
+    prevDate = date;
+  }
+
+  return { current, longest: Math.max(longest, current) };
+}


### PR DESCRIPTION
## 📋 Summary
Adds a daily listening heatmap to the Personal Stats view, similar in shape to Claude Desktop's usage heatmap: 7 rows by 14 weeks (~3 months), colored by that day's total minutes of music actually played, with a "Current Streak" / "Longest Streak" caption underneath. Placed top-right of the Stats header. Addresses #890.

## 🔍 Implementation Notes
**Backend**
- `play_history` didn't previously record how long a play was, so daily minutes couldn't be computed. Migration 32 adds `play_history.duration_secs`; existing rows default to 0 (there's no way to recover their original duration retroactively — plays recorded before this ships won't contribute to the heatmap until new plays accumulate under this build).
- `stats::record_play_context` now takes `duration_secs` and persists it; `player.rs` passes `Song::duration_secs()` at the scrobble point.
- New `stats_summary::listening_activity()` returns raw `(played_at, duration_secs)` pairs (same exclusion/library filtering as the existing Top 10 queries), exposed via a new `get_listening_activity` command.

**Frontend**
- Raw timestamps are bucketed into local calendar days and summed client-side (`listeningHeatmap.ts`), same rationale as the existing `play_timestamps` → `bucketListeningClock` pattern — no server-side UTC-offset day math, immune to DST/timezone changes between listen-time and view-time.
- Row order follows the existing "Start the week with" preference (`prefs.weekStart`) rather than a hardcoded Sun-Sat order.
- Cell color uses opacity steps of `--color-brand-accent` via `color-mix()`, not a fixed palette, so it reskins correctly across every color theme and light/dark mode.
- Current streak gives one day of grace (counts backward from yesterday if today has no listening yet), matching how most streak trackers behave.
- The heatmap refetches on each Stats view navigation, not live during playback — confirmed with the user that this is the desired behavior rather than a push-driven live update.

## 🧪 Test Plan
- [x] `bun run check` (svelte-check + knip)
- [x] `bun run test:run` (frontend — 725 tests, including 12 new for `listeningHeatmap.ts`)
- [x] `cargo test` (src-tauri — 344 tests, including new coverage for `duration_secs` persistence and `listening_activity`)
- [x] Manually verified in the app: heatmap renders top-right, today's cell reflects a completed play immediately, streak updates to 1 day

## 📸 Screenshots
Verified manually by the user — heatmap grid with a shaded "today" cell tooltip ("3 minutes on Sep 10") and "Current Streak: 1 day / Longest Streak: 1 day".

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed — n/a, no docs reference this view
