### PR TITLE
fix: window stays blank after restoring from a long minimize

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -176,6 +176,43 @@ fn with_webview2_occlusion_disabled(current: &str) -> String {
     }
 }
 
+/// Appends the Chromium switches that keep a minimized/hidden WebView2's
+/// renderer process from being deprioritized, to an existing
+/// `WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS` value, without duplicating any
+/// that are already present.
+///
+/// Regression test for #884: Chromium's own renderer-backgrounding drops a
+/// hidden/minimized page's renderer process to background OS scheduling
+/// priority (Windows 11 shows this as "Efficiency Mode" in Task Manager) and
+/// throttles its timers. Luminous's audio plays natively via CPAL, never
+/// through the DOM, so Chromium has no signal that the page still matters
+/// while minimized — and un-throttling after a long minimize isn't instant,
+/// leaving the window blank for up to a minute after restore. This is a
+/// distinct mechanism from `with_webview2_occlusion_disabled`'s
+/// `CalculateNativeWinOcclusion` (a rendering-pipeline feature): backgrounding
+/// is a process-priority/timer-throttling behavior that persists even with
+/// occlusion calculation disabled.
+#[cfg_attr(not(target_os = "windows"), allow(dead_code))]
+fn with_webview2_backgrounding_disabled(current: &str) -> String {
+    const SWITCHES: &[&str] = &[
+        "--disable-renderer-backgrounding",
+        "--disable-backgrounding-occluded-windows",
+        "--disable-background-timer-throttling",
+    ];
+    let mut result = current.to_string();
+    for switch in SWITCHES {
+        if !result.contains(switch) {
+            if result.is_empty() {
+                result = switch.to_string();
+            } else {
+                result.push(' ');
+                result.push_str(switch);
+            }
+        }
+    }
+    result
+}
+
 /// Reads persisted equalizer settings (linear + parametric) from the DB and
 /// applies them to a freshly-constructed `AudioEngine`, so playback starts
 /// with the user's last-saved EQ state instead of engine defaults.
@@ -582,7 +619,8 @@ pub fn run() {
     {
         let key = "WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS";
         let current = std::env::var(key).unwrap_or_default();
-        std::env::set_var(key, with_webview2_occlusion_disabled(&current));
+        let current = with_webview2_occlusion_disabled(&current);
+        std::env::set_var(key, with_webview2_backgrounding_disabled(&current));
     }
 
     tauri::Builder::default()
@@ -1181,6 +1219,39 @@ mod startup_rendering_workaround_tests {
         assert_eq!(
             with_webview2_occlusion_disabled("--foo --disable-features=msWebOOUI --bar"),
             "--foo --disable-features=msWebOOUI,CalculateNativeWinOcclusion --bar"
+        );
+    }
+
+    #[test]
+    fn test_webview2_backgrounding_flags_added_to_empty_value() {
+        assert_eq!(
+            with_webview2_backgrounding_disabled(""),
+            "--disable-renderer-backgrounding --disable-backgrounding-occluded-windows --disable-background-timer-throttling"
+        );
+    }
+
+    #[test]
+    fn test_webview2_backgrounding_flags_appended_to_existing_args() {
+        assert_eq!(
+            with_webview2_backgrounding_disabled("--disable-features=CalculateNativeWinOcclusion"),
+            "--disable-features=CalculateNativeWinOcclusion --disable-renderer-backgrounding --disable-backgrounding-occluded-windows --disable-background-timer-throttling"
+        );
+    }
+
+    #[test]
+    fn test_webview2_backgrounding_flags_not_duplicated_if_already_present() {
+        let already_set = "--disable-renderer-backgrounding --disable-backgrounding-occluded-windows --disable-background-timer-throttling";
+        assert_eq!(
+            with_webview2_backgrounding_disabled(already_set),
+            already_set
+        );
+    }
+
+    #[test]
+    fn test_webview2_backgrounding_flags_only_add_missing_ones() {
+        assert_eq!(
+            with_webview2_backgrounding_disabled("--disable-renderer-backgrounding"),
+            "--disable-renderer-backgrounding --disable-backgrounding-occluded-windows --disable-background-timer-throttling"
         );
     }
 }

--- a/src-tauri/src/taskbar.rs
+++ b/src-tauri/src/taskbar.rs
@@ -34,8 +34,9 @@ use windows::Win32::Graphics::Dwm::{
     DwmSetWindowAttribute, DWMWA_FORCE_ICONIC_REPRESENTATION, DWMWA_HAS_ICONIC_BITMAP,
 };
 use windows::Win32::Graphics::Gdi::{
-    CreateBitmap, CreateDIBSection, DeleteObject, GetDC, ReleaseDC, BITMAPINFO, BITMAPINFOHEADER,
-    BI_RGB, DIB_RGB_COLORS, HBITMAP,
+    CreateBitmap, CreateDIBSection, DeleteObject, GetDC, RedrawWindow, ReleaseDC, BITMAPINFO,
+    BITMAPINFOHEADER, BI_RGB, DIB_RGB_COLORS, HBITMAP, RDW_ALLCHILDREN, RDW_ERASE, RDW_INVALIDATE,
+    RDW_UPDATENOW,
 };
 use windows::Win32::System::Com::{CoCreateInstance, CLSCTX_INPROC_SERVER};
 use windows::Win32::UI::Shell::{
@@ -44,7 +45,7 @@ use windows::Win32::UI::Shell::{
 };
 use windows::Win32::UI::WindowsAndMessaging::{
     CreateIconIndirect, GetClientRect, GetSystemMetrics, RegisterWindowMessageW, HICON, ICONINFO,
-    SM_CXSMICON, WM_COMMAND,
+    SIZE_RESTORED, SM_CXSMICON, WM_COMMAND, WM_SIZE,
 };
 
 /// Not currently exported by the `windows` crate's `Win32_Graphics_Dwm`
@@ -287,10 +288,41 @@ unsafe extern "system" fn subclass_proc(
             send_live_preview(ctx, hwnd);
             return LRESULT(0);
         }
+        WM_SIZE if wparam.0 as u32 == SIZE_RESTORED => {
+            invalidate_iconic_representation(hwnd);
+        }
         _ => {}
     }
 
     DefSubclassProc(hwnd, msg, wparam, lparam)
+}
+
+/// Forces DWM to drop any cached iconic (taskbar thumbnail / live preview)
+/// representation of the window and repaint its real client area, then asks
+/// WebView2 to redraw. Windows only sends `WM_SIZE`/`SIZE_RESTORED` when the
+/// window transitions *out* of the minimized state, so this only fires on
+/// restore, not on every resize.
+///
+/// `force_iconic_representation`'s `DWMWA_FORCE_ICONIC_REPRESENTATION` tells
+/// DWM to always ask us for iconic bitmaps instead of taking its own live
+/// capture of the window. That capture is also what DWM's compositor falls
+/// back on to reconnect a window's surface after it's been minimized —
+/// without it, restoring can leave the window's real content unpainted for
+/// up to a minute until something else invalidates it (#884, a regression
+/// introduced by #852's taskbar integration; the window itself never
+/// previously opted into forced-iconic mode). Explicitly invalidating and
+/// forcing a synchronous repaint on restore keeps that reconnection from
+/// stalling.
+fn invalidate_iconic_representation(hwnd: HWND) {
+    unsafe {
+        let _ = DwmInvalidateIconicBitmaps(hwnd);
+        let _ = RedrawWindow(
+            Some(hwnd),
+            None,
+            None,
+            RDW_INVALIDATE | RDW_ALLCHILDREN | RDW_UPDATENOW | RDW_ERASE,
+        );
+    }
 }
 
 /// Mirrors `tray::handle_menu_event` / `lib.rs::register_media_shortcuts`:

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -23,7 +23,7 @@
         "transparent": false,
         "center": true,
         "dragDropEnabled": true,
-        "additionalBrowserArgs": "--disable-features=msWebOOUI,msPdfOOUI,msSmartScreenProtection,CalculateNativeWinOcclusion"
+        "additionalBrowserArgs": "--disable-features=msWebOOUI,msPdfOOUI,msSmartScreenProtection,CalculateNativeWinOcclusion --disable-renderer-backgrounding --disable-backgrounding-occluded-windows --disable-background-timer-throttling"
       }
     ],
     "security": {


### PR DESCRIPTION
## 📋 Summary
Fixes #884 — the window staying blank/unrendered for up to a minute after being restored from a minimize lasting roughly a song's length or longer. Audio playback was unaffected the whole time; only the visual content was stuck.

Two earlier fixes (#442, #790) addressed a different mechanism (Chromium's `CalculateNativeWinOcclusion` suspending WebView2's rendering pipeline) and are still valid, but didn't prevent this recurrence. This PR's first commit targeted a DWM iconic-bitmap regression from #852's taskbar integration, which turned out not to be the (whole) cause — it's kept since it's a real, separate correctness fix, but the actual root cause turned out to be Chromium's own renderer backgrounding: while minimized, Chromium drops the WebView2 renderer process to background OS scheduling priority (visible in Task Manager as Windows 11's "Efficiency Mode") and throttles its timers. Luminous's audio plays natively via CPAL, never through the DOM, so Chromium has no signal the page still matters while minimized, and un-throttling after a long minimize isn't instant.

## 🔍 Implementation Notes
- `src-tauri/src/taskbar.rs`: hook `WM_SIZE`/`SIZE_RESTORED` in the existing taskbar window subclass to invalidate DWM's cached iconic bitmaps and force a synchronous repaint on restore-from-minimize (fixes a real, separate DWM-iconic-mode interaction introduced by #852, even though it wasn't the primary cause of #884).
- `src-tauri/tauri.conf.json` + `src-tauri/src/lib.rs`: add `--disable-renderer-backgrounding`, `--disable-backgrounding-occluded-windows`, and `--disable-background-timer-throttling` to the WebView2 launch args (both the window's `additionalBrowserArgs` and the `WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS` env-var fallback) — this is the fix that actually resolved the manual repro.
- Tradeoff: disabling renderer backgrounding means the frontend's JS timers keep running at normal cadence while minimized instead of being throttled, so background CPU usage while minimized is somewhat higher than Chromium's default. It does not cause continuous GPU/paint work — visibility-driven paint skipping is a separate mechanism these flags don't touch.
- Filed #892 as a follow-up: the taskbar title/tooltip still lags behind a track change while minimized (a distinct, more minor issue noticed during manual verification of this fix) — playback and window repaint are correct, only the title text refresh is delayed until shortly after restore.

## 🧪 Test Plan
- [x] `cargo test` (src-tauri) — 346 lib tests + BDD suites pass
- [x] `cargo clippy` — no new warnings in touched files
- [x] Manually verified in the app: minimized for multiple songs, confirmed the window repaints immediately on restore instead of staying blank for up to a minute (tested by the repo owner against a running `bun run tauri dev` session)
- [ ] `bun run check` (svelte-check) — n/a, no frontend changes
- [ ] `bun run test -- --run` (frontend) — n/a, no frontend changes

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed — n/a, not a visual/UI change
