### PR TITLE
fix(audio): rebuild output stream on fresh thread in all decode_thread paths

### DIFF
--- a/src-tauri/src/audio.rs
+++ b/src-tauri/src/audio.rs
@@ -1039,7 +1039,7 @@ fn decode_thread(
                     }
                     Ok(AudioCommand::Cue(r)) => {
                         if output.is_none() {
-                            match build_output(
+                            match build_output_on_fresh_thread(
                                 &position,
                                 &volume,
                                 &visualizer_buf,
@@ -1158,8 +1158,12 @@ fn decode_thread(
 
         // Ensure the persistent output stream exists (built lazily on the
         // first track this thread ever plays; reused for every track after).
+        // Built on a fresh thread — `output` can already be `None` here after
+        // a mid-session device-change rebuild (see `check_and_rebuild_output`),
+        // and re-touching COM on `decode_thread`'s own long-lived OS thread a
+        // second time risks the same RPC_E_CHANGED_MODE wedge #624 fixed.
         if output.is_none() {
-            match build_output(
+            match build_output_on_fresh_thread(
                 &position,
                 &volume,
                 &visualizer_buf,


### PR DESCRIPTION
## 📋 Summary
Fixes #906. Switching the active audio output device (e.g. Bluetooth headphones connecting/disconnecting) could permanently hang playback — no more play/pause/stop, no audio, until app restart.

## 🔍 Implementation Notes
[#624](https://github.com/esoltys/luminous/pull/624) fixed a wedge where rebuilding the CPAL/WASAPI output stream a second time on `decode_thread`'s own long-lived OS thread (for a different device) could hang indefinitely inside `build_output_stream`/`stream.play()` with no timeout (`RPC_E_CHANGED_MODE`). The fix moved rebuilds onto a short-lived scratch thread with a bounded `recv_timeout` (`build_output_on_fresh_thread`), but only the device-change/error rebuild path in `check_and_rebuild_output` used it. Two other call sites in `decode_thread` still called the raw `build_output(...)` directly on the long-lived thread whenever `output` was `None` — the `Cue` handler, and the "ensure output exists" step at the top of the outer loop. `output` is set back to `None` right before `check_and_rebuild_output` attempts a rebuild (and stays `None` if that rebuild times out), so the very next `Play`/`Cue` command reaching `decode_thread` could re-trigger the same unbounded hang, wedging the one thread every playback command depends on.

Both call sites now go through `build_output_on_fresh_thread` instead.

## 🧪 Test Plan
- [x] `cargo check` (src-tauri)
- [x] Manually verified in the app — repeatedly switched the Windows default output device between two Bluetooth-paired devices (Soundcore Q20i headphones / Vmai M7 soundbar) during playback; the stream rebuilds and picks up on the new device each time, no hang.

## ✅ Checklist
- [x] No unrelated changes bundled in
- [ ] Docs/screenshots updated if user-facing behavior changed — n/a, backend-only fix
