### PR TITLE
feat: micro-animations, dynamic theme morphing & responsive playbar transitions

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -24,8 +24,97 @@
   --color-brand-gold: var(--color-accent-gold);
 }
 
+/* Interpolatable color properties for smooth dynamic theme morphing */
+@property --color-artwork-primary {
+  syntax: '<color>';
+  inherits: true;
+  initial-value: #2e3440;
+}
+@property --color-artwork-sidebar {
+  syntax: '<color>';
+  inherits: true;
+  initial-value: #242933;
+}
+@property --color-artwork-playerbar {
+  syntax: '<color>';
+  inherits: true;
+  initial-value: #2b303c;
+}
+@property --color-artwork-accent {
+  syntax: '<color>';
+  inherits: true;
+  initial-value: #88c0d0;
+}
+@property --color-artwork-accent-hover {
+  syntax: '<color>';
+  inherits: true;
+  initial-value: #8fbcbb;
+}
+@property --color-artwork-border {
+  syntax: '<color>';
+  inherits: true;
+  initial-value: #3b4252;
+}
+@property --bg-main {
+  syntax: '<color>';
+  inherits: true;
+  initial-value: #08090c;
+}
+@property --bg-sidebar {
+  syntax: '<color>';
+  inherits: true;
+  initial-value: #1c1f29;
+}
+@property --bg-playerbar {
+  syntax: '<color>';
+  inherits: true;
+  initial-value: #191b23;
+}
+@property --color-accent {
+  syntax: '<color>';
+  inherits: true;
+  initial-value: #6f7ea9;
+}
+@property --color-accent-hover {
+  syntax: '<color>';
+  inherits: true;
+  initial-value: #8c98ba;
+}
+@property --color-border {
+  syntax: '<color>';
+  inherits: true;
+  initial-value: #3d4255;
+}
+@property --glass-bg-sidebar {
+  syntax: '<color>';
+  inherits: true;
+  initial-value: rgba(28, 31, 41, 0.5);
+}
+@property --glass-bg-playerbar {
+  syntax: '<color>';
+  inherits: true;
+  initial-value: rgba(25, 27, 35, 0.5);
+}
+
 @layer base {
   :root {
+    --theme-morph-duration: 1.5s;
+    transition:
+      --color-artwork-primary var(--theme-morph-duration) ease,
+      --color-artwork-sidebar var(--theme-morph-duration) ease,
+      --color-artwork-playerbar var(--theme-morph-duration) ease,
+      --color-artwork-accent var(--theme-morph-duration) ease,
+      --color-artwork-accent-hover var(--theme-morph-duration) ease,
+      --color-artwork-border var(--theme-morph-duration) ease,
+      --bg-main var(--theme-morph-duration) ease,
+      --bg-sidebar var(--theme-morph-duration) ease,
+      --bg-playerbar var(--theme-morph-duration) ease,
+      --color-accent var(--theme-morph-duration) ease,
+      --color-accent-hover var(--theme-morph-duration) ease,
+      --color-border var(--theme-morph-duration) ease,
+      --glass-bg-sidebar var(--theme-morph-duration) ease,
+      --glass-bg-playerbar var(--theme-morph-duration) ease;
+
     /* Default theme colors (Luminous, dark variant) — overwritten by
        ThemeStore.applyActiveTheme() on load; this is only the first-paint
        fallback before JS runs. */
@@ -60,6 +149,12 @@
     font-family: 'Inter', system-ui, -apple-system, sans-serif;
     overflow: hidden;
     user-select: none;
+    transition: background-color var(--theme-morph-duration) ease, color var(--theme-morph-duration) ease;
+  }
+
+  aside,
+  main {
+    transition: background-color var(--theme-morph-duration) ease, border-color var(--theme-morph-duration) ease;
   }
 
   /* Desktop application cursor defaults: remove hand/pointer cursor everywhere */

--- a/src/app.css
+++ b/src/app.css
@@ -96,6 +96,32 @@
   initial-value: rgba(25, 27, 35, 0.5);
 }
 
+@property --color-text-primary {
+  syntax: '<color>';
+  inherits: true;
+  initial-value: #f1f3f8;
+}
+@property --color-text-secondary {
+  syntax: '<color>';
+  inherits: true;
+  initial-value: #a6adc4;
+}
+@property --color-accent-contrast {
+  syntax: '<color>';
+  inherits: true;
+  initial-value: #000000;
+}
+@property --color-accent-text {
+  syntax: '<color>';
+  inherits: true;
+  initial-value: #6f7ea9;
+}
+@property --color-accent-text-hover {
+  syntax: '<color>';
+  inherits: true;
+  initial-value: #8c98ba;
+}
+
 @layer base {
   :root {
     --theme-morph-duration: 1.5s;
@@ -112,6 +138,11 @@
       --color-accent var(--theme-morph-duration) ease,
       --color-accent-hover var(--theme-morph-duration) ease,
       --color-border var(--theme-morph-duration) ease,
+      --color-text-primary var(--theme-morph-duration) ease,
+      --color-text-secondary var(--theme-morph-duration) ease,
+      --color-accent-contrast var(--theme-morph-duration) ease,
+      --color-accent-text var(--theme-morph-duration) ease,
+      --color-accent-text-hover var(--theme-morph-duration) ease,
       --glass-bg-sidebar var(--theme-morph-duration) ease,
       --glass-bg-playerbar var(--theme-morph-duration) ease;
 
@@ -149,12 +180,6 @@
     font-family: 'Inter', system-ui, -apple-system, sans-serif;
     overflow: hidden;
     user-select: none;
-    transition: background-color var(--theme-morph-duration) ease, color var(--theme-morph-duration) ease;
-  }
-
-  aside,
-  main {
-    transition: background-color var(--theme-morph-duration) ease, border-color var(--theme-morph-duration) ease;
   }
 
   /* Desktop application cursor defaults: remove hand/pointer cursor everywhere */

--- a/src/lib/components/CollectionView.svelte
+++ b/src/lib/components/CollectionView.svelte
@@ -413,10 +413,15 @@
           </div>
 
           <div class="flex items-center gap-2">
-            <div data-walkthrough-target="collection-view" class="inline-flex items-center gap-0.5 bg-brand-sidebar border border-brand-border rounded-full p-1">
+            <div data-walkthrough-target="collection-view" class="relative inline-flex items-center gap-0.5 bg-brand-sidebar border border-brand-border rounded-full p-1">
+              <!-- Sliding background indicator -->
+              <span
+                class="absolute top-1 bottom-1 left-1 w-7 h-7 rounded-full bg-brand-accent shadow-sm pointer-events-none transition-transform duration-200 ease-out {activeViewMode === 'rows' ? 'translate-x-[30px]' : 'translate-x-0'}"
+                aria-hidden="true"
+              ></span>
               <button
                 onclick={() => setActiveViewMode("cards")}
-                class="flex items-center justify-center w-7 h-7 rounded-full transition-colors {activeViewMode === 'cards' ? 'bg-brand-accent text-white' : 'text-brand-text-secondary hover:text-brand-text-primary'}"
+                class="relative z-10 flex items-center justify-center w-7 h-7 rounded-full transition-colors duration-200 {activeViewMode === 'cards' ? 'text-white' : 'text-brand-text-secondary hover:text-brand-text-primary'}"
                 title={i18n.t('collection.viewCards')}
                 aria-label={i18n.t('collection.viewCards')}
                 aria-pressed={activeViewMode === "cards"}
@@ -425,7 +430,7 @@
               </button>
               <button
                 onclick={() => setActiveViewMode("rows")}
-                class="flex items-center justify-center w-7 h-7 rounded-full transition-colors {activeViewMode === 'rows' ? 'bg-brand-accent text-white' : 'text-brand-text-secondary hover:text-brand-text-primary'}"
+                class="relative z-10 flex items-center justify-center w-7 h-7 rounded-full transition-colors duration-200 {activeViewMode === 'rows' ? 'text-white' : 'text-brand-text-secondary hover:text-brand-text-primary'}"
                 title={i18n.t('collection.viewRows')}
                 aria-label={i18n.t('collection.viewRows')}
                 aria-pressed={activeViewMode === "rows"}

--- a/src/lib/components/Equalizer.svelte
+++ b/src/lib/components/Equalizer.svelte
@@ -11,6 +11,7 @@
   import Toggle from "./Toggle.svelte";
   import Select from "./Select.svelte";
   import Knob from "./Knob.svelte";
+  import { themeStore } from "../stores/theme.svelte";
 
   type EqMode = "graphic10" | "parametric20";
   interface ParametricBand {
@@ -345,6 +346,7 @@
           crossfade_suppress_same_album: crossfadeSuppressSameAlbum,
         },
       });
+      void themeStore.syncMorphDuration();
     } catch (e) {
       console.error("Failed to save fade settings:", e);
     }
@@ -387,16 +389,21 @@
     </div>
     <div class="flex items-center gap-4 flex-wrap">
 
-      <div class="flex items-center bg-brand-main border border-brand-border rounded-[2rem] p-0.5" role="group" aria-label={i18n.t('equalizer.modeLabel')}>
+      <div class="relative flex items-center bg-brand-main border border-brand-border rounded-[2rem] p-0.5" role="group" aria-label={i18n.t('equalizer.modeLabel')}>
+        <!-- Sliding background pill -->
+        <span
+          class="absolute top-0.5 bottom-0.5 left-0.5 w-[calc(50%-2px)] rounded-full bg-brand-accent shadow-sm pointer-events-none transition-transform duration-200 ease-out {mode === 'parametric20' ? 'translate-x-full' : 'translate-x-0'}"
+          aria-hidden="true"
+        ></span>
         <button
-          class="text-xs font-semibold px-4 py-1.5 rounded-full transition-colors {mode === 'graphic10' ? 'bg-brand-accent text-brand-accent-contrast shadow-sm' : 'text-brand-text-secondary hover:text-brand-text-primary'}"
+          class="relative z-10 flex-1 text-xs font-semibold px-4 py-1.5 rounded-full transition-colors duration-200 {mode === 'graphic10' ? 'text-brand-accent-contrast' : 'text-brand-text-secondary hover:text-brand-text-primary'}"
           onclick={() => handleModeChange("graphic10")}
           aria-pressed={mode === "graphic10"}
         >
           {i18n.t('equalizer.modeGraphic')}
         </button>
         <button
-          class="text-xs font-semibold px-4 py-1.5 rounded-full transition-colors {mode === 'parametric20' ? 'bg-brand-accent text-brand-accent-contrast shadow-sm' : 'text-brand-text-secondary hover:text-brand-text-primary'}"
+          class="relative z-10 flex-1 text-xs font-semibold px-4 py-1.5 rounded-full transition-colors duration-200 {mode === 'parametric20' ? 'text-brand-accent-contrast' : 'text-brand-text-secondary hover:text-brand-text-primary'}"
           onclick={() => handleModeChange("parametric20")}
           aria-pressed={mode === "parametric20"}
         >
@@ -607,9 +614,14 @@
 
         <div class="flex flex-col items-center justify-center gap-1.5 h-full">
           <span class="text-[10px] font-bold text-brand-text-secondary uppercase tracking-wider text-center">{i18n.t('loudness.mode')}</span>
-          <div class="flex items-center bg-brand-main border border-brand-border rounded-[2rem] p-0.5 mt-1 mx-auto w-full max-w-[200px]" role="group" aria-label={i18n.t('loudness.mode')}>
+          <div class="relative flex items-center bg-brand-main border border-brand-border rounded-[2rem] p-0.5 mt-1 mx-auto w-full max-w-[200px]" role="group" aria-label={i18n.t('loudness.mode')}>
+            <!-- Sliding background pill -->
+            <span
+              class="absolute top-0.5 bottom-0.5 left-0.5 w-[calc(50%-2px)] rounded-full bg-brand-accent shadow-sm pointer-events-none transition-transform duration-200 ease-out {loudnessMode === 'album' ? 'translate-x-full' : 'translate-x-0'} {!loudnessStore.enabled ? 'opacity-50' : ''}"
+              aria-hidden="true"
+            ></span>
             <button
-              class="flex-1 text-xs font-semibold px-4 py-1.5 rounded-full transition-colors {loudnessMode === 'track' ? 'bg-brand-accent text-brand-accent-contrast shadow-sm' : 'text-brand-text-secondary hover:text-brand-text-primary'}"
+              class="relative z-10 flex-1 text-xs font-semibold px-4 py-1.5 rounded-full transition-colors duration-200 {loudnessMode === 'track' ? 'text-brand-accent-contrast' : 'text-brand-text-secondary hover:text-brand-text-primary'}"
               onclick={() => handleLoudnessModeChange("track")}
               aria-pressed={loudnessMode === "track"}
               disabled={!loudnessStore.enabled}
@@ -617,7 +629,7 @@
               {i18n.t('loudness.modeTrack')}
             </button>
             <button
-              class="flex-1 text-xs font-semibold px-4 py-1.5 rounded-full transition-colors {loudnessMode === 'album' ? 'bg-brand-accent text-brand-accent-contrast shadow-sm' : 'text-brand-text-secondary hover:text-brand-text-primary'}"
+              class="relative z-10 flex-1 text-xs font-semibold px-4 py-1.5 rounded-full transition-colors duration-200 {loudnessMode === 'album' ? 'text-brand-accent-contrast' : 'text-brand-text-secondary hover:text-brand-text-primary'}"
               onclick={() => handleLoudnessModeChange("album")}
               aria-pressed={loudnessMode === "album"}
               disabled={!loudnessStore.enabled}

--- a/src/lib/components/GenreBrowseView.svelte
+++ b/src/lib/components/GenreBrowseView.svelte
@@ -26,6 +26,38 @@
   let mergeDialogNames = $state<string[] | null>(null);
   let deleteConfirmNames = $state<string[] | null>(null);
 
+  let genreViewElements = $state<Record<string, HTMLButtonElement>>({});
+  let genreIndicatorStyle = $state({ left: 4, width: 0, opacity: 0 });
+  let genreViewMounted = $state(false);
+
+  function updateGenreIndicator() {
+    const el = genreViewElements[prefs.genreViewMode];
+    if (el) {
+      genreIndicatorStyle = {
+        left: el.offsetLeft,
+        width: el.offsetWidth,
+        opacity: 1
+      };
+    }
+  }
+
+  onMount(() => {
+    const handleResize = () => updateGenreIndicator();
+    window.addEventListener("resize", handleResize);
+    return () => {
+      window.removeEventListener("resize", handleResize);
+    };
+  });
+
+  $effect(() => {
+    if (genreViewElements[prefs.genreViewMode]) {
+      updateGenreIndicator();
+      if (!genreViewMounted) {
+        requestAnimationFrame(() => { genreViewMounted = true; });
+      }
+    }
+  });
+
   function toggleSelectMode() {
     selectMode = !selectMode;
     selected = new Set();
@@ -177,10 +209,15 @@
               <option value="count-false">▼ {i18n.t('songTags.sortSongCount', {}, 'Song Count')}</option>
             </Select>
           </div>
-          <div class="inline-flex items-center gap-0.5 bg-brand-sidebar border border-brand-border rounded-full p-1">
+          <div class="relative inline-flex items-center gap-0.5 bg-brand-sidebar border border-brand-border rounded-full p-1">
+            <!-- Sliding background indicator -->
+            <span
+              class="absolute top-1 bottom-1 left-1 w-7 h-7 rounded-full bg-brand-accent shadow-sm pointer-events-none transition-transform duration-200 ease-out {prefs.genreCardsViewMode === 'rows' ? 'translate-x-[30px]' : 'translate-x-0'}"
+              aria-hidden="true"
+            ></span>
             <button
               onclick={() => prefs.setGenreCardsViewMode("cards")}
-              class="flex items-center justify-center w-7 h-7 rounded-full transition-colors {prefs.genreCardsViewMode === 'cards' ? 'bg-brand-accent text-white' : 'text-brand-text-secondary hover:text-brand-text-primary'}"
+              class="relative z-10 flex items-center justify-center w-7 h-7 rounded-full transition-colors duration-200 {prefs.genreCardsViewMode === 'cards' ? 'text-white' : 'text-brand-text-secondary hover:text-brand-text-primary'}"
               title={i18n.t("collection.viewCards", {}, "Card view")}
               aria-label={i18n.t("collection.viewCards", {}, "Card view")}
               aria-pressed={prefs.genreCardsViewMode === "cards"}
@@ -189,7 +226,7 @@
             </button>
             <button
               onclick={() => prefs.setGenreCardsViewMode("rows")}
-              class="flex items-center justify-center w-7 h-7 rounded-full transition-colors {prefs.genreCardsViewMode === 'rows' ? 'bg-brand-accent text-white' : 'text-brand-text-secondary hover:text-brand-text-primary'}"
+              class="relative z-10 flex items-center justify-center w-7 h-7 rounded-full transition-colors duration-200 {prefs.genreCardsViewMode === 'rows' ? 'text-white' : 'text-brand-text-secondary hover:text-brand-text-primary'}"
               title={i18n.t("collection.viewRows", {}, "Row view")}
               aria-label={i18n.t("collection.viewRows", {}, "Row view")}
               aria-pressed={prefs.genreCardsViewMode === "rows"}
@@ -198,17 +235,25 @@
             </button>
           </div>
         {/if}
-        <div class="inline-flex items-center gap-0.5 bg-brand-sidebar border border-brand-border rounded-full p-1">
+        <div class="relative inline-flex items-center gap-0.5 bg-brand-sidebar border border-brand-border rounded-full p-1">
+          <!-- Sliding background indicator -->
+          <span
+            class="absolute top-1 bottom-1 bg-brand-accent rounded-full shadow-sm pointer-events-none {genreViewMounted ? 'transition-[left,width] duration-200 ease-out' : 'transition-none'}"
+            style="left: {genreIndicatorStyle.left}px; width: {genreIndicatorStyle.width}px; opacity: {genreIndicatorStyle.opacity};"
+            aria-hidden="true"
+          ></span>
           <button
+            bind:this={genreViewElements["genre"]}
             onclick={() => setViewMode("genre")}
-            class="px-3 h-7 rounded-full text-xs font-semibold transition-colors {prefs.genreViewMode === 'genre' ? 'bg-brand-accent text-white' : 'text-brand-text-secondary hover:text-brand-text-primary'}"
+            class="relative z-10 px-3 h-7 rounded-full text-xs font-semibold transition-colors duration-200 {prefs.genreViewMode === 'genre' ? 'text-white' : 'text-brand-text-secondary hover:text-brand-text-primary'}"
             aria-pressed={prefs.genreViewMode === "genre"}
           >
             {i18n.t("songTags.viewGenre", {}, "Genre")}
           </button>
           <button
+            bind:this={genreViewElements["tags"]}
             onclick={() => setViewMode("tags")}
-            class="px-3 h-7 rounded-full text-xs font-semibold transition-colors {prefs.genreViewMode === 'tags' ? 'bg-brand-accent text-white' : 'text-brand-text-secondary hover:text-brand-text-primary'}"
+            class="relative z-10 px-3 h-7 rounded-full text-xs font-semibold transition-colors duration-200 {prefs.genreViewMode === 'tags' ? 'text-white' : 'text-brand-text-secondary hover:text-brand-text-primary'}"
             aria-pressed={prefs.genreViewMode === "tags"}
           >
             {i18n.t("songTags.viewTags", {}, "Tags")}

--- a/src/lib/components/PlayerBar.svelte
+++ b/src/lib/components/PlayerBar.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { fly, fade } from 'svelte/transition';
+  import { fly } from 'svelte/transition';
   import { cubicOut } from 'svelte/easing';
   import { playerStore } from "../stores/player.svelte";
   import { playlistsStore } from "../stores/playlists.svelte";
@@ -61,22 +61,6 @@
 
 
 
-
-  // Delay the appearance of the compact transport PiP button until the full-tier
-  // toolbar and seekbar finish fading out (200ms), preventing duplicate PiP buttons
-  // or flashing beside the transport controls before the toolbar is hidden.
-  let isToolbarGone = $state(windowLayoutStore.isPlayerBarCompact);
-
-  $effect(() => {
-    if (!windowLayoutStore.isPlayerBarCompact) {
-      isToolbarGone = false;
-    } else {
-      const timer = setTimeout(() => {
-        isToolbarGone = true;
-      }, 200);
-      return () => clearTimeout(timer);
-    }
-  });
 
   let volumePercent = $derived(playerStore.volume * 100);
   let volumeSliderStyle = $derived(
@@ -429,9 +413,8 @@
         </div>
       {/if}
 
-      {#if windowLayoutStore.isPlayerBarCompact && isToolbarGone}
+      {#if windowLayoutStore.isPlayerBarCompact}
         <button
-          in:fade={{ duration: 150 }}
           onclick={() => windowLayoutStore.toggleMiniplayerMode()}
           class="text-brand-text-secondary hover:text-brand-accent-text transition-colors flex-shrink-0"
           title={i18n.t('miniplayer.toggleTooltip', {}, 'Picture-in-Picture Mode (Ctrl+M)')}
@@ -444,7 +427,6 @@
 
     {#if !windowLayoutStore.isPlayerBarCompact}
       <div
-        transition:fade={{ duration: 200 }}
         class="flex items-center gap-2.5 w-full text-[10px] text-brand-text-secondary/60"
       >
         <!-- Invisible spacer matching the mode-toggle button's footprint, so the
@@ -475,7 +457,6 @@
   {#if !windowLayoutStore.isPlayerBarCompact}
     <div
       data-walkthrough-target="player-bar-toolbar"
-      transition:fade={{ duration: 200 }}
       class="flex flex-col items-center gap-1.5 flex-shrink-0 min-[768px]:w-1/3 min-[768px]:min-w-[200px] max-w-xs"
     >
       <div class="h-5 flex items-center gap-3 min-[768px]:gap-5">

--- a/src/lib/components/PlayerBar.svelte
+++ b/src/lib/components/PlayerBar.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { fly } from 'svelte/transition';
+  import { fly, fade } from 'svelte/transition';
   import { cubicOut } from 'svelte/easing';
   import { playerStore } from "../stores/player.svelte";
   import { playlistsStore } from "../stores/playlists.svelte";
@@ -410,6 +410,7 @@
       </button>
       {#if !windowLayoutStore.isRightPanelAutoHidden}
         <button
+          transition:fade={{ duration: 200 }}
           onclick={() => {
             windowLayoutStore.exitImmersiveMode();
             navigationStore.activeTab = "lyrics";
@@ -429,6 +430,7 @@
       </button>
       {#if !windowLayoutStore.isRightPanelAutoHidden}
         <button
+          transition:fade={{ duration: 200 }}
           onclick={handleInfoClick}
           class="hidden md:inline-flex transition-colors {windowLayoutStore.rightPanelOpen ? 'text-brand-accent-text' : 'text-brand-text-secondary hover:text-brand-text-primary'}"
           title={i18n.t('topNav.toggleRightPanel')}
@@ -446,9 +448,11 @@
     </div>
 
     <div class="flex items-center gap-2">
-      <div class="w-24 h-7 hidden md:block">
-        <SpectrumVisualizer />
-      </div>
+      {#if !windowLayoutStore.isRightPanelAutoHidden}
+        <div transition:fade={{ duration: 200 }} class="w-24 h-7 hidden md:block">
+          <SpectrumVisualizer />
+        </div>
+      {/if}
       <button onclick={toggleMute} class="text-brand-text-secondary hover:text-brand-text-primary transition-colors" title={i18n.t('playerBar.volume')}>
         {#if isMuted || playerStore.volume === 0}
           <VolumeX class="w-4 h-4" />

--- a/src/lib/components/PlayerBar.svelte
+++ b/src/lib/components/PlayerBar.svelte
@@ -291,28 +291,30 @@
 
   <div data-walkthrough-target="player-bar-controls" class="flex flex-col items-center gap-1.5 min-[400px]:min-w-[220px] min-[400px]:ml-auto min-[700px]:w-1/3 min-[700px]:flex-none min-[700px]:ml-0 max-w-[600px]">
     <div class="flex items-center gap-3 min-[700px]:gap-5">
-      <div class="hidden min-[700px]:block relative">
-        {#if playerStore.shuffleMode !== 'off'}
+      {#if !windowLayoutStore.isPlayerBarCompact}
+        <div transition:fade={{ duration: 200 }} class="relative">
+          {#if playerStore.shuffleMode !== 'off'}
+            <button
+              onclick={cycleShuffle}
+              class="absolute right-full top-1/2 -translate-y-1/2 mr-1.5 text-[10px] font-semibold text-brand-accent-text hover:text-brand-text-primary transition-colors uppercase tracking-wide whitespace-nowrap"
+              title={`${i18n.t('playerBar.shuffle')}: ${shuffleModeLabel(playerStore.shuffleMode)} — ${shuffleModeDescription(playerStore.shuffleMode)}`}
+            >
+              {i18n.t('playerBar.shuffle')} {shuffleModeLabel(playerStore.shuffleMode)}
+            </button>
+          {/if}
           <button
             onclick={cycleShuffle}
-            class="absolute right-full top-1/2 -translate-y-1/2 mr-1.5 text-[10px] font-semibold text-brand-accent-text hover:text-brand-text-primary transition-colors uppercase tracking-wide whitespace-nowrap"
+            class="text-xs transition-colors hover:text-brand-text-primary flex items-center gap-1 p-1 {playerStore.shuffleMode !== 'off' ? 'text-brand-accent-text font-bold' : 'text-brand-text-secondary/50'}"
             title={`${i18n.t('playerBar.shuffle')}: ${shuffleModeLabel(playerStore.shuffleMode)} — ${shuffleModeDescription(playerStore.shuffleMode)}`}
           >
-            {i18n.t('playerBar.shuffle')} {shuffleModeLabel(playerStore.shuffleMode)}
+            {#if shuffleTypeIcon(playerStore.shuffleMode)}
+              {@const ShuffleTypeIcon = shuffleTypeIcon(playerStore.shuffleMode)}
+              <ShuffleTypeIcon class="w-4 h-4" />
+            {/if}
+            <Shuffle class="w-4 h-4" />
           </button>
-        {/if}
-        <button
-          onclick={cycleShuffle}
-          class="text-xs transition-colors hover:text-brand-text-primary flex items-center gap-1 p-1 {playerStore.shuffleMode !== 'off' ? 'text-brand-accent-text font-bold' : 'text-brand-text-secondary/50'}"
-          title={`${i18n.t('playerBar.shuffle')}: ${shuffleModeLabel(playerStore.shuffleMode)} — ${shuffleModeDescription(playerStore.shuffleMode)}`}
-        >
-          {#if shuffleTypeIcon(playerStore.shuffleMode)}
-            {@const ShuffleTypeIcon = shuffleTypeIcon(playerStore.shuffleMode)}
-            <ShuffleTypeIcon class="w-4 h-4" />
-          {/if}
-          <Shuffle class="w-4 h-4" />
-        </button>
-      </div>
+        </div>
+      {/if}
 
       <button onclick={() => playerStore.previous()} class="hidden min-[400px]:block text-brand-text-secondary hover:text-brand-text-primary transition-colors" title={i18n.t('playerBar.previous')}>
         <SkipBack class="w-5 h-5 fill-current" />
@@ -340,143 +342,159 @@
         <SkipForward class="w-5 h-5 fill-current" />
       </button>
 
-      <div class="hidden min-[700px]:block relative">
-        <button
-          onclick={cycleRepeat}
-          class="text-xs transition-colors hover:text-brand-text-primary flex items-center gap-1 p-1 {playerStore.repeatMode !== 'off' ? 'text-brand-accent-text font-bold' : 'text-brand-text-secondary/50'}"
-          title={`${i18n.t('playerBar.repeat')}: ${repeatModeLabel(playerStore.repeatMode)} — ${repeatModeDescription(playerStore.repeatMode)}`}
-        >
-          <Repeat class="w-4 h-4" />
-          {#if repeatTypeIcon(playerStore.repeatMode)}
-            {@const RepeatTypeIcon = repeatTypeIcon(playerStore.repeatMode)}
-            <RepeatTypeIcon class="w-4 h-4" />
-          {/if}
-        </button>
-        {#if playerStore.repeatMode !== 'off'}
+      {#if !windowLayoutStore.isPlayerBarCompact}
+        <div transition:fade={{ duration: 200 }} class="relative">
           <button
             onclick={cycleRepeat}
-            class="absolute left-full top-1/2 -translate-y-1/2 ml-1.5 text-[10px] font-semibold text-brand-accent-text hover:text-brand-text-primary transition-colors uppercase tracking-wide whitespace-nowrap"
+            class="text-xs transition-colors hover:text-brand-text-primary flex items-center gap-1 p-1 {playerStore.repeatMode !== 'off' ? 'text-brand-accent-text font-bold' : 'text-brand-text-secondary/50'}"
             title={`${i18n.t('playerBar.repeat')}: ${repeatModeLabel(playerStore.repeatMode)} — ${repeatModeDescription(playerStore.repeatMode)}`}
           >
-            {i18n.t('playerBar.repeat')} {repeatModeLabel(playerStore.repeatMode)}
+            <Repeat class="w-4 h-4" />
+            {#if repeatTypeIcon(playerStore.repeatMode)}
+              {@const RepeatTypeIcon = repeatTypeIcon(playerStore.repeatMode)}
+              <RepeatTypeIcon class="w-4 h-4" />
+            {/if}
           </button>
-        {/if}
-      </div>
-
-      <button
-        onclick={() => windowLayoutStore.toggleMiniplayerMode()}
-        class="min-[700px]:hidden text-brand-text-secondary hover:text-brand-accent-text transition-colors flex-shrink-0"
-        title={i18n.t('miniplayer.toggleTooltip', {}, 'Picture-in-Picture Mode (Ctrl+M)')}
-      >
-        <PictureInPicture class="w-4 h-4" />
-      </button>
-
-    </div>
-
-    <div class="hidden min-[700px]:flex items-center gap-2.5 w-full text-[10px] text-brand-text-secondary/60">
-      <!-- Invisible spacer matching the mode-toggle button's footprint, so the
-           waveform + timers stay centered instead of skewing left toward it. -->
-      <div class="w-4 h-4 flex-shrink-0" aria-hidden="true"></div>
-      <span>{formatDuration(playerStore.positionNanosec)}</span>
-      <div class="flex-1 flex flex-col gap-1">
-        <WaveformSeekBar />
-      </div>
-      <span>{formatDuration(playerStore.currentSong?.length_nanosec)}</span>
-      <button
-        onclick={() => prefs.toggleSeekBarMode()}
-        class="text-brand-text-secondary/50 hover:text-brand-text-primary transition-colors p-0.5 flex-shrink-0"
-        title={prefs.seekBarMode === 'waveform'
-          ? i18n.t('playerBar.seekbarModeWaveform', {}, 'Waveform mode — click to switch to frequency bands')
-          : i18n.t('playerBar.seekbarModeBands', {}, 'Frequency bands mode — click to switch to waveform')}
-      >
-        {#if prefs.seekBarMode === 'waveform'}
-          <AudioWaveform class="w-3 h-3" />
-        {:else}
-          <Palette class="w-3 h-3" />
-        {/if}
-      </button>
-    </div>
-  </div>
-
-  <div data-walkthrough-target="player-bar-toolbar" class="hidden min-[700px]:flex flex-col items-center gap-1.5 w-1/3 min-w-[50px] min-[700px]:min-w-[200px] max-w-xs">
-    <div class="flex items-center gap-3 min-[700px]:gap-5">
-      <button
-        onclick={openCurrentSongMenu}
-        disabled={!playerStore.currentSong}
-        class="text-brand-text-secondary hover:text-brand-text-primary transition-colors disabled:opacity-40 disabled:pointer-events-none"
-        title={i18n.t('playerBar.menuTooltip', {}, 'Song menu')}
-      >
-        <Menu class="w-5 h-5" />
-      </button>
-      {#if !windowLayoutStore.isRightPanelAutoHidden}
-        <button
-          transition:fade={{ duration: 200 }}
-          onclick={() => {
-            windowLayoutStore.exitImmersiveMode();
-            navigationStore.activeTab = "lyrics";
-          }}
-          class="hidden md:inline-flex transition-colors {navigationStore.activeTab === 'lyrics' ? 'text-brand-accent-text' : 'text-brand-text-secondary hover:text-brand-text-primary'}"
-          title={i18n.t('sidebar.lyrics')}
-        >
-          <Lyrics class="w-5 h-5" />
-        </button>
-      {/if}
-      <button
-        onclick={navigateToQueue}
-        class="text-brand-text-secondary hover:text-brand-text-primary transition-colors"
-        title={i18n.t('playerBar.queueTitle', {}, 'Queue')}
-      >
-        <Layers class="w-5 h-5" />
-      </button>
-      {#if !windowLayoutStore.isRightPanelAutoHidden}
-        <button
-          transition:fade={{ duration: 200 }}
-          onclick={handleInfoClick}
-          class="hidden md:inline-flex transition-colors {windowLayoutStore.rightPanelOpen ? 'text-brand-accent-text' : 'text-brand-text-secondary hover:text-brand-text-primary'}"
-          title={i18n.t('topNav.toggleRightPanel')}
-        >
-          <Info class="w-5 h-5" />
-        </button>
-      {/if}
-      <button
-        onclick={() => windowLayoutStore.toggleMiniplayerMode()}
-        class="text-brand-text-secondary hover:text-brand-text-primary transition-colors"
-        title={i18n.t('miniplayer.toggleTooltip', {}, 'Picture-in-Picture Mode (Ctrl+M)')}
-      >
-        <PictureInPicture class="w-5 h-5" />
-      </button>
-    </div>
-
-    <div class="flex items-center gap-2">
-      {#if !windowLayoutStore.isRightPanelAutoHidden}
-        <div transition:fade={{ duration: 200 }} class="w-24 h-7 hidden md:block">
-          <SpectrumVisualizer />
+          {#if playerStore.repeatMode !== 'off'}
+            <button
+              onclick={cycleRepeat}
+              class="absolute left-full top-1/2 -translate-y-1/2 ml-1.5 text-[10px] font-semibold text-brand-accent-text hover:text-brand-text-primary transition-colors uppercase tracking-wide whitespace-nowrap"
+              title={`${i18n.t('playerBar.repeat')}: ${repeatModeLabel(playerStore.repeatMode)} — ${repeatModeDescription(playerStore.repeatMode)}`}
+            >
+              {i18n.t('playerBar.repeat')} {repeatModeLabel(playerStore.repeatMode)}
+            </button>
+          {/if}
         </div>
       {/if}
-      <button onclick={toggleMute} class="text-brand-text-secondary hover:text-brand-text-primary transition-colors" title={i18n.t('playerBar.volume')}>
-        {#if isMuted || playerStore.volume === 0}
-          <VolumeX class="w-4 h-4" />
-        {:else}
-          <Volume2 class="w-4 h-4" />
-        {/if}
-      </button>
-      <input
-        type="range"
-        min="0"
-        max="1"
-        step="0.01"
-        value={playerStore.volume}
-        oninput={handleVolumeChange}
-        onchange={releaseVolumeFocus}
-        onpointerup={releaseVolumeFocus}
-        onkeyup={releaseVolumeFocus}
-        class="volume-slider w-20 h-1 rounded-lg outline-none"
-        style={volumeSliderStyle}
-        aria-label={i18n.t('playerBar.volumeSlider')}
-        title={i18n.t('playerBar.volumeWithValue', { value: Math.round(volumePercent) })}
-      />
+
+      {#if windowLayoutStore.isPlayerBarCompact}
+        <button
+          transition:fade={{ duration: 200 }}
+          onclick={() => windowLayoutStore.toggleMiniplayerMode()}
+          class="text-brand-text-secondary hover:text-brand-accent-text transition-colors flex-shrink-0"
+          title={i18n.t('miniplayer.toggleTooltip', {}, 'Picture-in-Picture Mode (Ctrl+M)')}
+        >
+          <PictureInPicture class="w-4 h-4" />
+        </button>
+      {/if}
+
     </div>
+
+    {#if !windowLayoutStore.isPlayerBarCompact}
+      <div
+        transition:fade={{ duration: 200 }}
+        class="flex items-center gap-2.5 w-full text-[10px] text-brand-text-secondary/60"
+      >
+        <!-- Invisible spacer matching the mode-toggle button's footprint, so the
+             waveform + timers stay centered instead of skewing left toward it. -->
+        <div class="w-4 h-4 flex-shrink-0" aria-hidden="true"></div>
+        <span>{formatDuration(playerStore.positionNanosec)}</span>
+        <div class="flex-1 flex flex-col gap-1">
+          <WaveformSeekBar />
+        </div>
+        <span>{formatDuration(playerStore.currentSong?.length_nanosec)}</span>
+        <button
+          onclick={() => prefs.toggleSeekBarMode()}
+          class="text-brand-text-secondary/50 hover:text-brand-text-primary transition-colors p-0.5 flex-shrink-0"
+          title={prefs.seekBarMode === 'waveform'
+            ? i18n.t('playerBar.seekbarModeWaveform', {}, 'Waveform mode — click to switch to frequency bands')
+            : i18n.t('playerBar.seekbarModeBands', {}, 'Frequency bands mode — click to switch to waveform')}
+        >
+          {#if prefs.seekBarMode === 'waveform'}
+            <AudioWaveform class="w-3 h-3" />
+          {:else}
+            <Palette class="w-3 h-3" />
+          {/if}
+        </button>
+      </div>
+    {/if}
   </div>
+
+  {#if !windowLayoutStore.isPlayerBarCompact}
+    <div
+      data-walkthrough-target="player-bar-toolbar"
+      transition:fade={{ duration: 200 }}
+      class="flex flex-col items-center gap-1.5 w-1/3 min-w-[50px] min-[700px]:min-w-[200px] max-w-xs"
+    >
+      <div class="flex items-center gap-3 min-[700px]:gap-5">
+        <button
+          onclick={openCurrentSongMenu}
+          disabled={!playerStore.currentSong}
+          class="text-brand-text-secondary hover:text-brand-text-primary transition-colors disabled:opacity-40 disabled:pointer-events-none"
+          title={i18n.t('playerBar.menuTooltip', {}, 'Song menu')}
+        >
+          <Menu class="w-5 h-5" />
+        </button>
+        {#if !windowLayoutStore.isRightPanelAutoHidden}
+          <button
+            transition:fade={{ duration: 200 }}
+            onclick={() => {
+              windowLayoutStore.exitImmersiveMode();
+              navigationStore.activeTab = "lyrics";
+            }}
+            class="inline-flex transition-colors {navigationStore.activeTab === 'lyrics' ? 'text-brand-accent-text' : 'text-brand-text-secondary hover:text-brand-text-primary'}"
+            title={i18n.t('sidebar.lyrics')}
+          >
+            <Lyrics class="w-5 h-5" />
+          </button>
+        {/if}
+        <button
+          onclick={navigateToQueue}
+          class="text-brand-text-secondary hover:text-brand-text-primary transition-colors"
+          title={i18n.t('playerBar.queueTitle', {}, 'Queue')}
+        >
+          <Layers class="w-5 h-5" />
+        </button>
+        {#if !windowLayoutStore.isRightPanelAutoHidden}
+          <button
+            transition:fade={{ duration: 200 }}
+            onclick={handleInfoClick}
+            class="inline-flex transition-colors {windowLayoutStore.rightPanelOpen ? 'text-brand-accent-text' : 'text-brand-text-secondary hover:text-brand-text-primary'}"
+            title={i18n.t('topNav.toggleRightPanel')}
+          >
+            <Info class="w-5 h-5" />
+          </button>
+        {/if}
+        <button
+          onclick={() => windowLayoutStore.toggleMiniplayerMode()}
+          class="text-brand-text-secondary hover:text-brand-text-primary transition-colors"
+          title={i18n.t('miniplayer.toggleTooltip', {}, 'Picture-in-Picture Mode (Ctrl+M)')}
+        >
+          <PictureInPicture class="w-5 h-5" />
+        </button>
+      </div>
+
+      <div class="flex items-center gap-2">
+        {#if !windowLayoutStore.isRightPanelAutoHidden}
+          <div transition:fade={{ duration: 200 }} class="w-24 h-7 block">
+            <SpectrumVisualizer />
+          </div>
+        {/if}
+        <button onclick={toggleMute} class="text-brand-text-secondary hover:text-brand-text-primary transition-colors" title={i18n.t('playerBar.volume')}>
+          {#if isMuted || playerStore.volume === 0}
+            <VolumeX class="w-4 h-4" />
+          {:else}
+            <Volume2 class="w-4 h-4" />
+          {/if}
+        </button>
+        <input
+          type="range"
+          min="0"
+          max="1"
+          step="0.01"
+          value={playerStore.volume}
+          oninput={handleVolumeChange}
+          onchange={releaseVolumeFocus}
+          onpointerup={releaseVolumeFocus}
+          onkeyup={releaseVolumeFocus}
+          class="volume-slider w-20 h-1 rounded-lg outline-none"
+          style={volumeSliderStyle}
+          aria-label={i18n.t('playerBar.volumeSlider')}
+          title={i18n.t('playerBar.volumeWithValue', { value: Math.round(volumePercent) })}
+        />
+      </div>
+    </div>
+  {/if}
 </footer>
 
 {#if contextMenuState && playerStore.currentSong}

--- a/src/lib/components/PlayerBar.svelte
+++ b/src/lib/components/PlayerBar.svelte
@@ -408,16 +408,18 @@
       >
         <Menu class="w-5 h-5" />
       </button>
-      <button
-        onclick={() => {
-          windowLayoutStore.exitImmersiveMode();
-          navigationStore.activeTab = "lyrics";
-        }}
-        class="transition-colors {navigationStore.activeTab === 'lyrics' ? 'text-brand-accent-text' : 'text-brand-text-secondary hover:text-brand-text-primary'}"
-        title={i18n.t('sidebar.lyrics')}
-      >
-        <Lyrics class="w-5 h-5" />
-      </button>
+      {#if !windowLayoutStore.isRightPanelAutoHidden}
+        <button
+          onclick={() => {
+            windowLayoutStore.exitImmersiveMode();
+            navigationStore.activeTab = "lyrics";
+          }}
+          class="hidden md:inline-flex transition-colors {navigationStore.activeTab === 'lyrics' ? 'text-brand-accent-text' : 'text-brand-text-secondary hover:text-brand-text-primary'}"
+          title={i18n.t('sidebar.lyrics')}
+        >
+          <Lyrics class="w-5 h-5" />
+        </button>
+      {/if}
       <button
         onclick={navigateToQueue}
         class="text-brand-text-secondary hover:text-brand-text-primary transition-colors"
@@ -428,7 +430,7 @@
       {#if !windowLayoutStore.isRightPanelAutoHidden}
         <button
           onclick={handleInfoClick}
-          class="transition-colors {windowLayoutStore.rightPanelOpen ? 'text-brand-accent-text' : 'text-brand-text-secondary hover:text-brand-text-primary'}"
+          class="hidden md:inline-flex transition-colors {windowLayoutStore.rightPanelOpen ? 'text-brand-accent-text' : 'text-brand-text-secondary hover:text-brand-text-primary'}"
           title={i18n.t('topNav.toggleRightPanel')}
         >
           <Info class="w-5 h-5" />

--- a/src/lib/components/PlayerBar.svelte
+++ b/src/lib/components/PlayerBar.svelte
@@ -227,13 +227,22 @@
   }
 
   /**
+   * Custom transition for inline toolbar and transport elements when expanding or collapsing.
    * Smoothly fades opacity while collapsing horizontal width and absorbing flex gap,
    * so sibling items glide closer together when an item disappears, and glide apart
    * when it reappears.
    */
   function collapseFade(
     node: HTMLElement,
-    { duration = 250, easing = cubicOut }: { duration?: number; easing?: (t: number) => number } = {}
+    {
+      duration = 250,
+      easing = cubicOut,
+      marginSide = node.nextElementSibling ? 'right' : 'left',
+    }: {
+      duration?: number;
+      easing?: (t: number) => number;
+      marginSide?: 'left' | 'right';
+    } = {}
   ) {
     const style = getComputedStyle(node);
     const parentStyle = node.parentElement ? getComputedStyle(node.parentElement) : null;
@@ -243,6 +252,7 @@
     const width = parseFloat(style.width) || node.getBoundingClientRect().width || 20;
     const paddingLeft = parseFloat(style.paddingLeft) || 0;
     const paddingRight = parseFloat(style.paddingRight) || 0;
+    const marginProp = marginSide === 'left' ? 'margin-left' : 'margin-right';
 
     return {
       duration,
@@ -255,7 +265,7 @@
         max-width: ${t * width}px;
         padding-left: ${t * paddingLeft}px;
         padding-right: ${t * paddingRight}px;
-        margin-right: -${(1 - t) * gap}px;
+        ${marginProp}: -${(1 - t) * gap}px;
         white-space: nowrap;
         pointer-events: ${t < 0.1 ? 'none' : 'auto'};
       `,
@@ -327,8 +337,8 @@
 
   <div data-walkthrough-target="player-bar-controls" class="flex flex-col items-center gap-1.5 min-[400px]:min-w-[220px] min-[400px]:ml-auto min-[700px]:w-1/3 min-[700px]:flex-none min-[700px]:ml-0 max-w-[600px]">
     <div class="flex items-center gap-3 min-[700px]:gap-5">
-      {#if !windowLayoutStore.isPlayerBarCompact}
-        <div transition:fade={{ duration: 200 }} class="relative">
+      {#if !windowLayoutStore.isRightPanelAutoHidden}
+        <div transition:collapseFade={{ duration: 250 }} class="relative inline-flex items-center flex-shrink-0">
           {#if playerStore.shuffleMode !== 'off'}
             <button
               onclick={cycleShuffle}
@@ -378,8 +388,8 @@
         <SkipForward class="w-5 h-5 fill-current" />
       </button>
 
-      {#if !windowLayoutStore.isPlayerBarCompact}
-        <div transition:fade={{ duration: 200 }} class="relative">
+      {#if !windowLayoutStore.isRightPanelAutoHidden}
+        <div transition:collapseFade={{ duration: 250 }} class="relative inline-flex items-center flex-shrink-0">
           <button
             onclick={cycleRepeat}
             class="text-xs transition-colors hover:text-brand-text-primary flex items-center gap-1 p-1 {playerStore.repeatMode !== 'off' ? 'text-brand-accent-text font-bold' : 'text-brand-text-secondary/50'}"

--- a/src/lib/components/PlayerBar.svelte
+++ b/src/lib/components/PlayerBar.svelte
@@ -462,11 +462,11 @@
       transition:fade={{ duration: 200 }}
       class="flex flex-col items-center gap-1.5 w-1/3 min-w-[50px] min-[700px]:min-w-[200px] max-w-xs"
     >
-      <div class="flex items-center gap-3 min-[700px]:gap-5">
+      <div class="h-5 flex items-center gap-3 min-[700px]:gap-5">
         <button
           onclick={openCurrentSongMenu}
           disabled={!playerStore.currentSong}
-          class="text-brand-text-secondary hover:text-brand-text-primary transition-colors disabled:opacity-40 disabled:pointer-events-none flex-shrink-0"
+          class="inline-flex items-center justify-center flex-shrink-0 text-brand-text-secondary hover:text-brand-text-primary transition-colors disabled:opacity-40 disabled:pointer-events-none"
           title={i18n.t('playerBar.menuTooltip', {}, 'Song menu')}
         >
           <Menu class="w-5 h-5" />
@@ -486,7 +486,7 @@
         {/if}
         <button
           onclick={navigateToQueue}
-          class="text-brand-text-secondary hover:text-brand-text-primary transition-colors flex-shrink-0"
+          class="inline-flex items-center justify-center flex-shrink-0 text-brand-text-secondary hover:text-brand-text-primary transition-colors"
           title={i18n.t('playerBar.queueTitle', {}, 'Queue')}
         >
           <Layers class="w-5 h-5" />
@@ -503,20 +503,20 @@
         {/if}
         <button
           onclick={() => windowLayoutStore.toggleMiniplayerMode()}
-          class="text-brand-text-secondary hover:text-brand-text-primary transition-colors flex-shrink-0"
+          class="inline-flex items-center justify-center flex-shrink-0 text-brand-text-secondary hover:text-brand-text-primary transition-colors"
           title={i18n.t('miniplayer.toggleTooltip', {}, 'Picture-in-Picture Mode (Ctrl+M)')}
         >
           <PictureInPicture class="w-5 h-5" />
         </button>
       </div>
 
-      <div class="flex items-center gap-2">
+      <div class="h-7 flex items-center gap-2">
         {#if !windowLayoutStore.isRightPanelAutoHidden}
           <div transition:collapseFade={{ duration: 250 }} class="w-24 h-7 block flex-shrink-0">
             <SpectrumVisualizer />
           </div>
         {/if}
-        <button onclick={toggleMute} class="text-brand-text-secondary hover:text-brand-text-primary transition-colors" title={i18n.t('playerBar.volume')}>
+        <button onclick={toggleMute} class="inline-flex items-center justify-center text-brand-text-secondary hover:text-brand-text-primary transition-colors" title={i18n.t('playerBar.volume')}>
           {#if isMuted || playerStore.volume === 0}
             <VolumeX class="w-4 h-4" />
           {:else}

--- a/src/lib/components/PlayerBar.svelte
+++ b/src/lib/components/PlayerBar.svelte
@@ -225,6 +225,42 @@
     collectionStore.refreshLibrary();
     tagsStore.load();
   }
+
+  /**
+   * Smoothly fades opacity while collapsing horizontal width and absorbing flex gap,
+   * so sibling items glide closer together when an item disappears, and glide apart
+   * when it reappears.
+   */
+  function collapseFade(
+    node: HTMLElement,
+    { duration = 250, easing = cubicOut }: { duration?: number; easing?: (t: number) => number } = {}
+  ) {
+    const style = getComputedStyle(node);
+    const parentStyle = node.parentElement ? getComputedStyle(node.parentElement) : null;
+    const gap = parentStyle ? parseFloat(parentStyle.columnGap || parentStyle.gap) || 0 : 0;
+
+    const opacity = +style.opacity || 1;
+    const width = parseFloat(style.width) || node.getBoundingClientRect().width || 20;
+    const paddingLeft = parseFloat(style.paddingLeft) || 0;
+    const paddingRight = parseFloat(style.paddingRight) || 0;
+
+    return {
+      duration,
+      easing,
+      css: (t: number) => `
+        overflow: hidden;
+        opacity: ${t * opacity};
+        width: ${t * width}px;
+        min-width: 0;
+        max-width: ${t * width}px;
+        padding-left: ${t * paddingLeft}px;
+        padding-right: ${t * paddingRight}px;
+        margin-right: -${(1 - t) * gap}px;
+        white-space: nowrap;
+        pointer-events: ${t < 0.1 ? 'none' : 'auto'};
+      `,
+    };
+  }
 </script>
 
 <footer transition:fly={{ y: 40, duration: 300, easing: cubicOut }} class="h-20 max-w-[1200px] mx-auto bg-brand-playerbar border border-brand-border rounded-[2rem] flex items-center justify-between gap-3 px-8 text-brand-text-secondary select-none {themeStore.isGlassTheme || isLinux ? 'glass-surface' : ''} {isLinux ? 'opaque-linux' : ''}">
@@ -420,19 +456,19 @@
         <button
           onclick={openCurrentSongMenu}
           disabled={!playerStore.currentSong}
-          class="text-brand-text-secondary hover:text-brand-text-primary transition-colors disabled:opacity-40 disabled:pointer-events-none"
+          class="text-brand-text-secondary hover:text-brand-text-primary transition-colors disabled:opacity-40 disabled:pointer-events-none flex-shrink-0"
           title={i18n.t('playerBar.menuTooltip', {}, 'Song menu')}
         >
           <Menu class="w-5 h-5" />
         </button>
         {#if !windowLayoutStore.isRightPanelAutoHidden}
           <button
-            transition:fade={{ duration: 200 }}
+            transition:collapseFade={{ duration: 250 }}
             onclick={() => {
               windowLayoutStore.exitImmersiveMode();
               navigationStore.activeTab = "lyrics";
             }}
-            class="inline-flex transition-colors {navigationStore.activeTab === 'lyrics' ? 'text-brand-accent-text' : 'text-brand-text-secondary hover:text-brand-text-primary'}"
+            class="inline-flex items-center justify-center flex-shrink-0 transition-colors {navigationStore.activeTab === 'lyrics' ? 'text-brand-accent-text' : 'text-brand-text-secondary hover:text-brand-text-primary'}"
             title={i18n.t('sidebar.lyrics')}
           >
             <Lyrics class="w-5 h-5" />
@@ -440,16 +476,16 @@
         {/if}
         <button
           onclick={navigateToQueue}
-          class="text-brand-text-secondary hover:text-brand-text-primary transition-colors"
+          class="text-brand-text-secondary hover:text-brand-text-primary transition-colors flex-shrink-0"
           title={i18n.t('playerBar.queueTitle', {}, 'Queue')}
         >
           <Layers class="w-5 h-5" />
         </button>
         {#if !windowLayoutStore.isRightPanelAutoHidden}
           <button
-            transition:fade={{ duration: 200 }}
+            transition:collapseFade={{ duration: 250 }}
             onclick={handleInfoClick}
-            class="inline-flex transition-colors {windowLayoutStore.rightPanelOpen ? 'text-brand-accent-text' : 'text-brand-text-secondary hover:text-brand-text-primary'}"
+            class="inline-flex items-center justify-center flex-shrink-0 transition-colors {windowLayoutStore.rightPanelOpen ? 'text-brand-accent-text' : 'text-brand-text-secondary hover:text-brand-text-primary'}"
             title={i18n.t('topNav.toggleRightPanel')}
           >
             <Info class="w-5 h-5" />
@@ -457,7 +493,7 @@
         {/if}
         <button
           onclick={() => windowLayoutStore.toggleMiniplayerMode()}
-          class="text-brand-text-secondary hover:text-brand-text-primary transition-colors"
+          class="text-brand-text-secondary hover:text-brand-text-primary transition-colors flex-shrink-0"
           title={i18n.t('miniplayer.toggleTooltip', {}, 'Picture-in-Picture Mode (Ctrl+M)')}
         >
           <PictureInPicture class="w-5 h-5" />
@@ -466,7 +502,7 @@
 
       <div class="flex items-center gap-2">
         {#if !windowLayoutStore.isRightPanelAutoHidden}
-          <div transition:fade={{ duration: 200 }} class="w-24 h-7 block">
+          <div transition:collapseFade={{ duration: 250 }} class="w-24 h-7 block flex-shrink-0">
             <SpectrumVisualizer />
           </div>
         {/if}

--- a/src/lib/components/PlayerBar.svelte
+++ b/src/lib/components/PlayerBar.svelte
@@ -24,15 +24,15 @@
 
   // Responsive control trimming (issue #413, refined against real usage,
   // padding/seekbar fixed under #543): three named tiers as this floating
-  // bar narrows toward the app's 320px minWidth — Full (>=700px), Compact
-  // (400-700px), Minimal (<400px). Cover art, play/pause, and skip-next are
+  // bar narrows toward the app's 320px minWidth — Full (>=640px), Compact
+  // (400-640px), Minimal (<400px). Cover art, play/pause, and skip-next are
   // the constant core (shown in all three tiers); everything else drops out
   // in priority order: expand/shuffle/repeat/volume+mute/waveform seek bar
   // + time labels first (gone by Compact — the transport block takes the
   // freed space and sticks to the right edge via `ml-auto` rather than
   // re-centering in it), then prev (gone by Minimal). Horizontal padding on
   // the outer bar stays constant across all tiers so cover art never sits
-  // flush against the rounded edges. 400/700 are hand-tuned breakpoints
+  // flush against the rounded edges. 400/640 are hand-tuned breakpoints
   // specific to this bar, written as literal `min-[Npx]:` arbitrary-value
   // classes because Tailwind's class scanner can't resolve an interpolated
   // constants.ts value — don't try to centralize them.
@@ -273,8 +273,8 @@
   }
 </script>
 
-<footer transition:fly={{ y: 40, duration: 300, easing: cubicOut }} class="h-20 max-w-[1200px] mx-auto bg-brand-playerbar border border-brand-border rounded-[2rem] flex items-center justify-between gap-3 px-8 text-brand-text-secondary select-none {themeStore.isGlassTheme || isLinux ? 'glass-surface' : ''} {isLinux ? 'opaque-linux' : ''}">
-  <div data-walkthrough-target="player-bar-cover" class="flex items-center gap-3 flex-1 min-[700px]:w-1/3 min-[700px]:flex-none min-w-[90px] min-[400px]:min-w-[140px] min-[700px]:min-w-[200px] max-w-sm">
+<footer transition:fly={{ y: 40, duration: 300, easing: cubicOut }} class="h-20 max-w-[1200px] mx-auto bg-brand-playerbar border border-brand-border rounded-[2rem] flex items-center justify-between gap-3 px-5 min-[768px]:px-8 text-brand-text-secondary select-none {themeStore.isGlassTheme || isLinux ? 'glass-surface' : ''} {isLinux ? 'opaque-linux' : ''}">
+  <div data-walkthrough-target="player-bar-cover" class="flex items-center gap-3 min-w-0 flex-1 min-[768px]:w-1/3 min-[768px]:flex-none min-[768px]:min-w-[200px] max-w-sm">
     <button
       onclick={handleCoverClick}
       disabled={!playerStore.currentSong}
@@ -335,8 +335,8 @@
     </div>
   </div>
 
-  <div data-walkthrough-target="player-bar-controls" class="flex flex-col items-center gap-1.5 min-[400px]:min-w-[220px] min-[400px]:ml-auto min-[700px]:w-1/3 min-[700px]:flex-none min-[700px]:ml-0 max-w-[600px]">
-    <div class="flex items-center gap-3 min-[700px]:gap-5">
+  <div data-walkthrough-target="player-bar-controls" class="flex flex-col items-center gap-1.5 min-w-0 flex-1 min-[400px]:ml-auto min-[640px]:ml-0 min-[768px]:w-1/3 min-[768px]:flex-none max-w-[600px]">
+    <div class="flex items-center gap-3 min-[768px]:gap-5">
       {#if !windowLayoutStore.isRightPanelAutoHidden}
         <div transition:collapseFade={{ duration: 250 }} class="relative inline-flex items-center flex-shrink-0">
           {#if playerStore.shuffleMode !== 'off'}
@@ -460,9 +460,9 @@
     <div
       data-walkthrough-target="player-bar-toolbar"
       transition:fade={{ duration: 200 }}
-      class="flex flex-col items-center gap-1.5 w-1/3 min-w-[50px] min-[700px]:min-w-[200px] max-w-xs"
+      class="flex flex-col items-center gap-1.5 flex-shrink-0 min-[768px]:w-1/3 min-[768px]:min-w-[200px] max-w-xs"
     >
-      <div class="h-5 flex items-center gap-3 min-[700px]:gap-5">
+      <div class="h-5 flex items-center gap-3 min-[768px]:gap-5">
         <button
           onclick={openCurrentSongMenu}
           disabled={!playerStore.currentSong}

--- a/src/lib/components/PlayerBar.svelte
+++ b/src/lib/components/PlayerBar.svelte
@@ -62,6 +62,22 @@
 
 
 
+  // Delay the appearance of the compact transport PiP button until the full-tier
+  // toolbar and seekbar finish fading out (200ms), preventing duplicate PiP buttons
+  // or flashing beside the transport controls before the toolbar is hidden.
+  let isToolbarGone = $state(windowLayoutStore.isPlayerBarCompact);
+
+  $effect(() => {
+    if (!windowLayoutStore.isPlayerBarCompact) {
+      isToolbarGone = false;
+    } else {
+      const timer = setTimeout(() => {
+        isToolbarGone = true;
+      }, 200);
+      return () => clearTimeout(timer);
+    }
+  });
+
   let volumePercent = $derived(playerStore.volume * 100);
   let volumeSliderStyle = $derived(
     `background: linear-gradient(to right, var(--color-accent) 0%, var(--color-accent) ${volumePercent}%, var(--color-border) ${volumePercent}%, var(--color-border) 100%)`
@@ -413,9 +429,9 @@
         </div>
       {/if}
 
-      {#if windowLayoutStore.isPlayerBarCompact}
+      {#if windowLayoutStore.isPlayerBarCompact && isToolbarGone}
         <button
-          transition:fade={{ duration: 200 }}
+          in:fade={{ duration: 150 }}
           onclick={() => windowLayoutStore.toggleMiniplayerMode()}
           class="text-brand-text-secondary hover:text-brand-accent-text transition-colors flex-shrink-0"
           title={i18n.t('miniplayer.toggleTooltip', {}, 'Picture-in-Picture Mode (Ctrl+M)')}

--- a/src/lib/components/PlayerBar.test.ts
+++ b/src/lib/components/PlayerBar.test.ts
@@ -292,8 +292,8 @@ describe("PlayerBar.svelte", () => {
   });
 
   it("shows and hides controls matching Full, Compact, and Minimal tiers across breakpoints", () => {
-    // Tiers: Full (>=700px), Compact (400-700px), Minimal (<400px).
-    // Full tier (>=700px):
+    // Tiers: Full (>=640px), Compact (400-640px), Minimal (<400px).
+    // Full tier (>=640px):
     windowLayoutStore.viewportWidth = 1280;
     playerStore.currentSong = mockSong;
     playerStore.state = "playing";
@@ -324,7 +324,7 @@ describe("PlayerBar.svelte", () => {
 
     unmount();
 
-    // Compact tier (<700px):
+    // Compact tier (<640px):
     windowLayoutStore.viewportWidth = 600;
     const { getAllByTitle: getCompactAll, queryByTitle: queryCompactByTitle, container: compactContainer } = render(PlayerBar);
 

--- a/src/lib/components/PlayerBar.test.ts
+++ b/src/lib/components/PlayerBar.test.ts
@@ -496,28 +496,34 @@ describe("PlayerBar.svelte", () => {
     expect(getByTitle("Song menu")).toBeDisabled();
   });
 
-  it("hides the info and lyrics buttons at the same breakpoint that auto-hides the right panel and spectrum (< 768px)", () => {
+  it("hides the info, lyrics, shuffle, and repeat buttons at the same breakpoint that auto-hides the right panel and spectrum (< 768px)", () => {
     playerStore.currentSong = mockSong;
     windowLayoutStore.viewportWidth = 1280;
     expect(windowLayoutStore.isRightPanelAutoHidden).toBe(false);
     const { queryByTitle, unmount } = render(PlayerBar);
     expect(queryByTitle("Show Info Panel (Ctrl+I)")).not.toBeNull();
     expect(queryByTitle("Lyrics")).not.toBeNull();
+    expect(queryByTitle(/shuffle/i)).not.toBeNull();
+    expect(queryByTitle(/repeat/i)).not.toBeNull();
     unmount();
 
-    // 800px is >= 768px (md breakpoint): right panel is not auto-hidden, spectrum and all 5 buttons remain visible
+    // 800px is >= 768px (md breakpoint): right panel is not auto-hidden, spectrum, info, lyrics, shuffle, and repeat remain visible
     windowLayoutStore.viewportWidth = 800;
     expect(windowLayoutStore.isRightPanelAutoHidden).toBe(false);
     const { queryByTitle: queryByTitleMedium, unmount: unmountMedium } = render(PlayerBar);
     expect(queryByTitleMedium("Show Info Panel (Ctrl+I)")).not.toBeNull();
     expect(queryByTitleMedium("Lyrics")).not.toBeNull();
+    expect(queryByTitleMedium(/shuffle/i)).not.toBeNull();
+    expect(queryByTitleMedium(/repeat/i)).not.toBeNull();
     unmountMedium();
 
-    // 700px is < 768px: right panel auto-hides, Info and Lyrics buttons hide
+    // 700px is < 768px: right panel auto-hides, Info, Lyrics, Shuffle, and Repeat buttons hide
     windowLayoutStore.viewportWidth = 700;
     expect(windowLayoutStore.isRightPanelAutoHidden).toBe(true);
     const { queryByTitle: queryByTitleNarrow } = render(PlayerBar);
     expect(queryByTitleNarrow("Show Info Panel (Ctrl+I)")).toBeNull();
     expect(queryByTitleNarrow("Lyrics")).toBeNull();
+    expect(queryByTitleNarrow(/shuffle/i)).toBeNull();
+    expect(queryByTitleNarrow(/repeat/i)).toBeNull();
   });
 });

--- a/src/lib/components/PlayerBar.test.ts
+++ b/src/lib/components/PlayerBar.test.ts
@@ -492,16 +492,28 @@ describe("PlayerBar.svelte", () => {
     expect(getByTitle("Song menu")).toBeDisabled();
   });
 
-  it("hides the info-panel toggle at the same breakpoint that auto-hides the panel itself", () => {
+  it("hides the info and lyrics buttons at the same breakpoint that auto-hides the right panel and spectrum (< 768px)", () => {
     playerStore.currentSong = mockSong;
     windowLayoutStore.viewportWidth = 1280;
     expect(windowLayoutStore.isRightPanelAutoHidden).toBe(false);
-    const { queryByTitle } = render(PlayerBar);
+    const { queryByTitle, unmount } = render(PlayerBar);
     expect(queryByTitle("Show Info Panel (Ctrl+I)")).not.toBeNull();
+    expect(queryByTitle("Lyrics")).not.toBeNull();
+    unmount();
 
+    // 800px is >= 768px (md breakpoint): right panel is not auto-hidden, spectrum and all 5 buttons remain visible
     windowLayoutStore.viewportWidth = 800;
+    expect(windowLayoutStore.isRightPanelAutoHidden).toBe(false);
+    const { queryByTitle: queryByTitleMedium, unmount: unmountMedium } = render(PlayerBar);
+    expect(queryByTitleMedium("Show Info Panel (Ctrl+I)")).not.toBeNull();
+    expect(queryByTitleMedium("Lyrics")).not.toBeNull();
+    unmountMedium();
+
+    // 700px is < 768px: right panel auto-hides, Info and Lyrics buttons hide
+    windowLayoutStore.viewportWidth = 700;
     expect(windowLayoutStore.isRightPanelAutoHidden).toBe(true);
     const { queryByTitle: queryByTitleNarrow } = render(PlayerBar);
     expect(queryByTitleNarrow("Show Info Panel (Ctrl+I)")).toBeNull();
+    expect(queryByTitleNarrow("Lyrics")).toBeNull();
   });
 });

--- a/src/lib/components/PlayerBar.test.ts
+++ b/src/lib/components/PlayerBar.test.ts
@@ -291,47 +291,51 @@ describe("PlayerBar.svelte", () => {
     expect(exitImmersiveModeSpy).not.toHaveBeenCalled();
   });
 
-  it("marks controls with the Full/Compact/Minimal responsive classes matching their tier", () => {
-    // jsdom doesn't evaluate CSS media queries, so this checks the
-    // structural markup (the responsive classes are present on the right
-    // elements) rather than actual visibility at a given width — real
-    // breakpoint behavior is covered by manual verification. Tiers: Full
-    // (>=700px), Compact (400-700px), Minimal (<400px) — cover art, play/
-    // pause, and skip-next are the constant core shown in all three.
+  it("shows and hides controls matching Full, Compact, and Minimal tiers across breakpoints", () => {
+    // Tiers: Full (>=700px), Compact (400-700px), Minimal (<400px).
+    // Full tier (>=700px):
+    windowLayoutStore.viewportWidth = 1280;
     playerStore.currentSong = mockSong;
     playerStore.state = "playing";
-    const { getAllByTitle, getByTitle, container } = render(PlayerBar);
+    const { getAllByTitle, getByTitle, queryByTitle, container, unmount } = render(PlayerBar);
 
-    // Gone by Compact (Full-only): shuffle, repeat, the seek row, and the
-    // volume/mute controls in the right column — the transport block takes
-    // the freed space instead, sticking to the right edge via ml-auto. The
-    // miniplayer toggle itself must stay visible at every tier (issue: it
-    // should never disappear), so it has two instances that swap places at
-    // the 700px boundary: one alongside volume/mute (Full only) and one in
-    // the transport row (Compact/Minimal only, hidden again once the
-    // right-column instance takes over).
+    // Full tier has shuffle, repeat, seek row, right toolbar (with volume & miniplayer)
     const shuffleBtn = getAllByTitle(/shuffle/i).find(el => el.querySelector("svg"))!;
     const repeatBtn = getAllByTitle(/repeat/i).find(el => el.querySelector("svg"))!;
-    expect(shuffleBtn.closest(".hidden")).toHaveClass("min-[700px]:block");
-    expect(repeatBtn.closest(".hidden")).toHaveClass("min-[700px]:block");
+    expect(shuffleBtn).toBeInTheDocument();
+    expect(repeatBtn).toBeInTheDocument();
     const volumeSlider = container.querySelector('input[type="range"]');
-    expect(volumeSlider?.closest(".hidden")).toHaveClass("min-[700px]:flex");
-    const [transportToggle, rightColumnToggle] = getAllByTitle(/picture-in-picture/i);
-    expect(transportToggle).toHaveClass("min-[700px]:hidden");
-    expect(rightColumnToggle.closest(".hidden")).toHaveClass("min-[700px]:flex");
-    const rightColumn = Array.from(container.querySelectorAll("div")).find(d => d.className.includes("min-w-[50px]"))!;
-    expect(rightColumn).toHaveClass("hidden", "min-[700px]:flex");
+    expect(volumeSlider).toBeInTheDocument();
+    const rightColumn = container.querySelector('[data-walkthrough-target="player-bar-toolbar"]');
+    expect(rightColumn).toBeInTheDocument();
     const seekRow = Array.from(container.querySelectorAll("div")).find(d => d.className.includes("gap-2.5"))!;
-    expect(seekRow).toHaveClass("hidden", "min-[700px]:flex");
+    expect(seekRow).toBeInTheDocument();
 
-    // Gone by Minimal (Compact-and-up only): previous.
+    // In Full tier, only the right-column PiP toggle is rendered
+    expect(getAllByTitle(/picture-in-picture/i).length).toBe(1);
+
+    // Minimal-breakpoint class on previous:
     expect(getByTitle(/previous song/i)).toHaveClass("hidden", "min-[400px]:block");
 
-    // Never hidden (the constant core): cover art, play/pause, skip-next.
-    const coverButton = getByTitle("Immersive Mode");
-    expect(coverButton.closest(".hidden")).toBeNull();
-    expect(getByTitle(/^pause$/i)).not.toHaveClass("hidden");
-    expect(getByTitle(/next song/i)).not.toHaveClass("hidden");
+    // Core controls: cover art, play/pause, skip-next
+    expect(getByTitle("Immersive Mode")).toBeInTheDocument();
+    expect(getByTitle(/^pause$/i)).toBeInTheDocument();
+    expect(getByTitle(/next song/i)).toBeInTheDocument();
+
+    unmount();
+
+    // Compact tier (<700px):
+    windowLayoutStore.viewportWidth = 600;
+    const { getAllByTitle: getCompactAll, queryByTitle: queryCompactByTitle, container: compactContainer } = render(PlayerBar);
+
+    // Shuffle, repeat, seek row, and right toolbar unmounted in Compact tier
+    expect(queryCompactByTitle(/shuffle/i)).toBeNull();
+    expect(queryCompactByTitle(/repeat/i)).toBeNull();
+    expect(compactContainer.querySelector('input[type="range"]')).toBeNull();
+    expect(compactContainer.querySelector('[data-walkthrough-target="player-bar-toolbar"]')).toBeNull();
+
+    // Transport PiP toggle takes over in Compact tier so PiP mode is always accessible
+    expect(getCompactAll(/picture-in-picture/i).length).toBe(1);
   });
 
   it("handles mute toggle correctly", async () => {

--- a/src/lib/components/PlaylistsCollectionView.svelte
+++ b/src/lib/components/PlaylistsCollectionView.svelte
@@ -426,10 +426,15 @@
             >
               <RefreshCw class="w-4 h-4 {isRefreshingAll ? 'animate-spin' : ''}" />
             </button>
-            <div class="inline-flex items-center gap-0.5 bg-brand-sidebar border border-brand-border rounded-full p-1">
+            <div class="relative inline-flex items-center gap-0.5 bg-brand-sidebar border border-brand-border rounded-full p-1">
+              <!-- Sliding background indicator -->
+              <span
+                class="absolute top-1 bottom-1 left-1 w-7 h-7 rounded-full bg-brand-accent shadow-sm pointer-events-none transition-transform duration-200 ease-out {activeViewMode === 'rows' ? 'translate-x-[30px]' : 'translate-x-0'}"
+                aria-hidden="true"
+              ></span>
               <button
                 onclick={() => setActiveViewMode("cards")}
-                class="flex items-center justify-center w-7 h-7 rounded-full transition-colors {activeViewMode === 'cards' ? 'bg-brand-accent text-white' : 'text-brand-text-secondary hover:text-brand-text-primary'}"
+                class="relative z-10 flex items-center justify-center w-7 h-7 rounded-full transition-colors duration-200 {activeViewMode === 'cards' ? 'text-white' : 'text-brand-text-secondary hover:text-brand-text-primary'}"
                 title={i18n.t('collection.viewCards')}
                 aria-label={i18n.t('collection.viewCards')}
                 aria-pressed={activeViewMode === "cards"}
@@ -438,7 +443,7 @@
               </button>
               <button
                 onclick={() => setActiveViewMode("rows")}
-                class="flex items-center justify-center w-7 h-7 rounded-full transition-colors {activeViewMode === 'rows' ? 'bg-brand-accent text-white' : 'text-brand-text-secondary hover:text-brand-text-primary'}"
+                class="relative z-10 flex items-center justify-center w-7 h-7 rounded-full transition-colors duration-200 {activeViewMode === 'rows' ? 'text-white' : 'text-brand-text-secondary hover:text-brand-text-primary'}"
                 title={i18n.t('collection.viewRows')}
                 aria-label={i18n.t('collection.viewRows')}
                 aria-pressed={activeViewMode === "rows"}

--- a/src/lib/components/PopulationModeTabs.svelte
+++ b/src/lib/components/PopulationModeTabs.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { onMount } from "svelte";
   import { i18n } from "../stores/i18n.svelte";
   import type { QueuePopulationMode } from "../types";
 
@@ -9,6 +10,40 @@
   }
 
   let { mode, onChange, disabled = false }: Props = $props();
+
+  let tabElements = $state<Record<string, HTMLButtonElement>>({});
+  let indicatorStyle = $state({ left: 2, width: 0, opacity: 0 });
+  let mounted = $state(false);
+
+  function updateIndicator() {
+    const el = tabElements[mode];
+    if (el) {
+      indicatorStyle = {
+        left: el.offsetLeft,
+        width: el.offsetWidth,
+        opacity: 1
+      };
+    }
+  }
+
+  onMount(() => {
+    const handleResize = () => updateIndicator();
+    window.addEventListener("resize", handleResize);
+    return () => {
+      window.removeEventListener("resize", handleResize);
+    };
+  });
+
+  $effect(() => {
+    if (tabElements[mode]) {
+      updateIndicator();
+      if (!mounted) {
+        requestAnimationFrame(() => {
+          mounted = true;
+        });
+      }
+    }
+  });
 
   // Tab order per #120 feedback: All, Favourites, Familiar, Discover, Deep Cuts.
   const MODES: { value: QueuePopulationMode; labelKey: string; tooltipKey: string }[] = [
@@ -37,22 +72,30 @@
 </script>
 
 <div
-  class="flex items-center gap-0.5 p-0.5 rounded-full border border-brand-border bg-brand-main/40 shrink-0 select-none"
+  class="relative flex items-center gap-0.5 p-0.5 rounded-full border border-brand-border bg-brand-main/40 shrink-0 select-none"
   role="tablist"
   aria-label={i18n.t("playlists.populationModeLabel")}
 >
+  <!-- Sliding active indicator -->
+  <div
+    class="absolute top-0.5 bottom-0.5 bg-brand-accent rounded-full shadow-sm pointer-events-none {mounted ? 'transition-[left,width] duration-200 ease-out' : 'transition-none'}"
+    style="left: {indicatorStyle.left}px; width: {indicatorStyle.width}px; opacity: {indicatorStyle.opacity};"
+    aria-hidden="true"
+  ></div>
+
   {#each MODES as m (m.value)}
     <button
+      bind:this={tabElements[m.value]}
       type="button"
       role="tab"
       aria-selected={mode === m.value}
       {disabled}
       title={i18n.t(m.tooltipKey)}
       onclick={() => onChange(m.value)}
-      class="px-2.5 py-1 rounded-full text-[11px] font-semibold whitespace-nowrap transition-colors disabled:opacity-50 disabled:cursor-not-allowed
+      class="relative z-10 px-2.5 py-1 rounded-full text-[11px] font-semibold whitespace-nowrap transition-colors duration-200 disabled:opacity-50 disabled:cursor-not-allowed
         {mode === m.value
-        ? 'bg-brand-accent text-brand-accent-contrast shadow-sm'
-        : 'text-brand-text-secondary/70 hover:text-brand-text-primary hover:bg-brand-sidebar'}"
+        ? 'text-brand-accent-contrast'
+        : 'text-brand-text-secondary/70 hover:text-brand-text-primary'}"
     >
       {i18n.t(m.labelKey)}
     </button>

--- a/src/lib/components/SettingsThemes.svelte
+++ b/src/lib/components/SettingsThemes.svelte
@@ -58,12 +58,14 @@
     }
   }
 
+  let isUserEditingBuilder = $state(false);
+
   // Pre-fill theme builder with current active theme colors on mount and
   // updates — skipped while editing an existing custom theme, since that
   // case is seeded from the theme being edited instead (below).
   $effect(() => {
     const colors = themeStore.resolvedColors;
-    if (!editingThemeId) {
+    if (!editingThemeId && !isUserEditingBuilder) {
       customColors = { ...colors };
     }
   });
@@ -76,11 +78,12 @@
     if (editingTheme) {
       newThemeName = editingTheme.name;
       customColors = { ...editingTheme.colors };
+      isUserEditingBuilder = true;
     }
   });
 
   $effect(() => {
-    if (customColors) {
+    if (customColors && (isUserEditingBuilder || editingThemeId !== null)) {
       // deep read to trigger reactivity
       const _ = customColors["bg-main"] + customColors["bg-sidebar"] + customColors["bg-playerbar"] + customColors["color-accent"] + customColors["color-accent-hover"] + customColors["color-border"];
       themeStore.applyThemeColorsPreview(customColors);
@@ -107,6 +110,7 @@
         isCustom: true
       });
       editingThemeId = null;
+      isUserEditingBuilder = false;
     } else {
       const id = "custom-" + newThemeName.toLowerCase().replace(/[^a-z0-9]/g, "-");
       await themeStore.addCustomTheme({
@@ -116,6 +120,7 @@
         isCustom: true
       });
       newThemeName = "";
+      isUserEditingBuilder = false;
     }
   }
 
@@ -335,7 +340,7 @@
           <FolderInput class="w-3.5 h-3.5 text-brand-accent-text" /> {i18n.t('settings.importTheme')}
         </Button>
         {#if editingThemeId}
-          <Button onclick={() => { editingThemeId = null; themeStore.applyActiveTheme(); }} variant="secondary" size="sm">
+          <Button onclick={() => { editingThemeId = null; isUserEditingBuilder = false; themeStore.applyActiveTheme(); }} variant="secondary" size="sm">
             {i18n.t('settings.cancel')}
           </Button>
         {/if}

--- a/src/lib/components/SettingsView.svelte
+++ b/src/lib/components/SettingsView.svelte
@@ -16,25 +16,60 @@
   let settingsTab = $state<"general" | "folders" | "integrations" | "tools" | "themes" | "equalizer" | "about">("general");
   let isTabInitialized = $state(false);
 
-  onMount(async () => {
-    try {
-      const settings = await invoke<Record<string, string>>("get_all_app_settings");
-      if (settings && settings.active_settings_tab) {
-        const savedTab = settings.active_settings_tab;
-        if (savedTab === "general" || savedTab === "folders" || savedTab === "integrations" || savedTab === "tools" || savedTab === "themes" || savedTab === "equalizer" || savedTab === "about") {
-          settingsTab = savedTab;
-        }
-      }
-    } catch (e) {
-      console.error("Failed to fetch settings on mount:", e);
-    } finally {
-      isTabInitialized = true;
+  let tabElements = $state<Record<string, HTMLButtonElement>>({});
+  let indicatorStyle = $state({ left: 0, width: 0, opacity: 0 });
+  let indicatorMounted = $state(false);
+
+  function updateIndicator() {
+    const el = tabElements[settingsTab];
+    if (el) {
+      indicatorStyle = {
+        left: el.offsetLeft,
+        width: el.offsetWidth,
+        opacity: 1
+      };
     }
+  }
+
+  onMount(() => {
+    (async () => {
+      try {
+        const settings = await invoke<Record<string, string>>("get_all_app_settings");
+        if (settings && settings.active_settings_tab) {
+          const savedTab = settings.active_settings_tab;
+          if (savedTab === "general" || savedTab === "folders" || savedTab === "integrations" || savedTab === "tools" || savedTab === "themes" || savedTab === "equalizer" || savedTab === "about") {
+            settingsTab = savedTab;
+          }
+        }
+      } catch (e) {
+        console.error("Failed to fetch settings on mount:", e);
+      } finally {
+        isTabInitialized = true;
+      }
+    })();
+
+    const handleResize = () => updateIndicator();
+    window.addEventListener("resize", handleResize);
+    return () => {
+      window.removeEventListener("resize", handleResize);
+    };
   });
 
   $effect(() => {
     if (isTabInitialized) {
       invoke("set_app_setting", { key: "active_settings_tab", value: settingsTab });
+    }
+  });
+
+  $effect(() => {
+    // Re-measure when tab changes or element mounts
+    if (tabElements[settingsTab]) {
+      updateIndicator();
+      if (!indicatorMounted) {
+        requestAnimationFrame(() => {
+          indicatorMounted = true;
+        });
+      }
     }
   });
 </script>
@@ -46,46 +81,78 @@
       <h2 class="text-base font-bold text-brand-text-primary">{i18n.t('settings.title')}</h2>
     </div>
 
-    <div class="flex bg-brand-sidebar border border-brand-border rounded-xl p-0.5 text-xs shadow-sm">
+    <div
+      class="relative flex bg-brand-sidebar border border-brand-border rounded-xl p-0.5 text-xs shadow-sm"
+      role="tablist"
+      aria-label={i18n.t('settings.title')}
+    >
+      <!-- Sliding Active Indicator Pill with matching rounded-xl corner radius -->
+      <div
+        class="absolute top-0.5 bottom-0.5 bg-brand-accent rounded-xl shadow-md pointer-events-none {indicatorMounted ? 'transition-[left,width] duration-200 ease-out' : 'transition-none'}"
+        style="left: {indicatorStyle.left}px; width: {indicatorStyle.width}px; opacity: {indicatorStyle.opacity};"
+        aria-hidden="true"
+      ></div>
+
       <button
+        bind:this={tabElements["general"]}
         onclick={() => { settingsTab = "general"; }}
-        class="px-4 py-1.5 rounded-lg font-semibold transition-all {settingsTab === 'general' ? 'bg-brand-accent text-brand-accent-contrast shadow-md' : 'text-brand-text-secondary hover:text-brand-text-primary'}"
+        role="tab"
+        aria-selected={settingsTab === 'general'}
+        class="relative z-10 px-4 py-1.5 rounded-xl font-semibold transition-colors duration-200 {settingsTab === 'general' ? 'text-brand-accent-contrast' : 'text-brand-text-secondary hover:text-brand-text-primary'}"
       >
         {i18n.t('settings.tabGeneral')}
       </button>
       <button
+        bind:this={tabElements["folders"]}
         onclick={() => { settingsTab = "folders"; }}
-        class="px-4 py-1.5 rounded-lg font-semibold transition-all {settingsTab === 'folders' ? 'bg-brand-accent text-brand-accent-contrast shadow-md' : 'text-brand-text-secondary hover:text-brand-text-primary'}"
+        role="tab"
+        aria-selected={settingsTab === 'folders'}
+        class="relative z-10 px-4 py-1.5 rounded-xl font-semibold transition-colors duration-200 {settingsTab === 'folders' ? 'text-brand-accent-contrast' : 'text-brand-text-secondary hover:text-brand-text-primary'}"
       >
         {i18n.t('settings.tabFolders')}
       </button>
       <button
+        bind:this={tabElements["integrations"]}
         onclick={() => { settingsTab = "integrations"; }}
-        class="px-4 py-1.5 rounded-lg font-semibold transition-all {settingsTab === 'integrations' ? 'bg-brand-accent text-brand-accent-contrast shadow-md' : 'text-brand-text-secondary hover:text-brand-text-primary'}"
+        role="tab"
+        aria-selected={settingsTab === 'integrations'}
+        class="relative z-10 px-4 py-1.5 rounded-xl font-semibold transition-colors duration-200 {settingsTab === 'integrations' ? 'text-brand-accent-contrast' : 'text-brand-text-secondary hover:text-brand-text-primary'}"
       >
         {i18n.t('settings.tabIntegrations')}
       </button>
       <button
+        bind:this={tabElements["tools"]}
         onclick={() => { settingsTab = "tools"; }}
-        class="px-4 py-1.5 rounded-lg font-semibold transition-all {settingsTab === 'tools' ? 'bg-brand-accent text-brand-accent-contrast shadow-md' : 'text-brand-text-secondary hover:text-brand-text-primary'}"
+        role="tab"
+        aria-selected={settingsTab === 'tools'}
+        class="relative z-10 px-4 py-1.5 rounded-xl font-semibold transition-colors duration-200 {settingsTab === 'tools' ? 'text-brand-accent-contrast' : 'text-brand-text-secondary hover:text-brand-text-primary'}"
       >
         {i18n.t('settings.tabTools')}
       </button>
       <button
+        bind:this={tabElements["themes"]}
         onclick={() => { settingsTab = "themes"; }}
-        class="px-4 py-1.5 rounded-lg font-semibold transition-all {settingsTab === 'themes' ? 'bg-brand-accent text-brand-accent-contrast shadow-md' : 'text-brand-text-secondary hover:text-brand-text-primary'}"
+        role="tab"
+        aria-selected={settingsTab === 'themes'}
+        class="relative z-10 px-4 py-1.5 rounded-xl font-semibold transition-colors duration-200 {settingsTab === 'themes' ? 'text-brand-accent-contrast' : 'text-brand-text-secondary hover:text-brand-text-primary'}"
       >
         {i18n.t('settings.tabThemes')}
       </button>
       <button
+        bind:this={tabElements["equalizer"]}
         onclick={() => { settingsTab = "equalizer"; }}
-        class="px-4 py-1.5 rounded-lg font-semibold transition-all {settingsTab === 'equalizer' ? 'bg-brand-accent text-brand-accent-contrast shadow-md' : 'text-brand-text-secondary hover:text-brand-text-primary'}"
+        role="tab"
+        aria-selected={settingsTab === 'equalizer'}
+        class="relative z-10 px-4 py-1.5 rounded-xl font-semibold transition-colors duration-200 {settingsTab === 'equalizer' ? 'text-brand-accent-contrast' : 'text-brand-text-secondary hover:text-brand-text-primary'}"
       >
         {i18n.t('settings.tabEqualizer')}
       </button>
       <button
+        bind:this={tabElements["about"]}
         onclick={() => { settingsTab = "about"; }}
-        class="px-4 py-1.5 rounded-lg font-semibold transition-all {settingsTab === 'about' ? 'bg-brand-accent text-brand-accent-contrast shadow-md' : 'text-brand-text-secondary hover:text-brand-text-primary'}"
+        role="tab"
+        aria-selected={settingsTab === 'about'}
+        class="relative z-10 px-4 py-1.5 rounded-xl font-semibold transition-colors duration-200 {settingsTab === 'about' ? 'text-brand-accent-contrast' : 'text-brand-text-secondary hover:text-brand-text-primary'}"
       >
         {i18n.t('settings.tabAbout')}
       </button>

--- a/src/lib/components/TopNavigation.svelte
+++ b/src/lib/components/TopNavigation.svelte
@@ -314,7 +314,7 @@
   </div>
 
   <div bind:this={searchContainerRef} class="relative flex-1 max-w-2xl">
-    <form onsubmit={handleSearch} class="w-full flex items-center gap-3 bg-brand-main rounded-lg px-4 py-2 border border-brand-border focus-within:border-brand-accent transition-colors">
+    <form onsubmit={handleSearch} class="w-full flex items-center gap-3 bg-brand-main rounded-lg px-4 py-2 border border-brand-border focus-within:border-brand-accent focus-within:transition-colors duration-150">
       <Search class="w-4 h-4 text-brand-text-secondary flex-shrink-0" />
       <input
         bind:this={searchInput}

--- a/src/lib/components/WaveformSeekBar.svelte
+++ b/src/lib/components/WaveformSeekBar.svelte
@@ -160,9 +160,31 @@
   ) {
     const isPlaceholder = isLoadingWaveform || waveformData.length === 0;
     const data = isPlaceholder ? Array(150).fill(0) : waveformData;
-    const numBars = data.length;
     const barGap = width < NARROW_WIDTH_BREAKPOINT_PX ? 0.5 : 1.0;
-    const barWidth = Math.max(1, (width - (numBars - 1) * barGap) / numBars);
+    const minBarWidth = 1.0;
+
+    // Determine how many bars can cleanly fit in `width` without overflowing or truncating.
+    const maxBarsFit = Math.floor((width + barGap) / (minBarWidth + barGap));
+    const numBars = Math.min(data.length, Math.max(10, maxBarsFit));
+
+    // Downsample using peak-hold if container width is too narrow for all data points
+    let bars: number[];
+    if (numBars < data.length) {
+      bars = new Array(numBars);
+      for (let j = 0; j < numBars; j++) {
+        const start = Math.floor((j * data.length) / numBars);
+        const end = Math.max(start + 1, Math.floor(((j + 1) * data.length) / numBars));
+        let maxVal = 0;
+        for (let k = start; k < end && k < data.length; k++) {
+          if (data[k] > maxVal) maxVal = data[k];
+        }
+        bars[j] = maxVal;
+      }
+    } else {
+      bars = data;
+    }
+
+    const barWidth = Math.max(0.5, (width - (numBars - 1) * barGap) / numBars);
 
     const gradPlayed = ctx.createLinearGradient(0, height, 0, 0);
     gradPlayed.addColorStop(0, accentColor);
@@ -179,7 +201,7 @@
         ctx.fillStyle = accentColor;
         ctx.globalAlpha = 0.4 + 0.35 * Math.sin(pulseAngle + (i / numBars) * Math.PI * 3);
       } else {
-        val = data[i] / 255.0;
+        val = bars[i] / 255.0;
         const barPct = i / numBars;
         if (barPct <= progressPct) {
           ctx.globalAlpha = 1.0;
@@ -325,6 +347,15 @@
     const _wave = waveformData;
     const _bands = bandData;
     draw();
+  });
+
+  $effect(() => {
+    if (typeof ResizeObserver === "undefined" || !containerEl) return;
+    const observer = new ResizeObserver(() => {
+      draw();
+    });
+    observer.observe(containerEl);
+    return () => observer.disconnect();
   });
 
   // Handle seek actions (click / drag)

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -28,8 +28,11 @@ export const RIGHT_PANEL_MAX_WIDTH_PX = 480;
 /** Step size used by the keyboard-accessible resize handles for the sidebar/right panel. */
 export const PANEL_RESIZE_STEP_PX = 10;
 
-/** Window width below which the sidebar auto-collapses to its icon rail and the right panel auto-closes (routes/+layout.svelte, collection.svelte.ts). */
+/** Window width below which the sidebar auto-collapses to its icon rail (routes/+layout.svelte, collection.svelte.ts). */
 export const MEDIUM_BREAKPOINT_WIDTH_PX = 1024;
+
+/** Window width below which the right panel auto-hides and playbar spectrum/info/lyrics buttons hide, matching the md breakpoint (routes/+layout.svelte, PlayerBar.svelte). */
+export const RIGHT_PANEL_AUTO_HIDE_WIDTH_PX = 768;
 
 /** Window width below which Immersive Mode force-engages, since sidebars no longer fit (routes/+layout.svelte, collection.svelte.ts). */
 export const SMALL_BREAKPOINT_WIDTH_PX = 640;

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -34,10 +34,7 @@ export const MEDIUM_BREAKPOINT_WIDTH_PX = 1024;
 /** Window width below which the right panel auto-hides and playbar spectrum/info/lyrics buttons hide, matching the md breakpoint (routes/+layout.svelte, PlayerBar.svelte). */
 export const RIGHT_PANEL_AUTO_HIDE_WIDTH_PX = 768;
 
-/** Window width below which the PlayerBar transitions to Compact tier (PlayerBar.svelte). */
-export const COMPACT_PLAYBAR_BREAKPOINT_WIDTH_PX = 700;
-
-/** Window width below which Immersive Mode force-engages, since sidebars no longer fit (routes/+layout.svelte, collection.svelte.ts). */
+/** Window width below which Immersive Mode force-engages and PlayerBar transitions to Compact tier, since sidebars and full playdock no longer fit (routes/+layout.svelte, windowLayout.svelte.ts). */
 export const SMALL_BREAKPOINT_WIDTH_PX = 640;
 
 /** Window height below which the app collapses to showing only the PlayerBar (routes/+layout.svelte, collection.svelte.ts). */

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -34,6 +34,9 @@ export const MEDIUM_BREAKPOINT_WIDTH_PX = 1024;
 /** Window width below which the right panel auto-hides and playbar spectrum/info/lyrics buttons hide, matching the md breakpoint (routes/+layout.svelte, PlayerBar.svelte). */
 export const RIGHT_PANEL_AUTO_HIDE_WIDTH_PX = 768;
 
+/** Window width below which the PlayerBar transitions to Compact tier (PlayerBar.svelte). */
+export const COMPACT_PLAYBAR_BREAKPOINT_WIDTH_PX = 700;
+
 /** Window width below which Immersive Mode force-engages, since sidebars no longer fit (routes/+layout.svelte, collection.svelte.ts). */
 export const SMALL_BREAKPOINT_WIDTH_PX = 640;
 

--- a/src/lib/stores/theme.svelte.ts
+++ b/src/lib/stores/theme.svelte.ts
@@ -581,6 +581,12 @@ export class ThemeStore {
   async setTheme(themeId: string) {
     if (PREDEFINED_THEMES.some(t => t.id === themeId) || this.customThemes.some(t => t.id === themeId)) {
       this.activeThemeId = themeId;
+      if (typeof document !== "undefined") {
+        document.documentElement.style.setProperty("--theme-morph-duration", "0.35s");
+        setTimeout(() => {
+          void this.syncMorphDuration();
+        }, 400);
+      }
       this.applyActiveTheme();
       await invoke("set_app_setting", { key: "active_theme_id", value: themeId });
     }

--- a/src/lib/stores/theme.svelte.ts
+++ b/src/lib/stores/theme.svelte.ts
@@ -470,9 +470,33 @@ export class ThemeStore {
         }
       }
       this.applyActiveTheme();
+      void this.syncMorphDuration();
     } catch (e) {
       console.error("Failed to init ThemeStore:", e);
       this.applyActiveTheme();
+    }
+  }
+
+  /**
+   * Synchronizes the CSS theme morph transition duration with the
+   * player's active crossfade settings.
+   */
+  async syncMorphDuration() {
+    try {
+      const fadeSettings = await invoke<any>("get_fade_settings");
+      if (fadeSettings) {
+        let duration = 1.2;
+        if (fadeSettings.crossfade_auto_enabled && fadeSettings.crossfade_auto_duration_secs > 0) {
+          duration = fadeSettings.crossfade_auto_duration_secs;
+        } else if (fadeSettings.crossfade_manual_enabled && fadeSettings.crossfade_manual_duration_ms > 0) {
+          duration = fadeSettings.crossfade_manual_duration_ms / 1000;
+        }
+        if (typeof document !== "undefined") {
+          document.documentElement.style.setProperty("--theme-morph-duration", `${duration}s`);
+        }
+      }
+    } catch {
+      // ignore when IPC unavailable
     }
   }
 

--- a/src/lib/stores/theme.svelte.ts
+++ b/src/lib/stores/theme.svelte.ts
@@ -529,6 +529,12 @@ export class ThemeStore {
   async setColorSchemeMode(mode: "light" | "dark" | "system") {
     this.colorSchemeMode = mode;
     if (this.activeThemeId === "system") {
+      if (typeof document !== "undefined") {
+        document.documentElement.style.setProperty("--theme-morph-duration", "1.5s");
+        setTimeout(() => {
+          void this.syncMorphDuration();
+        }, 1600);
+      }
       this.applyActiveTheme();
     }
     await invoke("set_app_setting", { key: "color_scheme_mode", value: mode });
@@ -582,10 +588,10 @@ export class ThemeStore {
     if (PREDEFINED_THEMES.some(t => t.id === themeId) || this.customThemes.some(t => t.id === themeId)) {
       this.activeThemeId = themeId;
       if (typeof document !== "undefined") {
-        document.documentElement.style.setProperty("--theme-morph-duration", "0.35s");
+        document.documentElement.style.setProperty("--theme-morph-duration", "1.5s");
         setTimeout(() => {
           void this.syncMorphDuration();
-        }, 400);
+        }, 1600);
       }
       this.applyActiveTheme();
       await invoke("set_app_setting", { key: "active_theme_id", value: themeId });

--- a/src/lib/stores/windowLayout.svelte.ts
+++ b/src/lib/stores/windowLayout.svelte.ts
@@ -4,6 +4,7 @@ import {
   SIDEBAR_MIN_WIDTH_PX,
   SIDEBAR_COLLAPSED_WIDTH_PX,
   MEDIUM_BREAKPOINT_WIDTH_PX,
+  RIGHT_PANEL_AUTO_HIDE_WIDTH_PX,
   SMALL_BREAKPOINT_WIDTH_PX,
   PLAYBAR_ONLY_HEIGHT_BREAKPOINT_PX,
   DETAIL_HEADER_COLLAPSE_HEIGHT_PX,
@@ -340,7 +341,7 @@ class WindowLayoutStore {
   }
 
   get isRightPanelAutoHidden(): boolean {
-    return this.viewportWidth < MEDIUM_BREAKPOINT_WIDTH_PX;
+    return this.viewportWidth < RIGHT_PANEL_AUTO_HIDE_WIDTH_PX;
   }
 
   get isImmersiveForced(): boolean {

--- a/src/lib/stores/windowLayout.svelte.ts
+++ b/src/lib/stores/windowLayout.svelte.ts
@@ -5,6 +5,7 @@ import {
   SIDEBAR_COLLAPSED_WIDTH_PX,
   MEDIUM_BREAKPOINT_WIDTH_PX,
   RIGHT_PANEL_AUTO_HIDE_WIDTH_PX,
+  COMPACT_PLAYBAR_BREAKPOINT_WIDTH_PX,
   SMALL_BREAKPOINT_WIDTH_PX,
   PLAYBAR_ONLY_HEIGHT_BREAKPOINT_PX,
   DETAIL_HEADER_COLLAPSE_HEIGHT_PX,
@@ -342,6 +343,10 @@ class WindowLayoutStore {
 
   get isRightPanelAutoHidden(): boolean {
     return this.viewportWidth < RIGHT_PANEL_AUTO_HIDE_WIDTH_PX;
+  }
+
+  get isPlayerBarCompact(): boolean {
+    return this.viewportWidth < COMPACT_PLAYBAR_BREAKPOINT_WIDTH_PX;
   }
 
   get isImmersiveForced(): boolean {

--- a/src/lib/stores/windowLayout.svelte.ts
+++ b/src/lib/stores/windowLayout.svelte.ts
@@ -5,7 +5,6 @@ import {
   SIDEBAR_COLLAPSED_WIDTH_PX,
   MEDIUM_BREAKPOINT_WIDTH_PX,
   RIGHT_PANEL_AUTO_HIDE_WIDTH_PX,
-  COMPACT_PLAYBAR_BREAKPOINT_WIDTH_PX,
   SMALL_BREAKPOINT_WIDTH_PX,
   PLAYBAR_ONLY_HEIGHT_BREAKPOINT_PX,
   DETAIL_HEADER_COLLAPSE_HEIGHT_PX,
@@ -346,7 +345,7 @@ class WindowLayoutStore {
   }
 
   get isPlayerBarCompact(): boolean {
-    return this.viewportWidth < COMPACT_PLAYBAR_BREAKPOINT_WIDTH_PX;
+    return this.viewportWidth < SMALL_BREAKPOINT_WIDTH_PX;
   }
 
   get isImmersiveForced(): boolean {

--- a/src/lib/stores/windowLayout.test.ts
+++ b/src/lib/stores/windowLayout.test.ts
@@ -73,16 +73,22 @@ describe("CollectionStore - sidebar/right-panel layout and responsive breakpoint
     expect(windowLayoutStore.sidebarWidth).toBe(300);
     expect(windowLayoutStore.rightPanelOpen).toBe(true);
 
-    // Below 768px: right panel auto-hides. 700px is still Full tier for PlayerBar.
+    // Below 768px: right panel auto-hides. 700px and 640px are still Full tier for PlayerBar.
     windowLayoutStore.viewportWidth = 700;
     expect(windowLayoutStore.isSidebarAutoCollapsed).toBe(true);
     expect(windowLayoutStore.isRightPanelAutoHidden).toBe(true);
     expect(windowLayoutStore.isPlayerBarCompact).toBe(false);
     expect(windowLayoutStore.isImmersiveForced).toBe(false);
 
-    // Below 700px: PlayerBar transitions to Compact tier.
-    windowLayoutStore.viewportWidth = 699;
+    windowLayoutStore.viewportWidth = 640;
+    expect(windowLayoutStore.isPlayerBarCompact).toBe(false);
+    expect(windowLayoutStore.isImmersiveForced).toBe(false);
+
+    // Below 640px: PlayerBar transitions to Compact tier at the exact same breakpoint where Immersive Mode force-engages.
+    windowLayoutStore.viewportWidth = 639;
     expect(windowLayoutStore.isPlayerBarCompact).toBe(true);
+    expect(windowLayoutStore.isImmersiveForced).toBe(true);
+    expect(windowLayoutStore.effectiveImmersiveMode).toBe(true);
 
     // Small: immersive force-engages via the derived flag only.
     windowLayoutStore.viewportWidth = 500;

--- a/src/lib/stores/windowLayout.test.ts
+++ b/src/lib/stores/windowLayout.test.ts
@@ -73,14 +73,20 @@ describe("CollectionStore - sidebar/right-panel layout and responsive breakpoint
     expect(windowLayoutStore.sidebarWidth).toBe(300);
     expect(windowLayoutStore.rightPanelOpen).toBe(true);
 
-    // Below 768px: right panel auto-hides.
+    // Below 768px: right panel auto-hides. 700px is still Full tier for PlayerBar.
     windowLayoutStore.viewportWidth = 700;
     expect(windowLayoutStore.isSidebarAutoCollapsed).toBe(true);
     expect(windowLayoutStore.isRightPanelAutoHidden).toBe(true);
+    expect(windowLayoutStore.isPlayerBarCompact).toBe(false);
     expect(windowLayoutStore.isImmersiveForced).toBe(false);
+
+    // Below 700px: PlayerBar transitions to Compact tier.
+    windowLayoutStore.viewportWidth = 699;
+    expect(windowLayoutStore.isPlayerBarCompact).toBe(true);
 
     // Small: immersive force-engages via the derived flag only.
     windowLayoutStore.viewportWidth = 500;
+    expect(windowLayoutStore.isPlayerBarCompact).toBe(true);
     expect(windowLayoutStore.isImmersiveForced).toBe(true);
     expect(windowLayoutStore.effectiveImmersiveMode).toBe(true);
     expect(windowLayoutStore.immersiveMode).toBe(false);

--- a/src/lib/stores/windowLayout.test.ts
+++ b/src/lib/stores/windowLayout.test.ts
@@ -65,13 +65,19 @@ describe("CollectionStore - sidebar/right-panel layout and responsive breakpoint
     expect(windowLayoutStore.effectiveImmersiveMode).toBe(false);
     expect(windowLayoutStore.isPlaybarOnlyMode).toBe(false);
 
-    // Medium: sidebar/right-panel auto-collapse, real preferences untouched.
+    // Medium (between 768px and 1024px): sidebar auto-collapses, but right panel and playbar controls stay visible.
     windowLayoutStore.viewportWidth = 800;
     expect(windowLayoutStore.isSidebarAutoCollapsed).toBe(true);
-    expect(windowLayoutStore.isRightPanelAutoHidden).toBe(true);
+    expect(windowLayoutStore.isRightPanelAutoHidden).toBe(false);
     expect(windowLayoutStore.isImmersiveForced).toBe(false);
     expect(windowLayoutStore.sidebarWidth).toBe(300);
     expect(windowLayoutStore.rightPanelOpen).toBe(true);
+
+    // Below 768px: right panel auto-hides.
+    windowLayoutStore.viewportWidth = 700;
+    expect(windowLayoutStore.isSidebarAutoCollapsed).toBe(true);
+    expect(windowLayoutStore.isRightPanelAutoHidden).toBe(true);
+    expect(windowLayoutStore.isImmersiveForced).toBe(false);
 
     // Small: immersive force-engages via the derived flag only.
     windowLayoutStore.viewportWidth = 500;


### PR DESCRIPTION
## 📋 Summary
Implements smooth sliding micro-animations across segmented controls, unified settings container and indicator corner radii (`rounded-xl`), dynamic theme morphing via CSS `@property` with crossfade synchronization, responsive playbar breakpoint transitions with smooth collapsing action buttons, responsive waveform seekbar downsampling, and synchronous compact transport layout without button jumping.

## 🔍 Implementation Notes
- **Segmented Controls Sliding Animations**: Added hardware-accelerated and measured sliding indicator pills across `SettingsView.svelte` (with `rounded-xl` matching the group container), `Equalizer.svelte` (10-band/20-band & loudness mode), `CollectionView.svelte`, `PlaylistsCollectionView.svelte`, `GenreBrowseView.svelte` (cards/rows and genre/tags switchers), and `PopulationModeTabs.svelte`.
- **Dynamic Theme Morphing & Transition Harmonization**: Registered text and accent variables in `app.css` using CSS `@property` `<color>` rules so that theme switches animate smoothly across all surfaces. Set manual theme switches to 1.5s in `theme.svelte.ts` (re-syncing with audio crossfade for track changes). Fixed search bar high-frequency color pulsing by removing overlapping transitions and guarding Theme Builder preview injections.
- **Responsive Playbar Breakpoint Transitions**:
  - Implemented `collapseFade` in `PlayerBar.svelte` so Lyric and Info buttons collapse width and absorb flex gap, allowing Menu, Queue, and Miniplayer buttons to glide smoothly together.
  - Aligned Shuffle and Repeat visibility to 768px (`!isRightPanelAutoHidden`) with `collapseFade`, eliminating overlap with song title and rating.
  - Locked toolbar row heights (`h-5` button row, `h-7` volume row) so the 3-button compact state maintains an identical vertical baseline.
  - Aligned compact playbar tier transition to 640px (`SMALL_BREAKPOINT_WIDTH_PX`), matching where the main view transitions to the 3D immersive cover view. Adjusted padding and flex sizing to prevent dock overflow between 640px and 768px.
  - Rendered compact miniplayer (Picture-in-Picture) button synchronously alongside transport controls (`SkipBack`, `Play/Pause`, `SkipForward`) without delayed reveal or transition delays, avoiding any button shifting or flashing.
- **Waveform Seekbar Responsiveness**: Attached a `ResizeObserver` to `WaveformSeekBar.svelte` and implemented peak-hold downsampling in `drawWaveform()` to prevent bar truncation on resize.

## 🧪 Test Plan
- [x] `bun run check` (svelte-check found 0 errors and 0 warnings, knip clean)
- [x] `bun run test -- --run` (all 85 test files and 757 unit tests passed)
- [x] Manually verified in the app across breakpoints and theme switches

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed
