### PR TITLE
fix(playerbar): exit immersive mode when clicking navigation links or panel toggles (#909)

### DIFF
--- a/src/lib/components/PlayerBar.svelte
+++ b/src/lib/components/PlayerBar.svelte
@@ -204,9 +204,21 @@
   }
 
   async function navigateToQueue() {
+    windowLayoutStore.exitImmersiveMode();
     const queuePl = await playlistsStore.requireQueue();
     playlistsStore.selectPlaylist(queuePl.id);
     navigationStore.viewPlaylist(queuePl.id);
+  }
+
+  function handleInfoClick() {
+    if (windowLayoutStore.immersiveMode) {
+      windowLayoutStore.exitImmersiveMode();
+      if (!windowLayoutStore.rightPanelOpen) {
+        windowLayoutStore.toggleRightPanel();
+      }
+    } else {
+      windowLayoutStore.toggleRightPanel();
+    }
   }
 
   function handleTagEditorSaved() {
@@ -246,7 +258,11 @@
       </div>
       {#if playerStore.currentSong?.album?.trim()}
         <LinkButton
-          onclick={(e) => { e.stopPropagation(); navigationStore.viewAlbum(playerStore.currentSong?.album || ""); }}
+          onclick={(e) => {
+            e.stopPropagation();
+            windowLayoutStore.exitImmersiveMode();
+            navigationStore.viewAlbum(playerStore.currentSong?.album || "");
+          }}
           class="text-xs text-brand-text-secondary/70 truncate"
           title={i18n.t('collection.filterByAlbum', { album: playerStore.currentSong.album })}
         >
@@ -255,7 +271,11 @@
       {/if}
       {#if playerStore.currentSong?.artist}
         <LinkButton
-          onclick={(e) => { e.stopPropagation(); navigationStore.viewArtist(playerStore.currentSong?.album_artist?.trim() || playerStore.currentSong?.artist || ""); }}
+          onclick={(e) => {
+            e.stopPropagation();
+            windowLayoutStore.exitImmersiveMode();
+            navigationStore.viewArtist(playerStore.currentSong?.album_artist?.trim() || playerStore.currentSong?.artist || "");
+          }}
           class="text-xs text-brand-text-secondary/70 truncate"
           title={i18n.t('collection.filterByArtist', { artist: playerStore.currentSong.artist })}
         >
@@ -389,7 +409,10 @@
         <Menu class="w-5 h-5" />
       </button>
       <button
-        onclick={() => { navigationStore.activeTab = "lyrics"; }}
+        onclick={() => {
+          windowLayoutStore.exitImmersiveMode();
+          navigationStore.activeTab = "lyrics";
+        }}
         class="transition-colors {navigationStore.activeTab === 'lyrics' ? 'text-brand-accent-text' : 'text-brand-text-secondary hover:text-brand-text-primary'}"
         title={i18n.t('sidebar.lyrics')}
       >
@@ -404,7 +427,7 @@
       </button>
       {#if !windowLayoutStore.isRightPanelAutoHidden}
         <button
-          onclick={() => windowLayoutStore.toggleRightPanel()}
+          onclick={handleInfoClick}
           class="transition-colors {windowLayoutStore.rightPanelOpen ? 'text-brand-accent-text' : 'text-brand-text-secondary hover:text-brand-text-primary'}"
           title={i18n.t('topNav.toggleRightPanel')}
         >
@@ -458,9 +481,9 @@
     {song}
     onPlay={() => playerStore.playSong(song.id)}
     onAddToPlaylist={() => playlistsStore.addSongsToActiveTarget([song.id], song.title || "Song")}
-    onGoToArtist={song.artist ? () => navigationStore.viewArtist(song.album_artist?.trim() || song.artist || "") : undefined}
-    onGoToAlbum={song.album ? () => navigationStore.viewAlbum(song.album || "") : undefined}
-    onEditTags={() => { editingSongId = song.id; }}
+    onGoToArtist={song.artist ? () => { windowLayoutStore.exitImmersiveMode(); navigationStore.viewArtist(song.album_artist?.trim() || song.artist || ""); } : undefined}
+    onGoToAlbum={song.album ? () => { windowLayoutStore.exitImmersiveMode(); navigationStore.viewAlbum(song.album || ""); } : undefined}
+    onEditTags={() => { windowLayoutStore.exitImmersiveMode(); editingSongId = song.id; }}
     onOpenInPicard={() => openInPicard([song.id])}
     onClose={() => { contextMenuState = null; }}
   />

--- a/src/lib/components/PlayerBar.test.ts
+++ b/src/lib/components/PlayerBar.test.ts
@@ -107,6 +107,36 @@ describe("PlayerBar.svelte", () => {
     expect(viewAlbumSpy).toHaveBeenCalledWith("Test Album");
   });
 
+  it("exits Immersive Mode and navigates to album when album title is clicked while immersive (#909)", async () => {
+    playerStore.currentSong = mockSong;
+    playerStore.state = "playing";
+    windowLayoutStore.immersiveMode = true;
+    const exitImmersiveSpy = vi.spyOn(windowLayoutStore, "exitImmersiveMode");
+    const viewAlbumSpy = vi.spyOn(navigationStore, "viewAlbum").mockImplementation(() => {});
+
+    const { getByText } = render(PlayerBar);
+    await fireEvent.click(getByText("Test Album"));
+
+    expect(exitImmersiveSpy).toHaveBeenCalled();
+    expect(windowLayoutStore.immersiveMode).toBe(false);
+    expect(viewAlbumSpy).toHaveBeenCalledWith("Test Album");
+  });
+
+  it("exits Immersive Mode and navigates to artist when artist title is clicked while immersive (#909)", async () => {
+    playerStore.currentSong = mockSong;
+    playerStore.state = "playing";
+    windowLayoutStore.immersiveMode = true;
+    const exitImmersiveSpy = vi.spyOn(windowLayoutStore, "exitImmersiveMode");
+    const viewArtistSpy = vi.spyOn(navigationStore, "viewArtist").mockImplementation(() => {});
+
+    const { getByText } = render(PlayerBar);
+    await fireEvent.click(getByText("Test Artist"));
+
+    expect(exitImmersiveSpy).toHaveBeenCalled();
+    expect(windowLayoutStore.immersiveMode).toBe(false);
+    expect(viewArtistSpy).toHaveBeenCalledWith("Test Artist");
+  });
+
   const mockQueue: Playlist = {
     id: 1,
     name: "Queue",
@@ -330,6 +360,36 @@ describe("PlayerBar.svelte", () => {
     expect(windowLayoutStore.rightPanelOpen).toBe(true);
   });
 
+  it("exits Immersive Mode and opens the right panel when Info button is clicked while immersive and panel was closed (#909)", async () => {
+    playerStore.currentSong = mockSong;
+    windowLayoutStore.immersiveMode = true;
+    windowLayoutStore.rightPanelOpen = false;
+    const exitImmersiveSpy = vi.spyOn(windowLayoutStore, "exitImmersiveMode");
+
+    const { getByTitle } = render(PlayerBar);
+    const infoBtn = getByTitle("Show Info Panel (Ctrl+I)");
+    await fireEvent.click(infoBtn);
+
+    expect(exitImmersiveSpy).toHaveBeenCalled();
+    expect(windowLayoutStore.immersiveMode).toBe(false);
+    expect(windowLayoutStore.rightPanelOpen).toBe(true);
+  });
+
+  it("exits Immersive Mode and keeps the right panel open when Info button is clicked while immersive and panel was already open (#909)", async () => {
+    playerStore.currentSong = mockSong;
+    windowLayoutStore.immersiveMode = true;
+    windowLayoutStore.rightPanelOpen = true;
+    const exitImmersiveSpy = vi.spyOn(windowLayoutStore, "exitImmersiveMode");
+
+    const { getByTitle } = render(PlayerBar);
+    const infoBtn = getByTitle("Show Info Panel (Ctrl+I)");
+    await fireEvent.click(infoBtn);
+
+    expect(exitImmersiveSpy).toHaveBeenCalled();
+    expect(windowLayoutStore.immersiveMode).toBe(false);
+    expect(windowLayoutStore.rightPanelOpen).toBe(true);
+  });
+
   // #876: the playbar's Menu/Lyrics/Queue button row.
 
   it("switches to the Lyrics tab when the Lyrics button is clicked", async () => {
@@ -339,6 +399,20 @@ describe("PlayerBar.svelte", () => {
 
     await fireEvent.click(getByTitle("Lyrics"));
 
+    expect(navigationStore.activeTab).toBe("lyrics");
+  });
+
+  it("exits Immersive Mode and switches to the Lyrics tab when Lyrics button is clicked while immersive (#909)", async () => {
+    playerStore.currentSong = mockSong;
+    windowLayoutStore.immersiveMode = true;
+    navigationStore.activeTab = "collection";
+    const exitImmersiveSpy = vi.spyOn(windowLayoutStore, "exitImmersiveMode");
+
+    const { getByTitle } = render(PlayerBar);
+    await fireEvent.click(getByTitle("Lyrics"));
+
+    expect(exitImmersiveSpy).toHaveBeenCalled();
+    expect(windowLayoutStore.immersiveMode).toBe(false);
     expect(navigationStore.activeTab).toBe("lyrics");
   });
 
@@ -355,6 +429,23 @@ describe("PlayerBar.svelte", () => {
     expect(viewPlaylistSpy).toHaveBeenCalledWith(mockQueue.id);
   });
 
+  it("exits Immersive Mode and navigates to the Queue when Queue button is clicked while immersive (#909)", async () => {
+    playerStore.currentSong = mockSong;
+    windowLayoutStore.immersiveMode = true;
+    vi.spyOn(playlistsStore, "requireQueue").mockResolvedValue(mockQueue);
+    const selectPlaylistSpy = vi.spyOn(playlistsStore, "selectPlaylist").mockImplementation(async () => {});
+    const viewPlaylistSpy = vi.spyOn(navigationStore, "viewPlaylist").mockImplementation(() => {});
+    const exitImmersiveSpy = vi.spyOn(windowLayoutStore, "exitImmersiveMode");
+
+    const { getByTitle } = render(PlayerBar);
+    await fireEvent.click(getByTitle("Queue"));
+
+    expect(exitImmersiveSpy).toHaveBeenCalled();
+    expect(windowLayoutStore.immersiveMode).toBe(false);
+    expect(selectPlaylistSpy).toHaveBeenCalledWith(mockQueue.id);
+    expect(viewPlaylistSpy).toHaveBeenCalledWith(mockQueue.id);
+  });
+
   it("opens the current song's context menu from the Menu button", async () => {
     playerStore.currentSong = mockSong;
     const { getByTitle, getByText } = render(PlayerBar);
@@ -362,6 +453,36 @@ describe("PlayerBar.svelte", () => {
     await fireEvent.click(getByTitle("Song menu"));
 
     expect(getByText(/add to queue/i)).toBeInTheDocument();
+  });
+
+  it("exits Immersive Mode when 'Go to Artist' is clicked in the song context menu (#909)", async () => {
+    playerStore.currentSong = mockSong;
+    windowLayoutStore.immersiveMode = true;
+    const exitImmersiveSpy = vi.spyOn(windowLayoutStore, "exitImmersiveMode");
+    const viewArtistSpy = vi.spyOn(navigationStore, "viewArtist").mockImplementation(() => {});
+
+    const { getByTitle, getByText } = render(PlayerBar);
+    await fireEvent.click(getByTitle("Song menu"));
+    await fireEvent.click(getByText(/go to artist/i));
+
+    expect(exitImmersiveSpy).toHaveBeenCalled();
+    expect(windowLayoutStore.immersiveMode).toBe(false);
+    expect(viewArtistSpy).toHaveBeenCalledWith("Test Artist");
+  });
+
+  it("exits Immersive Mode when 'Go to Album' is clicked in the song context menu (#909)", async () => {
+    playerStore.currentSong = mockSong;
+    windowLayoutStore.immersiveMode = true;
+    const exitImmersiveSpy = vi.spyOn(windowLayoutStore, "exitImmersiveMode");
+    const viewAlbumSpy = vi.spyOn(navigationStore, "viewAlbum").mockImplementation(() => {});
+
+    const { getByTitle, getByText } = render(PlayerBar);
+    await fireEvent.click(getByTitle("Song menu"));
+    await fireEvent.click(getByText(/go to album/i));
+
+    expect(exitImmersiveSpy).toHaveBeenCalled();
+    expect(windowLayoutStore.immersiveMode).toBe(false);
+    expect(viewAlbumSpy).toHaveBeenCalledWith("Test Album");
   });
 
   it("disables the Menu button when nothing is playing", () => {


### PR DESCRIPTION
## 📋 Summary
When in Immersive View (the 3D flip card's back face showing album artwork), clicking navigation elements or sidebars on the floating PlayerBar (such as the artist link, album link, Queue button, lyrics button, or info sidebar toggle) navigated the underlying front face views or updated panel states in the background without exiting Immersive View. Because the UI remained flipped to the immersive back face, the results were obscured from the user.

This PR ensures clicking any of these navigation elements or panel toggles automatically calls `windowLayoutStore.exitImmersiveMode()`, returning the user to the front face and displaying the expected view or sidebar. Fixes #909.

## 🔍 Implementation Notes
- **`PlayerBar.svelte`**:
  - `LinkButton` handlers for artist and album now call `windowLayoutStore.exitImmersiveMode()` before navigating.
  - `navigateToQueue()` now calls `windowLayoutStore.exitImmersiveMode()` before selecting and navigating to the Queue.
  - Lyrics button click now calls `windowLayoutStore.exitImmersiveMode()` before switching `activeTab = "lyrics"`.
  - Info panel button now uses `handleInfoClick()`: if currently in Immersive View, it exits Immersive View and ensures the right panel is open so the user immediately sees it; if on the front face, it maintains standard toggle behavior.
  - `SongContextMenu` callbacks for `onGoToArtist`, `onGoToAlbum`, and `onEditTags` now call `windowLayoutStore.exitImmersiveMode()`.
- **`PlayerBar.test.ts`**:
  - Added unit test coverage for clicking artist link, album link, Queue button, Lyrics button, Info panel toggle (both when previously closed and when already open), and context menu actions while in Immersive Mode.

## 🧪 Test Plan
- [x] `bun run check` (svelte-check + knip: 0 errors, 0 warnings)
- [x] `bun run test -- --run` (frontend unit tests: all 31 tests passed in `PlayerBar.test.ts`)
- [x] Manually verified in the app:
  - Entered Immersive View and clicked artist/album links: UI flipped back and showed the artist/album details.
  - Entered Immersive View and clicked Queue button: UI flipped back and showed the Queue.
  - Entered Immersive View and clicked Info button: UI flipped back and ensured the right info panel is visible.

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed
