### PR TITLE
fix(brand): render crisp authentic logo for reactive mark resting state

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -268,8 +268,8 @@ These are the logo's own identity colors for marketing/social/app-icon-at-rest u
 
 ### Two artifacts
 
-- `luminous-mark.svg` — static, crisp, no blur or glow filters. Use for app icons, avatars, favicons, and anywhere the mark must render sharp at small sizes.
-- `luminous-mark-reactive.svg` — lush, heavier blur/glow baked in (bigger ambient glow, blurred rings, blurred burst halo). Use for hero/marketing placements and as the resting frame of the in-app audio-reactive element.
+- `luminous-mark.svg` — static, crisp, no blur or glow filters. Use for app icons, avatars, favicons, anywhere the mark must render sharp at small sizes, and as the resting state of the in-app audio-reactive element when playback is idle.
+- `luminous-mark-reactive.svg` — lush, heavier blur/glow baked in (bigger ambient glow, blurred rings, blurred burst halo). Use for hero/marketing placements and visualizer references.
 - Never blur the static mark or crisp up the reactive one — they're distinct assets for distinct contexts, not one file with a toggle.
 
 ### Usage rules

--- a/src/lib/components/ReactiveLogoBrand.svelte
+++ b/src/lib/components/ReactiveLogoBrand.svelte
@@ -113,37 +113,47 @@
     }
   }
 
+  // Authentic Luminous Brand Colors for resting state (matches docs/luminous-mark.svg and static/app-icon.svg)
+  const BRAND_INDIGO = "#626FE8";
+  const BRAND_GOLD = "#FFB648";
+  const BRAND_SILHOUETTE = "#0A0A0D";
+  const BRAND_BURST = "#FFFFFF";
+
   let isPlaying = $derived(playerStore.state === "playing");
+  let isResting = $derived(!isPlaying || !isPulsingEnabled);
 
-  // Geometry and resting values below mirror docs/luminous-mark-reactive.svg
-  // exactly: centered at (100,100), disc r=68, indigo inner rim r=77, gold
-  // eclipse ring r=92, burst at (152,57). That asset (not app-icon.svg/
-  // luminous-mark.svg, which are the crisp static variant — see DESIGN.md's
-  // "Two artifacts" section) is the lush, pre-blurred baseline for this
-  // in-app element; when paused/pulsing-disabled these derive to its own
-  // literal opacity/width values, so the logo is indistinguishable from the
-  // reactive mark's resting frame.
+  // In resting state (when playback is stopped/paused, or pulsing is disabled),
+  // the logo renders the authentic, crisp Luminous brand mark (docs/luminous-mark.svg)
+  // with no blur filters, authentic brand indigo (#626FE8) and gold (#FFB648),
+  // zero ambient glow, and sharp vector geometry.
+  //
+  // When music is playing and pulsing is enabled, it transitions into the audio-reactive
+  // visualizer driven live by the current track's frequency bands:
+  // - Mid frequencies drive the ambient glow halo and inner rim (re-targeting to active theme accent)
+  // - Treble frequencies drive the outer eclipse ring (re-targeting to theme accent-hover)
+  // - Bass frequencies drive the coronal burst flare halo
 
-  // Ambient glow (mid-driven): the blurred halo plus its crisp inner rim —
-  // both re-target to the active theme's accent color, per the Luminous
-  // Logo System spec.
-  let glowRadius = $derived(!isPlaying || !isPulsingEnabled ? 112 : 95 + midIntensity * 35);
-  let glowOpacity = $derived(!isPlaying || !isPulsingEnabled ? 0.4 : 0.2 + midIntensity * 0.7);
-  let innerRimWidth = $derived(!isPlaying || !isPulsingEnabled ? 16 : 12 + midIntensity * 12);
-  let innerRimOpacity = $derived(!isPlaying || !isPulsingEnabled ? 0.95 : 0.7 + midIntensity * 0.3);
+  // Ambient glow (mid-driven): soft blurred halo, active only while playing
+  let glowRadius = $derived(isResting ? 0 : 95 + midIntensity * 35);
+  let glowOpacity = $derived(isResting ? 0 : 0.2 + midIntensity * 0.7);
 
-  // Eclipse ring (treble-driven): re-targets to the active theme's
-  // accent-hover, one step brighter than the glow.
-  let ringWidth = $derived(!isPlaying || !isPulsingEnabled ? 9 : 5 + coronalIntensity * 16);
-  let ringOpacity = $derived(!isPlaying || !isPulsingEnabled ? 0.85 : 0.5 + coronalIntensity * 0.5);
+  // Ambient glow inner rim (mid-driven): crisp ring right at the disc's edge at rest, pulsing softly when playing
+  let innerRimStroke = $derived(isResting ? BRAND_INDIGO : "var(--color-accent)");
+  let innerRimWidth = $derived(isResting ? 14 : 12 + midIntensity * 12);
+  let innerRimOpacity = $derived(isResting ? 1.0 : 0.7 + midIntensity * 0.3);
 
-  // Coronal burst (bass-driven): the halo pulses; the small core dot stays
-  // fixed, matching the reactive mark's always-visible white highlight.
-  let burstRadius = $derived(!isPlaying || !isPulsingEnabled ? 26 : 18 + bassIntensity * 26);
-  let burstOpacity = $derived(!isPlaying || !isPulsingEnabled ? 0.4 : 0.15 + bassIntensity * 0.7);
+  // Eclipse ring (treble-driven): brand gold at rest, re-targets to active theme's accent-hover when playing
+  let ringStroke = $derived(isResting ? BRAND_GOLD : "var(--color-accent-hover)");
+  let ringWidth = $derived(isResting ? 8 : 5 + coronalIntensity * 16);
+  let ringOpacity = $derived(isResting ? 1.0 : 0.5 + coronalIntensity * 0.5);
+
+  // Coronal burst (bass-driven): the halo pulses when playing; the core dot stays
+  // fixed, matching the canonical mark's white highlight at (150.6, 59.6) with r=17.4
+  let burstRadius = $derived(isResting ? 0 : 18 + bassIntensity * 26);
+  let burstOpacity = $derived(isResting ? 0 : 0.15 + bassIntensity * 0.7);
 
   let maxIntensity = $derived(Math.max(bassIntensity, midIntensity, coronalIntensity));
-  let saturationVal = $derived(!isPlaying || !isPulsingEnabled ? 1.0 : 0.15 + maxIntensity * 2.35);
+  let saturationVal = $derived(isResting ? 1.0 : 0.15 + maxIntensity * 2.35);
 </script>
 
 <button
@@ -174,65 +184,62 @@
     </defs>
 
     <g
-      style="filter: saturate({saturationVal}); transition: filter 0.05s ease-out;"
+      style="filter: {isResting ? 'none' : `saturate(${saturationVal})`}; transition: filter 0.05s ease-out;"
     >
-      <!-- Ambient glow (mid-driven): soft blurred halo -->
+      <!-- Ambient glow (mid-driven): soft blurred halo, active only while playing -->
       <circle
         cx="100"
         cy="100"
         r={glowRadius}
         fill="var(--color-accent)"
         opacity={glowOpacity}
-        filter="url(#glowBlurOuter)"
-        style="transition: r 0.05s ease-out;"
+        filter={isResting ? undefined : "url(#glowBlurOuter)"}
+        style="transition: r 0.05s ease-out, opacity 0.3s ease;"
       />
 
-      <!-- Ambient glow inner rim (mid-driven): softly blurred ring right at the disc's edge -->
+      <!-- Ambient glow inner rim (mid-driven): crisp ring right at the disc's edge at rest, softly blurred when playing -->
       <circle
         cx="100"
         cy="100"
         r="77"
-        stroke="var(--color-accent)"
+        stroke={innerRimStroke}
         stroke-width={innerRimWidth}
         fill="none"
         opacity={innerRimOpacity}
-        filter="url(#ringBlur)"
-        style="transition: stroke-width 0.05s ease-out;"
+        filter={isResting ? undefined : "url(#ringBlur)"}
+        style="transition: stroke 0.3s ease, stroke-width 0.05s ease-out, opacity 0.3s ease;"
       />
 
       <!-- Eclipse ring (treble-driven): re-targets to the active theme's
-           accent-hover, one step brighter than the glow -->
+           accent-hover when playing -->
       <circle
         cx="100"
         cy="100"
         r="92"
-        stroke="var(--color-accent-hover)"
+        stroke={ringStroke}
         stroke-width={ringWidth}
         fill="none"
         opacity={ringOpacity}
-        filter="url(#ringBlur)"
-        style="transition: stroke-width 0.05s ease-out;"
+        filter={isResting ? undefined : "url(#ringBlur)"}
+        style="transition: stroke 0.3s ease, stroke-width 0.05s ease-out, opacity 0.3s ease;"
       />
 
       <!-- The planet disc -->
-      <circle cx="100" cy="100" r="68" fill="#0A0A0D" />
-
-      <!-- Inner border separating core disc from corona -->
-      <circle cx="100" cy="100" r="68" stroke="var(--bg-main)" stroke-width="1.5" fill="none" />
+      <circle cx="100" cy="100" r="68" fill={BRAND_SILHOUETTE} />
 
       <!-- Coronal burst halo (bass-driven) -->
       <circle
-        cx="152"
-        cy="57"
+        cx="150.6"
+        cy="59.6"
         r={burstRadius}
-        fill="#ffffff"
-        filter="url(#burstBlur)"
+        fill={BRAND_BURST}
+        filter={isResting ? undefined : "url(#burstBlur)"}
         opacity={burstOpacity}
-        style="transition: r 0.05s ease-out;"
+        style="transition: r 0.05s ease-out, opacity 0.3s ease;"
       />
 
-      <!-- Coronal burst core: fixed, always-visible white highlight -->
-      <circle cx="152" cy="57" r="12" fill="#ffffff" />
+      <!-- Coronal burst core: fixed, always-visible white highlight matching docs/luminous-mark.svg -->
+      <circle cx="150.6" cy="59.6" r="17.4" fill={BRAND_BURST} />
     </g>
   </svg>
 </button>

--- a/src/lib/components/ReactiveLogoBrand.test.ts
+++ b/src/lib/components/ReactiveLogoBrand.test.ts
@@ -1,0 +1,120 @@
+import "@testing-library/jest-dom";
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, fireEvent } from "@testing-library/svelte";
+import ReactiveLogoBrand from "./ReactiveLogoBrand.svelte";
+import { playerStore } from "../stores/player.svelte";
+
+describe("ReactiveLogoBrand.svelte", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    playerStore.state = "stopped";
+  });
+
+  it("renders the crisp authentic Luminous brand mark in resting state when playback is stopped", () => {
+    playerStore.state = "stopped";
+    const { container } = render(ReactiveLogoBrand, { props: { size: "lg" } });
+
+    // Inner rim (r=77)
+    const innerRim = container.querySelector('circle[r="77"]');
+    expect(innerRim).not.toBeNull();
+    expect(innerRim?.getAttribute("stroke")).toBe("#626FE8");
+    expect(innerRim?.getAttribute("stroke-width")).toBe("14");
+    expect(innerRim?.getAttribute("opacity")).toBe("1");
+    expect(innerRim?.getAttribute("filter")).toBeNull();
+
+    // Eclipse ring (r=92)
+    const eclipseRing = container.querySelector('circle[r="92"]');
+    expect(eclipseRing).not.toBeNull();
+    expect(eclipseRing?.getAttribute("stroke")).toBe("#FFB648");
+    expect(eclipseRing?.getAttribute("stroke-width")).toBe("8");
+    expect(eclipseRing?.getAttribute("opacity")).toBe("1");
+    expect(eclipseRing?.getAttribute("filter")).toBeNull();
+
+    // Planet silhouette disc (r=68)
+    const disc = container.querySelector('circle[r="68"]');
+    expect(disc).not.toBeNull();
+    expect(disc?.getAttribute("fill")).toBe("#0A0A0D");
+
+    // Coronal burst core (cx=150.6, cy=59.6, r=17.4)
+    const burstCore = container.querySelector('circle[cx="150.6"][cy="59.6"][r="17.4"]');
+    expect(burstCore).not.toBeNull();
+    expect(burstCore?.getAttribute("fill")).toBe("#FFFFFF");
+
+    // Ambient glow halo and burst halo should have opacity 0 at rest
+    const glowCircle = container.querySelector('circle[fill="var(--color-accent)"]');
+    expect(glowCircle?.getAttribute("opacity")).toBe("0");
+    expect(glowCircle?.getAttribute("filter")).toBeNull();
+
+    const burstHalo = container.querySelector('circle[cx="150.6"][cy="59.6"][r="0"]');
+    expect(burstHalo?.getAttribute("opacity")).toBe("0");
+    expect(burstHalo?.getAttribute("filter")).toBeNull();
+  });
+
+  it("renders the crisp authentic brand logo in resting state when playback is paused", () => {
+    playerStore.state = "paused";
+    const { container } = render(ReactiveLogoBrand, { props: { size: "md" } });
+
+    const innerRim = container.querySelector('circle[r="77"]');
+    expect(innerRim?.getAttribute("stroke")).toBe("#626FE8");
+    expect(innerRim?.getAttribute("stroke-width")).toBe("14");
+    expect(innerRim?.getAttribute("filter")).toBeNull();
+
+    const eclipseRing = container.querySelector('circle[r="92"]');
+    expect(eclipseRing?.getAttribute("stroke")).toBe("#FFB648");
+    expect(eclipseRing?.getAttribute("stroke-width")).toBe("8");
+    expect(eclipseRing?.getAttribute("filter")).toBeNull();
+  });
+
+  it("activates audio-reactive visualizer with theme accents and blur filters while playing", () => {
+    playerStore.state = "playing";
+    const { container } = render(ReactiveLogoBrand, { props: { size: "lg" } });
+
+    // Inner rim re-targets to theme accent with ringBlur filter
+    const innerRim = container.querySelector('circle[r="77"]');
+    expect(innerRim?.getAttribute("stroke")).toBe("var(--color-accent)");
+    expect(innerRim?.getAttribute("filter")).toBe("url(#ringBlur)");
+
+    // Eclipse ring re-targets to theme accent-hover with ringBlur filter
+    const eclipseRing = container.querySelector('circle[r="92"]');
+    expect(eclipseRing?.getAttribute("stroke")).toBe("var(--color-accent-hover)");
+    expect(eclipseRing?.getAttribute("filter")).toBe("url(#ringBlur)");
+
+    // Ambient glow halo becomes active
+    const glowCircle = container.querySelector('circle[fill="var(--color-accent)"]');
+    expect(glowCircle?.getAttribute("filter")).toBe("url(#glowBlurOuter)");
+    const glowOpacity = parseFloat(glowCircle?.getAttribute("opacity") || "0");
+    expect(glowOpacity).toBeGreaterThan(0);
+
+    // Burst halo becomes active
+    const burstHalo = container.querySelector('circle[cx="150.6"][cy="59.6"][filter="url(#burstBlur)"]');
+    expect(burstHalo).not.toBeNull();
+    const burstOpacity = parseFloat(burstHalo?.getAttribute("opacity") || "0");
+    expect(burstOpacity).toBeGreaterThan(0);
+  });
+
+  it("returns to resting crisp brand mark when clicking the button to disable pulsing", async () => {
+    playerStore.state = "playing";
+    const { container, getByRole } = render(ReactiveLogoBrand, { props: { size: "lg" } });
+
+    const button = getByRole("button");
+    // Initially playing: active visualizer
+    let innerRim = container.querySelector('circle[r="77"]');
+    expect(innerRim?.getAttribute("stroke")).toBe("var(--color-accent)");
+
+    // Toggle pulsing off
+    await fireEvent.click(button);
+
+    // Should return to resting crisp brand mark
+    innerRim = container.querySelector('circle[r="77"]');
+    expect(innerRim?.getAttribute("stroke")).toBe("#626FE8");
+    expect(innerRim?.getAttribute("stroke-width")).toBe("14");
+    expect(innerRim?.getAttribute("filter")).toBeNull();
+
+    const eclipseRing = container.querySelector('circle[r="92"]');
+    expect(eclipseRing?.getAttribute("stroke")).toBe("#FFB648");
+    expect(eclipseRing?.getAttribute("filter")).toBeNull();
+
+    const glowCircle = container.querySelector('circle[fill="var(--color-accent)"]');
+    expect(glowCircle?.getAttribute("opacity")).toBe("0");
+  });
+});


### PR DESCRIPTION
## 📋 Summary
Fixes #943. Updates the reactive brand mark in the top-right navigation header (`ReactiveLogoBrand.svelte`) so its resting state (when playback is stopped/paused or audio pulsing is inactive) renders the authentic, crisp Luminous brand logo rather than a blurred/fuzzy version.

## 🔍 Implementation Notes
* **`src/lib/components/ReactiveLogoBrand.svelte`**:
  * Derived `isResting = !isPlaying || !isPulsingEnabled`.
  * In resting state, rings render with zero blur (`filter: undefined`), exact stroke widths (`14` for inner rim, `8` for eclipse ring), full opacity (`1.0`), and canonical brand colors: Indigo (`#626FE8`) and Gold (`#FFB648`).
  * Burst core coordinates and radius match the canonical static SVG mark (`docs/luminous-mark.svg` / `static/app-icon.svg`) at `cx="150.6" cy="59.6" r="17.4"`.
  * Ambient glow halo and coronal burst halo opacities drop to `0` at rest so no Gaussian blur artifacts are visible.
  * Removed the artificial inner border circle stroke on the planet disc to match the clean canonical mark.
  * When playback is active (`isPlaying && isPulsingEnabled`), the logo smoothly transitions to the audio-reactive visualizer with theme accents and frequency pulsing.
* **`src/lib/components/ReactiveLogoBrand.test.ts`**:
  * Added unit tests verifying resting state attributes when stopped and paused, active visualizer state while playing, and toggling pulsing off via button click.
* **`DESIGN.md`**:
  * Updated the "Two artifacts" documentation section to state that `luminous-mark.svg` serves as the resting state for the in-app reactive mark when playback is idle.

## 🧪 Test Plan
- [x] `bun run check` (svelte-check)
- [x] `bun run test:run` (frontend Vitest suite, 86 files, 761 tests passed)
- [x] Manually verified in the app

## ✅ Checklist
- [x] No unrelated changes bundled in
- [x] Docs/screenshots updated if user-facing behavior changed
