### PR TITLE
feat: show total minutes listened in Stats view

### DIFF
--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -886,6 +886,9 @@ pub struct StatsSummary {
     /// Unix-second timestamps of every in-range, non-excluded play, for
     /// client-side local-time listening-clock bucketing.
     pub play_timestamps: Vec<i64>,
+    /// Total minutes listened across every in-range, non-excluded play
+    /// (`SUM(play_history.duration_secs) / 60`), for the range header.
+    pub total_minutes: i64,
 }
 
 /// One completed listen's timing, for the daily listening heatmap (#890) to

--- a/src-tauri/src/stats_summary.rs
+++ b/src-tauri/src/stats_summary.rs
@@ -74,6 +74,7 @@ fn get_summary_at(conn: &Connection, range: StatsRange, now: i64) -> Result<Stat
         top_artists: top_artists(conn, range_start)?,
         top_genres: top_genres(conn, range_start)?,
         play_timestamps: play_timestamps(conn, range_start)?,
+        total_minutes: total_minutes(conn, range_start)?,
     })
 }
 
@@ -277,6 +278,26 @@ fn play_timestamps(conn: &Connection, range_start: i64) -> Result<Vec<i64>> {
         .filter_map(|r| r.ok())
         .collect();
     Ok(rows)
+}
+
+/// Total minutes listened across every in-range, non-excluded play — same
+/// exclusion/library filtering as `play_timestamps`, rounded down to whole
+/// minutes.
+fn total_minutes(conn: &Connection, range_start: i64) -> Result<i64> {
+    let sql = format!(
+        "SELECT COALESCE(SUM(ph.duration_secs), 0)
+         FROM play_history ph
+         JOIN songs s ON s.id = ph.song_id
+         WHERE ph.played_at >= ?1
+           AND s.source IN ({lib}) AND s.unavailable = 0
+           AND NOT EXISTS (
+               SELECT 1 FROM stats_exclusions se
+               WHERE se.entity_type = 'song' AND se.entity_key = CAST(s.id AS TEXT)
+           )",
+        lib = *LIBRARY_SOURCES_SQL
+    );
+    let total_secs: i64 = conn.query_row(&sql, params![range_start], |row| row.get(0))?;
+    Ok(total_secs / 60)
 }
 
 /// Raw `(played_at, duration_secs)` pairs for every non-excluded play since
@@ -498,7 +519,7 @@ mod tests {
         let range_start = range_start_unix(StatsRange::SevenDays, now);
 
         let song = insert_song(&conn, "/s.flac", "Song", "Artist", "Album", "Rock");
-        insert_play(&conn, song, range_start + 10);
+        insert_play_with_duration(&conn, song, range_start + 10, 180);
 
         let summary = get_summary_at(&conn, StatsRange::SevenDays, now).unwrap();
         assert_eq!(summary.range, "7d");
@@ -507,6 +528,32 @@ mod tests {
         assert_eq!(summary.top_artists.len(), 1);
         assert_eq!(summary.top_genres.len(), 1);
         assert_eq!(summary.play_timestamps, vec![range_start + 10]);
+        assert_eq!(summary.total_minutes, 3);
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn test_total_minutes_excludes_out_of_range_and_flagged_songs() {
+        let (db, dir) = test_db();
+        let conn = db.pool.get().unwrap();
+        let now = 1_700_000_000;
+        let range_start = range_start_unix(StatsRange::SevenDays, now);
+
+        let in_range = insert_song(&conn, "/g.flac", "In Range", "Artist G", "Album G", "Rock");
+        let out_of_range = insert_song(&conn, "/h.flac", "Out", "Artist H", "Album H", "Pop");
+        let excluded = insert_song(&conn, "/i.flac", "Excluded", "Artist I", "Album I", "Jazz");
+
+        insert_play_with_duration(&conn, in_range, range_start + 10, 120);
+        insert_play_with_duration(&conn, out_of_range, range_start - 10, 600);
+        insert_play_with_duration(&conn, excluded, range_start + 10, 600);
+        conn.execute(
+            "INSERT INTO stats_exclusions (entity_type, entity_key) VALUES ('song', ?1)",
+            params![excluded.to_string()],
+        )
+        .unwrap();
+
+        assert_eq!(total_minutes(&conn, range_start).unwrap(), 2);
 
         let _ = std::fs::remove_dir_all(dir);
     }

--- a/src/lib/components/StatsView.svelte
+++ b/src/lib/components/StatsView.svelte
@@ -110,18 +110,27 @@
         <ListeningHeatmap />
       </div>
 
-      <div class="flex items-center gap-2 mt-4">
-        {#each RANGES as r (r.value)}
-          <button
-            onclick={() => {
-              range = r.value;
-              if (typeof window !== "undefined") localStorage.setItem("stats_range", r.value);
-            }}
-            class="px-3 py-1.5 rounded-lg text-sm font-medium transition-colors {range === r.value ? 'bg-brand-accent text-brand-accent-contrast shadow-lg shadow-brand-accent/20' : 'text-brand-text-secondary hover:bg-brand-accent/10 hover:text-brand-accent-text-hover'}"
-          >
-            {r.label()}
-          </button>
-        {/each}
+      <div class="flex items-center justify-between gap-2 mt-4">
+        <div class="flex items-center gap-2">
+          {#each RANGES as r (r.value)}
+            <button
+              onclick={() => {
+                range = r.value;
+                if (typeof window !== "undefined") localStorage.setItem("stats_range", r.value);
+              }}
+              class="px-3 py-1.5 rounded-lg text-sm font-medium transition-colors {range === r.value ? 'bg-brand-accent text-brand-accent-contrast shadow-lg shadow-brand-accent/20' : 'text-brand-text-secondary hover:bg-brand-accent/10 hover:text-brand-accent-text-hover'}"
+            >
+              {r.label()}
+            </button>
+          {/each}
+        </div>
+        {#if summary}
+          <span class="text-sm font-medium text-brand-text-secondary shrink-0">
+            {summary.total_minutes === 1
+              ? i18n.t("stats.totalMinutesOne", {}, "1 minute listened")
+              : i18n.t("stats.totalMinutes", { count: summary.total_minutes }, `${summary.total_minutes} minutes listened`)}
+          </span>
+        {/if}
       </div>
     </div>
 

--- a/src/lib/components/StatsView.test.ts
+++ b/src/lib/components/StatsView.test.ts
@@ -15,6 +15,7 @@ function makeSummary(range: StatsSummary["range"]): StatsSummary {
     top_artists: [{ key: "Artist A", label: "Artist A", secondary: null, play_count: 5, excluded: false, album: null }],
     top_genres: [{ key: "Rock", label: "Rock", secondary: null, play_count: 5, excluded: false, album: null }],
     play_timestamps: [1_700_000_000, 1_700_003_600],
+    total_minutes: 42,
   };
 }
 
@@ -43,6 +44,11 @@ describe("StatsView.svelte", () => {
     // "Artist A" appears twice: as the song row's secondary line and as the Top Artists entry.
     expect(getAllByText("Artist A").length).toBeGreaterThanOrEqual(2);
     expect(getByText("Rock")).toBeInTheDocument();
+  });
+
+  it("shows total minutes listened flush-right on the range row", async () => {
+    const { getByText } = render(StatsView);
+    await waitFor(() => expect(getByText("42 minutes listened")).toBeInTheDocument());
   });
 
   it("refetches when the range switcher changes", async () => {
@@ -101,6 +107,7 @@ describe("StatsView.svelte", () => {
           top_artists: [],
           top_genres: [],
           play_timestamps: [],
+          total_minutes: 0,
         } satisfies StatsSummary);
       }
       return Promise.resolve(null);

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -659,6 +659,8 @@ export const en = {
     loading: "Loading stats...",
     empty: "No listening history for this range yet.",
     noData: "No data for this range.",
+    totalMinutesOne: "1 minute listened",
+    totalMinutes: "{count} minutes listened",
     excludeFromStats: "Don't Include in Stats",
     includeInStats: "Include in Stats",
     excludedToast: "Excluded {name} from Stats",

--- a/src/lib/locales/fr.ts
+++ b/src/lib/locales/fr.ts
@@ -658,6 +658,8 @@ export const fr = {
     loading: "Chargement des statistiques...",
     empty: "Aucun historique d'écoute pour cette période pour le moment.",
     noData: "Aucune donnée pour cette période.",
+    totalMinutesOne: "1 minute écoutée",
+    totalMinutes: "{count} minutes écoutées",
     excludeFromStats: "Ne pas inclure dans les statistiques",
     includeInStats: "Inclure dans les statistiques",
     excludedToast: "{name} exclu des statistiques",

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -351,6 +351,8 @@ export interface StatsSummary {
   /** Unix-second timestamps of every in-range, non-excluded play, for
    * client-side local-time listening-clock bucketing. */
   play_timestamps: number[];
+  /** Total minutes listened across every in-range, non-excluded play. */
+  total_minutes: number;
 }
 
 /** One completed listen's timing, for the daily listening heatmap to bucket


### PR DESCRIPTION
## 📋 Summary
Adds a total minutes-listened figure to the Stats view, shown flush-right on the same row as the 7-day/28-day/Year range slider, in the same type style as the range buttons. The value updates whenever the range changes.

## 🔍 Implementation Notes
- Added `total_minutes: i64` to `StatsSummary` (`src-tauri/src/models.rs`).
- Added a `total_minutes()` query in `src-tauri/src/stats_summary.rs` that sums `play_history.duration_secs` for the selected range, using the same library/exclusion filtering as the other Top 10 queries, rounded down to whole minutes.
- Frontend: `StatsView.svelte` renders the total next to the range buttons, singular/plural strings added to `en.ts`/`fr.ts` (`stats.totalMinutesOne` / `stats.totalMinutes`).

## 🧪 Test Plan
- [x] `bun run check` (svelte-check)
- [x] `bun run test -- --run` (frontend)
- [x] `cargo test` (src-tauri)
- [x] Manually verified in the app — confirmed the total renders correctly and updates across all three range tabs.

## 📸 Screenshots
Not included — text-only addition to an existing row.

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed (n/a — no screenshot-worthy new feature, just an existing view's row)
