### PR TITLE
feat: interactive feature walkthrough / onboarding tour

### DIFF
--- a/src/lib/components/CollectionView.svelte
+++ b/src/lib/components/CollectionView.svelte
@@ -413,7 +413,7 @@
           </div>
 
           <div class="flex items-center gap-2">
-            <div class="inline-flex items-center gap-0.5 bg-brand-sidebar border border-brand-border rounded-full p-1">
+            <div data-walkthrough-target="collection-view" class="inline-flex items-center gap-0.5 bg-brand-sidebar border border-brand-border rounded-full p-1">
               <button
                 onclick={() => setActiveViewMode("cards")}
                 class="flex items-center justify-center w-7 h-7 rounded-full transition-colors {activeViewMode === 'cards' ? 'bg-brand-accent text-white' : 'text-brand-text-secondary hover:text-brand-text-primary'}"

--- a/src/lib/components/HelpView.svelte
+++ b/src/lib/components/HelpView.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
   import { i18n } from "../stores/i18n.svelte";
+  import { walkthroughStore } from "../stores/walkthrough.svelte";
+  import { CompassIcon as Compass } from "phosphor-svelte";
   import LoadingSpinner from "./LoadingSpinner.svelte";
+  import Button from "./Button.svelte";
 
   let isLoading = $state(true);
 </script>
@@ -11,6 +14,12 @@
       <LoadingSpinner label={i18n.t('help.loading', {}, "Loading user guide...")} />
     </div>
   {/if}
+  <div class="absolute top-4 right-4 z-20">
+    <Button onclick={() => walkthroughStore.start()} variant="secondary" size="sm">
+      <Compass class="w-3.5 h-3.5" />
+      {i18n.t('walkthrough.restartTour', {}, 'Restart Feature Walkthrough')}
+    </Button>
+  </div>
   <iframe
     src="/luminous-user-guide-{i18n.currentLocale.toUpperCase()}.html"
     title={i18n.t('sidebar.help')}

--- a/src/lib/components/LibraryWelcome.svelte
+++ b/src/lib/components/LibraryWelcome.svelte
@@ -3,6 +3,7 @@
   import { i18n } from "../stores/i18n.svelte";
   import { collectionStore } from "../stores/collection.svelte";
   import { navigationStore } from "../stores/navigation.svelte";
+  import { walkthroughStore } from "../stores/walkthrough.svelte";
   import Button from "./Button.svelte";
 
   // A database last opened by a newer Luminous build looks identical to a
@@ -46,6 +47,9 @@
       </Button>
       <Button onclick={() => { navigationStore.activeTab = 'help'; }} variant="secondary" size="sm">
         {i18n.t('sidebar.help')}
+      </Button>
+      <Button onclick={() => walkthroughStore.start()} variant="secondary" size="sm">
+        {i18n.t('walkthrough.takeTour', {}, 'Take a quick tour')}
       </Button>
     </div>
   {/if}

--- a/src/lib/components/PlayerBar.svelte
+++ b/src/lib/components/PlayerBar.svelte
@@ -215,7 +215,7 @@
   }
 </script>
 
-<footer transition:fly={{ y: 40, duration: 300, easing: cubicOut }} class="h-20 max-w-[1200px] mx-auto bg-brand-playerbar border border-brand-border rounded-[2rem] flex items-center justify-between gap-3 px-8 text-brand-text-secondary select-none {themeStore.isGlassTheme || isLinux ? 'glass-surface' : ''} {isLinux ? 'opaque-linux' : ''}">
+<footer data-walkthrough-target="player-bar" transition:fly={{ y: 40, duration: 300, easing: cubicOut }} class="h-20 max-w-[1200px] mx-auto bg-brand-playerbar border border-brand-border rounded-[2rem] flex items-center justify-between gap-3 px-8 text-brand-text-secondary select-none {themeStore.isGlassTheme || isLinux ? 'glass-surface' : ''} {isLinux ? 'opaque-linux' : ''}">
   <div class="flex items-center gap-3 flex-1 min-[700px]:w-1/3 min-[700px]:flex-none min-w-[90px] min-[400px]:min-w-[140px] min-[700px]:min-w-[200px] max-w-sm">
     <button
       onclick={handleCoverClick}

--- a/src/lib/components/PlayerBar.svelte
+++ b/src/lib/components/PlayerBar.svelte
@@ -215,8 +215,8 @@
   }
 </script>
 
-<footer data-walkthrough-target="player-bar" transition:fly={{ y: 40, duration: 300, easing: cubicOut }} class="h-20 max-w-[1200px] mx-auto bg-brand-playerbar border border-brand-border rounded-[2rem] flex items-center justify-between gap-3 px-8 text-brand-text-secondary select-none {themeStore.isGlassTheme || isLinux ? 'glass-surface' : ''} {isLinux ? 'opaque-linux' : ''}">
-  <div class="flex items-center gap-3 flex-1 min-[700px]:w-1/3 min-[700px]:flex-none min-w-[90px] min-[400px]:min-w-[140px] min-[700px]:min-w-[200px] max-w-sm">
+<footer transition:fly={{ y: 40, duration: 300, easing: cubicOut }} class="h-20 max-w-[1200px] mx-auto bg-brand-playerbar border border-brand-border rounded-[2rem] flex items-center justify-between gap-3 px-8 text-brand-text-secondary select-none {themeStore.isGlassTheme || isLinux ? 'glass-surface' : ''} {isLinux ? 'opaque-linux' : ''}">
+  <div data-walkthrough-target="player-bar-cover" class="flex items-center gap-3 flex-1 min-[700px]:w-1/3 min-[700px]:flex-none min-w-[90px] min-[400px]:min-w-[140px] min-[700px]:min-w-[200px] max-w-sm">
     <button
       onclick={handleCoverClick}
       disabled={!playerStore.currentSong}
@@ -269,7 +269,7 @@
     </div>
   </div>
 
-  <div class="flex flex-col items-center gap-1.5 min-[400px]:min-w-[220px] min-[400px]:ml-auto min-[700px]:w-1/3 min-[700px]:flex-none min-[700px]:ml-0 max-w-[600px]">
+  <div data-walkthrough-target="player-bar-controls" class="flex flex-col items-center gap-1.5 min-[400px]:min-w-[220px] min-[400px]:ml-auto min-[700px]:w-1/3 min-[700px]:flex-none min-[700px]:ml-0 max-w-[600px]">
     <div class="flex items-center gap-3 min-[700px]:gap-5">
       <div class="hidden min-[700px]:block relative">
         {#if playerStore.shuffleMode !== 'off'}
@@ -378,7 +378,7 @@
     </div>
   </div>
 
-  <div class="hidden min-[700px]:flex flex-col items-center gap-1.5 w-1/3 min-w-[50px] min-[700px]:min-w-[200px] max-w-xs">
+  <div data-walkthrough-target="player-bar-toolbar" class="hidden min-[700px]:flex flex-col items-center gap-1.5 w-1/3 min-w-[50px] min-[700px]:min-w-[200px] max-w-xs">
     <div class="flex items-center gap-3 min-[700px]:gap-5">
       <button
         onclick={openCurrentSongMenu}

--- a/src/lib/components/RightPanel.svelte
+++ b/src/lib/components/RightPanel.svelte
@@ -178,6 +178,7 @@
 </script>
 
 <aside
+  data-walkthrough-target="right-panel"
   style="width: {width}px;"
   class="relative bg-brand-sidebar flex flex-col h-full text-brand-text-secondary select-none flex-shrink-0 overflow-hidden {themeStore.isGlassTheme ? 'glass-surface' : ''}"
 >

--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -77,7 +77,7 @@
 </script>
 
 <aside style="width: {width}px;" class="bg-brand-sidebar flex flex-col h-full text-brand-text-secondary select-none flex-shrink-0 overflow-hidden transition-[width] duration-200 ease-out {themeStore.isGlassTheme ? 'glass-surface' : ''}" class:transition-none={resizing}>
-  <nav class="{isCollapsed ? 'p-2' : 'p-4'} space-y-0.5 flex flex-col items-center">
+  <nav data-walkthrough-target="sidebar" class="{isCollapsed ? 'p-2' : 'p-4'} space-y-0.5 flex flex-col items-center">
     <button
       onclick={() => { navigationStore.activeTab = "home"; }}
       class="flex items-center gap-3 transition-all duration-150 {navigationStore.activeTab === 'home' ? 'bg-brand-accent text-brand-accent-contrast shadow-lg shadow-brand-accent/20' : 'text-brand-text-secondary hover:bg-brand-accent/10 hover:text-brand-accent-text-hover'} {isCollapsed ? 'justify-center w-10 h-10 rounded-xl p-0' : 'w-full px-3 py-1.5 rounded-lg text-sm font-medium'}"
@@ -246,6 +246,7 @@
     {/if}
 
     <button
+      data-walkthrough-target="library-folders"
       onclick={() => { navigationStore.activeTab = "settings"; }}
       class="relative flex items-center gap-3 transition-all duration-150 {navigationStore.activeTab === 'settings' ? 'bg-brand-accent text-brand-accent-contrast shadow-lg shadow-brand-accent/20' : 'text-brand-text-secondary hover:bg-brand-accent/10 hover:text-brand-accent-text-hover'} {isCollapsed ? 'justify-center w-10 h-10 rounded-xl p-0' : 'w-full px-3 py-1.5 rounded-lg text-sm font-medium'}"
       title={showUpdateBadge ? `${i18n.t('sidebar.settings')} (${i18n.t('settings.updateAvailable', {}, 'Update available')})` : i18n.t('sidebar.settings')}

--- a/src/lib/components/TopNavigation.svelte
+++ b/src/lib/components/TopNavigation.svelte
@@ -277,7 +277,7 @@
 
 <svelte:window on:keydown={handleKeyDown} on:mouseup={handleMouseUp} on:mousedown={handleWindowMouseDown} />
 
-<header in:fade={{ duration: 600 }} class="w-full h-20 bg-brand-sidebar flex items-center px-6 gap-6 z-50 overflow-visible {themeStore.isGlassTheme ? 'glass-surface' : ''}">
+<header data-walkthrough-target="top-navigation" in:fade={{ duration: 600 }} class="w-full h-20 bg-brand-sidebar flex items-center px-6 gap-6 z-50 overflow-visible {themeStore.isGlassTheme ? 'glass-surface' : ''}">
   <div class="flex items-center gap-2">
     {#if !windowLayoutStore.isSidebarAutoCollapsed}
       <button

--- a/src/lib/components/WalkthroughOverlay.svelte
+++ b/src/lib/components/WalkthroughOverlay.svelte
@@ -142,7 +142,7 @@
       role="dialog"
       aria-modal="true"
       aria-labelledby="walkthrough-step-title"
-      class="absolute w-80 max-w-[calc(100vw-2rem)] bg-brand-sidebar border border-brand-border rounded-2xl shadow-2xl p-5 pointer-events-auto"
+      class="absolute w-96 max-w-[calc(100vw-2rem)] bg-brand-sidebar border border-brand-border rounded-2xl shadow-2xl p-5 pointer-events-auto"
       style="top: {popoverPos.top}px; left: {popoverPos.left}px;"
     >
       <div class="flex items-start justify-between gap-3 mb-2">
@@ -163,7 +163,7 @@
         {i18n.t(walkthroughStore.currentStep.descriptionKey)}
       </p>
 
-      <div class="flex items-center justify-between gap-3">
+      <div class="flex items-center justify-between gap-x-3 gap-y-2 flex-wrap">
         <div class="flex items-center gap-1.5" role="tablist" aria-label={i18n.t('walkthrough.progress', {}, 'Walkthrough progress')}>
           {#each walkthroughStore.steps as step, i (step.id)}
             <span

--- a/src/lib/components/WalkthroughOverlay.svelte
+++ b/src/lib/components/WalkthroughOverlay.svelte
@@ -1,0 +1,199 @@
+<script lang="ts">
+  import { walkthroughStore } from "../stores/walkthrough.svelte";
+  import { i18n } from "../stores/i18n.svelte";
+  import { portal } from "../utils/portal";
+  import { XIcon as X, CaretLeftIcon as ChevronLeft, CaretRightIcon as ChevronRight } from "phosphor-svelte";
+
+  const SPOTLIGHT_PADDING = 8;
+  const POPOVER_GAP = 16;
+  const VIEWPORT_MARGIN = 16;
+
+  let targetRect = $state<DOMRect | null>(null);
+  let popoverEl = $state<HTMLDivElement | undefined>();
+  let popoverPos = $state<{ top: number; left: number }>({ top: 0, left: 0 });
+
+  function resolveTarget(): HTMLElement | null {
+    const step = walkthroughStore.currentStep;
+    if (!step) return null;
+    return document.querySelector<HTMLElement>(step.targetSelector);
+  }
+
+  // The target element for a step may not be in the DOM for the app's
+  // current state (e.g. the player-bar step with nothing ever played, or
+  // the right-panel step before its beforeStep hook has had a chance to
+  // open the panel) — skip forward rather than spotlighting nothing. This
+  // terminates: next() calls finish() once the last step is reached.
+  function updateTargetRect() {
+    const el = resolveTarget();
+    if (!el) {
+      targetRect = null;
+      if (walkthroughStore.isActive) {
+        walkthroughStore.next();
+      }
+      return;
+    }
+    targetRect = el.getBoundingClientRect();
+  }
+
+  function updatePopoverPosition() {
+    if (!targetRect || !popoverEl) return;
+    const popoverRect = popoverEl.getBoundingClientRect();
+    const placement = walkthroughStore.currentStep?.placement ?? "bottom";
+    let top: number;
+    let left: number;
+    switch (placement) {
+      case "top":
+        top = targetRect.top - popoverRect.height - POPOVER_GAP;
+        left = targetRect.left + targetRect.width / 2 - popoverRect.width / 2;
+        break;
+      case "left":
+        top = targetRect.top + targetRect.height / 2 - popoverRect.height / 2;
+        left = targetRect.left - popoverRect.width - POPOVER_GAP;
+        break;
+      case "right":
+        top = targetRect.top + targetRect.height / 2 - popoverRect.height / 2;
+        left = targetRect.right + POPOVER_GAP;
+        break;
+      case "center":
+        top = window.innerHeight / 2 - popoverRect.height / 2;
+        left = window.innerWidth / 2 - popoverRect.width / 2;
+        break;
+      case "bottom":
+      default:
+        top = targetRect.bottom + POPOVER_GAP;
+        left = targetRect.left + targetRect.width / 2 - popoverRect.width / 2;
+        break;
+    }
+    top = Math.min(Math.max(top, VIEWPORT_MARGIN), window.innerHeight - popoverRect.height - VIEWPORT_MARGIN);
+    left = Math.min(Math.max(left, VIEWPORT_MARGIN), window.innerWidth - popoverRect.width - VIEWPORT_MARGIN);
+    popoverPos = { top, left };
+  }
+
+  $effect(() => {
+    if (!walkthroughStore.isActive) {
+      targetRect = null;
+      return;
+    }
+    void walkthroughStore.currentStepIndex;
+    updateTargetRect();
+  });
+
+  $effect(() => {
+    if (!targetRect || !popoverEl) return;
+    updatePopoverPosition();
+  });
+
+  $effect(() => {
+    if (!walkthroughStore.isActive || !targetRect) return;
+    const el = resolveTarget();
+    if (!el) return;
+    const observer = new ResizeObserver(() => updateTargetRect());
+    observer.observe(el);
+    return () => observer.disconnect();
+  });
+
+  function handleWindowChange() {
+    if (walkthroughStore.isActive) updateTargetRect();
+  }
+
+  function handleKeydown(e: KeyboardEvent) {
+    if (!walkthroughStore.isActive) return;
+    if (e.key === "Escape") {
+      e.preventDefault();
+      walkthroughStore.skip();
+    } else if (e.key === "ArrowRight" || e.key === "Enter") {
+      e.preventDefault();
+      walkthroughStore.next();
+    } else if (e.key === "ArrowLeft") {
+      e.preventDefault();
+      walkthroughStore.prev();
+    }
+  }
+</script>
+
+<svelte:window onresize={handleWindowChange} onscroll={handleWindowChange} onkeydown={handleKeydown} />
+
+{#if walkthroughStore.isActive && targetRect && walkthroughStore.currentStep}
+  <div use:portal class="fixed inset-0 z-[110] select-none" role="presentation">
+    <svg class="absolute inset-0 w-full h-full pointer-events-none" aria-hidden="true">
+      <defs>
+        <mask id="walkthrough-spotlight-mask">
+          <rect x="0" y="0" width="100%" height="100%" fill="white" />
+          <rect
+            x={targetRect.left - SPOTLIGHT_PADDING}
+            y={targetRect.top - SPOTLIGHT_PADDING}
+            width={targetRect.width + SPOTLIGHT_PADDING * 2}
+            height={targetRect.height + SPOTLIGHT_PADDING * 2}
+            rx="12"
+            fill="black"
+          />
+        </mask>
+      </defs>
+      <rect x="0" y="0" width="100%" height="100%" fill="black" fill-opacity="0.75" mask="url(#walkthrough-spotlight-mask)" />
+    </svg>
+
+    <div
+      class="absolute border-2 border-brand-accent rounded-xl pointer-events-none transition-[top,left,width,height] duration-200"
+      style="top: {targetRect.top - SPOTLIGHT_PADDING}px; left: {targetRect.left - SPOTLIGHT_PADDING}px; width: {targetRect.width + SPOTLIGHT_PADDING * 2}px; height: {targetRect.height + SPOTLIGHT_PADDING * 2}px;"
+    ></div>
+
+    <div
+      bind:this={popoverEl}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="walkthrough-step-title"
+      class="absolute w-80 max-w-[calc(100vw-2rem)] bg-brand-sidebar border border-brand-border rounded-2xl shadow-2xl p-5 pointer-events-auto"
+      style="top: {popoverPos.top}px; left: {popoverPos.left}px;"
+    >
+      <div class="flex items-start justify-between gap-3 mb-2">
+        <h3 id="walkthrough-step-title" class="text-sm font-bold text-brand-text-primary">
+          {i18n.t(walkthroughStore.currentStep.titleKey)}
+        </h3>
+        <button
+          onclick={() => walkthroughStore.skip()}
+          class="text-brand-text-secondary hover:text-brand-text-primary p-1 -m-1 rounded-lg hover:bg-brand-main/80 transition-colors shrink-0"
+          title={i18n.t('walkthrough.skip', {}, 'Skip')}
+          aria-label={i18n.t('walkthrough.skip', {}, 'Skip')}
+        >
+          <X class="w-4 h-4" />
+        </button>
+      </div>
+
+      <p class="text-xs text-brand-text-secondary leading-relaxed mb-4">
+        {i18n.t(walkthroughStore.currentStep.descriptionKey)}
+      </p>
+
+      <div class="flex items-center justify-between gap-3">
+        <div class="flex items-center gap-1.5" role="tablist" aria-label={i18n.t('walkthrough.progress', {}, 'Walkthrough progress')}>
+          {#each walkthroughStore.steps as step, i (step.id)}
+            <span
+              class="h-1.5 rounded-full transition-all {i === walkthroughStore.currentStepIndex ? 'w-4 bg-brand-accent' : 'w-1.5 bg-brand-border'}"
+            ></span>
+          {/each}
+        </div>
+        <div class="flex items-center gap-2">
+          {#if walkthroughStore.currentStepIndex > 0}
+            <button
+              onclick={() => walkthroughStore.prev()}
+              class="flex items-center gap-1 px-3 py-1.5 rounded-full text-xs font-semibold text-brand-text-secondary hover:text-brand-text-primary hover:bg-brand-main/80 transition-colors"
+            >
+              <ChevronLeft class="w-3.5 h-3.5" />
+              {i18n.t('walkthrough.back', {}, 'Back')}
+            </button>
+          {/if}
+          <button
+            onclick={() => walkthroughStore.next()}
+            class="flex items-center gap-1 px-4 py-1.5 rounded-full text-xs font-semibold bg-brand-accent hover:bg-brand-accent-hover text-brand-accent-contrast transition-colors"
+          >
+            {walkthroughStore.currentStepIndex === walkthroughStore.totalSteps - 1
+              ? i18n.t('walkthrough.finish', {}, 'Finish')
+              : i18n.t('walkthrough.next', {}, 'Next')}
+            {#if walkthroughStore.currentStepIndex < walkthroughStore.totalSteps - 1}
+              <ChevronRight class="w-3.5 h-3.5" />
+            {/if}
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+{/if}

--- a/src/lib/components/WalkthroughOverlay.test.ts
+++ b/src/lib/components/WalkthroughOverlay.test.ts
@@ -1,0 +1,102 @@
+import "@testing-library/jest-dom";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/svelte";
+import WalkthroughOverlay from "./WalkthroughOverlay.svelte";
+import { walkthroughStore } from "../stores/walkthrough.svelte";
+import { i18n } from "../stores/i18n.svelte";
+
+/** Every step's real anchor lives in a different app component — stub one
+ * target element per step id directly on document.body so the overlay can
+ * resolve `[data-walkthrough-target="<id>"]` without mounting the whole app. */
+function mountAllTargets() {
+  for (const step of walkthroughStore.steps) {
+    const el = document.createElement("div");
+    el.setAttribute("data-walkthrough-target", step.id);
+    document.body.appendChild(el);
+  }
+}
+
+describe("WalkthroughOverlay.svelte", () => {
+  beforeEach(() => {
+    i18n.currentLocale = "en";
+    walkthroughStore.isActive = false;
+    walkthroughStore.currentStepIndex = 0;
+    walkthroughStore.hasCompleted = false;
+    mountAllTargets();
+  });
+
+  afterEach(() => {
+    document.querySelectorAll("[data-walkthrough-target]").forEach((el) => el.remove());
+    walkthroughStore.isActive = false;
+  });
+
+  it("renders nothing when the tour isn't active", () => {
+    render(WalkthroughOverlay);
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("shows the first step's title and description once started", async () => {
+    render(WalkthroughOverlay);
+    walkthroughStore.start();
+
+    await waitFor(() => {
+      expect(screen.getByText("Navigate your library")).toBeInTheDocument();
+    });
+    expect(screen.getByText(/Jump between Home, Collection/)).toBeInTheDocument();
+  });
+
+  it("Next advances the store to the next step", async () => {
+    render(WalkthroughOverlay);
+    walkthroughStore.start();
+    await waitFor(() => expect(screen.getByRole("dialog")).toBeInTheDocument());
+
+    await fireEvent.click(screen.getByText("Next"));
+
+    expect(walkthroughStore.currentStepIndex).toBe(1);
+  });
+
+  it("Back is hidden on the first step and appears after advancing", async () => {
+    render(WalkthroughOverlay);
+    walkthroughStore.start();
+    await waitFor(() => expect(screen.getByRole("dialog")).toBeInTheDocument());
+
+    expect(screen.queryByText("Back")).not.toBeInTheDocument();
+
+    await fireEvent.click(screen.getByText("Next"));
+    await waitFor(() => expect(screen.getByText("Back")).toBeInTheDocument());
+  });
+
+  it("the skip button deactivates the tour and marks it completed", async () => {
+    render(WalkthroughOverlay);
+    walkthroughStore.start();
+    await waitFor(() => expect(screen.getByRole("dialog")).toBeInTheDocument());
+
+    await fireEvent.click(screen.getByLabelText("Skip"));
+
+    expect(walkthroughStore.isActive).toBe(false);
+    expect(walkthroughStore.hasCompleted).toBe(true);
+  });
+
+  it("Escape skips the tour", async () => {
+    render(WalkthroughOverlay);
+    walkthroughStore.start();
+    await waitFor(() => expect(screen.getByRole("dialog")).toBeInTheDocument());
+
+    await fireEvent.keyDown(window, { key: "Escape" });
+
+    expect(walkthroughStore.isActive).toBe(false);
+  });
+
+  it("the last step's button reads Finish and ends the tour", async () => {
+    render(WalkthroughOverlay);
+    walkthroughStore.start();
+    await waitFor(() => expect(screen.getByRole("dialog")).toBeInTheDocument());
+
+    for (let i = 0; i < walkthroughStore.totalSteps; i++) {
+      await fireEvent.click(screen.getByText(i === walkthroughStore.totalSteps - 1 ? "Finish" : "Next"));
+    }
+
+    expect(walkthroughStore.isActive).toBe(false);
+    expect(walkthroughStore.hasCompleted).toBe(true);
+  });
+});

--- a/src/lib/components/WalkthroughOverlay.test.ts
+++ b/src/lib/components/WalkthroughOverlay.test.ts
@@ -42,7 +42,7 @@ describe("WalkthroughOverlay.svelte", () => {
     await waitFor(() => {
       expect(screen.getByText("Navigate your library")).toBeInTheDocument();
     });
-    expect(screen.getByText(/Jump between Home, Collection/)).toBeInTheDocument();
+    expect(screen.getByText(/Jump between Home, your Collection/)).toBeInTheDocument();
   });
 
   it("Next advances the store to the next step", async () => {

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -1268,5 +1268,40 @@ export const en = {
     addedSong: "Added 1 song to queue",
     addedSongs: "Added {count} songs to queue",
     nothingToAdd: "No supported audio files found to add."
+  },
+  walkthrough: {
+    takeTour: "Take a quick tour",
+    restartTour: "Restart Feature Walkthrough",
+    skip: "Skip",
+    back: "Back",
+    next: "Next",
+    finish: "Finish",
+    progress: "Walkthrough progress",
+    steps: {
+      sidebar: {
+        title: "Navigate your library",
+        description: "Jump between Home, Collection, Playlists, Genres, and Settings from here."
+      },
+      topNavigation: {
+        title: "Search and go back",
+        description: "Search your library instantly, move back and forward through your browsing history, and toggle layout options."
+      },
+      collectionView: {
+        title: "Browse your collection",
+        description: "Switch between Albums, Artists, Songs, and Genres, and toggle between card and row density."
+      },
+      playerBar: {
+        title: "Control playback",
+        description: "Play, pause, seek, adjust volume, and toggle shuffle, repeat, or the miniplayer from here."
+      },
+      rightPanel: {
+        title: "See track details and queue",
+        description: "View track details, your live queue, synchronized lyrics, and the audio spectrum visualizer."
+      },
+      libraryFolders: {
+        title: "Add your music",
+        description: "Add folders to scan from Settings, and Luminous keeps your library up to date automatically."
+      }
+    }
   }
 };

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -1299,8 +1299,8 @@ export const en = {
         description: "Play, pause, skip, seek, and cycle shuffle or repeat from here."
       },
       playerBarToolbar: {
-        title: "Song menu, lyrics, queue, and info",
-        description: "Open the song menu, jump to Lyrics, view your Queue, or show the info panel — plus volume, right here."
+        title: "Song menu, lyrics, queue, info, and miniplayer",
+        description: "Open the song menu, jump to Lyrics, view your Queue, show the info panel, or switch to the floating Miniplayer — plus volume, right here."
       },
       rightPanel: {
         title: "Track details",

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -1280,23 +1280,31 @@ export const en = {
     steps: {
       sidebar: {
         title: "Navigate your library",
-        description: "Jump between Home, Collection, Playlists, Genres, and Settings from here."
+        description: "Jump between Home, your Collection, Playlists, Stats, Settings, and Help from here."
       },
       topNavigation: {
         title: "Search and go back",
-        description: "Search your library instantly, move back and forward through your browsing history, and toggle layout options."
+        description: "Search your library instantly, and move back and forward through your browsing history."
       },
       collectionView: {
         title: "Browse your collection",
-        description: "Switch between Albums, Artists, Songs, and Genres, and toggle between card and row density."
+        description: "Toggle between card and row density while browsing Albums or Artists."
       },
-      playerBar: {
-        title: "Control playback",
-        description: "Play, pause, seek, adjust volume, and toggle shuffle, repeat, or the miniplayer from here."
+      playerBarCover: {
+        title: "Cover art",
+        description: "Click the cover art to switch to Immersive View, a full-screen look at what's playing."
+      },
+      playerBarControls: {
+        title: "Playback controls",
+        description: "Play, pause, skip, seek, and cycle shuffle or repeat from here."
+      },
+      playerBarToolbar: {
+        title: "Song menu, lyrics, queue, and info",
+        description: "Open the song menu, jump to Lyrics, view your Queue, or show the info panel — plus volume, right here."
       },
       rightPanel: {
-        title: "See track details and queue",
-        description: "View track details, your live queue, synchronized lyrics, and the audio spectrum visualizer."
+        title: "Track details",
+        description: "See the current song's artist bio, MusicBrainz links, and technical details like format and bitrate."
       },
       libraryFolders: {
         title: "Add your music",

--- a/src/lib/locales/fr.ts
+++ b/src/lib/locales/fr.ts
@@ -1279,23 +1279,31 @@ export const fr = {
     steps: {
       sidebar: {
         title: "Naviguez dans votre bibliothèque",
-        description: "Passez d'Accueil à Collection, Listes de lecture, Genres et Paramètres depuis ici."
+        description: "Passez d'Accueil à Collection, Listes de lecture, Statistiques, Paramètres et Aide depuis ici."
       },
       topNavigation: {
         title: "Recherchez et revenez en arrière",
-        description: "Recherchez instantanément dans votre bibliothèque, naviguez dans votre historique et basculez les options de mise en page."
+        description: "Recherchez instantanément dans votre bibliothèque, et naviguez dans votre historique."
       },
       collectionView: {
         title: "Parcourez votre collection",
-        description: "Basculez entre Albums, Artistes, Chansons et Genres, et entre l'affichage en cartes ou en lignes."
+        description: "Basculez entre l'affichage en cartes ou en lignes lorsque vous parcourez Albums ou Artistes."
       },
-      playerBar: {
-        title: "Contrôlez la lecture",
-        description: "Lisez, mettez en pause, avancez, réglez le volume et activez la lecture aléatoire, la répétition ou le mini-lecteur depuis ici."
+      playerBarCover: {
+        title: "Pochette",
+        description: "Cliquez sur la pochette pour passer en mode Immersif, un affichage plein écran du morceau en cours."
+      },
+      playerBarControls: {
+        title: "Contrôles de lecture",
+        description: "Lisez, mettez en pause, passez au morceau suivant, avancez dans la piste et activez la lecture aléatoire ou la répétition depuis ici."
+      },
+      playerBarToolbar: {
+        title: "Menu, paroles, file d'attente et infos",
+        description: "Ouvrez le menu du morceau, accédez aux Paroles, à votre file d'attente ou au panneau d'informations — ainsi que le volume, juste ici."
       },
       rightPanel: {
-        title: "Consultez les détails et la file d'attente",
-        description: "Affichez les détails du morceau, votre file d'attente en direct, les paroles synchronisées et le visualiseur de spectre audio."
+        title: "Détails du morceau",
+        description: "Consultez la biographie de l'artiste, les liens MusicBrainz et les détails techniques comme le format et le débit."
       },
       libraryFolders: {
         title: "Ajoutez votre musique",

--- a/src/lib/locales/fr.ts
+++ b/src/lib/locales/fr.ts
@@ -1298,8 +1298,8 @@ export const fr = {
         description: "Lisez, mettez en pause, passez au morceau suivant, avancez dans la piste et activez la lecture aléatoire ou la répétition depuis ici."
       },
       playerBarToolbar: {
-        title: "Menu, paroles, file d'attente et infos",
-        description: "Ouvrez le menu du morceau, accédez aux Paroles, à votre file d'attente ou au panneau d'informations — ainsi que le volume, juste ici."
+        title: "Menu, paroles, file d'attente, infos et mini-lecteur",
+        description: "Ouvrez le menu du morceau, accédez aux Paroles, à votre file d'attente, au panneau d'informations, ou passez en Mini-lecteur flottant — ainsi que le volume, juste ici."
       },
       rightPanel: {
         title: "Détails du morceau",

--- a/src/lib/locales/fr.ts
+++ b/src/lib/locales/fr.ts
@@ -1267,5 +1267,40 @@ export const fr = {
     addedSong: "1 chanson ajoutée à la file d'attente",
     addedSongs: "{count} chansons ajoutées à la file d'attente",
     nothingToAdd: "Aucun fichier audio pris en charge trouvé à ajouter."
+  },
+  walkthrough: {
+    takeTour: "Faire une visite rapide",
+    restartTour: "Relancer la visite guidée",
+    skip: "Passer",
+    back: "Précédent",
+    next: "Suivant",
+    finish: "Terminer",
+    progress: "Progression de la visite guidée",
+    steps: {
+      sidebar: {
+        title: "Naviguez dans votre bibliothèque",
+        description: "Passez d'Accueil à Collection, Listes de lecture, Genres et Paramètres depuis ici."
+      },
+      topNavigation: {
+        title: "Recherchez et revenez en arrière",
+        description: "Recherchez instantanément dans votre bibliothèque, naviguez dans votre historique et basculez les options de mise en page."
+      },
+      collectionView: {
+        title: "Parcourez votre collection",
+        description: "Basculez entre Albums, Artistes, Chansons et Genres, et entre l'affichage en cartes ou en lignes."
+      },
+      playerBar: {
+        title: "Contrôlez la lecture",
+        description: "Lisez, mettez en pause, avancez, réglez le volume et activez la lecture aléatoire, la répétition ou le mini-lecteur depuis ici."
+      },
+      rightPanel: {
+        title: "Consultez les détails et la file d'attente",
+        description: "Affichez les détails du morceau, votre file d'attente en direct, les paroles synchronisées et le visualiseur de spectre audio."
+      },
+      libraryFolders: {
+        title: "Ajoutez votre musique",
+        description: "Ajoutez des dossiers à analyser depuis les Paramètres, et Luminous maintient votre bibliothèque à jour automatiquement."
+      }
+    }
   }
 };

--- a/src/lib/stores/walkthrough.svelte.ts
+++ b/src/lib/stores/walkthrough.svelte.ts
@@ -1,6 +1,7 @@
 import { invoke } from "@tauri-apps/api/core";
 import { navigationStore } from "./navigation.svelte";
 import { windowLayoutStore } from "./windowLayout.svelte";
+import { playerStore } from "./player.svelte";
 
 type WalkthroughPlacement = "top" | "bottom" | "left" | "right" | "center";
 
@@ -44,10 +45,24 @@ const STEPS: WalkthroughStep[] = [
     },
   },
   {
-    id: "player-bar",
-    targetSelector: '[data-walkthrough-target="player-bar"]',
-    titleKey: "walkthrough.steps.playerBar.title",
-    descriptionKey: "walkthrough.steps.playerBar.description",
+    id: "player-bar-cover",
+    targetSelector: '[data-walkthrough-target="player-bar-cover"]',
+    titleKey: "walkthrough.steps.playerBarCover.title",
+    descriptionKey: "walkthrough.steps.playerBarCover.description",
+    placement: "top",
+  },
+  {
+    id: "player-bar-controls",
+    targetSelector: '[data-walkthrough-target="player-bar-controls"]',
+    titleKey: "walkthrough.steps.playerBarControls.title",
+    descriptionKey: "walkthrough.steps.playerBarControls.description",
+    placement: "top",
+  },
+  {
+    id: "player-bar-toolbar",
+    targetSelector: '[data-walkthrough-target="player-bar-toolbar"]',
+    titleKey: "walkthrough.steps.playerBarToolbar.title",
+    descriptionKey: "walkthrough.steps.playerBarToolbar.description",
     placement: "top",
   },
   {
@@ -56,8 +71,14 @@ const STEPS: WalkthroughStep[] = [
     titleKey: "walkthrough.steps.rightPanel.title",
     descriptionKey: "walkthrough.steps.rightPanel.description",
     placement: "left",
+    // Only force it open when something's playing — that's the only state
+    // where the panel's own close control (the Info toggle in the player
+    // bar's button row) is reachable. With nothing playing there'd be no
+    // way back except the Ctrl+I shortcut, so leave it alone and let the
+    // step skip forward if the panel isn't already open (see
+    // WalkthroughOverlay's target-resolution skip logic).
     beforeStep: () => {
-      if (!windowLayoutStore.rightPanelOpen) {
+      if (playerStore.currentSong && !windowLayoutStore.rightPanelOpen) {
         windowLayoutStore.toggleRightPanel();
       }
     },

--- a/src/lib/stores/walkthrough.svelte.ts
+++ b/src/lib/stores/walkthrough.svelte.ts
@@ -1,0 +1,148 @@
+import { invoke } from "@tauri-apps/api/core";
+import { navigationStore } from "./navigation.svelte";
+import { windowLayoutStore } from "./windowLayout.svelte";
+
+type WalkthroughPlacement = "top" | "bottom" | "left" | "right" | "center";
+
+interface WalkthroughStep {
+  id: string;
+  targetSelector: string;
+  titleKey: string;
+  descriptionKey: string;
+  placement: WalkthroughPlacement;
+  beforeStep?: () => void;
+}
+
+const STEPS: WalkthroughStep[] = [
+  {
+    id: "sidebar",
+    targetSelector: '[data-walkthrough-target="sidebar"]',
+    titleKey: "walkthrough.steps.sidebar.title",
+    descriptionKey: "walkthrough.steps.sidebar.description",
+    placement: "right",
+  },
+  {
+    id: "top-navigation",
+    targetSelector: '[data-walkthrough-target="top-navigation"]',
+    titleKey: "walkthrough.steps.topNavigation.title",
+    descriptionKey: "walkthrough.steps.topNavigation.description",
+    placement: "bottom",
+  },
+  {
+    id: "collection-view",
+    targetSelector: '[data-walkthrough-target="collection-view"]',
+    titleKey: "walkthrough.steps.collectionView.title",
+    descriptionKey: "walkthrough.steps.collectionView.description",
+    placement: "bottom",
+    beforeStep: () => {
+      // The cards/rows toggle only renders on the Albums/Artists sub-tabs
+      // (not Songs or Genres) — force one of those so the target exists.
+      navigationStore.activeTab = "collection";
+      if (navigationStore.activeSubTab !== "albums" && navigationStore.activeSubTab !== "artists") {
+        navigationStore.activeSubTab = "albums";
+      }
+    },
+  },
+  {
+    id: "player-bar",
+    targetSelector: '[data-walkthrough-target="player-bar"]',
+    titleKey: "walkthrough.steps.playerBar.title",
+    descriptionKey: "walkthrough.steps.playerBar.description",
+    placement: "top",
+  },
+  {
+    id: "right-panel",
+    targetSelector: '[data-walkthrough-target="right-panel"]',
+    titleKey: "walkthrough.steps.rightPanel.title",
+    descriptionKey: "walkthrough.steps.rightPanel.description",
+    placement: "left",
+    beforeStep: () => {
+      if (!windowLayoutStore.rightPanelOpen) {
+        windowLayoutStore.toggleRightPanel();
+      }
+    },
+  },
+  {
+    id: "library-folders",
+    targetSelector: '[data-walkthrough-target="library-folders"]',
+    titleKey: "walkthrough.steps.libraryFolders.title",
+    descriptionKey: "walkthrough.steps.libraryFolders.description",
+    placement: "right",
+    beforeStep: () => {
+      navigationStore.activeTab = "settings";
+      invoke("set_app_setting", { key: "active_settings_tab", value: "folders" });
+    },
+  },
+];
+
+/** Persisted via the generic app_state key/value store (see RightPanel's
+ * `right_panel_active_tab` / Sidebar's `active_settings_tab`) — a one-off
+ * UI-only flag doesn't need its own Rust command or a UiPreferences field. */
+const COMPLETED_SETTING_KEY = "walkthrough_completed";
+
+class WalkthroughStore {
+  isActive = $state(false);
+  currentStepIndex = $state(0);
+  hasCompleted = $state(false);
+
+  readonly steps = STEPS;
+
+  get totalSteps() {
+    return this.steps.length;
+  }
+
+  get currentStep() {
+    return this.steps[this.currentStepIndex];
+  }
+
+  async init() {
+    try {
+      const settings = await invoke<Record<string, string>>("get_all_app_settings");
+      this.hasCompleted = settings?.[COMPLETED_SETTING_KEY] === "true";
+    } catch (e) {
+      console.error("Failed to load walkthrough completion state:", e);
+    }
+  }
+
+  start() {
+    this.currentStepIndex = 0;
+    this.isActive = true;
+    this.steps[0].beforeStep?.();
+  }
+
+  next() {
+    if (this.currentStepIndex >= this.steps.length - 1) {
+      this.finish();
+      return;
+    }
+    this.currentStepIndex += 1;
+    this.currentStep.beforeStep?.();
+  }
+
+  prev() {
+    if (this.currentStepIndex === 0) return;
+    this.currentStepIndex -= 1;
+    this.currentStep.beforeStep?.();
+  }
+
+  skip() {
+    if (!this.isActive) return;
+    this.isActive = false;
+    this.markCompleted();
+  }
+
+  finish() {
+    this.isActive = false;
+    this.markCompleted();
+  }
+
+  private markCompleted() {
+    if (this.hasCompleted) return;
+    this.hasCompleted = true;
+    invoke("set_app_setting", { key: COMPLETED_SETTING_KEY, value: "true" }).catch((e) =>
+      console.error("Failed to persist walkthrough completion:", e)
+    );
+  }
+}
+
+export const walkthroughStore = new WalkthroughStore();

--- a/src/lib/stores/walkthrough.test.ts
+++ b/src/lib/stores/walkthrough.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { invoke } from "@tauri-apps/api/core";
+import { walkthroughStore } from "./walkthrough.svelte";
+import { navigationStore } from "./navigation.svelte";
+import { windowLayoutStore } from "./windowLayout.svelte";
+
+describe("WalkthroughStore", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    walkthroughStore.isActive = false;
+    walkthroughStore.currentStepIndex = 0;
+    walkthroughStore.hasCompleted = false;
+  });
+
+  it("loads completion state from the backend on init", async () => {
+    vi.mocked(invoke).mockImplementationOnce(async (cmd) => {
+      if (cmd === "get_all_app_settings") return { walkthrough_completed: "true" };
+      return null;
+    });
+
+    await walkthroughStore.init();
+
+    expect(walkthroughStore.hasCompleted).toBe(true);
+    expect(invoke).toHaveBeenCalledWith("get_all_app_settings");
+  });
+
+  it("defaults to not completed when the backend has no flag", async () => {
+    vi.mocked(invoke).mockImplementationOnce(async (cmd) => {
+      if (cmd === "get_all_app_settings") return {};
+      return null;
+    });
+
+    await walkthroughStore.init();
+
+    expect(walkthroughStore.hasCompleted).toBe(false);
+  });
+
+  it("start() activates the tour at the first step", () => {
+    walkthroughStore.currentStepIndex = 3;
+    walkthroughStore.start();
+
+    expect(walkthroughStore.isActive).toBe(true);
+    expect(walkthroughStore.currentStepIndex).toBe(0);
+    expect(walkthroughStore.currentStep.id).toBe("sidebar");
+  });
+
+  it("next() advances through steps and finishes (persisting completion) after the last one", () => {
+    walkthroughStore.start();
+    const total = walkthroughStore.totalSteps;
+
+    for (let i = 1; i < total; i++) {
+      walkthroughStore.next();
+      expect(walkthroughStore.currentStepIndex).toBe(i);
+      expect(walkthroughStore.isActive).toBe(true);
+    }
+
+    walkthroughStore.next();
+
+    expect(walkthroughStore.isActive).toBe(false);
+    expect(walkthroughStore.hasCompleted).toBe(true);
+    expect(invoke).toHaveBeenCalledWith("set_app_setting", {
+      key: "walkthrough_completed",
+      value: "true",
+    });
+  });
+
+  it("prev() moves back a step and does nothing at the first step", () => {
+    walkthroughStore.start();
+    walkthroughStore.next();
+    expect(walkthroughStore.currentStepIndex).toBe(1);
+
+    walkthroughStore.prev();
+    expect(walkthroughStore.currentStepIndex).toBe(0);
+
+    walkthroughStore.prev();
+    expect(walkthroughStore.currentStepIndex).toBe(0);
+  });
+
+  it("skip() deactivates the tour and persists completion", () => {
+    walkthroughStore.start();
+    walkthroughStore.skip();
+
+    expect(walkthroughStore.isActive).toBe(false);
+    expect(walkthroughStore.hasCompleted).toBe(true);
+    expect(invoke).toHaveBeenCalledWith("set_app_setting", {
+      key: "walkthrough_completed",
+      value: "true",
+    });
+  });
+
+  it("the collection-view step's beforeStep switches to the collection tab on an albums/artists sub-tab", () => {
+    navigationStore.activeTab = "home";
+    navigationStore.activeSubTab = "songs";
+    walkthroughStore.start();
+
+    walkthroughStore.next(); // top-navigation
+    walkthroughStore.next(); // collection-view
+
+    expect(navigationStore.activeTab).toBe("collection");
+    expect(["albums", "artists"]).toContain(navigationStore.activeSubTab);
+  });
+
+  it("the right-panel step's beforeStep opens the right panel if it's closed", () => {
+    windowLayoutStore.rightPanelOpen = false;
+    walkthroughStore.start();
+
+    walkthroughStore.next(); // top-navigation
+    walkthroughStore.next(); // collection-view
+    walkthroughStore.next(); // player-bar
+    walkthroughStore.next(); // right-panel
+
+    expect(windowLayoutStore.rightPanelOpen).toBe(true);
+  });
+});

--- a/src/lib/stores/walkthrough.test.ts
+++ b/src/lib/stores/walkthrough.test.ts
@@ -3,6 +3,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { walkthroughStore } from "./walkthrough.svelte";
 import { navigationStore } from "./navigation.svelte";
 import { windowLayoutStore } from "./windowLayout.svelte";
+import { playerStore } from "./player.svelte";
 
 describe("WalkthroughStore", () => {
   beforeEach(() => {
@@ -100,15 +101,31 @@ describe("WalkthroughStore", () => {
     expect(["albums", "artists"]).toContain(navigationStore.activeSubTab);
   });
 
-  it("the right-panel step's beforeStep opens the right panel if it's closed", () => {
+  it("the right-panel step's beforeStep opens the right panel if something is playing and it's closed", () => {
     windowLayoutStore.rightPanelOpen = false;
+    playerStore.currentSong = { id: 1 } as any;
     walkthroughStore.start();
 
     walkthroughStore.next(); // top-navigation
     walkthroughStore.next(); // collection-view
-    walkthroughStore.next(); // player-bar
+    walkthroughStore.next(); // player-bar-cover
+    walkthroughStore.next(); // player-bar-controls
+    walkthroughStore.next(); // player-bar-toolbar
     walkthroughStore.next(); // right-panel
 
     expect(windowLayoutStore.rightPanelOpen).toBe(true);
+
+    playerStore.currentSong = undefined;
+  });
+
+  it("the right-panel step's beforeStep leaves the panel closed when nothing is playing", () => {
+    windowLayoutStore.rightPanelOpen = false;
+    playerStore.currentSong = undefined;
+    walkthroughStore.start();
+
+    for (let i = 0; i < 6; i++) walkthroughStore.next();
+    expect(walkthroughStore.currentStep.id).toBe("right-panel");
+
+    expect(windowLayoutStore.rightPanelOpen).toBe(false);
   });
 });

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -85,7 +85,15 @@
     isLinux = platformIsLinux;
     i18n.init();
     prefs.init();
-    walkthroughStore.init();
+    // Auto-prompt the tour once, on first launch — skippable in one click via
+    // the overlay's Skip button or Escape, and the steps themselves already
+    // degrade gracefully against an empty library (see WalkthroughOverlay's
+    // target-resolution skip logic).
+    walkthroughStore.init().then(() => {
+      if (!walkthroughStore.hasCompleted) {
+        walkthroughStore.start();
+      }
+    });
     tagsStore.load().catch((err) => console.error('Failed to load tags:', err));
     updaterStore.init();
     picardStore.init();

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -14,6 +14,7 @@
   import Miniplayer from '../lib/components/Miniplayer.svelte';
   import KeyboardShortcutsModal from '../lib/components/KeyboardShortcutsModal.svelte';
   import Toast from '../lib/components/Toast.svelte';
+  import WalkthroughOverlay from '../lib/components/WalkthroughOverlay.svelte';
   import { IconContext, MusicNotesIcon as Music, CloudArrowUpIcon as UploadCloud } from 'phosphor-svelte';
 
   import { i18n } from '../lib/stores/i18n.svelte';
@@ -23,6 +24,7 @@
   import { picardStore } from '../lib/stores/picard.svelte';
   import { scrobblerStore } from '../lib/stores/scrobbler.svelte';
   import { toastStore } from '../lib/stores/toast.svelte';
+  import { walkthroughStore } from '../lib/stores/walkthrough.svelte';
   import { isLinux as platformIsLinux } from '../lib/platform';
   import { themeStore } from '../lib/stores/theme.svelte';
   import { generateEllipseGradientSvg } from '../lib/utils/ellipseGradient';
@@ -83,6 +85,7 @@
     isLinux = platformIsLinux;
     i18n.init();
     prefs.init();
+    walkthroughStore.init();
     tagsStore.load().catch((err) => console.error('Failed to load tags:', err));
     updaterStore.init();
     picardStore.init();
@@ -564,6 +567,8 @@
 {#if isShortcutsModalOpen}
   <KeyboardShortcutsModal onClose={() => (isShortcutsModalOpen = false)} />
 {/if}
+
+<WalkthroughOverlay />
 
   <Toast />
 </IconContext>


### PR DESCRIPTION
## 📋 Summary
Adds an interactive, guided feature walkthrough tour modeled on Heroic Games Launcher's onboarding, addressing #775: a darkened spotlight overlay highlights one UI region at a time, paired with an anchored popover (title, copy, step dots, Back/Next/Skip).
Fixes #775

## 🔍 Implementation Notes
No new dependency — spotlight/popover positioning (`getBoundingClientRect` + viewport clamping) is hand-rolled to match this codebase's existing conventions (`Modal.svelte`'s backdrop styling, the `portal` action, the app's z-index scale) rather than pulling in a coachmark library like driver.js/shepherd.js.
No Rust/backend changes — completion is persisted through the existing generic `set_app_setting`/`get_all_app_settings` key-value store (the same mechanism `RightPanel` already uses for `right_panel_active_tab`), not a new typed `UiPreferences` field or migration.
Eight steps: Sidebar → Top Navigation → Collection view (cards/rows toggle) → Player Bar cover art → Player Bar transport controls → Player Bar button row → Right Panel → Library Folders (Settings). The Player Bar was originally one step but got split into three after review, since it's dense enough to need separate explanations for the cover-art toggle, transport controls, and the menu/lyrics/queue/info/miniplayer button row.
Entry points: auto-starts once on first launch (gated on the persisted `walkthrough_completed` flag — this fires for every user including existing installs upgrading to this version, intentionally, since it's a new feature and 2.0 moves UI elements around), plus a "Take a quick tour" button on the empty-library welcome screen and a "Restart Feature Walkthrough" button on the Help view.
The Right Panel step's `beforeStep` only force-opens the panel when something is actually playing — its only close control (the Info toggle) lives in the player bar's button row, which is itself hidden with nothing playing, so forcing it open on an empty library would leave no way to close it back except the undiscoverable Ctrl+I shortcut. With nothing playing, the step just skips forward instead (targets that aren't in the DOM auto-skip — same graceful-degradation logic used for the responsive player-bar steps).
The Library Folders step's spotlight target is the sidebar's Settings button (its `beforeStep` also best-effort navigates to Settings → Folders) rather than a `data-*` attribute inside `SettingsFolders.svelte`, to avoid a fire-and-forget IPC race between the tour setting the active Settings tab and `SettingsView`'s own `onMount` fetch.
New files: `src/lib/stores/walkthrough.svelte.ts` (tour state/steps), `src/lib/components/WalkthroughOverlay.svelte` (spotlight + popover UI).
Edited: `Sidebar.svelte`, `TopNavigation.svelte`, `PlayerBar.svelte`, `RightPanel.svelte`, `CollectionView.svelte` (added `data-walkthrough-target` anchors), `LibraryWelcome.svelte`/`HelpView.svelte` (entry points), `+layout.svelte` (mounts the overlay, auto-prompt effect), `en.ts`/`fr.ts` (new `walkthrough` locale section).

## 🧪 Test Plan
- [x] `bun run check` (svelte-check)
- [x] `bun run test -- --run` (frontend, 741/741 passing)
- [ ] `cargo test` (src-tauri, if Rust changed) — not applicable, no Rust changes
- [x] Manually verified in the app by the repo owner across several review rounds (tour flow, French locale layout, right-panel force-open behavior, player-bar splits)

## 📸 Screenshots
See the review discussion on this branch for in-app screenshots (English and French) of the spotlight overlay and popover.

## ✅ Checklist
- [x] No unrelated changes bundled in
- [ ] Docs/screenshots updated if user-facing behavior changed — the automated screenshot harness (`scripts/take-screenshots.ts` / `mock-config.json`) doesn't yet have an action to trigger the tour; flagging for a follow-up rather than bundling harness changes into this PR
